### PR TITLE
DRY: unify stack-top vector ops and consolidate WASM/IndexedDB boilerplate

### DIFF
--- a/js/indexeddb-user-word-store.ts
+++ b/js/indexeddb-user-word-store.ts
@@ -23,6 +23,23 @@ interface ExportData {
     interpreterState: InterpreterState | null;
 }
 
+const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
+    new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+
+const withObjectStore = <T>(
+    db: IDBDatabase,
+    storeName: string,
+    mode: IDBTransactionMode,
+    action: (store: IDBObjectStore, transaction: IDBTransaction) => Promise<T>
+): Promise<T> => {
+    const transaction = db.transaction([storeName], mode);
+    const store = transaction.objectStore(storeName);
+    return action(store, transaction);
+};
+
 class AjisaiDB {
     private dbName = 'AjisaiDB';
     private version = 4;
@@ -78,110 +95,69 @@ class AjisaiDB {
 
     async saveTable(name: string, schema: any, records: any): Promise<void> {
         if (!this.db) await this.open();
-        
-        return new Promise((resolve, reject) => {
-            const transaction = this.db!.transaction([this.storeName], 'readwrite');
-            const store = transaction.objectStore(this.storeName);
-            
+
+        return withObjectStore(this.db!, this.storeName, 'readwrite', async store => {
             const tableData: TableData = {
                 name,
                 schema,
                 records,
                 updatedAt: new Date().toISOString()
             };
-            
-            const request = store.put(tableData);
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
+            await promisifyRequest(store.put(tableData));
         });
     }
 
     async loadTable(name: string): Promise<{ schema: any; records: any } | null> {
         if (!this.db) await this.open();
         
-        return new Promise((resolve, reject) => {
-            const transaction = this.db!.transaction([this.storeName], 'readonly');
-            const store = transaction.objectStore(this.storeName);
-            
-            const request = store.get(name);
-            request.onsuccess = () => {
-                const result = request.result;
-                if (result) {
-                    resolve({ schema: result.schema, records: result.records });
-                } else {
-                    resolve(null);
-                }
-            };
-            request.onerror = () => reject(request.error);
+        return withObjectStore(this.db!, this.storeName, 'readonly', async store => {
+            const result = await promisifyRequest(store.get(name));
+            return result ? { schema: result.schema, records: result.records } : null;
         });
     }
 
     async collectTableNames(): Promise<string[]> {
         if (!this.db) await this.open();
         
-        return new Promise((resolve, reject) => {
-            const transaction = this.db!.transaction([this.storeName], 'readonly');
-            const store = transaction.objectStore(this.storeName);
-            
-            const request = store.getAllKeys();
-            request.onsuccess = () => resolve(request.result as string[]);
-            request.onerror = () => reject(request.error);
-        });
+        return withObjectStore(this.db!, this.storeName, 'readonly', async store =>
+            (await promisifyRequest(store.getAllKeys())) as string[]
+        );
     }
 
     async deleteTable(name: string): Promise<void> {
         if (!this.db) await this.open();
         
-        return new Promise((resolve, reject) => {
-            const transaction = this.db!.transaction([this.storeName], 'readwrite');
-            const store = transaction.objectStore(this.storeName);
-            
-            const request = store.delete(name);
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
+        return withObjectStore(this.db!, this.storeName, 'readwrite', async store => {
+            await promisifyRequest(store.delete(name));
         });
     }
 
     async saveInterpreterState(state: Omit<InterpreterState, 'key' | 'updatedAt'>): Promise<void> {
         if (!this.db) await this.open();
         
-        return new Promise((resolve, reject) => {
-            const transaction = this.db!.transaction([this.stateStoreName], 'readwrite');
-            const store = transaction.objectStore(this.stateStoreName);
-            
+        return withObjectStore(this.db!, this.stateStoreName, 'readwrite', async store => {
             const stateData: InterpreterState = {
                 key: 'interpreter_state',
                 ...state,
                 updatedAt: new Date().toISOString()
             };
-            
-            const request = store.put(stateData);
-            request.onsuccess = () => resolve();
-            request.onerror = () => reject(request.error);
+            await promisifyRequest(store.put(stateData));
         });
     }
 
     async loadInterpreterState(): Promise<Omit<InterpreterState, 'key' | 'updatedAt'> | null> {
         if (!this.db) await this.open();
         
-        return new Promise((resolve, reject) => {
-            const transaction = this.db!.transaction([this.stateStoreName], 'readonly');
-            const store = transaction.objectStore(this.stateStoreName);
-            
-            const request = store.get('interpreter_state');
-            request.onsuccess = () => {
-                const result = request.result;
-                if (result) {
-                    resolve({
-                        stack: result.stack,
-                        userWords: result.userWords ?? result.customWords,
-                        demoWordsVersion: result.demoWordsVersion ?? result.sampleWordsVersion
-                    });
-                } else {
-                    resolve(null);
-                }
+        return withObjectStore(this.db!, this.stateStoreName, 'readonly', async store => {
+            const result = await promisifyRequest(store.get('interpreter_state'));
+            if (!result) {
+                return null;
+            }
+            return {
+                stack: result.stack,
+                userWords: result.userWords ?? result.customWords,
+                demoWordsVersion: result.demoWordsVersion ?? result.sampleWordsVersion
             };
-            request.onerror = () => reject(request.error);
         });
     }
 

--- a/rust/src/interpreter/vector_ops/quantity.rs
+++ b/rust/src/interpreter/vector_ops/quantity.rs
@@ -4,11 +4,71 @@
 
 use super::extract_vector_elements;
 use crate::error::{AjisaiError, Result};
-use crate::interpreter::value_extraction_helpers::{extract_bigint_from_value, extract_integer_from_value, create_number_value};
+use crate::interpreter::value_extraction_helpers::{
+    create_number_value, extract_bigint_from_value, extract_integer_from_value,
+};
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_traits::ToPrimitive;
+
+fn acquire_stacktop_target(
+    interp: &mut Interpreter,
+    arg_to_restore: &Value,
+    preserve_source: bool,
+    missing_target_error: AjisaiError,
+) -> Result<Value> {
+    if preserve_source {
+        return interp.stack.last().cloned().ok_or_else(|| {
+            interp.stack.push(arg_to_restore.clone());
+            missing_target_error
+        });
+    }
+
+    interp.stack.pop().ok_or_else(|| {
+        interp.stack.push(arg_to_restore.clone());
+        missing_target_error
+    })
+}
+
+fn with_stacktop_vector_target<R, F>(
+    interp: &mut Interpreter,
+    arg_to_restore: &Value,
+    preserve_source: bool,
+    missing_target_error: AjisaiError,
+    action: F,
+) -> Result<R>
+where
+    F: FnOnce(&Value) -> Result<R>,
+{
+    let target_val = acquire_stacktop_target(
+        interp,
+        arg_to_restore,
+        preserve_source,
+        missing_target_error,
+    )?;
+    if !target_val.is_vector() {
+        if !preserve_source {
+            interp.stack.push(target_val);
+        }
+        interp.stack.push(arg_to_restore.clone());
+        return Err(AjisaiError::create_structure_error(
+            "vector",
+            "other format",
+        ));
+    }
+
+    match action(&target_val) {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            if !preserve_source {
+                interp.stack.push(target_val);
+            }
+            interp.stack.push(arg_to_restore.clone());
+            Err(error)
+        }
+    }
+}
 
 fn compute_take_bounds(len: usize, count: i64, target: &str) -> Result<(usize, usize)> {
     if count < 0 {
@@ -52,7 +112,10 @@ pub fn op_length(interp: &mut Interpreter) -> Result<()> {
                 } else if target_val.is_vector() {
                     extract_vector_elements(target_val).len()
                 } else {
-                    return Err(AjisaiError::create_structure_error("vector", "other format"));
+                    return Err(AjisaiError::create_structure_error(
+                        "vector",
+                        "other format",
+                    ));
                 }
             } else {
                 let target_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
@@ -63,7 +126,10 @@ pub fn op_length(interp: &mut Interpreter) -> Result<()> {
                     extract_vector_elements(&target_val).len()
                 } else {
                     interp.stack.push(target_val);
-                    return Err(AjisaiError::create_structure_error("vector", "other format"));
+                    return Err(AjisaiError::create_structure_error(
+                        "vector",
+                        "other format",
+                    ));
                 }
             }
         }
@@ -100,38 +166,17 @@ pub fn op_take(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let vector_val = if is_keep_mode {
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(count_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            } else {
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(count_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            };
-
-            if !vector_val.is_vector() {
-                if !is_keep_mode {
-                    interp.stack.push(vector_val);
-                }
-                interp.stack.push(count_val);
-                return Err(AjisaiError::create_structure_error("vector", "other format"));
-            }
-
-            let elements = extract_vector_elements(&vector_val);
-            let (start, end) = match compute_take_bounds(elements.len(), count, "vector") {
-                Ok(bounds) => bounds,
-                Err(error) => {
-                    if !is_keep_mode {
-                        interp.stack.push(vector_val);
-                    }
-                    interp.stack.push(count_val);
-                    return Err(error);
-                }
-            };
-            let result = elements[start..end].to_vec();
+            let result = with_stacktop_vector_target(
+                interp,
+                &count_val,
+                is_keep_mode,
+                AjisaiError::StackUnderflow,
+                |vector_val| {
+                    let elements = extract_vector_elements(vector_val);
+                    let (start, end) = compute_take_bounds(elements.len(), count, "vector")?;
+                    Ok(elements[start..end].to_vec())
+                },
+            )?;
 
             if is_keep_mode {
                 interp.stack.push(count_val);
@@ -209,53 +254,38 @@ pub fn op_split(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let vector_val = if is_keep_mode {
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(args_val.clone());
-                    AjisaiError::from("SPLIT requires a vector to split")
-                })?
-            } else {
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(args_val.clone());
-                    AjisaiError::from("SPLIT requires a vector to split")
-                })?
-            };
-
-            if vector_val.is_vector() {
-                let elements = extract_vector_elements(&vector_val);
-                let total_size: usize = sizes.iter().sum();
-                if total_size > elements.len() {
-                    if !is_keep_mode {
-                        interp.stack.push(vector_val);
+            let result_vectors = with_stacktop_vector_target(
+                interp,
+                &args_val,
+                is_keep_mode,
+                AjisaiError::from("SPLIT requires a vector to split"),
+                |vector_val| {
+                    let elements = extract_vector_elements(vector_val);
+                    let total_size: usize = sizes.iter().sum();
+                    if total_size > elements.len() {
+                        return Err(AjisaiError::from("Split sizes sum exceeds vector length"));
                     }
-                    interp.stack.push(args_val);
-                    return Err(AjisaiError::from("Split sizes sum exceeds vector length"));
-                }
 
-                let mut current_pos = 0;
-                let mut result_vectors = Vec::new();
+                    let mut current_pos = 0;
+                    let mut result_vectors = Vec::new();
+                    for &size in &sizes {
+                        let chunk = elements[current_pos..current_pos + size].to_vec();
+                        result_vectors.push(Value::from_vector(chunk));
+                        current_pos += size;
+                    }
+                    if current_pos < elements.len() {
+                        let chunk = elements[current_pos..].to_vec();
+                        result_vectors.push(Value::from_vector(chunk));
+                    }
+                    Ok(result_vectors)
+                },
+            )?;
 
-                for &size in &sizes {
-                    let chunk = elements[current_pos..current_pos + size].to_vec();
-                    result_vectors.push(Value::from_vector(chunk));
-                    current_pos += size;
-                }
-                if current_pos < elements.len() {
-                    let chunk = elements[current_pos..].to_vec();
-                    result_vectors.push(Value::from_vector(chunk));
-                }
-                if is_keep_mode {
-                    interp.stack.push(args_val);
-                }
-                interp.stack.extend(result_vectors);
-                Ok(())
-            } else {
-                if !is_keep_mode {
-                    interp.stack.push(vector_val);
-                }
+            if is_keep_mode {
                 interp.stack.push(args_val);
-                Err(AjisaiError::create_structure_error("vector", "other format"))
             }
+            interp.stack.extend(result_vectors);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             let total_size: usize = sizes.iter().sum();

--- a/rust/src/interpreter/vector_ops/structure.rs
+++ b/rust/src/interpreter/vector_ops/structure.rs
@@ -4,11 +4,102 @@
 
 use super::extract_vector_elements;
 use crate::error::{AjisaiError, Result};
-use crate::interpreter::value_extraction_helpers::{extract_bigint_from_value, extract_integer_from_value, normalize_index};
+use crate::interpreter::value_extraction_helpers::{
+    extract_bigint_from_value, extract_integer_from_value, normalize_index,
+};
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_traits::ToPrimitive;
+
+fn acquire_stacktop_target(
+    interp: &mut Interpreter,
+    arg_to_restore: &Value,
+    preserve_source: bool,
+) -> Result<Value> {
+    if preserve_source {
+        return interp.stack.last().cloned().ok_or_else(|| {
+            interp.stack.push(arg_to_restore.clone());
+            AjisaiError::StackUnderflow
+        });
+    }
+
+    interp.stack.pop().ok_or_else(|| {
+        interp.stack.push(arg_to_restore.clone());
+        AjisaiError::StackUnderflow
+    })
+}
+
+fn with_stacktop_vector_target<R, F>(
+    interp: &mut Interpreter,
+    arg_to_restore: &Value,
+    preserve_source: bool,
+    action: F,
+) -> Result<R>
+where
+    F: FnOnce(&Value) -> Result<R>,
+{
+    let target_val = acquire_stacktop_target(interp, arg_to_restore, preserve_source)?;
+    if !target_val.is_vector() {
+        if !preserve_source {
+            interp.stack.push(target_val);
+        }
+        interp.stack.push(arg_to_restore.clone());
+        return Err(AjisaiError::create_structure_error(
+            "vector",
+            "other format",
+        ));
+    }
+
+    match action(&target_val) {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            if !preserve_source {
+                interp.stack.push(target_val);
+            }
+            interp.stack.push(arg_to_restore.clone());
+            Err(error)
+        }
+    }
+}
+
+fn with_stacktop_vector_target_no_arg<R, F>(
+    interp: &mut Interpreter,
+    preserve_source: bool,
+    action: F,
+) -> Result<R>
+where
+    F: FnOnce(&Value) -> Result<R>,
+{
+    let target_val = if preserve_source {
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
+    } else {
+        interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
+    };
+    if !target_val.is_vector() {
+        if !preserve_source {
+            interp.stack.push(target_val);
+        }
+        return Err(AjisaiError::create_structure_error(
+            "vector",
+            "other format",
+        ));
+    }
+
+    match action(&target_val) {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            if !preserve_source {
+                interp.stack.push(target_val);
+            }
+            Err(error)
+        }
+    }
+}
 
 fn parse_concat_count(
     interp: &mut Interpreter,
@@ -156,49 +247,30 @@ pub fn op_reverse(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let val = if is_keep_mode {
-                interp
-                    .stack
-                    .last()
-                    .cloned()
-                    .ok_or(AjisaiError::StackUnderflow)?
-            } else {
-                interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
-            };
-
-            if val.is_vector() {
-                let mut v = extract_vector_elements(&val).to_vec();
-                if !interp.disable_no_change_check {
-                    if v.len() < 2 {
-                        if !is_keep_mode {
-                            interp.stack.push(Value::from_vector(v));
+            let disable_no_change_check = interp.disable_no_change_check;
+            let reversed =
+                with_stacktop_vector_target_no_arg(interp, is_keep_mode, |vector_val| {
+                    let mut v = extract_vector_elements(vector_val).to_vec();
+                    if !disable_no_change_check {
+                        if v.len() < 2 {
+                            return Err(AjisaiError::NoChange {
+                                word: "REVERSE".into(),
+                            });
                         }
-                        return Err(AjisaiError::NoChange {
-                            word: "REVERSE".into(),
-                        });
-                    }
-                    let original_v = v.clone();
-                    v.reverse();
-                    if v == original_v {
-                        if !is_keep_mode {
-                            interp.stack.push(Value::from_vector(original_v));
+                        let original_v = v.clone();
+                        v.reverse();
+                        if v == original_v {
+                            return Err(AjisaiError::NoChange {
+                                word: "REVERSE".into(),
+                            });
                         }
-                        return Err(AjisaiError::NoChange {
-                            word: "REVERSE".into(),
-                        });
+                    } else {
+                        v.reverse();
                     }
-                    interp.stack.push(Value::from_vector(v));
-                } else {
-                    v.reverse();
-                    interp.stack.push(Value::from_vector(v));
-                }
-                Ok(())
-            } else {
-                if !is_keep_mode {
-                    interp.stack.push(val);
-                }
-                Err(AjisaiError::create_structure_error("vector", "other format"))
-            }
+                    Ok(Value::from_vector(v))
+                })?;
+            interp.stack.push(reversed);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             if is_keep_mode {
@@ -315,63 +387,35 @@ pub fn op_reorder(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let target_val = if is_keep_mode {
-                interp.stack.last().cloned().ok_or_else(|| {
-                    interp.stack.push(indices_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            } else {
-                interp.stack.pop().ok_or_else(|| {
-                    interp.stack.push(indices_val.clone());
-                    AjisaiError::StackUnderflow
-                })?
-            };
-
-            if target_val.is_vector() {
-                let len = target_val.len();
-
-                if len == 0 {
-                    if !is_keep_mode {
-                        interp.stack.push(target_val);
+            let reordered =
+                with_stacktop_vector_target(interp, &indices_val, is_keep_mode, |target_val| {
+                    let len = target_val.len();
+                    if len == 0 {
+                        return Err(AjisaiError::from("REORDER: target vector is empty"));
                     }
-                    interp.stack.push(indices_val);
-                    return Err(AjisaiError::from("REORDER: target vector is empty"));
-                }
 
-                let mut result = Vec::with_capacity(indices.len());
-                for &idx in &indices {
-                    let actual = match normalize_index(idx, len) {
-                        Some(i) => i,
-                        None => {
-                            if !is_keep_mode {
-                                interp.stack.push(target_val);
-                            }
-                            interp.stack.push(indices_val);
-                            return Err(AjisaiError::IndexOutOfBounds {
+                    let mut result = Vec::with_capacity(indices.len());
+                    for &idx in &indices {
+                        let actual =
+                            normalize_index(idx, len).ok_or(AjisaiError::IndexOutOfBounds {
                                 index: idx,
                                 length: len,
-                            });
-                        }
-                    };
-                    result.push(target_val.get_child(actual).unwrap().clone());
-                }
+                            })?;
+                        result.push(target_val.get_child(actual).unwrap().clone());
+                    }
 
-                if is_keep_mode {
-                    interp.stack.push(indices_val);
-                }
-                if result.is_empty() {
-                    interp.stack.push(Value::nil());
-                } else {
-                    interp.stack.push(Value::from_vector(result));
-                }
-                Ok(())
-            } else {
-                if !is_keep_mode {
-                    interp.stack.push(target_val);
-                }
+                    if result.is_empty() {
+                        Ok(Value::nil())
+                    } else {
+                        Ok(Value::from_vector(result))
+                    }
+                })?;
+
+            if is_keep_mode {
                 interp.stack.push(indices_val);
-                Err(AjisaiError::create_structure_error("vector", "other format"))
             }
+            interp.stack.push(reordered);
+            Ok(())
         }
         OperationTargetMode::Stack => {
             let len = interp.stack.len();
@@ -413,7 +457,10 @@ pub fn op_collect(interp: &mut Interpreter) -> Result<()> {
         Ok(bi) => bi,
         Err(_) => {
             interp.stack.push(count_val);
-            return Err(AjisaiError::create_structure_error("integer", "other format"));
+            return Err(AjisaiError::create_structure_error(
+                "integer",
+                "other format",
+            ));
         }
     };
 

--- a/rust/src/wasm-interpreter-bindings.rs
+++ b/rust/src/wasm-interpreter-bindings.rs
@@ -20,6 +20,10 @@ pub struct AjisaiInterpreter {
     current_step_code: String,
 }
 
+pub(crate) fn set_js_prop(obj: &js_sys::Object, key: &str, value: &JsValue) {
+    js_sys::Reflect::set(obj, &JsValue::from_str(key), value).unwrap();
+}
+
 #[wasm_bindgen]
 impl AjisaiInterpreter {
     #[wasm_bindgen(constructor)]

--- a/rust/src/wasm-interpreter-execution.rs
+++ b/rust/src/wasm-interpreter-execution.rs
@@ -1,9 +1,7 @@
+use super::wasm_value_conversion::{build_bracket_structure_from_shape, is_vector_value};
+use super::{set_js_prop, AjisaiInterpreter};
 use crate::tokenizer;
 use crate::types::{ExecutionLine, ValueData};
-use super::wasm_value_conversion::{
-    build_bracket_structure_from_shape, is_vector_value,
-};
-use super::AjisaiInterpreter;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -32,10 +30,9 @@ impl AjisaiInterpreter {
                     let prefix_code = &trimmed[..prefix_len].trim();
                     if !prefix_code.is_empty() {
                         if let Err(e) = self.interpreter.execute(prefix_code).await {
-                            js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                            js_sys::Reflect::set(&obj, &"message".into(), &e.to_string().into())
-                                .unwrap();
-                            js_sys::Reflect::set(&obj, &"error".into(), &true.into()).unwrap();
+                            set_js_prop(&obj, "status", &("ERROR".into()));
+                            set_js_prop(&obj, "message", &(e.to_string().into()));
+                            set_js_prop(&obj, "error", &(true.into()));
                             return Ok(obj.into());
                         }
                     }
@@ -79,21 +76,20 @@ impl AjisaiInterpreter {
                 if let Some(shape_vec) = shape {
                     self.interpreter.stack.pop();
                     let helper_text = build_bracket_structure_from_shape(&shape_vec);
-                    js_sys::Reflect::set(&obj, &"inputHelper".into(), &helper_text.into()).unwrap();
-                    js_sys::Reflect::set(&obj, &"status".into(), &"OK".into()).unwrap();
-                    js_sys::Reflect::set(&obj, &"stack".into(), &self.collect_stack()).unwrap();
-                    js_sys::Reflect::set(
+                    set_js_prop(&obj, "inputHelper", &(helper_text.into()));
+                    set_js_prop(&obj, "status", &("OK".into()));
+                    set_js_prop(&obj, "stack", &(self.collect_stack()));
+                    set_js_prop(&obj, "userWords", &(self.collect_user_words_for_state()));
+                    set_js_prop(
                         &obj,
-                        &"userWords".into(),
-                        &self.collect_user_words_for_state(),
-                    )
-                    .unwrap();
-                    js_sys::Reflect::set(&obj, &"importedModules".into(), &self.collect_imported_modules_array()).unwrap();
+                        "importedModules",
+                        &(self.collect_imported_modules_array()),
+                    );
                     return Ok(obj.into());
                 } else {
-                    js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                    js_sys::Reflect::set(&obj, &"message".into(), &"FRAME requires a shape vector [ dim1 dim2 ... ] (1-9 dimensions, values 1-100)".into()).unwrap();
-                    js_sys::Reflect::set(&obj, &"error".into(), &true.into()).unwrap();
+                    set_js_prop(&obj, "status", &("ERROR".into()));
+                    set_js_prop(&obj, "message", &("FRAME requires a shape vector [ dim1 dim2 ... ] (1-9 dimensions, values 1-100)".into()));
+                    set_js_prop(&obj, "error", &(true.into()));
                     return Ok(obj.into());
                 }
             }
@@ -101,28 +97,26 @@ impl AjisaiInterpreter {
 
         match self.interpreter.execute(code).await {
             Ok(()) => {
-                js_sys::Reflect::set(&obj, &"status".into(), &"OK".into()).unwrap();
+                set_js_prop(&obj, "status", &("OK".into()));
                 let output = self.interpreter.collect_output();
-                js_sys::Reflect::set(&obj, &"output".into(), &output.clone().into()).unwrap();
-                js_sys::Reflect::set(&obj, &"stack".into(), &self.collect_stack()).unwrap();
-                js_sys::Reflect::set(
+                set_js_prop(&obj, "output", &(output.clone().into()));
+                set_js_prop(&obj, "stack", &(self.collect_stack()));
+                set_js_prop(&obj, "userWords", &(self.collect_user_words_for_state()));
+                set_js_prop(
                     &obj,
-                    &"userWords".into(),
-                    &self.collect_user_words_for_state(),
-                )
-                .unwrap();
-                js_sys::Reflect::set(&obj, &"importedModules".into(), &self.collect_imported_modules_array()).unwrap();
+                    "importedModules",
+                    &(self.collect_imported_modules_array()),
+                );
 
                 if let Some(def_str) = self.interpreter.definition_to_load.take() {
-                    js_sys::Reflect::set(&obj, &"definition_to_load".into(), &def_str.into())
-                        .unwrap();
+                    set_js_prop(&obj, "definition_to_load", &(def_str.into()));
                 }
             }
             Err(e) => {
                 let error_msg = e.to_string();
-                js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                js_sys::Reflect::set(&obj, &"message".into(), &error_msg.into()).unwrap();
-                js_sys::Reflect::set(&obj, &"error".into(), &true.into()).unwrap();
+                set_js_prop(&obj, "status", &("ERROR".into()));
+                set_js_prop(&obj, "message", &(error_msg.into()));
+                set_js_prop(&obj, "error", &(true.into()));
             }
         }
         Ok(obj.into())
@@ -143,14 +137,13 @@ impl AjisaiInterpreter {
                 }
                 Err(e) => {
                     self.step_mode = false;
-                    js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                    js_sys::Reflect::set(
+                    set_js_prop(&obj, "status", &("ERROR".into()));
+                    set_js_prop(
                         &obj,
-                        &"message".into(),
-                        &format!("Tokenization error: {}", e).into(),
-                    )
-                    .unwrap();
-                    js_sys::Reflect::set(&obj, &"error".into(), &true.into()).unwrap();
+                        "message",
+                        &(format!("Tokenization error: {}", e).into()),
+                    );
+                    set_js_prop(&obj, "error", &(true.into()));
                     return obj.into();
                 }
             }
@@ -158,10 +151,9 @@ impl AjisaiInterpreter {
 
         if self.step_position >= self.step_tokens.len() {
             self.step_mode = false;
-            js_sys::Reflect::set(&obj, &"status".into(), &"OK".into()).unwrap();
-            js_sys::Reflect::set(&obj, &"output".into(), &"Step execution completed".into())
-                .unwrap();
-            js_sys::Reflect::set(&obj, &"hasMore".into(), &false.into()).unwrap();
+            set_js_prop(&obj, "status", &("OK".into()));
+            set_js_prop(&obj, "output", &("Step execution completed".into()));
+            set_js_prop(&obj, "hasMore", &(false.into()));
             return obj.into();
         }
 
@@ -176,41 +168,29 @@ impl AjisaiInterpreter {
             Ok(()) => {
                 let output = self.interpreter.collect_output();
                 self.step_position += 1;
-                js_sys::Reflect::set(&obj, &"status".into(), &"OK".into()).unwrap();
-                js_sys::Reflect::set(&obj, &"output".into(), &output.into()).unwrap();
-                js_sys::Reflect::set(
+                set_js_prop(&obj, "status", &("OK".into()));
+                set_js_prop(&obj, "output", &(output.into()));
+                set_js_prop(
                     &obj,
-                    &"hasMore".into(),
-                    &(self.step_position < self.step_tokens.len()).into(),
-                )
-                .unwrap();
-                js_sys::Reflect::set(
+                    "hasMore",
+                    &((self.step_position < self.step_tokens.len()).into()),
+                );
+                set_js_prop(&obj, "position", &((self.step_position as u32).into()));
+                set_js_prop(&obj, "total", &((self.step_tokens.len() as u32).into()));
+                set_js_prop(&obj, "stack", &(self.collect_stack()));
+                set_js_prop(&obj, "userWords", &(self.collect_user_words_for_state()));
+                set_js_prop(
                     &obj,
-                    &"position".into(),
-                    &(self.step_position as u32).into(),
-                )
-                .unwrap();
-                js_sys::Reflect::set(
-                    &obj,
-                    &"total".into(),
-                    &(self.step_tokens.len() as u32).into(),
-                )
-                .unwrap();
-                js_sys::Reflect::set(&obj, &"stack".into(), &self.collect_stack()).unwrap();
-                js_sys::Reflect::set(
-                    &obj,
-                    &"userWords".into(),
-                    &self.collect_user_words_for_state(),
-                )
-                .unwrap();
-                js_sys::Reflect::set(&obj, &"importedModules".into(), &self.collect_imported_modules_array()).unwrap();
+                    "importedModules",
+                    &(self.collect_imported_modules_array()),
+                );
             }
             Err(e) => {
                 self.step_mode = false;
-                js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                js_sys::Reflect::set(&obj, &"message".into(), &e.to_string().into()).unwrap();
-                js_sys::Reflect::set(&obj, &"error".into(), &true.into()).unwrap();
-                js_sys::Reflect::set(&obj, &"hasMore".into(), &false.into()).unwrap();
+                set_js_prop(&obj, "status", &("ERROR".into()));
+                set_js_prop(&obj, "message", &(e.to_string().into()));
+                set_js_prop(&obj, "error", &(true.into()));
+                set_js_prop(&obj, "hasMore", &(false.into()));
             }
         }
 
@@ -228,22 +208,20 @@ impl AjisaiInterpreter {
 
         match self.interpreter.execute_reset() {
             Ok(()) => {
-                js_sys::Reflect::set(&obj, &"status".into(), &"OK".into()).unwrap();
-                js_sys::Reflect::set(&obj, &"output".into(), &"System reinitialized.".into())
-                    .unwrap();
-                js_sys::Reflect::set(&obj, &"stack".into(), &self.collect_stack()).unwrap();
-                js_sys::Reflect::set(
+                set_js_prop(&obj, "status", &("OK".into()));
+                set_js_prop(&obj, "output", &("System reinitialized.".into()));
+                set_js_prop(&obj, "stack", &(self.collect_stack()));
+                set_js_prop(&obj, "userWords", &(self.collect_user_words_for_state()));
+                set_js_prop(
                     &obj,
-                    &"userWords".into(),
-                    &self.collect_user_words_for_state(),
-                )
-                .unwrap();
-                js_sys::Reflect::set(&obj, &"importedModules".into(), &self.collect_imported_modules_array()).unwrap();
+                    "importedModules",
+                    &(self.collect_imported_modules_array()),
+                );
             }
             Err(e) => {
-                js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                js_sys::Reflect::set(&obj, &"message".into(), &e.to_string().into()).unwrap();
-                js_sys::Reflect::set(&obj, &"error".into(), &true.into()).unwrap();
+                set_js_prop(&obj, "status", &("ERROR".into()));
+                set_js_prop(&obj, "message", &(e.to_string().into()));
+                set_js_prop(&obj, "error", &(true.into()));
             }
         }
         obj.into()

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -1,8 +1,10 @@
+use super::wasm_value_conversion::{
+    extract_display_hint_from_js, js_value_to_value, value_to_js_value_with_hint, UserWordData,
+};
+use super::{set_js_prop, AjisaiInterpreter};
 use crate::builtins;
 use crate::interpreter;
 use crate::tokenizer;
-use super::wasm_value_conversion::{extract_display_hint_from_js, js_value_to_value, value_to_js_value_with_hint, UserWordData};
-use super::AjisaiInterpreter;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 
@@ -13,7 +15,10 @@ impl AjisaiInterpreter {
         let js_array = js_sys::Array::new();
         let hints = self.interpreter.collect_stack_hints();
         for (i, value) in self.interpreter.get_stack().iter().enumerate() {
-            let hint = hints.get(i).copied().unwrap_or(crate::types::DisplayHint::Auto);
+            let hint = hints
+                .get(i)
+                .copied()
+                .unwrap_or(crate::types::DisplayHint::Auto);
             js_array.push(&value_to_js_value_with_hint(value, hint));
         }
         js_array.into()
@@ -230,22 +235,20 @@ impl AjisaiInterpreter {
             Ok(json_val) => match deserialize_json_to_value(json_val, 1) {
                 Ok(parsed) => {
                     self.interpreter.stack.push(parsed);
-                    js_sys::Reflect::set(&obj, &"status".into(), &"OK".into()).unwrap();
+                    set_js_prop(&obj, "status", &("OK".into()));
                 }
                 Err(e) => {
-                    js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                    js_sys::Reflect::set(&obj, &"message".into(), &format!("{}", e).into())
-                        .unwrap();
+                    set_js_prop(&obj, "status", &("ERROR".into()));
+                    set_js_prop(&obj, "message", &(format!("{}", e).into()));
                 }
             },
             Err(e) => {
-                js_sys::Reflect::set(&obj, &"status".into(), &"ERROR".into()).unwrap();
-                js_sys::Reflect::set(
+                set_js_prop(&obj, "status", &("ERROR".into()));
+                set_js_prop(
                     &obj,
-                    &"message".into(),
-                    &format!("JSON parse error: {}", e).into(),
-                )
-                .unwrap();
+                    "message",
+                    &(format!("JSON parse error: {}", e).into()),
+                );
             }
         }
         Ok(obj.into())


### PR DESCRIPTION
### Motivation
- Reduce duplication in stack-top vector handling for `TAKE / SPLIT / REVERSE / REORDER` by separating semantic action from stack pop/restore logic. 
- Centralize repeated `js_sys::Reflect::set(...)` calls into a small helper to make WASM response construction consistent. 
- Simplify IndexedDB request handling by promisifying `onsuccess/onerror` flows to improve readability and reduce boilerplate.

### Description
- Introduced shared stack-top helpers `acquire_stacktop_target` and `with_stacktop_vector_target` (and a no-arg variant) and applied them to `TAKE`/`SPLIT` in `rust/src/interpreter/vector_ops/quantity.rs` and to `REVERSE`/`REORDER` in `rust/src/interpreter/vector_ops/structure.rs` to consolidate pop/restore/error paths while preserving existing error messages and restoration order. 
- Added `set_js_prop(obj, key, value)` in `rust/src/wasm-interpreter-bindings.rs` and replaced many direct `js_sys::Reflect::set(...)` uses in `rust/src/wasm-interpreter-execution.rs` and `rust/src/wasm-interpreter-state.rs` to unify WASM object property assignments without changing returned shapes. 
- Added `promisifyRequest` and `withObjectStore` helpers to `js/indexeddb-user-word-store.ts` and migrated `saveTable`, `loadTable`, `collectTableNames`, `deleteTable`, `saveInterpreterState`, and `loadInterpreterState` to use them, converting callback-based `onsuccess/onerror` code to Promise-based flows. 
- Kept all behavioral semantics intact (stack restore, `NoChange`/`IndexOutOfBounds` messages, and WASM API shapes); changes are focused on local small helpers and duplication removal.

### Testing
- Ran `cd rust && cargo test --lib` and all library tests passed (`440 passed`).
- Ran `cd rust && cargo test --test gui-interpreter-test-cases` and GUI interpreter tests passed (`77 passed`).
- Ran `npm run check` (TypeScript `tsc --noEmit`) and the type check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d714586c208326b277a7a45420587b)