### PR TITLE
Refactor DRY hotspots: builtin registry, vector operand scaffolding, and interpreter snapshots

### DIFF
--- a/docs/dev/dry-refactor-followup-handover.md
+++ b/docs/dev/dry-refactor-followup-handover.md
@@ -1,0 +1,145 @@
+# DRY リファクタ追加対応 引き継ぎ書（未着手項目対応）
+
+作成日: 2026-04-09  
+対象リポジトリ: `masamoto1982/Ajisai`
+
+---
+
+## 0. 背景
+前回の DRY リファクタでは、以下は **未着手または見送り** として残した。
+
+1. `TAKE / SPLIT / REVERSE / REORDER` の vector 周辺制御共通化
+2. Rust/WASM 側の `js_sys::Reflect::set(...)` 定型の共通化
+3. TypeScript/IndexedDB 側の request Promise 化定型の共通化
+
+本書は、上記 3 点を次担当者が安全に改修するための引き継ぎ資料である。
+
+---
+
+## 1. 現在までに完了済み（前提）
+
+- Built-in registry は導入済み（`BuiltinSpec` 正本化）。
+- `GET / INSERT / REPLACE / REMOVE` の StackTop 周辺制御は共通化済み。
+- TypeScript 側 `InterpreterSnapshot` は共通型/復元ヘルパ化済み。
+- Rust GUI integration tests 向け `test_support` は導入済み。
+
+> したがって、今回の作業は「既存共通化の横展開」と「小規模定型の整理」が主目的。
+
+---
+
+## 2. 未着手項目ごとの改修ガイド
+
+## 2-1. vector 操作（`TAKE / SPLIT / REVERSE / REORDER`）の共通化
+
+### 対象ファイル（主）
+- `rust/src/interpreter/vector_ops/quantity.rs`
+- `rust/src/interpreter/vector_ops/structure.rs`
+- 必要に応じて `rust/src/interpreter/vector_ops/mod.rs`
+
+### 目標
+`position.rs` で実施した方針（「演算意味論」と「周辺スタック制御」の分離）を、上記 4 operator に適用する。
+
+### 推奨アプローチ
+1. まず `TAKE` と `SPLIT`（`quantity.rs`）の重複箇所を抽出。
+2. 次に `REVERSE` と `REORDER`（`structure.rs`）へ同型ヘルパを適用。
+3. ヘルパ名は、意図が明確な局所名を優先（例: `with_stacktop_vector_target`, `restore_vector_args_on_error` など）。
+4. 既存エラー文言・stack 復元順序を変更しない。
+
+### 完了条件
+- 少なくとも上記 4 operator で、同一の pop/restore/keep-mode 分岐が減っている。
+- 既存テスト（特に mode 系、vector ops 系）が green。
+
+---
+
+## 2-2. Rust/WASM の `Reflect::set` 定型共通化
+
+### 対象ファイル（候補）
+- `rust/src/wasm-interpreter-execution.rs`
+- `rust/src/wasm-interpreter-state.rs`
+- `rust/src/wasm-value-conversion.rs`
+
+### 目標
+`js_sys::Reflect::set(...)` の同型処理を小さな builder / helper で統一し、プロパティ追加時の修正箇所を減らす。
+
+### 推奨アプローチ
+1. まず `Object` 生成と `Reflect::set` を行う箇所を列挙。
+2. `set_prop(obj, key, value)` のような最小ヘルパを導入。
+3. 必要であれば `build_ok_result` / `build_error_result` / `build_state_result` 相当の関数を追加。
+4. 例外系（set 失敗時）ハンドリング方針は既存と合わせる。
+
+### 完了条件
+- `Reflect::set` の重複記述が実質削減される。
+- WASM API の返却 shape が不変。
+
+---
+
+## 2-3. TypeScript/IndexedDB request Promise 化共通化
+
+### 対象ファイル（主）
+- `js/indexeddb-user-word-store.ts`
+- `js/gui/interpreter-state-persistence.ts`
+
+### 目標
+`onsuccess/onerror` の定型を `promisifyRequest` 等で共通化し、保存系コードの見通しを改善する。
+
+### 推奨アプローチ
+1. 同型の request ハンドリングを抽出。
+2. `promisifyRequest<T>(request: IDBRequest<T>)` を先に導入。
+3. 必要なら `withObjectStore`（transaction + store 取得）を追加。
+4. 呼び出し側は段階的に差し替え、挙動差分が出ないことを確認。
+
+### 完了条件
+- IndexedDB アクセス経路の重複が減る。
+- 既存の保存/復元動作（GUI 起動時の state 復元含む）が維持される。
+
+---
+
+## 3. 推奨実施順（安全優先）
+
+1. `TAKE / SPLIT / REVERSE / REORDER` の共通化
+2. Rust/WASM `Reflect::set` 共通化
+3. TypeScript/IndexedDB 共通化
+
+理由:
+- 1 は既存パターン（`position.rs`）を横展開しやすい。
+- 2 は Rust 側返却 shape に注意が必要だが影響範囲は比較的局所。
+- 3 は UI 実行時にしか露呈しない不具合が出やすく、最後にまとめて確認した方が安全。
+
+---
+
+## 4. 変更時の注意事項
+
+- **仕様変更禁止**（エラーメッセージ含む）。
+- keep/consume と stack target（`.` / `..`）の挙動維持を最優先。
+- 「DRY のための過剰抽象化」は避け、局所ヘルパ中心で進める。
+- 1 PR あたりの責務は小さく分割（理想は 2〜3 PR）。
+
+---
+
+## 5. 推奨テストコマンド
+
+### 必須
+- `cd rust && cargo test --lib`
+- `cd rust && cargo test --test gui-interpreter-test-cases`
+- `npm run check`
+
+### 可能なら追加
+- `cd rust && cargo test --tests`
+- GUI 手動確認（state 保存/復元、worker 実行、step 実行）
+
+---
+
+## 6. 受け入れ基準（Definition of Done）
+
+- [ ] 未着手 3 項目のうち、最低 2 項目は改修完了。
+- [ ] 既存テスト green。
+- [ ] 新規ヘルパ導入により、同型コードの重複削減を diff で説明可能。
+- [ ] 既存 API / GUI 挙動 / テスト期待値を維持。
+
+---
+
+## 7. 次担当者へのメモ
+
+- まず `position.rs` の helper 設計を参照し、同じ抽象度で横展開すること。
+- snapshot 系はすでに共通化済みのため、IndexedDB 側の共通化時は重複導入に注意。
+- 大規模整形（fmt/lint による全体差分）はレビュー負荷が高いため、対象ファイル限定で実施すること。

--- a/js/gui/execution-controller.ts
+++ b/js/gui/execution-controller.ts
@@ -1,4 +1,9 @@
 import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import {
+    applyInterpreterSnapshot,
+    createInterpreterSnapshot,
+    type InterpreterSnapshot
+} from '../workers/interpreter-snapshot';
 import type { AjisaiInterpreter, ExecuteResult, UserWord } from '../wasm-interpreter-types';
 import { createStepExecutor, StepExecutor } from './step-executor';
 import type { ViewMode } from './mobile-view-switcher';
@@ -25,12 +30,6 @@ export interface ExecutionController {
     readonly abortExecution: () => void;
 }
 
-interface ExecutionSnapshot {
-    readonly stack: ReturnType<AjisaiInterpreter['collect_stack']>;
-    readonly userWords: UserWord[];
-    readonly importedModules: string[];
-}
-
 const mapWordDataToUserWord = (
     interpreter: AjisaiInterpreter,
     wordData: [string, string, string | null, boolean]
@@ -52,16 +51,11 @@ const restoreInterpreterState = (
 ): void => {
     if (!result || result.error) return;
 
-    interpreter.reset();
-    if (result.importedModules?.length) {
-        interpreter.restore_imported_modules(result.importedModules);
-    }
-    if (result.stack) {
-        interpreter.restore_stack(result.stack);
-    }
-    if (result.userWords) {
-        interpreter.restore_user_words(result.userWords);
-    }
+    applyInterpreterSnapshot(interpreter, {
+        stack: result.stack,
+        userWords: result.userWords,
+        importedModules: result.importedModules
+    });
 };
 
 const checkIsResetCommand = (code: string): boolean =>
@@ -70,11 +64,12 @@ const checkIsResetCommand = (code: string): boolean =>
 const isAbortError = (error: Error): boolean =>
     error.message.includes('aborted');
 
-const createExecutionSnapshot = (interpreter: AjisaiInterpreter): ExecutionSnapshot => ({
-    stack: interpreter.collect_stack(),
-    userWords: collectUserWords(interpreter),
-    importedModules: interpreter.collect_imported_modules()
-});
+const createExecutionSnapshot = (interpreter: AjisaiInterpreter): InterpreterSnapshot =>
+    createInterpreterSnapshot({
+        stack: interpreter.collect_stack(),
+        userWords: collectUserWords(interpreter),
+        importedModules: interpreter.collect_imported_modules()
+    });
 
 const resolveExecutionException = (
     error: unknown,

--- a/js/gui/step-executor.ts
+++ b/js/gui/step-executor.ts
@@ -2,6 +2,11 @@
 
 import { WORKER_MANAGER } from '../workers/execution-worker-manager';
 import type { AjisaiInterpreter, UserWord, ExecuteResult } from '../wasm-interpreter-types';
+import {
+    applyInterpreterSnapshot,
+    createInterpreterSnapshot,
+    type InterpreterSnapshot
+} from '../workers/interpreter-snapshot';
 
 export interface StepState {
     readonly active: boolean;
@@ -16,11 +21,6 @@ export interface StepExecutorCallbacks {
     readonly showExecutionResult: (result: ExecuteResult) => void;
     readonly updateDisplays: () => void;
     readonly saveState: () => Promise<void>;
-}
-
-interface StepExecutionSnapshot {
-    readonly stack: ReturnType<AjisaiInterpreter['collect_stack']>;
-    readonly userWords: UserWord[];
 }
 
 export interface StepExecutor {
@@ -72,10 +72,12 @@ const collectUserWords = (interpreter: AjisaiInterpreter): UserWord[] => {
 
 const createStepExecutionSnapshot = (
     interpreter: AjisaiInterpreter
-): StepExecutionSnapshot => ({
-    stack: interpreter.collect_stack(),
-    userWords: collectUserWords(interpreter)
-});
+): InterpreterSnapshot =>
+    createInterpreterSnapshot({
+        stack: interpreter.collect_stack(),
+        userWords: collectUserWords(interpreter),
+        importedModules: interpreter.collect_imported_modules()
+    });
 
 const resolveStepExecutionException = (
     error: unknown,
@@ -96,13 +98,11 @@ const syncInterpreterState = (
 ): void => {
     if (!result || result.error) return;
 
-    interpreter.reset();
-    if (result.stack) {
-        interpreter.restore_stack(result.stack);
-    }
-    if (result.userWords) {
-        interpreter.restore_user_words(result.userWords);
-    }
+    applyInterpreterSnapshot(interpreter, {
+        stack: result.stack,
+        userWords: result.userWords,
+        importedModules: result.importedModules
+    });
 };
 
 export const createStepExecutor = (

--- a/js/workers/execution-worker-manager.ts
+++ b/js/workers/execution-worker-manager.ts
@@ -1,16 +1,13 @@
 // js/workers/execution-worker-manager.ts
 
-import type { ExecuteResult, Value, UserWord } from '../wasm-interpreter-types';
+import type { ExecuteResult } from '../wasm-interpreter-types';
+import type { InterpreterSnapshot } from './interpreter-snapshot';
 import { extractCompiledWasmModule } from '../wasm-module-loader';
 
 interface WorkerTask {
     id: string;
     code: string;
-    state: {
-        stack: Value[];
-        userWords: UserWord[];
-        importedModules?: string[];
-    };
+    state: InterpreterSnapshot;
     resolve: (result: any) => void;
     reject: (error: any) => void;
 }
@@ -147,7 +144,7 @@ export class WorkerManager {
         return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     }
 
-    execute(code: string, state: { stack: Value[], userWords: UserWord[], importedModules?: string[] }): Promise<ExecuteResult> {
+    execute(code: string, state: InterpreterSnapshot): Promise<ExecuteResult> {
         this.ensureWorkers();
         return new Promise((resolve, reject) => {
             const task: WorkerTask = {

--- a/js/workers/interpreter-execution-worker.ts
+++ b/js/workers/interpreter-execution-worker.ts
@@ -1,6 +1,7 @@
 // js/workers/interpreter-execution-worker.ts
 
 import type { AjisaiInterpreter, ExecuteResult } from '../wasm-interpreter-types';
+import { applyInterpreterSnapshot } from './interpreter-snapshot';
 
 let interpreter: AjisaiInterpreter | null = null;
 let isAborted = false;
@@ -81,16 +82,7 @@ self.onmessage = async (event: MessageEvent) => {
 
     try {
         // 実行前に状態を復元
-        interpreter!.reset();
-        if (event.data.state?.importedModules?.length) {
-            interpreter!.restore_imported_modules(event.data.state.importedModules);
-        }
-        if (event.data.state?.stack) {
-            interpreter!.restore_stack(event.data.state.stack);
-        }
-        if (event.data.state?.userWords) {
-            interpreter!.restore_user_words(event.data.state.userWords);
-        }
+        applyInterpreterSnapshot(interpreter!, event.data.state);
 
         if (isAborted) throw new Error('aborted');
 

--- a/js/workers/interpreter-snapshot.ts
+++ b/js/workers/interpreter-snapshot.ts
@@ -1,0 +1,35 @@
+import type { AjisaiInterpreter, UserWord, Value } from '../wasm-interpreter-types';
+
+export interface InterpreterSnapshot {
+    readonly stack: Value[];
+    readonly userWords: UserWord[];
+    readonly importedModules: string[];
+}
+
+export const createInterpreterSnapshot = (snapshot: {
+    readonly stack: Value[];
+    readonly userWords: UserWord[];
+    readonly importedModules?: string[];
+}): InterpreterSnapshot => ({
+    stack: snapshot.stack,
+    userWords: snapshot.userWords,
+    importedModules: snapshot.importedModules ?? []
+});
+
+export const applyInterpreterSnapshot = (
+    interpreter: AjisaiInterpreter,
+    snapshot?: Partial<InterpreterSnapshot> | null
+): void => {
+    interpreter.reset();
+    if (!snapshot) return;
+
+    if (snapshot.importedModules?.length) {
+        interpreter.restore_imported_modules(snapshot.importedModules);
+    }
+    if (snapshot.stack) {
+        interpreter.restore_stack(snapshot.stack);
+    }
+    if (snapshot.userWords) {
+        interpreter.restore_user_words(snapshot.userWords);
+    }
+};

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -1,421 +1,744 @@
 // rust/src/builtins/builtin-word-definitions.rs
 //
-// Built-in word definitions (name, description, syntax_example, signature_type)
+// Built-in word registry (single source of truth for metadata + execution binding key)
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BuiltinDetailGroup {
+    Modifier,
+    ArithmeticLogic,
+    VectorOps,
+    StringCast,
+    ControlHigherOrder,
+    Cond,
+    IoModule,
+    None,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BuiltinExecutorKey {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Eq,
+    Lt,
+    Le,
+    Map,
+    Filter,
+    Fold,
+    Get,
+    Length,
+    Concat,
+    And,
+    Or,
+    Not,
+    True,
+    False,
+    Nil,
+    Idle,
+    Exec,
+    Eval,
+    Cond,
+    Def,
+    Del,
+    Lookup,
+    Import,
+    Force,
+    Print,
+    Insert,
+    Replace,
+    Remove,
+    Take,
+    Split,
+    Reverse,
+    Range,
+    Reorder,
+    Collect,
+    Sort,
+    Shape,
+    Rank,
+    Reshape,
+    Transpose,
+    Fill,
+    Floor,
+    Ceil,
+    Round,
+    Mod,
+    Str,
+    Num,
+    Bool,
+    Chr,
+    Chars,
+    Join,
+    Now,
+    Datetime,
+    Timestamp,
+    Csprng,
+    Hash,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BuiltinSpec {
+    pub name: &'static str,
+    pub category: &'static str,
+    pub short_description: &'static str,
+    pub syntax: &'static str,
+    pub signature_type: &'static str,
+    pub detail_group: BuiltinDetailGroup,
+    pub executor_key: Option<BuiltinExecutorKey>,
+}
+
+macro_rules! builtin_spec {
+    ($name:expr, $category:expr, $description:expr, $syntax:expr, $signature:expr, $detail:expr, $executor:expr) => {
+        BuiltinSpec {
+            name: $name,
+            category: $category,
+            short_description: $description,
+            syntax: $syntax,
+            signature_type: $signature,
+            detail_group: $detail,
+            executor_key: $executor,
+        }
+    };
+}
+
+const BUILTIN_SPECS: &[BuiltinSpec] = &[
+    builtin_spec!(
+        ".",
+        "modifier",
+        "Set operation target to stack top (default)",
+        ". + → add to stack top",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        "..",
+        "modifier",
+        "Set operation target to entire stack",
+        ".. + [ 3 ] → add 3 to all stack elements",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        ",",
+        "modifier",
+        "Set consumption mode to consume (default)",
+        ", + → consume operands",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        ",,",
+        "modifier",
+        "Set bifurcation mode. Preserve operands and append result",
+        "[1] [2] ,, + → [1] [2] [3]",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        "~",
+        "modifier",
+        "Safe mode. Return NIL on error",
+        "[ 1 2 3 ] [ 10 ] ~ GET → NIL",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        "'",
+        "modifier",
+        "Input single quote (input helper)",
+        "' → '",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        "FRAME",
+        "vector",
+        "Generate empty vector structure from shape. Shape Vector -> Vector",
+        "[ 2 3 ] FRAME → [ [ ] [ ] [ ] ] [ [ ] [ ] [ ] ]",
+        "none",
+        BuiltinDetailGroup::VectorOps,
+        None
+    ),
+    builtin_spec!(
+        "GET",
+        "vector",
+        "Form: Extract element at index. Vector, Index Vector -> element",
+        "[ 10 20 30 ] [ 0 ] GET → [ 10 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Get)
+    ),
+    builtin_spec!(
+        "INSERT",
+        "vector",
+        "Form: Insert element at index. Vector, [Index, Value] Vector -> Vector",
+        "[ 1 3 ] [ 1 2 ] INSERT → [ 1 2 3 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Insert)
+    ),
+    builtin_spec!(
+        "REPLACE",
+        "vector",
+        "Form: Replace element at index. Vector, [Index, Value] Vector -> Vector",
+        "[ 1 2 3 ] [ 0 9 ] REPLACE → [ 9 2 3 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Replace)
+    ),
+    builtin_spec!(
+        "REMOVE",
+        "vector",
+        "Form: Remove element at index. Vector, Index Vector -> Vector",
+        "[ 1 2 3 ] [ 0 ] REMOVE → [ 2 3 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Remove)
+    ),
+    builtin_spec!(
+        "LENGTH",
+        "vector",
+        "Form: Return element count. Vector -> Scalar",
+        "[ 1 2 3 4 5 ] LENGTH → [ 5 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Length)
+    ),
+    builtin_spec!(
+        "TAKE",
+        "vector",
+        "Form: Take N elements from start or end. Vector, Scalar -> Vector",
+        "[ 1 2 3 4 5 ] [ 3 ] TAKE → [ 1 2 3 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Take)
+    ),
+    builtin_spec!(
+        "SPLIT",
+        "vector",
+        "Form: Split vector at specified sizes. Vector, Sizes Vector -> Vectors",
+        "[ 1 2 3 4 5 6 ] [ 2 3 ] SPLIT → [ 1 2 ] [ 3 4 5 ] [ 6 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Split)
+    ),
+    builtin_spec!(
+        "CONCAT",
+        "vector",
+        "Form: Flatten-concatenate two vectors. Vector, Vector -> Vector",
+        "[ 1 2 ] [ 3 4 ] CONCAT → [ 1 2 3 4 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Concat)
+    ),
+    builtin_spec!(
+        "REVERSE",
+        "vector",
+        "Form: Reverse element order. Vector -> Vector",
+        "[ 1 2 3 ] REVERSE → [ 3 2 1 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Reverse)
+    ),
+    builtin_spec!(
+        "RANGE",
+        "vector",
+        "Form: Generate numeric sequence. [start, end] or [end] -> Vector",
+        "[ 0 5 ] RANGE → [ 0 1 2 3 4 5 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Range)
+    ),
+    builtin_spec!(
+        "REORDER",
+        "vector",
+        "Form: Reorder elements by index list. Vector, Index Vector -> Vector",
+        "[ a b c ] [ 2 0 1 ] REORDER → [ c a b ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Reorder)
+    ),
+    builtin_spec!(
+        "COLLECT",
+        "vector",
+        "Collect N items from stack into vector. ...values, Scalar -> Vector",
+        "1 2 3 3 COLLECT → [ 1 2 3 ]",
+        "none",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Collect)
+    ),
+    builtin_spec!(
+        "SORT",
+        "vector",
+        "Form: Sort elements ascending. Vector -> Vector",
+        "[ 3 1 2 ] SORT → [ 1 2 3 ]",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Sort)
+    ),
+    builtin_spec!(
+        "TRUE",
+        "constant",
+        "Push TRUE to stack",
+        "TRUE → TRUE",
+        "none",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::True)
+    ),
+    builtin_spec!(
+        "FALSE",
+        "constant",
+        "Push FALSE to stack",
+        "FALSE → FALSE",
+        "none",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::False)
+    ),
+    builtin_spec!(
+        "NIL",
+        "constant",
+        "Push NIL to stack",
+        "NIL → NIL",
+        "none",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Nil)
+    ),
+    builtin_spec!(
+        "CHARS",
+        "cast",
+        "Map: Split string into character code vector. String -> Numeric Vector",
+        "[ 'hello' ] CHARS → [ 'h' 'e' 'l' 'l' 'o' ]",
+        "map",
+        BuiltinDetailGroup::StringCast,
+        Some(BuiltinExecutorKey::Chars)
+    ),
+    builtin_spec!(
+        "JOIN",
+        "cast",
+        "Map: Join character code vector into string. Numeric Vector -> String",
+        "[ 'h' 'e' 'l' 'l' 'o' ] JOIN → [ 'hello' ]",
+        "map",
+        BuiltinDetailGroup::StringCast,
+        Some(BuiltinExecutorKey::Join)
+    ),
+    builtin_spec!(
+        "NUM",
+        "cast",
+        "Map: Parse to number. Any -> Numeric (NIL on failure)",
+        "'123' NUM → [ 123 ], returns NIL on failure",
+        "map",
+        BuiltinDetailGroup::StringCast,
+        Some(BuiltinExecutorKey::Num)
+    ),
+    builtin_spec!(
+        "STR",
+        "cast",
+        "Map: Convert to string representation. Any -> String",
+        "123 STR → '123'",
+        "map",
+        BuiltinDetailGroup::StringCast,
+        Some(BuiltinExecutorKey::Str)
+    ),
+    builtin_spec!(
+        "BOOL",
+        "cast",
+        "Map: Convert to boolean. Any -> Boolean",
+        "'true' BOOL → TRUE, 100 BOOL → TRUE",
+        "map",
+        BuiltinDetailGroup::StringCast,
+        Some(BuiltinExecutorKey::Bool)
+    ),
+    builtin_spec!(
+        "CHR",
+        "cast",
+        "Map: Convert character code to single-char string. Numeric -> String",
+        "65 CHR → 'A'",
+        "map",
+        BuiltinDetailGroup::StringCast,
+        Some(BuiltinExecutorKey::Chr)
+    ),
+    builtin_spec!(
+        "NOW",
+        "datetime",
+        "Get current UNIX timestamp. -> Scalar",
+        "NOW → [ 1732531200 ]",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Now)
+    ),
+    builtin_spec!(
+        "DATETIME",
+        "datetime",
+        "Convert timestamp to datetime string. Scalar -> String",
+        "[ 1732531200 ] 'LOCAL' DATETIME → [ 2024 11 25 23 0 0 ]",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Datetime)
+    ),
+    builtin_spec!(
+        "TIMESTAMP",
+        "datetime",
+        "Convert datetime string to timestamp. String -> Scalar",
+        "[ 2024 11 25 23 0 0 ] 'LOCAL' TIMESTAMP → [ 1732531200 ]",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Timestamp)
+    ),
+    builtin_spec!(
+        "+",
+        "arithmetic",
+        "Fold: Addition (broadcast). Numeric, Numeric -> Numeric",
+        "[ 1 2 ] [ 3 4 ] + → [ 4 6 ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Add)
+    ),
+    builtin_spec!(
+        "-",
+        "arithmetic",
+        "Fold: Subtraction (broadcast). Numeric, Numeric -> Numeric",
+        "[ 5 3 ] [ 2 1 ] - → [ 3 2 ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Sub)
+    ),
+    builtin_spec!(
+        "*",
+        "arithmetic",
+        "Fold: Multiplication (broadcast). Numeric, Numeric -> Numeric",
+        "[ 2 3 ] [ 4 5 ] * → [ 8 15 ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Mul)
+    ),
+    builtin_spec!(
+        "/",
+        "arithmetic",
+        "Fold: Division (broadcast). Numeric, Numeric -> Numeric",
+        "[ 10 20 ] [ 2 4 ] / → [ 5 5 ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Div)
+    ),
+    builtin_spec!(
+        "=",
+        "comparison",
+        "Fold: Equality comparison (broadcast). Any, Any -> Boolean",
+        "[ 1 2 ] [ 1 2 ] = → [ TRUE ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Eq)
+    ),
+    builtin_spec!(
+        "<",
+        "comparison",
+        "Fold: Less-than comparison (broadcast). Numeric, Numeric -> Boolean",
+        "[ 1 ] [ 2 ] < → [ TRUE ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Lt)
+    ),
+    builtin_spec!(
+        "<=",
+        "comparison",
+        "Fold: Less-or-equal comparison (broadcast). Numeric, Numeric -> Boolean",
+        "[ 1 ] [ 1 ] <= → [ TRUE ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Le)
+    ),
+    builtin_spec!(
+        "AND",
+        "logic",
+        "Fold: Logical AND (Kleene three-valued). Boolean, Boolean -> Boolean",
+        "[ TRUE FALSE ] [ TRUE TRUE ] AND → [ TRUE FALSE ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::And)
+    ),
+    builtin_spec!(
+        "OR",
+        "logic",
+        "Fold: Logical OR (Kleene three-valued). Boolean, Boolean -> Boolean",
+        "[ TRUE FALSE ] [ FALSE FALSE ] OR → [ TRUE FALSE ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Or)
+    ),
+    builtin_spec!(
+        "NOT",
+        "logic",
+        "Map: Logical negation. Boolean -> Boolean",
+        "[ TRUE FALSE ] NOT → [ FALSE TRUE ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Not)
+    ),
+    builtin_spec!(
+        "IDLE",
+        "control",
+        "Pass through flow unchanged (no-op)",
+        "IDLE",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Idle)
+    ),
+    builtin_spec!(
+        "COND",
+        "control",
+        "Form: Evaluate guard/body pairs, execute first match. Any, ...CodeBlock pairs -> Any",
+        "value { guard1 } { body1 } { IDLE } { else_body } COND",
+        "form",
+        BuiltinDetailGroup::Cond,
+        Some(BuiltinExecutorKey::Cond)
+    ),
+    builtin_spec!(
+        "==",
+        "modifier",
+        "Pipeline visual marker (no-op)",
+        "[ 1 2 3 ] == { [ 2 ] * } MAP",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        "=>",
+        "modifier",
+        "Nil coalescing. Return alternative if NIL. Any, Any -> Any",
+        "NIL => [ 0 ] → [ 0 ]",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        None
+    ),
+    builtin_spec!(
+        "MAP",
+        "higher-order",
+        "Form: Apply code block to each element. Vector, CodeBlock -> Vector",
+        "[ 1 2 3 ] { [ 2 ] * } MAP → [ 2 4 6 ]",
+        "form",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Map)
+    ),
+    builtin_spec!(
+        "FILTER",
+        "higher-order",
+        "Form: Extract elements matching predicate. Vector, CodeBlock -> Vector",
+        "[ 1 2 3 4 ] { [ 2 ] MOD [ 0 ] = } FILTER → [ 2 4 ]",
+        "form",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Filter)
+    ),
+    builtin_spec!(
+        "FOLD",
+        "higher-order",
+        "Form: Reduce with initial value. Vector, Scalar, CodeBlock -> Scalar",
+        "[ 1 2 3 4 ] [ 0 ] { + } FOLD → [ 10 ]",
+        "form",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Fold)
+    ),
+    builtin_spec!(
+        "PRINT",
+        "io",
+        "Map: Output value to display. Any -> Any",
+        "[ 42 ] PRINT → (outputs 42)",
+        "map",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Print)
+    ),
+    builtin_spec!(
+        "DEF",
+        "dictionary",
+        "Define user word in dictionary. CodeBlock, String [, String] -> (dictionary effect)",
+        "{ [ 2 ] * } 'DOUBLE' DEF",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Def)
+    ),
+    builtin_spec!(
+        "DEL",
+        "dictionary",
+        "Delete user word from dictionary. String -> (dictionary effect)",
+        "'WORD' DEL",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Del)
+    ),
+    builtin_spec!(
+        "?",
+        "dictionary",
+        "Display word definition and details. String -> (output effect)",
+        "'DOUBLE' ?",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Lookup)
+    ),
+    builtin_spec!(
+        "!",
+        "modifier",
+        "Force flag. Allow DEL/DEF of dependent user words",
+        "! 'WORD' DEL",
+        "none",
+        BuiltinDetailGroup::Modifier,
+        Some(BuiltinExecutorKey::Force)
+    ),
+    builtin_spec!(
+        "SHAPE",
+        "tensor",
+        "Map: Return vector shape. Vector -> Numeric Vector",
+        "[ 1 2 3 ] SHAPE → [ 3 ]",
+        "map",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Shape)
+    ),
+    builtin_spec!(
+        "RANK",
+        "tensor",
+        "Map: Return number of dimensions. Vector -> Scalar",
+        "[ [ 1 2 ] [ 3 4 ] ] RANK → [ 2 ]",
+        "map",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Rank)
+    ),
+    builtin_spec!(
+        "RESHAPE",
+        "tensor",
+        "Form: Reshape vector to specified shape. Vector, Shape Vector -> Vector",
+        "[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE → { ( 1 2 3 ) ( 4 5 6 ) }",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Reshape)
+    ),
+    builtin_spec!(
+        "TRANSPOSE",
+        "tensor",
+        "Form: Transpose vector axes. Vector -> Vector",
+        "{ ( 1 2 3 ) ( 4 5 6 ) } TRANSPOSE → { ( 1 4 ) ( 2 5 ) ( 3 6 ) }",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Transpose)
+    ),
+    builtin_spec!(
+        "FILL",
+        "tensor",
+        "Form: Fill shape with value. Scalar, Shape Vector -> Vector",
+        "[ 2 3 0 ] FILL → { ( 0 0 0 ) ( 0 0 0 ) }",
+        "form",
+        BuiltinDetailGroup::VectorOps,
+        Some(BuiltinExecutorKey::Fill)
+    ),
+    builtin_spec!(
+        "MOD",
+        "arithmetic",
+        "Fold: Modulo (broadcast). Numeric, Numeric -> Numeric",
+        "[ 7 ] [ 3 ] MOD → [ 1 ]",
+        "fold",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Mod)
+    ),
+    builtin_spec!(
+        "FLOOR",
+        "arithmetic",
+        "Map: Floor (round toward negative infinity). Numeric -> Numeric",
+        "[ 7/3 ] FLOOR → [ 2 ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Floor)
+    ),
+    builtin_spec!(
+        "CEIL",
+        "arithmetic",
+        "Map: Ceiling (round toward positive infinity). Numeric -> Numeric",
+        "[ 7/3 ] CEIL → [ 3 ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Ceil)
+    ),
+    builtin_spec!(
+        "ROUND",
+        "arithmetic",
+        "Map: Round to nearest integer. Numeric -> Numeric",
+        "[ 5/2 ] ROUND → [ 3 ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Round)
+    ),
+    builtin_spec!(
+        "CSPRNG",
+        "random",
+        "Generate cryptographic pseudorandom number. -> Scalar",
+        "[ 6 ] [ 1 ] CSPRNG → [ 0 ] to [ 5/6 ], [ 5 ] CSPRNG → 5 randoms",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Csprng)
+    ),
+    builtin_spec!(
+        "HASH",
+        "hash",
+        "Compute hash value. Any -> Numeric",
+        "'hello' HASH → [ 0.xxx ], [ 128 ] 'hello' HASH → 128-bit",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Hash)
+    ),
+    builtin_spec!(
+        "EXEC",
+        "control",
+        "Interpret vector as code and execute. Vector -> (execution result)",
+        "[ 1 2 + ] EXEC → 3, 1 2 + .. EXEC → 3",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Exec)
+    ),
+    builtin_spec!(
+        "EVAL",
+        "control",
+        "Parse string as code and execute. String -> (execution result)",
+        "'1 2 +' EVAL → 3",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Eval)
+    ),
+    builtin_spec!(
+        "IMPORT",
+        "module",
+        "Load standard library module. String -> (dictionary effect)",
+        "'music' IMPORT → registers MUSIC::* words",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::Import)
+    ),
+];
+
+pub fn builtin_specs() -> &'static [BuiltinSpec] {
+    BUILTIN_SPECS
+}
+
+pub fn lookup_builtin_spec(name: &str) -> Option<&'static BuiltinSpec> {
+    BUILTIN_SPECS.iter().find(|spec| spec.name == name)
+}
 
 /// Returns the list of all built-in word definitions.
 /// Each tuple contains: (word_name, description, syntax_example, signature_type)
 /// signature_type: "map" | "form" | "fold" | "none"
-pub fn collect_builtin_definitions() -> Vec<(&'static str, &'static str, &'static str, &'static str)> {
-    vec![
-        // Target specification (Operation Target Mode)
-        (
-            ".",
-            "Set operation target to stack top (default)",
-            ". + → add to stack top",
-            "none",
-        ),
-        (
-            "..",
-            "Set operation target to entire stack",
-            ".. + [ 3 ] → add 3 to all stack elements",
-            "none",
-        ),
-        // Consumption mode specification
-        (
-            ",",
-            "Set consumption mode to consume (default)",
-            ", + → consume operands",
-            "none",
-        ),
-        (
-            ",,",
-            "Set bifurcation mode. Preserve operands and append result",
-            "[1] [2] ,, + → [1] [2] [3]",
-            "none",
-        ),
-        // Safe mode
-        (
-            "~",
-            "Safe mode. Return NIL on error",
-            "[ 1 2 3 ] [ 10 ] ~ GET → NIL",
-            "none",
-        ),
-        // Input helpers
-        ("'", "Input single quote (input helper)", "' → '", "none"),
-        (
-            "FRAME",
-            "Generate empty vector structure from shape. Shape Vector -> Vector",
-            "[ 2 3 ] FRAME → [ [ ] [ ] [ ] ] [ [ ] [ ] [ ] ]",
-            "none",
-        ),
-        // Position operations (0-indexed)
-        (
-            "GET",
-            "Form: Extract element at index. Vector, Index Vector -> element",
-            "[ 10 20 30 ] [ 0 ] GET → [ 10 ]",
-            "form",
-        ),
-        (
-            "INSERT",
-            "Form: Insert element at index. Vector, [Index, Value] Vector -> Vector",
-            "[ 1 3 ] [ 1 2 ] INSERT → [ 1 2 3 ]",
-            "form",
-        ),
-        (
-            "REPLACE",
-            "Form: Replace element at index. Vector, [Index, Value] Vector -> Vector",
-            "[ 1 2 3 ] [ 0 9 ] REPLACE → [ 9 2 3 ]",
-            "form",
-        ),
-        (
-            "REMOVE",
-            "Form: Remove element at index. Vector, Index Vector -> Vector",
-            "[ 1 2 3 ] [ 0 ] REMOVE → [ 2 3 ]",
-            "form",
-        ),
-        // Quantity operations
-        (
-            "LENGTH",
-            "Form: Return element count. Vector -> Scalar",
-            "[ 1 2 3 4 5 ] LENGTH → [ 5 ]",
-            "form",
-        ),
-        (
-            "TAKE",
-            "Form: Take N elements from start or end. Vector, Scalar -> Vector",
-            "[ 1 2 3 4 5 ] [ 3 ] TAKE → [ 1 2 3 ]",
-            "form",
-        ),
-        // Vector operations
-        (
-            "SPLIT",
-            "Form: Split vector at specified sizes. Vector, Sizes Vector -> Vectors",
-            "[ 1 2 3 4 5 6 ] [ 2 3 ] SPLIT → [ 1 2 ] [ 3 4 5 ] [ 6 ]",
-            "form",
-        ),
-        (
-            "CONCAT",
-            "Form: Flatten-concatenate two vectors. Vector, Vector -> Vector",
-            "[ 1 2 ] [ 3 4 ] CONCAT → [ 1 2 3 4 ]",
-            "form",
-        ),
-        (
-            "REVERSE",
-            "Form: Reverse element order. Vector -> Vector",
-            "[ 1 2 3 ] REVERSE → [ 3 2 1 ]",
-            "form",
-        ),
-        (
-            "RANGE",
-            "Form: Generate numeric sequence. [start, end] or [end] -> Vector",
-            "[ 0 5 ] RANGE → [ 0 1 2 3 4 5 ]",
-            "form",
-        ),
-        (
-            "REORDER",
-            "Form: Reorder elements by index list. Vector, Index Vector -> Vector",
-            "[ a b c ] [ 2 0 1 ] REORDER → [ c a b ]",
-            "form",
-        ),
-        (
-            "COLLECT",
-            "Collect N items from stack into vector. ...values, Scalar -> Vector",
-            "1 2 3 3 COLLECT → [ 1 2 3 ]",
-            "none",
-        ),
-        (
-            "SORT",
-            "Form: Sort elements ascending. Vector -> Vector",
-            "[ 3 1 2 ] SORT → [ 1 2 3 ]",
-            "form",
-        ),
-        // Constants
-        ("TRUE", "Push TRUE to stack", "TRUE → TRUE", "none"),
-        ("FALSE", "Push FALSE to stack", "FALSE → FALSE", "none"),
-        ("NIL", "Push NIL to stack", "NIL → NIL", "none"),
-        // String operations
-        (
-            "CHARS",
-            "Map: Split string into character code vector. String -> Numeric Vector",
-            "[ 'hello' ] CHARS → [ 'h' 'e' 'l' 'l' 'o' ]",
-            "map",
-        ),
-        (
-            "JOIN",
-            "Map: Join character code vector into string. Numeric Vector -> String",
-            "[ 'h' 'e' 'l' 'l' 'o' ] JOIN → [ 'hello' ]",
-            "map",
-        ),
-        // Parse/Convert
-        (
-            "NUM",
-            "Map: Parse to number. Any -> Numeric (NIL on failure)",
-            "'123' NUM → [ 123 ], returns NIL on failure",
-            "map",
-        ),
-        (
-            "STR",
-            "Map: Convert to string representation. Any -> String",
-            "123 STR → '123'",
-            "map",
-        ),
-        (
-            "BOOL",
-            "Map: Convert to boolean. Any -> Boolean",
-            "'true' BOOL → TRUE, 100 BOOL → TRUE",
-            "map",
-        ),
-        (
-            "CHR",
-            "Map: Convert character code to single-char string. Numeric -> String",
-            "65 CHR → 'A'",
-            "map",
-        ),
-        // DateTime
-        (
-            "NOW",
-            "Get current UNIX timestamp. -> Scalar",
-            "NOW → [ 1732531200 ]",
-            "none",
-        ),
-        (
-            "DATETIME",
-            "Convert timestamp to datetime string. Scalar -> String",
-            "[ 1732531200 ] 'LOCAL' DATETIME → [ 2024 11 25 23 0 0 ]",
-            "none",
-        ),
-        (
-            "TIMESTAMP",
-            "Convert datetime string to timestamp. String -> Scalar",
-            "[ 2024 11 25 23 0 0 ] 'LOCAL' TIMESTAMP → [ 1732531200 ]",
-            "none",
-        ),
-        // Arithmetic
-        (
-            "+",
-            "Fold: Addition (broadcast). Numeric, Numeric -> Numeric",
-            "[ 1 2 ] [ 3 4 ] + → [ 4 6 ]",
-            "fold",
-        ),
-        (
-            "-",
-            "Fold: Subtraction (broadcast). Numeric, Numeric -> Numeric",
-            "[ 5 3 ] [ 2 1 ] - → [ 3 2 ]",
-            "fold",
-        ),
-        (
-            "*",
-            "Fold: Multiplication (broadcast). Numeric, Numeric -> Numeric",
-            "[ 2 3 ] [ 4 5 ] * → [ 8 15 ]",
-            "fold",
-        ),
-        (
-            "/",
-            "Fold: Division (broadcast). Numeric, Numeric -> Numeric",
-            "[ 10 20 ] [ 2 4 ] / → [ 5 5 ]",
-            "fold",
-        ),
-        // Comparison
-        (
-            "=",
-            "Fold: Equality comparison (broadcast). Any, Any -> Boolean",
-            "[ 1 2 ] [ 1 2 ] = → [ TRUE ]",
-            "fold",
-        ),
-        (
-            "<",
-            "Fold: Less-than comparison (broadcast). Numeric, Numeric -> Boolean",
-            "[ 1 ] [ 2 ] < → [ TRUE ]",
-            "fold",
-        ),
-        (
-            "<=",
-            "Fold: Less-or-equal comparison (broadcast). Numeric, Numeric -> Boolean",
-            "[ 1 ] [ 1 ] <= → [ TRUE ]",
-            "fold",
-        ),
-        // > と >= は廃止されました。< と <= のみ使用可能です。
-
-        // Logic
-        (
-            "AND",
-            "Fold: Logical AND (Kleene three-valued). Boolean, Boolean -> Boolean",
-            "[ TRUE FALSE ] [ TRUE TRUE ] AND → [ TRUE FALSE ]",
-            "fold",
-        ),
-        (
-            "OR",
-            "Fold: Logical OR (Kleene three-valued). Boolean, Boolean -> Boolean",
-            "[ TRUE FALSE ] [ FALSE FALSE ] OR → [ TRUE FALSE ]",
-            "fold",
-        ),
-        (
-            "NOT",
-            "Map: Logical negation. Boolean -> Boolean",
-            "[ TRUE FALSE ] NOT → [ FALSE TRUE ]",
-            "map",
-        ),
-        // Control
-        ("IDLE", "Pass through flow unchanged (no-op)", "IDLE", "none"),
-        (
-            "COND",
-            "Form: Evaluate guard/body pairs, execute first match. Any, ...CodeBlock pairs -> Any",
-            "value { guard1 } { body1 } { IDLE } { else_body } COND",
-            "form",
-        ),
-        // Pipeline and Nil Coalescing
-        (
-            "==",
-            "Pipeline visual marker (no-op)",
-            "[ 1 2 3 ] == { [ 2 ] * } MAP",
-            "none",
-        ),
-        (
-            "=>",
-            "Nil coalescing. Return alternative if NIL. Any, Any -> Any",
-            "NIL => [ 0 ] → [ 0 ]",
-            "none",
-        ),
-        // Higher-order functions
-        (
-            "MAP",
-            "Form: Apply code block to each element. Vector, CodeBlock -> Vector",
-            "[ 1 2 3 ] { [ 2 ] * } MAP → [ 2 4 6 ]",
-            "form",
-        ),
-        (
-            "FILTER",
-            "Form: Extract elements matching predicate. Vector, CodeBlock -> Vector",
-            "[ 1 2 3 4 ] { [ 2 ] MOD [ 0 ] = } FILTER → [ 2 4 ]",
-            "form",
-        ),
-        (
-            "FOLD",
-            "Form: Reduce with initial value. Vector, Scalar, CodeBlock -> Scalar",
-            "[ 1 2 3 4 ] [ 0 ] { + } FOLD → [ 10 ]",
-            "form",
-        ),
-        // I/O
-        (
-            "PRINT",
-            "Map: Output value to display. Any -> Any",
-            "[ 42 ] PRINT → (outputs 42)",
-            "map",
-        ),
-        // Word management
-        (
-            "DEF",
-            "Define user word in dictionary. CodeBlock, String [, String] -> (dictionary effect)",
-            "{ [ 2 ] * } 'DOUBLE' DEF",
-            "none",
-        ),
-        (
-            "DEL",
-            "Delete user word from dictionary. String -> (dictionary effect)",
-            "'WORD' DEL",
-            "none",
-        ),
-        (
-            "?",
-            "Display word definition and details. String -> (output effect)",
-            "'DOUBLE' ?",
-            "none",
-        ),
-        (
-            "!",
-            "Force flag. Allow DEL/DEF of dependent user words",
-            "! 'WORD' DEL",
-            "none",
-        ),
-        // Shape operations
-        (
-            "SHAPE",
-            "Map: Return vector shape. Vector -> Numeric Vector",
-            "[ 1 2 3 ] SHAPE → [ 3 ]",
-            "map",
-        ),
-        (
-            "RANK",
-            "Map: Return number of dimensions. Vector -> Scalar",
-            "[ [ 1 2 ] [ 3 4 ] ] RANK → [ 2 ]",
-            "map",
-        ),
-        (
-            "RESHAPE",
-            "Form: Reshape vector to specified shape. Vector, Shape Vector -> Vector",
-            "[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE → { ( 1 2 3 ) ( 4 5 6 ) }",
-            "form",
-        ),
-        (
-            "TRANSPOSE",
-            "Form: Transpose vector axes. Vector -> Vector",
-            "{ ( 1 2 3 ) ( 4 5 6 ) } TRANSPOSE → { ( 1 4 ) ( 2 5 ) ( 3 6 ) }",
-            "form",
-        ),
-        (
-            "FILL",
-            "Form: Fill shape with value. Scalar, Shape Vector -> Vector",
-            "[ 2 3 0 ] FILL → { ( 0 0 0 ) ( 0 0 0 ) }",
-            "form",
-        ),
-        // Math functions
-        (
-            "MOD",
-            "Fold: Modulo (broadcast). Numeric, Numeric -> Numeric",
-            "[ 7 ] [ 3 ] MOD → [ 1 ]",
-            "fold",
-        ),
-        (
-            "FLOOR",
-            "Map: Floor (round toward negative infinity). Numeric -> Numeric",
-            "[ 7/3 ] FLOOR → [ 2 ]",
-            "map",
-        ),
-        (
-            "CEIL",
-            "Map: Ceiling (round toward positive infinity). Numeric -> Numeric",
-            "[ 7/3 ] CEIL → [ 3 ]",
-            "map",
-        ),
-        (
-            "ROUND",
-            "Map: Round to nearest integer. Numeric -> Numeric",
-            "[ 5/2 ] ROUND → [ 3 ]",
-            "map",
-        ),
-        // Cryptographic random
-        (
-            "CSPRNG",
-            "Generate cryptographic pseudorandom number. -> Scalar",
-            "[ 6 ] [ 1 ] CSPRNG → [ 0 ] to [ 5/6 ], [ 5 ] CSPRNG → 5 randoms",
-            "none",
-        ),
-        // Hash
-        (
-            "HASH",
-            "Compute hash value. Any -> Numeric",
-            "'hello' HASH → [ 0.xxx ], [ 128 ] 'hello' HASH → 128-bit",
-            "none",
-        ),
-        // Meta-programming
-        (
-            "EXEC",
-            "Interpret vector as code and execute. Vector -> (execution result)",
-            "[ 1 2 + ] EXEC → 3, 1 2 + .. EXEC → 3",
-            "none",
-        ),
-        (
-            "EVAL",
-            "Parse string as code and execute. String -> (execution result)",
-            "'1 2 +' EVAL → 3",
-            "none",
-        ),
-        // Module system
-        (
-            "IMPORT",
-            "Load standard library module. String -> (dictionary effect)",
-            "'music' IMPORT → registers MUSIC::* words",
-            "none",
-        ),
-    ]
+pub fn collect_builtin_definitions() -> Vec<(&'static str, &'static str, &'static str, &'static str)>
+{
+    BUILTIN_SPECS
+        .iter()
+        .map(|spec| {
+            (
+                spec.name,
+                spec.short_description,
+                spec.syntax,
+                spec.signature_type,
+            )
+        })
+        .collect()
 }

--- a/rust/src/builtins/builtin-word-details.rs
+++ b/rust/src/builtins/builtin-word-details.rs
@@ -1,12 +1,12 @@
 // rust/src/builtins/builtin-word-details.rs
 //
 // Detailed documentation for built-in words (used by the ? word).
-// Delegates to category-specific lookup functions.
+// Delegates by registry-defined detail group.
 
-use super::builtin_word_definitions::collect_builtin_definitions;
+use super::builtin_word_definitions::{lookup_builtin_spec, BuiltinDetailGroup};
 use super::detail_lookup_arithmetic_logic::lookup_detail_arithmetic_logic;
-use super::detail_lookup_control_higher_order::lookup_detail_control_higher_order;
 use super::detail_lookup_cond::lookup_detail_cond;
+use super::detail_lookup_control_higher_order::lookup_detail_control_higher_order;
 use super::detail_lookup_io_module::lookup_detail_io_module;
 use super::detail_lookup_modifier::lookup_detail_modifier;
 use super::detail_lookup_string_cast::lookup_detail_string_cast;
@@ -15,37 +15,27 @@ use super::detail_lookup_vector_ops::lookup_detail_vector_ops;
 /// Returns detailed documentation for a built-in word.
 /// Used by the `?` word to display help information.
 pub fn lookup_builtin_detail(name: &str) -> String {
-    if let Some(detail) = lookup_detail_modifier(name) {
-        return detail;
-    }
-    if let Some(detail) = lookup_detail_arithmetic_logic(name) {
-        return detail;
-    }
-    if let Some(detail) = lookup_detail_vector_ops(name) {
-        return detail;
-    }
-    if let Some(detail) = lookup_detail_string_cast(name) {
-        return detail;
-    }
-    if let Some(detail) = lookup_detail_control_higher_order(name) {
-        return detail;
-    }
-    if let Some(detail) = lookup_detail_cond(name) {
-        return detail;
-    }
-    if let Some(detail) = lookup_detail_io_module(name) {
-        return detail;
+    let Some(spec) = lookup_builtin_spec(name) else {
+        return format!("'{}' の詳細情報はありません。", name);
+    };
+
+    let detail = match spec.detail_group {
+        BuiltinDetailGroup::Modifier => lookup_detail_modifier(name),
+        BuiltinDetailGroup::ArithmeticLogic => lookup_detail_arithmetic_logic(name),
+        BuiltinDetailGroup::VectorOps => lookup_detail_vector_ops(name),
+        BuiltinDetailGroup::StringCast => lookup_detail_string_cast(name),
+        BuiltinDetailGroup::ControlHigherOrder => lookup_detail_control_higher_order(name),
+        BuiltinDetailGroup::Cond => lookup_detail_cond(name),
+        BuiltinDetailGroup::IoModule => lookup_detail_io_module(name),
+        BuiltinDetailGroup::None => None,
+    };
+
+    if let Some(content) = detail {
+        return content;
     }
 
-    // Fallback: generate basic info from word definitions
-    for (word_name, description, syntax, sig_type) in collect_builtin_definitions() {
-        if word_name == name {
-            return format!(
-                "# {} - {}\n\n## シグネチャタイプ\n{}\n\n## 構文\n{}\n",
-                name, description, sig_type, syntax
-            );
-        }
-    }
-
-    format!("'{}' の詳細情報はありません。", name)
+    format!(
+        "# {} - {}\n\n## カテゴリ\n{}\n\n## シグネチャタイプ\n{}\n\n## 構文\n{}\n",
+        spec.name, spec.short_description, spec.category, spec.signature_type, spec.syntax
+    )
 }

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -4,10 +4,10 @@ mod builtin_word_definitions;
 mod builtin_word_details;
 #[path = "detail-lookup-arithmetic-logic.rs"]
 mod detail_lookup_arithmetic_logic;
-#[path = "detail-lookup-control-higher-order.rs"]
-mod detail_lookup_control_higher_order;
 #[path = "detail-lookup-cond.rs"]
 mod detail_lookup_cond;
+#[path = "detail-lookup-control-higher-order.rs"]
+mod detail_lookup_control_higher_order;
 #[path = "detail-lookup-io-module.rs"]
 mod detail_lookup_io_module;
 #[path = "detail-lookup-modifier.rs"]
@@ -17,7 +17,9 @@ mod detail_lookup_string_cast;
 #[path = "detail-lookup-vector-ops.rs"]
 mod detail_lookup_vector_ops;
 
-pub use builtin_word_definitions::collect_builtin_definitions;
+pub use builtin_word_definitions::{
+    builtin_specs, collect_builtin_definitions, lookup_builtin_spec, BuiltinExecutorKey,
+};
 pub use builtin_word_details::lookup_builtin_detail;
 
 use crate::types::WordDefinition;
@@ -26,7 +28,9 @@ use std::sync::Arc;
 
 /// Registers core built-in words into the dictionary.
 pub fn register_builtins(dictionary: &mut HashMap<String, Arc<WordDefinition>>) {
-    for (name, description, _, _) in collect_builtin_definitions() {
+    for spec in builtin_specs() {
+        let name = spec.name;
+        let description = spec.short_description;
         dictionary.insert(
             name.to_string(),
             Arc::new(WordDefinition {

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -1,11 +1,12 @@
+use crate::builtins::{lookup_builtin_spec, BuiltinExecutorKey};
 use crate::error::{AjisaiError, Result};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, FlowToken, Token, Value};
 
 use super::{
     arithmetic, cast, comparison, control, control_cond, datetime, execute_def, execute_del,
-    execute_lookup, hash, higher_order, higher_order_fold, io, logic, modules, random, sort, tensor_cmds,
-    vector_ops, Interpreter,
+    execute_lookup, hash, higher_order, higher_order_fold, io, logic, modules, random, sort,
+    tensor_cmds, vector_ops, Interpreter,
 };
 
 impl Interpreter {
@@ -74,83 +75,92 @@ impl Interpreter {
     }
 
     pub(crate) fn execute_builtin_with_conservation(&mut self, name: &str) -> Result<()> {
-        match name {
-            "+" => arithmetic::op_add(self),
-            "-" => arithmetic::op_sub(self),
-            "*" => arithmetic::op_mul(self),
-            "/" => arithmetic::op_div(self),
-            "=" => comparison::op_eq(self),
-            "<" => comparison::op_lt(self),
-            "<=" => comparison::op_le(self),
-            "MAP" => higher_order::op_map(self),
-            "FILTER" => higher_order::op_filter(self),
-            "FOLD" => higher_order_fold::op_fold(self),
-            "GET" => vector_ops::op_get(self),
-            "LENGTH" => vector_ops::op_length(self),
-            "CONCAT" => vector_ops::op_concat(self),
-            "AND" => logic::op_and(self),
-            "OR" => logic::op_or(self),
-            "NOT" => logic::op_not(self),
-            "TRUE" => {
+        if let Some(spec) = lookup_builtin_spec(name) {
+            if let Some(executor_key) = spec.executor_key {
+                return self.execute_builtin_by_key(executor_key);
+            }
+        }
+
+        modules::execute_module_word(self, name)
+            .unwrap_or_else(|| Err(AjisaiError::UnknownWord(name.to_string())))
+    }
+
+    fn execute_builtin_by_key(&mut self, key: BuiltinExecutorKey) -> Result<()> {
+        match key {
+            BuiltinExecutorKey::Add => arithmetic::op_add(self),
+            BuiltinExecutorKey::Sub => arithmetic::op_sub(self),
+            BuiltinExecutorKey::Mul => arithmetic::op_mul(self),
+            BuiltinExecutorKey::Div => arithmetic::op_div(self),
+            BuiltinExecutorKey::Eq => comparison::op_eq(self),
+            BuiltinExecutorKey::Lt => comparison::op_lt(self),
+            BuiltinExecutorKey::Le => comparison::op_le(self),
+            BuiltinExecutorKey::Map => higher_order::op_map(self),
+            BuiltinExecutorKey::Filter => higher_order::op_filter(self),
+            BuiltinExecutorKey::Fold => higher_order_fold::op_fold(self),
+            BuiltinExecutorKey::Get => vector_ops::op_get(self),
+            BuiltinExecutorKey::Length => vector_ops::op_length(self),
+            BuiltinExecutorKey::Concat => vector_ops::op_concat(self),
+            BuiltinExecutorKey::And => logic::op_and(self),
+            BuiltinExecutorKey::Or => logic::op_or(self),
+            BuiltinExecutorKey::Not => logic::op_not(self),
+            BuiltinExecutorKey::True => {
                 self.stack.push(Value::from_bool(true));
                 self.semantic_registry.push_hint(DisplayHint::Boolean);
                 Ok(())
             }
-            "FALSE" => {
+            BuiltinExecutorKey::False => {
                 self.stack.push(Value::from_bool(false));
                 self.semantic_registry.push_hint(DisplayHint::Boolean);
                 Ok(())
             }
-            "NIL" => {
+            BuiltinExecutorKey::Nil => {
                 self.stack.push(Value::nil());
                 self.semantic_registry.push_hint(DisplayHint::Nil);
                 Ok(())
             }
-            "IDLE" => Ok(()),
-            "EXEC" => control::op_exec(self),
-            "EVAL" => control::op_eval(self),
-            "COND" => control_cond::op_cond(self),
-            "DEF" => execute_def::op_def(self),
-            "DEL" => execute_del::op_del(self),
-            "?" => execute_lookup::op_lookup(self),
-            "IMPORT" => modules::op_import(self),
-            "!" => {
+            BuiltinExecutorKey::Idle => Ok(()),
+            BuiltinExecutorKey::Exec => control::op_exec(self),
+            BuiltinExecutorKey::Eval => control::op_eval(self),
+            BuiltinExecutorKey::Cond => control_cond::op_cond(self),
+            BuiltinExecutorKey::Def => execute_def::op_def(self),
+            BuiltinExecutorKey::Del => execute_del::op_del(self),
+            BuiltinExecutorKey::Lookup => execute_lookup::op_lookup(self),
+            BuiltinExecutorKey::Import => modules::op_import(self),
+            BuiltinExecutorKey::Force => {
                 self.force_flag = true;
                 Ok(())
             }
-            "PRINT" => io::op_print(self),
-            "INSERT" => vector_ops::op_insert(self),
-            "REPLACE" => vector_ops::op_replace(self),
-            "REMOVE" => vector_ops::op_remove(self),
-            "TAKE" => vector_ops::op_take(self),
-            "SPLIT" => vector_ops::op_split(self),
-            "REVERSE" => vector_ops::op_reverse(self),
-            "RANGE" => vector_ops::op_range(self),
-            "REORDER" => vector_ops::op_reorder(self),
-            "COLLECT" => vector_ops::op_collect(self),
-            "SORT" => sort::op_sort(self),
-            "SHAPE" => tensor_cmds::op_shape(self),
-            "RANK" => tensor_cmds::op_rank(self),
-            "RESHAPE" => tensor_cmds::op_reshape(self),
-            "TRANSPOSE" => tensor_cmds::op_transpose(self),
-            "FILL" => tensor_cmds::op_fill(self),
-            "FLOOR" => tensor_cmds::op_floor(self),
-            "CEIL" => tensor_cmds::op_ceil(self),
-            "ROUND" => tensor_cmds::op_round(self),
-            "MOD" => tensor_cmds::op_mod(self),
-            "STR" => cast::op_str(self),
-            "NUM" => cast::op_num(self),
-            "BOOL" => cast::op_bool(self),
-            "CHR" => cast::op_chr(self),
-            "CHARS" => cast::op_chars(self),
-            "JOIN" => cast::op_join(self),
-            "NOW" => datetime::op_now(self),
-            "DATETIME" => datetime::op_datetime(self),
-            "TIMESTAMP" => datetime::op_timestamp(self),
-            "CSPRNG" => random::op_csprng(self),
-            "HASH" => hash::op_hash(self),
-            _ => modules::execute_module_word(self, name)
-                .unwrap_or_else(|| Err(AjisaiError::UnknownWord(name.to_string()))),
+            BuiltinExecutorKey::Print => io::op_print(self),
+            BuiltinExecutorKey::Insert => vector_ops::op_insert(self),
+            BuiltinExecutorKey::Replace => vector_ops::op_replace(self),
+            BuiltinExecutorKey::Remove => vector_ops::op_remove(self),
+            BuiltinExecutorKey::Take => vector_ops::op_take(self),
+            BuiltinExecutorKey::Split => vector_ops::op_split(self),
+            BuiltinExecutorKey::Reverse => vector_ops::op_reverse(self),
+            BuiltinExecutorKey::Range => vector_ops::op_range(self),
+            BuiltinExecutorKey::Reorder => vector_ops::op_reorder(self),
+            BuiltinExecutorKey::Collect => vector_ops::op_collect(self),
+            BuiltinExecutorKey::Sort => sort::op_sort(self),
+            BuiltinExecutorKey::Shape => tensor_cmds::op_shape(self),
+            BuiltinExecutorKey::Rank => tensor_cmds::op_rank(self),
+            BuiltinExecutorKey::Reshape => tensor_cmds::op_reshape(self),
+            BuiltinExecutorKey::Transpose => tensor_cmds::op_transpose(self),
+            BuiltinExecutorKey::Fill => tensor_cmds::op_fill(self),
+            BuiltinExecutorKey::Floor => tensor_cmds::op_floor(self),
+            BuiltinExecutorKey::Ceil => tensor_cmds::op_ceil(self),
+            BuiltinExecutorKey::Round => tensor_cmds::op_round(self),
+            BuiltinExecutorKey::Mod => tensor_cmds::op_mod(self),
+            BuiltinExecutorKey::Str => cast::op_str(self),
+            BuiltinExecutorKey::Num => cast::op_num(self),
+            BuiltinExecutorKey::Bool => cast::op_bool(self),
+            BuiltinExecutorKey::Chr => cast::op_chr(self),
+            BuiltinExecutorKey::Chars => cast::op_chars(self),
+            BuiltinExecutorKey::Join => cast::op_join(self),
+            BuiltinExecutorKey::Now => datetime::op_now(self),
+            BuiltinExecutorKey::Datetime => datetime::op_datetime(self),
+            BuiltinExecutorKey::Timestamp => datetime::op_timestamp(self),
+            BuiltinExecutorKey::Csprng => random::op_csprng(self),
+            BuiltinExecutorKey::Hash => hash::op_hash(self),
         }
     }
 

--- a/rust/src/interpreter/vector_ops/position.rs
+++ b/rust/src/interpreter/vector_ops/position.rs
@@ -8,6 +8,69 @@ use crate::interpreter::value_extraction_helpers::{extract_integer_from_value, n
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::Value;
 
+fn pop_index_operand(interp: &mut Interpreter) -> Result<(Value, i64)> {
+    let index_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let index = match extract_integer_from_value(&index_val) {
+        Ok(value) => value,
+        Err(error) => {
+            interp.stack.push(index_val);
+            return Err(error);
+        }
+    };
+    Ok((index_val, index))
+}
+
+fn acquire_stacktop_target(
+    interp: &mut Interpreter,
+    arg_to_restore: &Value,
+    preserve_source: bool,
+) -> Result<Value> {
+    if preserve_source {
+        return interp.stack.last().cloned().ok_or_else(|| {
+            interp.stack.push(arg_to_restore.clone());
+            AjisaiError::StackUnderflow
+        });
+    }
+
+    interp.stack.pop().ok_or_else(|| {
+        interp.stack.push(arg_to_restore.clone());
+        AjisaiError::StackUnderflow
+    })
+}
+
+fn with_stacktop_vector_target<R, F>(
+    interp: &mut Interpreter,
+    arg_to_restore: &Value,
+    preserve_source: bool,
+    action: F,
+) -> Result<R>
+where
+    F: FnOnce(&Value) -> Result<R>,
+{
+    let target_val = acquire_stacktop_target(interp, arg_to_restore, preserve_source)?;
+    if !target_val.is_vector() {
+        if !preserve_source {
+            interp.stack.push(target_val);
+        }
+        interp.stack.push(arg_to_restore.clone());
+        return Err(AjisaiError::create_structure_error(
+            "vector",
+            "other format",
+        ));
+    }
+
+    match action(&target_val) {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            if !preserve_source {
+                interp.stack.push(target_val);
+            }
+            interp.stack.push(arg_to_restore.clone());
+            Err(error)
+        }
+    }
+}
+
 fn parse_index_element_args(word: &str, args_val: &Value) -> Result<(i64, Value)> {
     if !args_val.is_vector() || args_val.len() != 2 {
         return Err(AjisaiError::from(format!(
@@ -29,68 +92,30 @@ fn parse_index_element_args(word: &str, args_val: &Value) -> Result<(i64, Value)
 /// - Keep（,,）: 対象ベクタを保持し、取得した要素を追加する
 pub fn op_get(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
-    let index_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let index = match extract_integer_from_value(&index_val) {
-        Ok(v) => v,
-        Err(e) => {
-            interp.stack.push(index_val);
-            return Err(e);
-        }
-    };
+    let (index_val, index) = pop_index_operand(interp)?;
 
     // In gui_mode, GET always preserves the source vector (Form型)
     let preserve_source = interp.gui_mode || is_keep_mode;
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let target_val = if preserve_source {
-                // Preserve mode: peek without removing
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(index_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            } else {
-                // Consume mode: pop
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(index_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            };
-
-            if target_val.is_vector() {
-                let len = target_val.len();
-                if len == 0 {
-                    if !preserve_source {
-                        interp.stack.push(target_val);
+            let result_elem =
+                with_stacktop_vector_target(interp, &index_val, preserve_source, |target_val| {
+                    let len = target_val.len();
+                    if len == 0 {
+                        return Err(AjisaiError::IndexOutOfBounds { index, length: 0 });
                     }
-                    interp.stack.push(index_val);
-                    return Err(AjisaiError::IndexOutOfBounds { index, length: 0 });
-                }
 
-                let actual_index = match normalize_index(index, len) {
-                    Some(idx) => idx,
-                    None => {
-                        if !preserve_source {
-                            interp.stack.push(target_val);
-                        }
-                        interp.stack.push(index_val);
-                        return Err(AjisaiError::IndexOutOfBounds { index, length: len });
-                    }
-                };
+                    let actual_index = normalize_index(index, len)
+                        .ok_or(AjisaiError::IndexOutOfBounds { index, length: len })?;
+                    Ok(target_val.get_child(actual_index).unwrap().clone())
+                })?;
 
-                let result_elem = target_val.get_child(actual_index).unwrap().clone();
-                if is_keep_mode {
-                    interp.stack.push(index_val);
-                }
-                interp.stack.push(result_elem);
-                Ok(())
-            } else {
-                if !preserve_source {
-                    interp.stack.push(target_val);
-                }
+            if is_keep_mode {
                 interp.stack.push(index_val);
-                Err(AjisaiError::create_structure_error("vector", "other format"))
             }
+            interp.stack.push(result_elem);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             let stack_len = interp.stack.len();
@@ -143,40 +168,25 @@ pub fn op_insert(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let vector_val = if is_keep_mode {
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(args_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            } else {
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(args_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            };
+            let inserted =
+                with_stacktop_vector_target(interp, &args_val, is_keep_mode, |vector_val| {
+                    let mut values = extract_vector_elements(vector_val).to_vec();
+                    let len = values.len() as i64;
+                    let insert_index = if index < 0 {
+                        (len + index).max(0) as usize
+                    } else {
+                        (index as usize).min(values.len())
+                    };
 
-            if vector_val.is_vector() {
-                let mut v = extract_vector_elements(&vector_val).to_vec();
-                let len = v.len() as i64;
-                let insert_index = if index < 0 {
-                    (len + index).max(0) as usize
-                } else {
-                    (index as usize).min(v.len())
-                };
+                    values.insert(insert_index, element.clone());
+                    Ok(Value::from_vector(values))
+                })?;
 
-                v.insert(insert_index, element.clone());
-                if is_keep_mode {
-                    interp.stack.push(args_val);
-                }
-                interp.stack.push(Value::from_vector(v));
-                Ok(())
-            } else {
-                if !is_keep_mode {
-                    interp.stack.push(vector_val);
-                }
+            if is_keep_mode {
                 interp.stack.push(args_val);
-                Err(AjisaiError::create_structure_error("vector", "other format"))
             }
+            interp.stack.push(inserted);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             let len = interp.stack.len() as i64;
@@ -212,45 +222,22 @@ pub fn op_replace(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let vector_val = if is_keep_mode {
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(args_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            } else {
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(args_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            };
+            let replaced =
+                with_stacktop_vector_target(interp, &args_val, is_keep_mode, |vector_val| {
+                    let mut values = extract_vector_elements(vector_val).to_vec();
+                    let len = values.len();
+                    let actual_index = normalize_index(index, len)
+                        .ok_or(AjisaiError::IndexOutOfBounds { index, length: len })?;
 
-            if vector_val.is_vector() {
-                let mut v = extract_vector_elements(&vector_val).to_vec();
-                let len = v.len();
-                let actual_index = match normalize_index(index, len) {
-                    Some(idx) => idx,
-                    None => {
-                        if !is_keep_mode {
-                            interp.stack.push(Value::from_vector(v));
-                        }
-                        interp.stack.push(args_val);
-                        return Err(AjisaiError::IndexOutOfBounds { index, length: len });
-                    }
-                };
+                    values[actual_index] = new_element.clone();
+                    Ok(Value::from_vector(values))
+                })?;
 
-                v[actual_index] = new_element;
-                if is_keep_mode {
-                    interp.stack.push(args_val);
-                }
-                interp.stack.push(Value::from_vector(v));
-                Ok(())
-            } else {
-                if !is_keep_mode {
-                    interp.stack.push(vector_val);
-                }
+            if is_keep_mode {
                 interp.stack.push(args_val);
-                Err(AjisaiError::create_structure_error("vector", "other format"))
             }
+            interp.stack.push(replaced);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             let len = interp.stack.len();
@@ -286,60 +273,29 @@ pub fn op_replace(interp: &mut Interpreter) -> Result<()> {
 /// - Keep（,,）: 対象ベクタを保持し、削除結果を追加する
 pub fn op_remove(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
-    let index_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let index = match extract_integer_from_value(&index_val) {
-        Ok(v) => v,
-        Err(e) => {
-            interp.stack.push(index_val);
-            return Err(e);
-        }
-    };
+    let (index_val, index) = pop_index_operand(interp)?;
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let vector_val = if is_keep_mode {
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(index_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            } else {
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(index_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            };
+            let removed =
+                with_stacktop_vector_target(interp, &index_val, is_keep_mode, |vector_val| {
+                    let mut values = extract_vector_elements(vector_val).to_vec();
+                    let len = values.len();
+                    let actual_index = normalize_index(index, len)
+                        .ok_or(AjisaiError::IndexOutOfBounds { index, length: len })?;
 
-            if vector_val.is_vector() {
-                let mut v = extract_vector_elements(&vector_val).to_vec();
-                let len = v.len();
-                let actual_index = match normalize_index(index, len) {
-                    Some(idx) => idx,
-                    None => {
-                        if !is_keep_mode {
-                            interp.stack.push(Value::from_vector(v));
-                        }
-                        interp.stack.push(index_val);
-                        return Err(AjisaiError::IndexOutOfBounds { index, length: len });
+                    values.remove(actual_index);
+                    if values.is_empty() {
+                        return Ok(Value::nil());
                     }
-                };
+                    Ok(Value::from_vector(values))
+                })?;
 
-                v.remove(actual_index);
-                if is_keep_mode {
-                    interp.stack.push(index_val);
-                }
-                if v.is_empty() {
-                    interp.stack.push(Value::nil());
-                } else {
-                    interp.stack.push(Value::from_vector(v));
-                }
-                Ok(())
-            } else {
-                if !is_keep_mode {
-                    interp.stack.push(vector_val);
-                }
+            if is_keep_mode {
                 interp.stack.push(index_val);
-                Err(AjisaiError::create_structure_error("vector", "other format"))
             }
+            interp.stack.push(removed);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             let len = interp.stack.len();

--- a/rust/tests/gui-interpreter-test-cases.rs
+++ b/rust/tests/gui-interpreter-test-cases.rs
@@ -1,25 +1,11 @@
 // Integration tests mirroring js/gui/gui-interpreter-test-cases.ts
 // These tests verify the interpreter produces the same results as expected by the GUI tests.
 
-use ajisai_core::interpreter::Interpreter;
+mod test_support;
+
 use ajisai_core::types::fraction::Fraction;
 use ajisai_core::types::Value;
 use num_bigint::BigInt;
-
-// Helper to run code and return the stack (gui_mode = true to match WASM API behavior)
-async fn run(code: &str) -> Result<Vec<Value>, String> {
-    let mut interp = Interpreter::new();
-    interp.gui_mode = true;
-    interp.execute(code).await.map_err(|e| e.to_string())?;
-    Ok(interp.get_stack().clone())
-}
-
-// Helper to run code expecting an error
-async fn run_expect_error(code: &str) -> bool {
-    let mut interp = Interpreter::new();
-    interp.gui_mode = true;
-    interp.execute(code).await.is_err()
-}
 
 // Helper: check a scalar value on the stack
 fn assert_number(val: &Value, num: i64, denom: i64) {
@@ -90,21 +76,21 @@ fn assert_vector_numbers(val: &Value, nums: &[(i64, i64)]) {
 
 #[tokio::test]
 async fn test_number_integer() {
-    let stack = run("[ 42 ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 42 ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(42, 1)]);
 }
 
 #[tokio::test]
 async fn test_number_negative() {
-    let stack = run("[ -17 ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ -17 ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(-17, 1)]);
 }
 
 #[tokio::test]
 async fn test_number_fraction() {
-    let stack = run("[ 3/4 ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 3/4 ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_number(&vec[0], 3, 4);
@@ -112,7 +98,7 @@ async fn test_number_fraction() {
 
 #[tokio::test]
 async fn test_number_decimal_converts_to_fraction() {
-    let stack = run("[ 0.5 ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 0.5 ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_number(&vec[0], 1, 2);
@@ -120,7 +106,7 @@ async fn test_number_decimal_converts_to_fraction() {
 
 #[tokio::test]
 async fn test_string_simple() {
-    let stack = run("[ 'hello' ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 'hello' ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_eq!(vec.len(), 1);
@@ -129,7 +115,9 @@ async fn test_string_simple() {
 
 #[tokio::test]
 async fn test_string_with_spaces() {
-    let stack = run("[ 'hello world' ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 'hello world' ]")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_eq!(vec.len(), 1);
@@ -138,7 +126,7 @@ async fn test_string_with_spaces() {
 
 #[tokio::test]
 async fn test_boolean_true() {
-    let stack = run("[ TRUE ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ TRUE ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_eq!(vec.len(), 1);
@@ -147,7 +135,7 @@ async fn test_boolean_true() {
 
 #[tokio::test]
 async fn test_boolean_false() {
-    let stack = run("[ FALSE ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ FALSE ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_eq!(vec.len(), 1);
@@ -156,7 +144,7 @@ async fn test_boolean_false() {
 
 #[tokio::test]
 async fn test_nil() {
-    let stack = run("[ NIL ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ NIL ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_eq!(vec.len(), 1);
@@ -169,14 +157,16 @@ async fn test_nil() {
 
 #[tokio::test]
 async fn test_addition_integers() {
-    let stack = run("[ 2 ] [ 3 ] +").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 2 ] [ 3 ] +").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(5, 1)]);
 }
 
 #[tokio::test]
 async fn test_addition_fractions() {
-    let stack = run("[ 1/2 ] [ 1/3 ] +").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1/2 ] [ 1/3 ] +")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_number(&vec[0], 5, 6);
@@ -184,21 +174,21 @@ async fn test_addition_fractions() {
 
 #[tokio::test]
 async fn test_subtraction() {
-    let stack = run("[ 10 ] [ 3 ] -").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 10 ] [ 3 ] -").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(7, 1)]);
 }
 
 #[tokio::test]
 async fn test_multiplication() {
-    let stack = run("[ 4 ] [ 5 ] *").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 4 ] [ 5 ] *").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(20, 1)]);
 }
 
 #[tokio::test]
 async fn test_division() {
-    let stack = run("[ 10 ] [ 4 ] /").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 10 ] [ 4 ] /").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_number(&vec[0], 5, 2);
@@ -206,33 +196,33 @@ async fn test_division() {
 
 #[tokio::test]
 async fn test_division_by_zero_error() {
-    assert!(run_expect_error("[ 1 ] [ 0 ] /").await);
+    assert!(test_support::exec_err_gui("[ 1 ] [ 0 ] /").await);
 }
 
 #[tokio::test]
 async fn test_modulo() {
-    let stack = run("[ 7 ] [ 3 ] MOD").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 7 ] [ 3 ] MOD").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1)]);
 }
 
 #[tokio::test]
 async fn test_floor() {
-    let stack = run("[ 7/3 ] FLOOR").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 7/3 ] FLOOR").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(2, 1)]);
 }
 
 #[tokio::test]
 async fn test_ceil() {
-    let stack = run("[ 7/3 ] CEIL").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 7/3 ] CEIL").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(3, 1)]);
 }
 
 #[tokio::test]
 async fn test_round() {
-    let stack = run("[ 5/2 ] ROUND").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 5/2 ] ROUND").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(3, 1)]);
 }
@@ -243,7 +233,7 @@ async fn test_round() {
 
 #[tokio::test]
 async fn test_less_than_true() {
-    let stack = run("[ 3 ] [ 5 ] <").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 3 ] [ 5 ] <").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -251,7 +241,7 @@ async fn test_less_than_true() {
 
 #[tokio::test]
 async fn test_less_than_false() {
-    let stack = run("[ 5 ] [ 3 ] <").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 5 ] [ 3 ] <").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], false);
@@ -259,7 +249,9 @@ async fn test_less_than_false() {
 
 #[tokio::test]
 async fn test_greater_than_via_le_not() {
-    let stack = run("[ 5 ] [ 3 ] <= NOT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 5 ] [ 3 ] <= NOT")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -267,7 +259,7 @@ async fn test_greater_than_via_le_not() {
 
 #[tokio::test]
 async fn test_less_than_or_equal() {
-    let stack = run("[ 3 ] [ 3 ] <=").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 3 ] [ 3 ] <=").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -275,7 +267,9 @@ async fn test_less_than_or_equal() {
 
 #[tokio::test]
 async fn test_greater_than_or_equal_via_lt_not() {
-    let stack = run("[ 3 ] [ 3 ] < NOT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 3 ] [ 3 ] < NOT")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -283,7 +277,7 @@ async fn test_greater_than_or_equal_via_lt_not() {
 
 #[tokio::test]
 async fn test_equal_numbers() {
-    let stack = run("[ 5 ] [ 5 ] =").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 5 ] [ 5 ] =").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -291,7 +285,9 @@ async fn test_equal_numbers() {
 
 #[tokio::test]
 async fn test_equal_fraction_auto_reduction() {
-    let stack = run("[ 1/2 ] [ 2/4 ] =").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1/2 ] [ 2/4 ] =")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -303,7 +299,9 @@ async fn test_equal_fraction_auto_reduction() {
 
 #[tokio::test]
 async fn test_and_true_true() {
-    let stack = run("[ TRUE ] [ TRUE ] AND").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ TRUE ] [ TRUE ] AND")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -311,7 +309,9 @@ async fn test_and_true_true() {
 
 #[tokio::test]
 async fn test_and_true_false() {
-    let stack = run("[ TRUE ] [ FALSE ] AND").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ TRUE ] [ FALSE ] AND")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], false);
@@ -319,7 +319,9 @@ async fn test_and_true_false() {
 
 #[tokio::test]
 async fn test_or_false_true() {
-    let stack = run("[ FALSE ] [ TRUE ] OR").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ FALSE ] [ TRUE ] OR")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -327,7 +329,7 @@ async fn test_or_false_true() {
 
 #[tokio::test]
 async fn test_not_true() {
-    let stack = run("[ TRUE ] NOT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ TRUE ] NOT").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], false);
@@ -335,7 +337,7 @@ async fn test_not_true() {
 
 #[tokio::test]
 async fn test_not_false() {
-    let stack = run("[ FALSE ] NOT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ FALSE ] NOT").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_bool_val(&vec[0], true);
@@ -347,7 +349,9 @@ async fn test_not_false() {
 
 #[tokio::test]
 async fn test_length() {
-    let stack = run("[ 1 2 3 4 5 ] LENGTH").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 4 5 ] LENGTH")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 2);
     assert_vector_numbers(&stack[0], &[(1, 1), (2, 1), (3, 1), (4, 1), (5, 1)]);
     // LENGTH returns a scalar number
@@ -356,7 +360,9 @@ async fn test_length() {
 
 #[tokio::test]
 async fn test_get_first_element() {
-    let stack = run("[ 10 20 30 ] [ 0 ] GET").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 10 20 30 ] [ 0 ] GET")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 2);
     assert_vector_numbers(&stack[0], &[(10, 1), (20, 1), (30, 1)]);
     assert_number(&stack[1], 10, 1);
@@ -364,7 +370,9 @@ async fn test_get_first_element() {
 
 #[tokio::test]
 async fn test_get_negative_index() {
-    let stack = run("[ 10 20 30 ] [ -1 ] GET").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 10 20 30 ] [ -1 ] GET")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 2);
     assert_vector_numbers(&stack[0], &[(10, 1), (20, 1), (30, 1)]);
     assert_number(&stack[1], 30, 1);
@@ -372,49 +380,63 @@ async fn test_get_negative_index() {
 
 #[tokio::test]
 async fn test_take_positive() {
-    let stack = run("[ 1 2 3 4 5 ] [ 3 ] TAKE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 4 5 ] [ 3 ] TAKE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (2, 1), (3, 1)]);
 }
 
 #[tokio::test]
 async fn test_take_negative() {
-    let stack = run("[ 1 2 3 4 5 ] [ -2 ] TAKE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 4 5 ] [ -2 ] TAKE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(4, 1), (5, 1)]);
 }
 
 #[tokio::test]
 async fn test_reverse() {
-    let stack = run("[ 1 2 3 ] REVERSE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] REVERSE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(3, 1), (2, 1), (1, 1)]);
 }
 
 #[tokio::test]
 async fn test_concat() {
-    let stack = run("[ 1 2 ] [ 3 4 ] CONCAT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 ] [ 3 4 ] CONCAT")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (2, 1), (3, 1), (4, 1)]);
 }
 
 #[tokio::test]
 async fn test_insert() {
-    let stack = run("[ 1 3 ] [ 1 2 ] INSERT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 3 ] [ 1 2 ] INSERT")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (2, 1), (3, 1)]);
 }
 
 #[tokio::test]
 async fn test_replace() {
-    let stack = run("[ 1 2 3 ] [ 1 9 ] REPLACE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] [ 1 9 ] REPLACE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (9, 1), (3, 1)]);
 }
 
 #[tokio::test]
 async fn test_remove() {
-    let stack = run("[ 1 2 3 ] [ 1 ] REMOVE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] [ 1 ] REMOVE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (3, 1)]);
 }
@@ -425,35 +447,41 @@ async fn test_remove() {
 
 #[tokio::test]
 async fn test_shape_1d() {
-    let stack = run("[ 1 2 3 ] SHAPE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] SHAPE").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(3, 1)]);
 }
 
 #[tokio::test]
 async fn test_shape_2d() {
-    let stack = run("[ [ 1 2 3 ] [ 4 5 6 ] ] SHAPE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ [ 1 2 3 ] [ 4 5 6 ] ] SHAPE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(2, 1), (3, 1)]);
 }
 
 #[tokio::test]
 async fn test_rank_1d() {
-    let stack = run("[ 1 2 3 ] RANK").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] RANK").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_number(&stack[0], 1, 1);
 }
 
 #[tokio::test]
 async fn test_rank_2d() {
-    let stack = run("[ [ 1 2 ] [ 3 4 ] ] RANK").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ [ 1 2 ] [ 3 4 ] ] RANK")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_number(&stack[0], 2, 1);
 }
 
 #[tokio::test]
 async fn test_transpose() {
-    let stack = run("[ [ 1 2 3 ] [ 4 5 6 ] ] TRANSPOSE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ [ 1 2 3 ] [ 4 5 6 ] ] TRANSPOSE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let outer = stack[0].as_vector().unwrap();
     assert_eq!(outer.len(), 3);
@@ -464,7 +492,9 @@ async fn test_transpose() {
 
 #[tokio::test]
 async fn test_reshape() {
-    let stack = run("[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let outer = stack[0].as_vector().unwrap();
     assert_eq!(outer.len(), 2);
@@ -478,28 +508,36 @@ async fn test_reshape() {
 
 #[tokio::test]
 async fn test_broadcast_scalar_plus_vector() {
-    let stack = run("[ 10 ] [ 1 2 3 ] +").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 10 ] [ 1 2 3 ] +")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(11, 1), (12, 1), (13, 1)]);
 }
 
 #[tokio::test]
 async fn test_broadcast_vector_times_scalar() {
-    let stack = run("[ 1 2 3 ] [ 2 ] *").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] [ 2 ] *")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(2, 1), (4, 1), (6, 1)]);
 }
 
 #[tokio::test]
 async fn test_broadcast_vector_plus_vector() {
-    let stack = run("[ 1 2 3 ] [ 10 20 30 ] +").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] [ 10 20 30 ] +")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(11, 1), (22, 1), (33, 1)]);
 }
 
 #[tokio::test]
 async fn test_broadcast_matrix_plus_row_vector() {
-    let stack = run("[ [ 1 2 3 ] [ 4 5 6 ] ] [ 10 20 30 ] +").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ [ 1 2 3 ] [ 4 5 6 ] ] [ 10 20 30 ] +")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     let outer = stack[0].as_vector().unwrap();
     assert_eq!(outer.len(), 2);
@@ -513,7 +551,7 @@ async fn test_broadcast_matrix_plus_row_vector() {
 
 #[tokio::test]
 async fn test_map_double() {
-    let stack = run("{ [ 2 ] * } 'DBL' DEF\n[ 1 2 3 ] 'DBL' MAP")
+    let stack = test_support::exec_ok_gui("{ [ 2 ] * } 'DBL' DEF\n[ 1 2 3 ] 'DBL' MAP")
         .await
         .unwrap();
     assert_eq!(stack.len(), 1);
@@ -522,16 +560,19 @@ async fn test_map_double() {
 
 #[tokio::test]
 async fn test_filter_positive() {
-    let stack = run("{ [ 0 ] <= NOT } 'POS' DEF\n[ -2 -1 0 1 2 ] 'POS' FILTER")
-        .await
-        .unwrap();
+    let stack =
+        test_support::exec_ok_gui("{ [ 0 ] <= NOT } 'POS' DEF\n[ -2 -1 0 1 2 ] 'POS' FILTER")
+            .await
+            .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (2, 1)]);
 }
 
 #[tokio::test]
 async fn test_fold_sum() {
-    let stack = run("[ 1 2 3 4 ] [ 0 ] '+' FOLD").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 4 ] [ 0 ] '+' FOLD")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(10, 1)]);
 }
@@ -543,35 +584,35 @@ async fn test_fold_sum() {
 #[tokio::test]
 async fn test_str_number_to_string() {
     // Use scalar 42 (not vector [42], which is now heuristically a string '*')
-    let stack = run("42 STR").await.unwrap();
+    let stack = test_support::exec_ok_gui("42 STR").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_string_val(&stack[0], "42");
 }
 
 #[tokio::test]
 async fn test_str_fraction_to_string() {
-    let stack = run("[ 3/4 ] STR").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 3/4 ] STR").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_string_val(&stack[0], "3/4");
 }
 
 #[tokio::test]
 async fn test_num_string_to_number() {
-    let stack = run("'42' NUM").await.unwrap();
+    let stack = test_support::exec_ok_gui("'42' NUM").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_number(&stack[0], 42, 1);
 }
 
 #[tokio::test]
 async fn test_bool_1_to_true() {
-    let stack = run("1 BOOL").await.unwrap();
+    let stack = test_support::exec_ok_gui("1 BOOL").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_bool_val(&stack[0], true);
 }
 
 #[tokio::test]
 async fn test_bool_0_to_false() {
-    let stack = run("0 BOOL").await.unwrap();
+    let stack = test_support::exec_ok_gui("0 BOOL").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_bool_val(&stack[0], false);
 }
@@ -582,7 +623,7 @@ async fn test_bool_0_to_false() {
 
 #[tokio::test]
 async fn test_chars_split_string() {
-    let stack = run("'hello' CHARS").await.unwrap();
+    let stack = test_support::exec_ok_gui("'hello' CHARS").await.unwrap();
     assert_eq!(stack.len(), 1);
     let vec = stack[0].as_vector().unwrap();
     assert_eq!(vec.len(), 5);
@@ -595,7 +636,9 @@ async fn test_chars_split_string() {
 
 #[tokio::test]
 async fn test_join_strings() {
-    let stack = run("[ 'h' 'e' 'l' 'l' 'o' ] JOIN").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 'h' 'e' 'l' 'l' 'o' ] JOIN")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_string_val(&stack[0], "hello");
 }
@@ -606,7 +649,9 @@ async fn test_join_strings() {
 
 #[tokio::test]
 async fn test_stack_mode_length() {
-    let stack = run("[ 1 ] [ 2 ] [ 3 ] .. LENGTH").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 ] [ 2 ] [ 3 ] .. LENGTH")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 4);
     assert_vector_numbers(&stack[0], &[(1, 1)]);
     assert_vector_numbers(&stack[1], &[(2, 1)]);
@@ -616,7 +661,9 @@ async fn test_stack_mode_length() {
 
 #[tokio::test]
 async fn test_stack_mode_get() {
-    let stack = run("[ 'a' ] [ 'b' ] [ 'c' ] [ 1 ] .. GET").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 'a' ] [ 'b' ] [ 'c' ] [ 1 ] .. GET")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 4);
     // First 3 are original vectors
     let vec0 = stack[0].as_vector().unwrap();
@@ -632,7 +679,9 @@ async fn test_stack_mode_get() {
 
 #[tokio::test]
 async fn test_stack_mode_reverse() {
-    let stack = run("[ 1 ] [ 2 ] [ 3 ] .. REVERSE").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 ] [ 2 ] [ 3 ] .. REVERSE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 3);
     assert_vector_numbers(&stack[0], &[(3, 1)]);
     assert_vector_numbers(&stack[1], &[(2, 1)]);
@@ -645,7 +694,9 @@ async fn test_stack_mode_reverse() {
 
 #[tokio::test]
 async fn test_def_and_call() {
-    let stack = run("{ [ 2 ] * } 'DOUBLE' DEF\n[ 5 ] DOUBLE").await.unwrap();
+    let stack = test_support::exec_ok_gui("{ [ 2 ] * } 'DOUBLE' DEF\n[ 5 ] DOUBLE")
+        .await
+        .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(10, 1)]);
 }
@@ -654,16 +705,18 @@ async fn test_def_and_call() {
 async fn test_def_with_branch_guard() {
     // [ 3 ] < 10 → TRUE, so first branch runs: 3 * 2 = 6
     // Migrated from legacy `$` branch guard syntax to COND
-    let stack = run("{ { ,, [ 10 ] < } { [ 2 ] * } { IDLE } { [ 3 ] * } COND } 'GUARD' DEF\n[ 3 ] GUARD")
-        .await
-        .unwrap();
+    let stack = test_support::exec_ok_gui(
+        "{ { ,, [ 10 ] < } { [ 2 ] * } { IDLE } { [ 3 ] * } COND } 'GUARD' DEF\n[ 3 ] GUARD",
+    )
+    .await
+    .unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(6, 1)]);
 }
 
 #[tokio::test]
 async fn test_del_delete_user_word() {
-    assert!(run_expect_error("{ [ 2 ] * } 'TEMP' DEF\n'TEMP' DEL\nTEMP").await);
+    assert!(test_support::exec_err_gui("{ [ 2 ] * } 'TEMP' DEF\n'TEMP' DEL\nTEMP").await);
 }
 
 // ============================================
@@ -675,9 +728,11 @@ async fn test_cond_multi_branch() {
     // Test multi-branch COND: [ 10 ] matches second guard (> 5 via reversed <)
     // Migrated from legacy `&` loop guard syntax; loop construct removed from spec.
     // Tests COND with multiple guard/body pairs instead.
-    let stack = run("[ 10 ] { ,, [ 0 ] < } { 'negative' } { ,, [ 5 ] < } { 'small' } { IDLE } { 'big' } COND")
-        .await
-        .unwrap();
+    let stack = test_support::exec_ok_gui(
+        "[ 10 ] { ,, [ 0 ] < } { 'negative' } { ,, [ 5 ] < } { 'small' } { IDLE } { 'big' } COND",
+    )
+    .await
+    .unwrap();
     assert_eq!(stack.len(), 1);
     assert_string_val(&stack[0], "big");
 }
@@ -688,7 +743,7 @@ async fn test_cond_multi_branch() {
 
 #[tokio::test]
 async fn test_fill() {
-    let stack = run("[ 3 7 ] FILL").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 3 7 ] FILL").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(7, 1), (7, 1), (7, 1)]);
 }
@@ -699,14 +754,14 @@ async fn test_fill() {
 
 #[tokio::test]
 async fn test_nil_coalescing_nil_case() {
-    let stack = run("NIL => [ 0 ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("NIL => [ 0 ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(0, 1)]);
 }
 
 #[tokio::test]
 async fn test_nil_coalescing_non_nil_case() {
-    let stack = run("[ 42 ] => [ 0 ]").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 42 ] => [ 0 ]").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(42, 1)]);
 }
@@ -717,32 +772,32 @@ async fn test_nil_coalescing_non_nil_case() {
 
 #[tokio::test]
 async fn test_error_stack_underflow() {
-    assert!(run_expect_error("+").await);
+    assert!(test_support::exec_err_gui("+").await);
 }
 
 #[tokio::test]
 async fn test_error_unknown_word() {
-    assert!(run_expect_error("UNKNOWNWORD").await);
+    assert!(test_support::exec_err_gui("UNKNOWNWORD").await);
 }
 
 #[tokio::test]
 async fn test_error_index_out_of_bounds() {
-    assert!(run_expect_error("[ 1 2 3 ] [ 10 ] GET").await);
+    assert!(test_support::exec_err_gui("[ 1 2 3 ] [ 10 ] GET").await);
 }
 
 #[tokio::test]
 async fn test_error_incompatible_shapes() {
-    assert!(run_expect_error("[ 1 2 3 ] [ 1 2 ] +").await);
+    assert!(test_support::exec_err_gui("[ 1 2 3 ] [ 1 2 ] +").await);
 }
 
 #[tokio::test]
 async fn test_error_empty_vector() {
-    assert!(run_expect_error("[ ]").await);
+    assert!(test_support::exec_err_gui("[ ]").await);
 }
 
 #[tokio::test]
 async fn test_sort_already_sorted_succeeds() {
-    let stack = run("[ 1 2 3 ] SORT").await.unwrap();
+    let stack = test_support::exec_ok_gui("[ 1 2 3 ] SORT").await.unwrap();
     assert_eq!(stack.len(), 1);
     assert_vector_numbers(&stack[0], &[(1, 1), (2, 1), (3, 1)]);
 }

--- a/rust/tests/test_support/mod.rs
+++ b/rust/tests/test_support/mod.rs
@@ -1,0 +1,15 @@
+use ajisai_core::interpreter::Interpreter;
+use ajisai_core::types::Value;
+
+pub async fn exec_ok_gui(code: &str) -> Result<Vec<Value>, String> {
+    let mut interp = Interpreter::new();
+    interp.gui_mode = true;
+    interp.execute(code).await.map_err(|e| e.to_string())?;
+    Ok(interp.get_stack().clone())
+}
+
+pub async fn exec_err_gui(code: &str) -> bool {
+    let mut interp = Interpreter::new();
+    interp.gui_mode = true;
+    interp.execute(code).await.is_err()
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated builtin metadata and name-to-executor mappings by providing a single source of truth. 
- Eliminate repetitive stack/operand boilerplate in vector position operators so the core semantics become concise and easier to maintain. 
- Unify interpreter state snapshot/restore logic across workers/controllers and shorten Rust GUI integration tests via helpers.

### Description
- Introduced a `BuiltinSpec` registry in `rust/src/builtins/builtin-word-definitions.rs` with `BuiltinDetailGroup`, `BuiltinExecutorKey`, `builtin_specs()`, and `lookup_builtin_spec()` and made `collect_builtin_definitions()` derive from that registry. 
- Routed detailed help via the registry by updating `lookup_builtin_detail()` to consult `detail_group` and fall back to registry metadata when needed (`rust/src/builtins/builtin-word-details.rs`). 
- Replaced the large name-based `match` in `execute_builtin_with_conservation()` with registry-driven resolution and a keyed dispatcher `execute_builtin_by_key()` to reduce duplication between name lists and execution wiring (`rust/src/interpreter/execute-builtin.rs`). 
- Centralized repeated stack/argument scaffolding for `GET/INSERT/REPLACE/REMOVE` by adding `pop_index_operand`, `acquire_stacktop_target`, and `with_stacktop_vector_target` and refactoring those operators to use the helpers while preserving existing semantics and error/restore behavior (`rust/src/interpreter/vector_ops/position.rs`). 
- Added a TypeScript `InterpreterSnapshot` helper with `createInterpreterSnapshot` and `applyInterpreterSnapshot` and applied it across the worker pipeline and controllers (`js/workers/interpreter-snapshot.ts`, `js/workers/execution-worker-manager.ts`, `js/workers/interpreter-execution-worker.ts`, `js/gui/execution-controller.ts`, `js/gui/step-executor.ts`). 
- Added Rust test helpers `rust/tests/test_support/mod.rs` (`exec_ok_gui`, `exec_err_gui`) and migrated GUI integration tests to use them (`rust/tests/gui-interpreter-test-cases.rs`).

### Testing
- Ran `cd rust && cargo test --lib` and all unit/integration tests passed. 
- Ran `cd rust && cargo test --test gui-interpreter-test-cases` and the GUI-mirroring integration tests passed. 
- Ran `npm run check` (`tsc --noEmit`) and TypeScript type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70c1ce5f883269e1b98a646ab1e38)