### PR TITLE
Refactor module imports to registry/import-table with IMPORT-ONLY support

### DIFF
--- a/js/wasm-interpreter-types.ts
+++ b/js/wasm-interpreter-types.ts
@@ -26,6 +26,7 @@ export interface AjisaiInterpreter {
     collect_imported_modules(): string[];
     collect_module_words_info(module_name: string): Array<[string, string | null]>;
     collect_module_sample_words_info(module_name: string): Array<[string, string | null]>;
+    collect_dictionary_dependencies(): Array<[string, string[], string[]]>;
     restore_imported_modules(modules: string[]): void;
 }
 

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -43,6 +43,7 @@ pub enum BuiltinExecutorKey {
     Del,
     Lookup,
     Import,
+    ImportOnly,
     Force,
     Print,
     Insert,
@@ -710,10 +711,19 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         "IMPORT",
         "module",
         "Load standard library module. String -> (dictionary effect)",
-        "'music' IMPORT → registers MUSIC::* words",
+        "'music' IMPORT → imports all public words from MUSIC",
         "none",
         BuiltinDetailGroup::IoModule,
         Some(BuiltinExecutorKey::Import)
+    ),
+    builtin_spec!(
+        "IMPORT-ONLY",
+        "module",
+        "Import selected public words from a module. String Vector -> (dictionary effect)",
+        "'json' [ 'parse' ] IMPORT-ONLY → imports JSON@PARSE only",
+        "none",
+        BuiltinDetailGroup::IoModule,
+        Some(BuiltinExecutorKey::ImportOnly)
     ),
 ];
 

--- a/rust/src/interpreter/dictionary-resolution-tests.rs
+++ b/rust/src/interpreter/dictionary-resolution-tests.rs
@@ -9,8 +9,13 @@ mod tests {
             let tokens = tokenizer::tokenize(definition)
                 .unwrap_or_else(|e| panic!("Failed to tokenize {}: {}", name, e));
 
-            crate::interpreter::execute_def::op_def_inner(interp, name, &tokens, Some(description.to_string()))
-                .unwrap_or_else(|e| panic!("Failed to define {}: {}", name, e));
+            crate::interpreter::execute_def::op_def_inner(
+                interp,
+                name,
+                &tokens,
+                Some(description.to_string()),
+            )
+            .unwrap_or_else(|e| panic!("Failed to define {}: {}", name, e));
         }
 
         interp
@@ -27,7 +32,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("SAY-HELLO-WORLD").await;
-        assert!(result.is_ok(), "Short name should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Short name should resolve: {:?}",
+            result.err()
+        );
         assert_eq!(interp.stack.len(), 1);
     }
 
@@ -40,7 +49,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("DEMO@SAY-HELLO-WORLD").await;
-        assert!(result.is_ok(), "DEMO@SAY-HELLO-WORLD should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "DEMO@SAY-HELLO-WORLD should resolve: {:?}",
+            result.err()
+        );
         assert_eq!(interp.stack.len(), 1);
     }
 
@@ -53,7 +66,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("USER@DEMO@SAY-HELLO-WORLD").await;
-        assert!(result.is_ok(), "USER@DEMO@SAY-HELLO-WORLD should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "USER@DEMO@SAY-HELLO-WORLD should resolve: {:?}",
+            result.err()
+        );
         assert_eq!(interp.stack.len(), 1);
     }
 
@@ -66,7 +83,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("DICT@USER@DEMO@SAY-HELLO-WORLD").await;
-        assert!(result.is_ok(), "DICT@USER@DEMO@SAY-HELLO-WORLD should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "DICT@USER@DEMO@SAY-HELLO-WORLD should resolve: {:?}",
+            result.err()
+        );
         assert_eq!(interp.stack.len(), 1);
     }
 
@@ -78,7 +99,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("MUSIC@C4").await;
-        assert!(result.is_ok(), "MUSIC@C4 should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "MUSIC@C4 should resolve: {:?}",
+            result.err()
+        );
         if let Some(val) = interp.stack.last() {
             assert_eq!(val.as_scalar().unwrap().to_i64().unwrap(), 264);
         }
@@ -92,7 +117,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("DICT@MUSIC@C4").await;
-        assert!(result.is_ok(), "DICT@MUSIC@C4 should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "DICT@MUSIC@C4 should resolve: {:?}",
+            result.err()
+        );
         if let Some(val) = interp.stack.last() {
             assert_eq!(val.as_scalar().unwrap().to_i64().unwrap(), 264);
         }
@@ -105,7 +134,11 @@ mod tests {
         interp.execute("[ 10 20 30 ]").await.unwrap();
 
         let result = interp.execute("[ 1 ] CORE@GET").await;
-        assert!(result.is_ok(), "CORE@GET should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "CORE@GET should resolve: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]
@@ -115,7 +148,11 @@ mod tests {
         interp.execute("[ 10 20 30 ]").await.unwrap();
 
         let result = interp.execute("[ 1 ] DICT@CORE@GET").await;
-        assert!(result.is_ok(), "DICT@CORE@GET should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "DICT@CORE@GET should resolve: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]
@@ -126,7 +163,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("music@c4").await;
-        assert!(result.is_ok(), "music@c4 should resolve (case insensitive): {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "music@c4 should resolve (case insensitive): {:?}",
+            result.err()
+        );
         if let Some(val) = interp.stack.last() {
             assert_eq!(val.as_scalar().unwrap().to_i64().unwrap(), 264);
         }
@@ -141,7 +182,11 @@ mod tests {
         let _ = interp.collect_output();
 
         let result = interp.execute("demo@say-hello-world").await;
-        assert!(result.is_ok(), "demo@say-hello-world should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "demo@say-hello-world should resolve: {:?}",
+            result.err()
+        );
         assert_eq!(interp.stack.len(), 1);
     }
 
@@ -159,9 +204,21 @@ mod tests {
         let result = interp.execute("C4").await;
         assert!(result.is_err(), "C4 should be ambiguous");
         let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("Ambiguous"), "Expected ambiguity error, got: {}", err_msg);
-        assert!(err_msg.contains("MUSIC@C4"), "Should mention MUSIC@C4: {}", err_msg);
-        assert!(err_msg.contains("DEMO@C4"), "Should mention DEMO@C4: {}", err_msg);
+        assert!(
+            err_msg.contains("Ambiguous"),
+            "Expected ambiguity error, got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("MUSIC@C4"),
+            "Should mention MUSIC@C4: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("DEMO@C4"),
+            "Should mention DEMO@C4: {}",
+            err_msg
+        );
     }
 
     #[tokio::test]
@@ -176,7 +233,11 @@ mod tests {
 
         // MUSIC@C4 should resolve to 264
         let result = interp.execute("MUSIC@C4").await;
-        assert!(result.is_ok(), "MUSIC@C4 should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "MUSIC@C4 should resolve: {:?}",
+            result.err()
+        );
         if let Some(val) = interp.stack.last() {
             assert_eq!(val.as_scalar().unwrap().to_i64().unwrap(), 264);
         }
@@ -205,7 +266,11 @@ mod tests {
         // GET is a built-in. Even if we somehow had a user GET (blocked by protection),
         // the built-in always wins without ambiguity
         let result = interp.execute("[ 10 20 30 ] [ 0 ] GET").await;
-        assert!(result.is_ok(), "Built-in GET should always work: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Built-in GET should always work: {:?}",
+            result.err()
+        );
     }
 
     #[tokio::test]
@@ -217,7 +282,39 @@ mod tests {
 
         // MUSIC@SEQ is a module built-in (not a sample word)
         let result = interp.execute("[ 440 ] MUSIC@SEQ MUSIC@PLAY").await;
-        assert!(result.is_ok(), "MUSIC@SEQ MUSIC@PLAY should work: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "MUSIC@SEQ MUSIC@PLAY should work: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fully_qualified_requires_import() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("JSON@PARSE").await;
+        assert!(
+            result.is_err(),
+            "Unimported module words should not resolve"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_only_selective_visibility() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'json' [ 'parse' ] IMPORT-ONLY")
+            .await
+            .unwrap();
+
+        let parse_result = interp.execute("'[1,2]' JSON@PARSE").await;
+        assert!(parse_result.is_ok(), "Selected word should resolve");
+
+        let stringify_result = interp.execute("JSON@STRINGIFY").await;
+        assert!(
+            stringify_result.is_err(),
+            "Unselected word should remain unresolved"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -126,6 +126,7 @@ impl Interpreter {
             BuiltinExecutorKey::Del => execute_del::op_del(self),
             BuiltinExecutorKey::Lookup => execute_lookup::op_lookup(self),
             BuiltinExecutorKey::Import => modules::op_import(self),
+            BuiltinExecutorKey::ImportOnly => modules::op_import_only(self),
             BuiltinExecutorKey::Force => {
                 self.force_flag = true;
                 Ok(())

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -159,13 +159,15 @@ pub(crate) fn op_def_inner(
         });
     }
 
-    if let Some(warning) = crate::interpreter::naming_convention_checker::check_word_name_convention(name) {
+    if let Some(warning) =
+        crate::interpreter::naming_convention_checker::check_word_name_convention(name)
+    {
         interp.output_buffer.push_str(&format!("{}\n", warning));
     }
 
     // Module sample collision check — warn but allow DEF
     let mut collision_modules = Vec::new();
-    for (module_name, module_dict) in &interp.module_samples {
+    for (module_name, module_dict) in &interp.module_vocabulary {
         if module_dict.sample_words.contains_key(&upper_name) {
             collision_modules.push(module_name.clone());
         }
@@ -244,22 +246,35 @@ pub(crate) fn op_def_inner(
         .get(&dict_name)
         .map(|dict| dict.order)
         .unwrap_or_else(|| new_def.registration_order);
-    interp.user_dictionaries.entry(dict_name.clone()).or_insert_with(|| crate::interpreter::UserDictionary {
-        order: dict_order,
-        words: std::collections::HashMap::new(),
-    }).words.insert(upper_name.clone(), Arc::new(new_def));
+    interp
+        .user_dictionaries
+        .entry(dict_name.clone())
+        .or_insert_with(|| crate::interpreter::UserDictionary {
+            order: dict_order,
+            words: std::collections::HashMap::new(),
+        })
+        .words
+        .insert(upper_name.clone(), Arc::new(new_def));
     interp.sync_user_words_cache();
     interp
         .output_buffer
         .push_str(&format!("Defined word: {}@{}\n", dict_name, name));
     // Warn about collisions with module sample words
     if !collision_modules.is_empty() {
-        let module_paths: Vec<String> = collision_modules.iter().map(|m| format!("{}@{}", m, upper_name)).collect();
+        let module_paths: Vec<String> = collision_modules
+            .iter()
+            .map(|m| format!("{}@{}", m, upper_name))
+            .collect();
         let user_path = format!("{}@{}", dict_name, upper_name);
-        let all_paths: Vec<String> = module_paths.iter().chain(std::iter::once(&user_path)).cloned().collect();
+        let all_paths: Vec<String> = module_paths
+            .iter()
+            .chain(std::iter::once(&user_path))
+            .cloned()
+            .collect();
         interp.output_buffer.push_str(&format!(
             "Warning: '{}' now exists in both {}. Use a qualified path when calling this word.\n",
-            upper_name, all_paths.join(" and ")
+            upper_name,
+            all_paths.join(" and ")
         ));
     }
     interp.force_flag = false;

--- a/rust/src/interpreter/execute-del.rs
+++ b/rust/src/interpreter/execute-del.rs
@@ -44,9 +44,9 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             return Ok(());
         }
 
-        if interp.module_samples.contains_key(&word_name) {
-            interp.module_samples.remove(&word_name);
-            interp.imported_modules.remove(&word_name);
+        if interp.module_vocabulary.contains_key(&word_name) {
+            interp.module_vocabulary.remove(&word_name);
+            interp.import_table.modules.remove(&word_name);
             interp.sync_user_words_cache();
             interp.rebuild_dependencies()?;
             interp
@@ -83,7 +83,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
     // 削除実行
     let removed_def = if is_module {
         interp
-            .module_samples
+            .module_vocabulary
             .get_mut(&owner_name)
             .and_then(|dict| dict.sample_words.remove(&word_name))
     } else {
@@ -137,7 +137,7 @@ fn find_word_owner(
                 return Ok((dict_name.to_string(), false));
             }
         }
-        if let Some(module) = interp.module_samples.get(dict_name) {
+        if let Some(module) = interp.module_vocabulary.get(dict_name) {
             if module.sample_words.contains_key(word_name) {
                 return Ok((dict_name.to_string(), true));
             }
@@ -153,7 +153,7 @@ fn find_word_owner(
                 return Ok((dict_name.clone(), false));
             }
         }
-        for (module_name, module) in &interp.module_samples {
+        for (module_name, module) in &interp.module_vocabulary {
             if module.sample_words.contains_key(word_name) {
                 return Ok((module_name.clone(), true));
             }

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -27,7 +27,28 @@ pub(crate) struct UserDictionary {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleDictionary {
+    pub words: HashMap<String, Arc<WordDefinition>>,
     pub sample_words: HashMap<String, Arc<WordDefinition>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ImportedModule {
+    pub module_name: String,
+    pub import_all_public: bool,
+    pub imported_words: HashSet<String>,
+    pub imported_samples: HashSet<String>,
+    pub imported_at: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ImportTable {
+    pub modules: HashMap<String, ImportedModule>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DictionaryDependencyInfo {
+    pub depends_on: HashSet<String>,
+    pub depended_by: HashSet<String>,
 }
 
 pub struct Interpreter {
@@ -46,7 +67,7 @@ pub struct Interpreter {
     pub(crate) pending_tokens: Option<Vec<Token>>,
     pub(crate) pending_token_index: usize,
     pub(crate) module_state: HashMap<String, Box<dyn std::any::Any>>,
-    pub(crate) imported_modules: HashSet<String>,
+    pub(crate) import_table: ImportTable,
     pub(crate) call_stack: SmallVec<[String; 5]>,
     pub(crate) execution_step_count: usize,
     pub(crate) max_execution_steps: usize,
@@ -61,7 +82,8 @@ pub struct Interpreter {
     pub(crate) active_flows: Vec<FlowToken>,
     pub(crate) flow_consumed_log: Vec<(u64, Fraction)>,
     // ── Module-scoped sample words ───────────────────────────────────
-    pub(crate) module_samples: HashMap<String, ModuleDictionary>,
+    pub(crate) module_vocabulary: HashMap<String, ModuleDictionary>,
+    pub(crate) dictionary_dependencies: HashMap<String, DictionaryDependencyInfo>,
     pub(crate) next_registration_order: u64,
     pub(crate) active_user_dictionary: String,
     // ── Semantic plane ──────────────────────────────────────────────
@@ -86,7 +108,7 @@ impl Interpreter {
             pending_tokens: None,
             pending_token_index: 0,
             module_state: HashMap::new(),
-            imported_modules: HashSet::new(),
+            import_table: ImportTable::default(),
             call_stack: SmallVec::new(),
             execution_step_count: 0,
             max_execution_steps: DEFAULT_MAX_EXECUTION_STEPS,
@@ -96,7 +118,8 @@ impl Interpreter {
             flow_tracking: false,
             active_flows: Vec::new(),
             flow_consumed_log: Vec::new(),
-            module_samples: HashMap::new(),
+            module_vocabulary: HashMap::new(),
+            dictionary_dependencies: HashMap::new(),
             next_registration_order: 1,
             active_user_dictionary: "DEMO".to_string(),
             semantic_registry: SemanticRegistry::new(),
@@ -217,8 +240,9 @@ impl Interpreter {
         self.pending_token_index = 0;
         self.module_state.clear();
         self.call_stack.clear();
-        self.imported_modules.clear();
-        self.module_samples.clear();
+        self.import_table.modules.clear();
+        self.module_vocabulary.clear();
+        self.dictionary_dependencies.clear();
         self.next_registration_order = 1;
         self.active_user_dictionary = "DEMO".to_string();
         self.semantic_registry.clear();
@@ -236,13 +260,15 @@ impl Interpreter {
 
     pub fn update_stack(&mut self, stack: Stack) {
         self.stack = stack;
-        self.semantic_registry.normalize_to_stack_len(self.stack.len());
+        self.semantic_registry
+            .normalize_to_stack_len(self.stack.len());
     }
 
     pub fn update_stack_with_hints(&mut self, stack: Stack, hints: Vec<DisplayHint>) {
         self.stack = stack;
         self.semantic_registry.stack_hints = hints;
-        self.semantic_registry.normalize_to_stack_len(self.stack.len());
+        self.semantic_registry
+            .normalize_to_stack_len(self.stack.len());
     }
 
     pub fn collect_stack_hints(&self) -> &[DisplayHint] {

--- a/rust/src/interpreter/modules.rs
+++ b/rust/src/interpreter/modules.rs
@@ -1,25 +1,30 @@
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::{is_string_value, value_as_string};
-use crate::interpreter::{audio, json, ConsumptionMode, Interpreter, ModuleDictionary};
-use crate::types::{Value, WordDefinition};
+use crate::interpreter::{
+    audio, json, ConsumptionMode, ImportedModule, Interpreter, ModuleDictionary,
+};
+use crate::types::{Value, ValueData, WordDefinition};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 type ModuleExecutor = fn(&mut Interpreter) -> Result<()>;
 
+#[derive(Clone)]
 struct ModuleWord {
-    name: &'static str,
+    short_name: &'static str,
     description: &'static str,
     executor: ModuleExecutor,
     preserves_modes: bool,
 }
 
+#[derive(Clone)]
 struct SampleWord {
     name: &'static str,
     definition: &'static str,
     description: &'static str,
 }
 
+#[derive(Clone)]
 struct ModuleSpec {
     name: &'static str,
     words: &'static [ModuleWord],
@@ -28,91 +33,91 @@ struct ModuleSpec {
 
 const MUSIC_WORDS: &[ModuleWord] = &[
     ModuleWord {
-        name: "MUSIC@SEQ",
+        short_name: "SEQ",
         description: "Set sequential playback mode",
         executor: audio::op_seq,
         preserves_modes: true,
     },
     ModuleWord {
-        name: "MUSIC@SIM",
+        short_name: "SIM",
         description: "Set simultaneous playback mode",
         executor: audio::op_sim,
         preserves_modes: true,
     },
     ModuleWord {
-        name: "MUSIC@SLOT",
+        short_name: "SLOT",
         description: "Set slot duration in seconds",
         executor: audio::op_slot,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@GAIN",
+        short_name: "GAIN",
         description: "Set volume level (0.0-1.0)",
         executor: audio::op_gain,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@GAIN-RESET",
+        short_name: "GAIN-RESET",
         description: "Reset volume to default (1.0)",
         executor: audio::op_gain_reset,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@PAN",
+        short_name: "PAN",
         description: "Set stereo position (-1.0 left to 1.0 right)",
         executor: audio::op_pan,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@PAN-RESET",
+        short_name: "PAN-RESET",
         description: "Reset pan to center (0.0)",
         executor: audio::op_pan_reset,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@FX-RESET",
+        short_name: "FX-RESET",
         description: "Reset all audio effects to defaults",
         executor: audio::op_fx_reset,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@PLAY",
+        short_name: "PLAY",
         description: "Play audio",
         executor: audio::op_play,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@CHORD",
+        short_name: "CHORD",
         description: "Mark vector as chord (simultaneous)",
         executor: audio::op_chord,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@ADSR",
+        short_name: "ADSR",
         description: "Set ADSR envelope",
         executor: audio::op_adsr,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@SINE",
+        short_name: "SINE",
         description: "Set sine waveform",
         executor: audio::op_sine,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@SQUARE",
+        short_name: "SQUARE",
         description: "Set square waveform",
         executor: audio::op_square,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@SAW",
+        short_name: "SAW",
         description: "Set sawtooth waveform",
         executor: audio::op_saw,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "MUSIC@TRI",
+        short_name: "TRI",
         description: "Set triangle waveform",
         executor: audio::op_tri,
         preserves_modes: false,
@@ -121,37 +126,37 @@ const MUSIC_WORDS: &[ModuleWord] = &[
 
 const JSON_WORDS: &[ModuleWord] = &[
     ModuleWord {
-        name: "JSON@PARSE",
+        short_name: "PARSE",
         description: "Parse JSON string to Ajisai value",
         executor: json::op_parse,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "JSON@STRINGIFY",
+        short_name: "STRINGIFY",
         description: "Convert Ajisai value to JSON string",
         executor: json::op_stringify,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "JSON@GET",
+        short_name: "GET",
         description: "Get value by key from JSON object",
         executor: json::op_json_get,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "JSON@KEYS",
+        short_name: "KEYS",
         description: "Get all keys from JSON object",
         executor: json::op_json_keys,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "JSON@SET",
+        short_name: "SET",
         description: "Set key-value in JSON object",
         executor: json::op_json_set,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "JSON@EXPORT",
+        short_name: "EXPORT",
         description: "Export stack top as JSON file download",
         executor: json::op_json_export,
         preserves_modes: false,
@@ -160,13 +165,13 @@ const JSON_WORDS: &[ModuleWord] = &[
 
 const IO_WORDS: &[ModuleWord] = &[
     ModuleWord {
-        name: "IO@INPUT",
+        short_name: "INPUT",
         description: "Read text from input buffer",
         executor: json::op_input,
         preserves_modes: false,
     },
     ModuleWord {
-        name: "IO@OUTPUT",
+        short_name: "OUTPUT",
         description: "Write value to output buffer",
         executor: json::op_output,
         preserves_modes: false,
@@ -174,14 +179,46 @@ const IO_WORDS: &[ModuleWord] = &[
 ];
 
 const MUSIC_SAMPLES: &[SampleWord] = &[
-    SampleWord { name: "C4", definition: "264", description: "純正律 C4 / ド (264Hz)" },
-    SampleWord { name: "D4", definition: "C4 9 * 8 /", description: "純正律 D4 / レ (297Hz)" },
-    SampleWord { name: "E4", definition: "C4 5 * 4 /", description: "純正律 E4 / ミ (330Hz)" },
-    SampleWord { name: "F4", definition: "C4 4 * 3 /", description: "純正律 F4 / ファ (352Hz)" },
-    SampleWord { name: "G4", definition: "C4 3 * 2 /", description: "純正律 G4 / ソ (396Hz)" },
-    SampleWord { name: "A4", definition: "C4 5 * 3 /", description: "純正律 A4 / ラ (440Hz)" },
-    SampleWord { name: "B4", definition: "C4 15 * 8 /", description: "純正律 B4 / シ (495Hz)" },
-    SampleWord { name: "C5", definition: "C4 2 *", description: "純正律 C5 / 高いド (528Hz)" },
+    SampleWord {
+        name: "C4",
+        definition: "264",
+        description: "純正律 C4 / ド (264Hz)",
+    },
+    SampleWord {
+        name: "D4",
+        definition: "C4 9 * 8 /",
+        description: "純正律 D4 / レ (297Hz)",
+    },
+    SampleWord {
+        name: "E4",
+        definition: "C4 5 * 4 /",
+        description: "純正律 E4 / ミ (330Hz)",
+    },
+    SampleWord {
+        name: "F4",
+        definition: "C4 4 * 3 /",
+        description: "純正律 F4 / ファ (352Hz)",
+    },
+    SampleWord {
+        name: "G4",
+        definition: "C4 3 * 2 /",
+        description: "純正律 G4 / ソ (396Hz)",
+    },
+    SampleWord {
+        name: "A4",
+        definition: "C4 5 * 3 /",
+        description: "純正律 A4 / ラ (440Hz)",
+    },
+    SampleWord {
+        name: "B4",
+        definition: "C4 15 * 8 /",
+        description: "純正律 B4 / シ (495Hz)",
+    },
+    SampleWord {
+        name: "C5",
+        definition: "C4 2 *",
+        description: "純正律 C5 / 高いド (528Hz)",
+    },
 ];
 
 const MODULE_SPECS: &[ModuleSpec] = &[
@@ -202,21 +239,134 @@ const MODULE_SPECS: &[ModuleSpec] = &[
     },
 ];
 
-fn register_module_words_in_dictionary(interp: &mut Interpreter, words: &[ModuleWord]) {
-    for word in words {
-        interp.core_vocabulary.insert(
-            word.name.to_string(),
+fn ensure_module_dictionary(interp: &mut Interpreter, module_name: &str) -> Result<()> {
+    if interp.module_vocabulary.contains_key(module_name) {
+        return Ok(());
+    }
+    let module = MODULE_SPECS
+        .iter()
+        .find(|module| module.name == module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.to_string()))?;
+
+    let mut words = HashMap::new();
+    for word in module.words {
+        let qualified = format!("{}@{}", module.name, word.short_name);
+        words.insert(
+            qualified.clone(),
             Arc::new(WordDefinition {
                 lines: Arc::from([]),
                 is_builtin: true,
                 description: Some(word.description.to_string()),
                 dependencies: HashSet::new(),
                 original_source: None,
-                namespace: word.name.split_once('@').map(|(ns, _)| ns.to_string()),
+                namespace: Some(module.name.to_string()),
                 registration_order: 0,
             }),
         );
     }
+
+    let sample_words = build_sample_words(module.name, module.sample_words)?;
+    interp.module_vocabulary.insert(
+        module_name.to_string(),
+        ModuleDictionary {
+            words,
+            sample_words,
+        },
+    );
+    Ok(())
+}
+
+fn build_sample_words(
+    module_name: &str,
+    sample_words: &[SampleWord],
+) -> Result<HashMap<String, Arc<WordDefinition>>> {
+    let mut result = HashMap::new();
+    for sample in sample_words {
+        let tokens = crate::tokenizer::tokenize(sample.definition).map_err(|e| {
+            AjisaiError::from(format!(
+                "Failed to tokenize sample word '{}': {}",
+                sample.name, e
+            ))
+        })?;
+        let lines = parse_sample_definition_body(&tokens)?;
+        result.insert(
+            sample.name.to_uppercase(),
+            Arc::new(WordDefinition {
+                lines: lines.into(),
+                is_builtin: false,
+                description: Some(sample.description.to_string()),
+                dependencies: HashSet::new(),
+                original_source: None,
+                namespace: Some(module_name.to_string()),
+                registration_order: 0,
+            }),
+        );
+    }
+    Ok(result)
+}
+
+fn parse_only_items(value: &Value) -> Result<Vec<String>> {
+    if is_string_value(value) {
+        let s = value_as_string(value)
+            .ok_or_else(|| AjisaiError::from("IMPORT-ONLY expects string selectors"))?;
+        return Ok(vec![s]);
+    }
+
+    let Some(items) = value.as_vector() else {
+        return Err(AjisaiError::from(
+            "IMPORT-ONLY expects a vector of word names",
+        ));
+    };
+
+    let mut result = Vec::new();
+    for item in items {
+        if !is_string_value(item) {
+            return Err(AjisaiError::from("IMPORT-ONLY selectors must be strings"));
+        }
+        let Some(name) = value_as_string(item) else {
+            continue;
+        };
+        result.push(name);
+    }
+    Ok(result)
+}
+
+fn import_all_public(interp: &mut Interpreter, module_name: &str) -> Result<()> {
+    ensure_module_dictionary(interp, module_name)?;
+    let module_dict = interp
+        .module_vocabulary
+        .get(module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.to_string()))?;
+
+    let mut imported_words = HashSet::new();
+    let mut imported_samples = HashSet::new();
+
+    for qualified in module_dict.words.keys() {
+        if let Some((_, short)) = qualified.split_once('@') {
+            imported_words.insert(short.to_string());
+        }
+    }
+    for short in module_dict.sample_words.keys() {
+        imported_samples.insert(short.clone());
+    }
+
+    let imported_at = interp.next_registration_order();
+    let entry = interp
+        .import_table
+        .modules
+        .entry(module_name.to_string())
+        .or_insert_with(|| ImportedModule {
+            module_name: module_name.to_string(),
+            import_all_public: false,
+            imported_words: HashSet::new(),
+            imported_samples: HashSet::new(),
+            imported_at,
+        });
+
+    entry.import_all_public = true;
+    entry.imported_words = imported_words;
+    entry.imported_samples = imported_samples;
+    Ok(())
 }
 
 pub fn op_import(interp: &mut Interpreter) -> Result<()> {
@@ -235,77 +385,120 @@ pub fn op_import(interp: &mut Interpreter) -> Result<()> {
         .ok_or_else(|| AjisaiError::UnknownModule(value.to_string()))?
         .to_uppercase();
 
-    if interp.imported_modules.contains(&module_name) {
-        return Ok(());
-    }
-
-    let module = MODULE_SPECS
-        .iter()
-        .find(|module| module.name == module_name)
-        .ok_or_else(|| AjisaiError::UnknownModule(module_name.clone()))?;
-
-    register_module_words_in_dictionary(interp, module.words);
-    register_module_sample_words(interp, &module_name, module.sample_words)?;
-    interp.imported_modules.insert(module_name);
+    import_all_public(interp, &module_name)?;
+    interp.rebuild_dependencies()?;
     Ok(())
 }
 
-fn register_module_sample_words(
-    interp: &mut Interpreter,
-    module_name: &str,
-    sample_words: &[SampleWord],
-) -> Result<()> {
-    if sample_words.is_empty() {
-        interp.module_samples.insert(
-            module_name.to_string(),
-            ModuleDictionary {
-                sample_words: HashMap::new(),
-            },
-        );
-        return Ok(());
+pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
     }
-    let mut module_dict = ModuleDictionary {
-        sample_words: HashMap::new(),
+
+    let selectors = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let module_value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+
+    let module_name = extract_module_name_from_value(&module_value)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_value.to_string()))?
+        .to_uppercase();
+
+    ensure_module_dictionary(interp, &module_name)?;
+    let selected = parse_only_items(&selectors)?;
+
+    let module_dict = interp
+        .module_vocabulary
+        .get(&module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.clone()))?;
+    let mut validated: Vec<(String, bool)> = Vec::new();
+    for item in selected {
+        let short = item.to_uppercase();
+        let qualified = format!("{}@{}", module_name, short);
+        if module_dict.words.contains_key(&qualified) {
+            validated.push((short, true));
+        } else if module_dict.sample_words.contains_key(&short) {
+            validated.push((short, false));
+        } else {
+            return Err(AjisaiError::from(format!(
+                "Unknown module word '{}' in {}",
+                short, module_name
+            )));
+        }
+    }
+
+    let imported_at = interp.next_registration_order();
+    let entry = interp
+        .import_table
+        .modules
+        .entry(module_name.clone())
+        .or_insert_with(|| ImportedModule {
+            module_name: module_name.clone(),
+            import_all_public: false,
+            imported_words: HashSet::new(),
+            imported_samples: HashSet::new(),
+            imported_at,
+        });
+
+    for (short, is_word) in validated {
+        if is_word {
+            entry.imported_words.insert(short.clone());
+        } else {
+            entry.imported_samples.insert(short.clone());
+        }
+    }
+
+    interp.rebuild_dependencies()?;
+    Ok(())
+}
+
+/// Re-import a module by name without requiring a stack value.
+/// Used for restoring module state from JS side.
+pub fn restore_module(interp: &mut Interpreter, module_name: &str) -> bool {
+    let upper = module_name.to_uppercase();
+    import_all_public(interp, &upper).is_ok()
+}
+
+pub fn execute_module_word(interp: &mut Interpreter, name: &str) -> Option<Result<()>> {
+    let upper = name.to_uppercase();
+    let (module_name, word_name) = upper.split_once('@')?;
+    let module = MODULE_SPECS.iter().find(|m| m.name == module_name)?;
+    let word = module.words.iter().find(|w| w.short_name == word_name)?;
+    Some((word.executor)(interp))
+}
+
+pub fn is_mode_preserving_word(name: &str) -> bool {
+    let upper = name.to_uppercase();
+    let Some((module_name, word_name)) = upper.split_once('@') else {
+        return false;
     };
 
-    for sample in sample_words {
-        let tokens = crate::tokenizer::tokenize(sample.definition)
-            .map_err(|e| AjisaiError::from(format!(
-                "Failed to tokenize sample word '{}': {}", sample.name, e
-            )))?;
-        let lines = parse_sample_definition_body(&tokens)?;
-        let def = WordDefinition {
-            lines: lines.into(),
-            is_builtin: false,
-            description: Some(sample.description.to_string()),
-            dependencies: HashSet::new(),
-            original_source: None,
-            namespace: Some(module_name.to_string()),
-            registration_order: 0,
-        };
-        let short_name = sample.name.to_uppercase();
-        if interp.core_vocabulary.contains_key(&short_name) {
-            interp.output_buffer.push_str(&format!(
-                "Warning: '{}' in module {} conflicts with a built-in word.\nUse {}@{} to call it explicitly.\n",
-                short_name, module_name, module_name, short_name
-            ));
-        } else if let Some((winner, _)) = interp.resolve_word_entry(&short_name) {
-            interp.output_buffer.push_str(&format!(
-                "Warning: '{}' now exists in both {}@{} and {}. Use a qualified path when calling this word.\n",
-                short_name, module_name, short_name, winner
-            ));
-        }
-        module_dict.sample_words.insert(short_name, Arc::new(def));
+    MODULE_SPECS
+        .iter()
+        .find(|m| m.name == module_name)
+        .and_then(|m| m.words.iter().find(|w| w.short_name == word_name))
+        .map(|w| w.preserves_modes)
+        .unwrap_or(false)
+}
+
+fn extract_module_name_from_value(value: &Value) -> Option<String> {
+    if is_string_value(value) {
+        return value_as_string(value);
     }
 
-    interp
-        .module_samples
-        .insert(module_name.to_string(), module_dict);
-
-    // Rebuild dependencies for module sample words
-    rebuild_module_sample_dependencies(interp, module_name);
-
-    Ok(())
+    match &value.data {
+        ValueData::Vector(children)
+        | ValueData::Record {
+            pairs: children, ..
+        } => {
+            if children.len() != 1 {
+                return None;
+            }
+            if !is_string_value(&children[0]) {
+                return None;
+            }
+            value_as_string(&children[0])
+        }
+        _ => None,
+    }
 }
 
 fn parse_sample_definition_body(
@@ -341,101 +534,4 @@ fn parse_sample_definition_body(
     }
 
     Ok(lines)
-}
-
-fn rebuild_module_sample_dependencies(interp: &mut Interpreter, module_name: &str) {
-    if let Some(module_dict) = interp.module_samples.get(module_name) {
-        let word_names: Vec<String> = module_dict.sample_words.keys().cloned().collect();
-        let word_name_set: HashSet<String> = word_names.iter().cloned().collect();
-
-        let mut updates: Vec<(String, HashSet<String>)> = Vec::new();
-
-        for (word_name, def) in &module_dict.sample_words {
-            let mut dependencies = HashSet::new();
-            for line in def.lines.iter() {
-                for token in line.body_tokens.iter() {
-                    if let crate::types::Token::Symbol(s) = token {
-                        let upper_s = s.to_uppercase();
-                        if word_name_set.contains(&upper_s) {
-                            dependencies.insert(format!("{}@{}", module_name, upper_s));
-                        }
-                    }
-                }
-            }
-            updates.push((word_name.clone(), dependencies));
-        }
-
-        // Apply dependency updates
-        if let Some(module_dict) = interp.module_samples.get_mut(module_name) {
-            for (word_name, dependencies) in &updates {
-                if let Some(def) = module_dict.sample_words.get_mut(word_name) {
-                    Arc::make_mut(def).dependencies = dependencies.clone();
-                }
-            }
-        }
-
-        // Update dependents map
-        for (word_name, dependencies) in updates {
-            for dep in dependencies {
-                interp.dependents
-                    .entry(dep)
-                    .or_default()
-                    .insert(format!("{}@{}", module_name, word_name));
-            }
-        }
-    }
-}
-
-/// Re-import a module by name without requiring a stack value.
-/// Used for restoring module state from JS side.
-pub fn restore_module(interp: &mut Interpreter, module_name: &str) -> bool {
-    let upper = module_name.to_uppercase();
-    if interp.imported_modules.contains(&upper) {
-        return true;
-    }
-    if let Some(module) = MODULE_SPECS.iter().find(|m| m.name == upper) {
-        register_module_words_in_dictionary(interp, module.words);
-        if register_module_sample_words(interp, &upper, module.sample_words).is_err() {
-            return false;
-        }
-        interp.imported_modules.insert(upper);
-        true
-    } else {
-        false
-    }
-}
-
-pub fn execute_module_word(interp: &mut Interpreter, name: &str) -> Option<Result<()>> {
-    for module in MODULE_SPECS {
-        for word in module.words {
-            if word.name == name {
-                return Some((word.executor)(interp));
-            }
-        }
-    }
-    None
-}
-
-/// Check if a module word should preserve operation modes (target/consumption).
-/// Uses metadata from ModuleWord rather than hardcoding word names.
-pub fn is_mode_preserving_word(name: &str) -> bool {
-    MODULE_SPECS
-        .iter()
-        .flat_map(|m| m.words.iter())
-        .any(|w| w.name == name && w.preserves_modes)
-}
-
-fn extract_module_name_from_value(value: &Value) -> Option<String> {
-    if is_string_value(value) {
-        return value_as_string(value);
-    }
-
-    let children = value.as_vector()?;
-    if children.len() != 1 {
-        return None;
-    }
-    if !is_string_value(&children[0]) {
-        return None;
-    }
-    value_as_string(&children[0])
 }

--- a/rust/src/interpreter/modules.rs
+++ b/rust/src/interpreter/modules.rs
@@ -366,6 +366,7 @@ fn import_all_public(interp: &mut Interpreter, module_name: &str) -> Result<()> 
     entry.import_all_public = true;
     entry.imported_words = imported_words;
     entry.imported_samples = imported_samples;
+    emit_import_conflict_warnings(interp, module_name);
     Ok(())
 }
 
@@ -446,6 +447,7 @@ pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
         }
     }
 
+    emit_import_conflict_warnings(interp, &module_name);
     interp.rebuild_dependencies()?;
     Ok(())
 }
@@ -534,4 +536,30 @@ fn parse_sample_definition_body(
     }
 
     Ok(lines)
+}
+
+fn emit_import_conflict_warnings(interp: &mut Interpreter, module_name: &str) {
+    let Some(module_dict) = interp.module_vocabulary.get(module_name) else {
+        return;
+    };
+
+    for short_name in module_dict.sample_words.keys() {
+        let mut collisions: Vec<String> = Vec::new();
+        for (dict_name, dict) in &interp.user_dictionaries {
+            if dict.words.contains_key(short_name) {
+                collisions.push(format!("{}@{}", dict_name, short_name));
+            }
+        }
+        if collisions.is_empty() {
+            continue;
+        }
+
+        let mut all_paths = vec![format!("{}@{}", module_name, short_name)];
+        all_paths.extend(collisions);
+        interp.output_buffer.push_str(&format!(
+            "Warning: '{}' now exists in both {}. Use a qualified path when calling this word.\n",
+            short_name,
+            all_paths.join(" and ")
+        ));
+    }
 }

--- a/rust/src/interpreter/resolve-word.rs
+++ b/rust/src/interpreter/resolve-word.rs
@@ -1,11 +1,10 @@
 use crate::types::WordDefinition;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use super::Interpreter;
+use super::{DictionaryDependencyInfo, Interpreter};
 
 impl Interpreter {
-    /// `@` 区切りのパスを解析して (layers, word) を返す。
     pub(crate) fn split_path(name: &str) -> (Vec<String>, String) {
         let parts: Vec<String> = name.split('@').map(|s| s.to_uppercase()).collect();
         if parts.len() == 1 {
@@ -57,51 +56,74 @@ impl Interpreter {
             .unwrap_or_default();
     }
 
+    fn is_module_word_imported(&self, module_name: &str, short_name: &str) -> bool {
+        self.import_table
+            .modules
+            .get(module_name)
+            .map(|m| m.import_all_public || m.imported_words.contains(short_name))
+            .unwrap_or(false)
+    }
+
+    fn is_module_sample_imported(&self, module_name: &str, short_name: &str) -> bool {
+        self.import_table
+            .modules
+            .get(module_name)
+            .map(|m| m.import_all_public || m.imported_samples.contains(short_name))
+            .unwrap_or(false)
+    }
+
     pub(crate) fn resolve_short_name(&self, name: &str) -> Option<(String, Arc<WordDefinition>)> {
         let upper = name.to_uppercase();
 
-        // 1. Built-in words (always highest priority, no ambiguity check)
         if let Some(def) = self.core_vocabulary.get(&upper) {
             return Some((upper, def.clone()));
         }
 
-        // 2. Check imported module words (e.g., "PLAY" → "MUSIC@PLAY" in core_vocabulary)
-        for module_name in &self.imported_modules {
+        for (module_name, module) in &self.module_vocabulary {
+            if !self.is_module_word_imported(module_name, &upper) {
+                continue;
+            }
             let qualified = format!("{}@{}", module_name, upper);
-            if let Some(def) = self.core_vocabulary.get(&qualified) {
+            if let Some(def) = module.words.get(&qualified) {
                 return Some((qualified, def.clone()));
             }
         }
 
-        // 3. Collect all module sample matches
         let mut module_matches: Vec<(String, Arc<WordDefinition>, u64)> = Vec::new();
-        for (module_name, dict) in &self.module_samples {
+        for (module_name, dict) in &self.module_vocabulary {
+            if !self.is_module_sample_imported(module_name, &upper) {
+                continue;
+            }
             if let Some(def) = dict.sample_words.get(&upper) {
-                module_matches.push((format!("{}@{}", module_name, upper), def.clone(), def.registration_order));
+                module_matches.push((
+                    format!("{}@{}", module_name, upper),
+                    def.clone(),
+                    def.registration_order,
+                ));
             }
         }
 
-        // 4. Collect all user dictionary matches
         let mut user_matches: Vec<(String, Arc<WordDefinition>, u64)> = Vec::new();
         for (dict_name, dict) in &self.user_dictionaries {
             if let Some(def) = dict.words.get(&upper) {
-                user_matches.push((format!("{}@{}", dict_name, upper), def.clone(), def.registration_order));
+                user_matches.push((
+                    format!("{}@{}", dict_name, upper),
+                    def.clone(),
+                    def.registration_order,
+                ));
             }
         }
 
-        // 5. Ambiguity detection
         if !module_matches.is_empty() && !user_matches.is_empty() {
             return None;
         }
 
-        // 6. Return best module match
         if !module_matches.is_empty() {
             module_matches.sort_by_key(|(_, _, order)| *order);
             let (name, def, _) = module_matches.into_iter().next().unwrap();
             return Some((name, def));
         }
 
-        // 7. Return best user match
         if !user_matches.is_empty() {
             user_matches.sort_by_key(|(_, _, order)| *order);
             let (name, def, _) = user_matches.into_iter().next().unwrap();
@@ -119,8 +141,10 @@ impl Interpreter {
         }
 
         let mut paths = Vec::new();
-        for (module_name, dict) in &self.module_samples {
-            if dict.sample_words.contains_key(&upper) {
+        for (module_name, dict) in &self.module_vocabulary {
+            if self.is_module_sample_imported(module_name, &upper)
+                && dict.sample_words.contains_key(&upper)
+            {
                 paths.push(format!("{}@{}", module_name, upper));
             }
         }
@@ -130,33 +154,47 @@ impl Interpreter {
             }
         }
 
-        if paths.len() > 1 { paths } else { vec![] }
+        if paths.len() > 1 {
+            paths
+        } else {
+            vec![]
+        }
     }
 
     pub(crate) fn resolve_word_entry(&self, name: &str) -> Option<(String, Arc<WordDefinition>)> {
         let (layers, word) = Self::split_path(name);
 
         match layers.len() {
-            0 => {
-                self.resolve_short_name(name)
-            }
+            0 => self.resolve_short_name(name),
             1 => {
                 let ns = &layers[0];
                 if ns == "CORE" {
-                    return self.core_vocabulary.get(&word).cloned().map(|def| (word.clone(), def));
+                    return self
+                        .core_vocabulary
+                        .get(&word)
+                        .cloned()
+                        .map(|def| (word.clone(), def));
                 }
-                if let Some(module_dict) = self.module_samples.get(ns.as_str()) {
-                    if let Some(def) = module_dict.sample_words.get(&word) {
-                        return Some((format!("{}@{}", ns, word), def.clone()));
+                if let Some(module_dict) = self.module_vocabulary.get(ns.as_str()) {
+                    let qualified = format!("{}@{}", ns, word);
+                    if self.is_module_word_imported(ns, &word) {
+                        if let Some(def) = module_dict.words.get(&qualified) {
+                            return Some((qualified, def.clone()));
+                        }
                     }
+                    if self.is_module_sample_imported(ns, &word) {
+                        if let Some(def) = module_dict.sample_words.get(&word) {
+                            return Some((format!("{}@{}", ns, word), def.clone()));
+                        }
+                    }
+                    return None;
                 }
                 if let Some(user_dict) = self.user_dictionaries.get(ns.as_str()) {
                     if let Some(def) = user_dict.words.get(&word) {
                         return Some((format!("{}@{}", ns, word), def.clone()));
                     }
                 }
-                let qualified = format!("{}@{}", ns, word);
-                self.core_vocabulary.get(&qualified).cloned().map(|def| (qualified, def))
+                None
             }
             2 => {
                 let first = &layers[0];
@@ -169,15 +207,23 @@ impl Interpreter {
                     }
                 } else if first == "DICT" {
                     if second == "CORE" {
-                        return self.core_vocabulary.get(&word).cloned().map(|def| (word.clone(), def));
+                        return self
+                            .core_vocabulary
+                            .get(&word)
+                            .cloned()
+                            .map(|def| (word.clone(), def));
                     }
-                    let qualified = format!("{}@{}", second, word);
-                    if let Some(def) = self.core_vocabulary.get(&qualified) {
-                        return Some((qualified, def.clone()));
-                    }
-                    if let Some(module_dict) = self.module_samples.get(second.as_str()) {
-                        if let Some(def) = module_dict.sample_words.get(&word) {
-                            return Some((format!("{}@{}", second, word), def.clone()));
+                    if let Some(module_dict) = self.module_vocabulary.get(second.as_str()) {
+                        let qualified = format!("{}@{}", second, word);
+                        if self.is_module_word_imported(second, &word) {
+                            if let Some(def) = module_dict.words.get(&qualified) {
+                                return Some((qualified, def.clone()));
+                            }
+                        }
+                        if self.is_module_sample_imported(second, &word) {
+                            if let Some(def) = module_dict.sample_words.get(&word) {
+                                return Some((format!("{}@{}", second, word), def.clone()));
+                            }
                         }
                     }
                 }
@@ -210,28 +256,33 @@ impl Interpreter {
 
     pub fn rebuild_dependencies(&mut self) -> crate::error::Result<()> {
         self.dependents.clear();
+        self.dictionary_dependencies.clear();
 
-        let mut all_user_words: Vec<(String, Arc<WordDefinition>)> = Vec::new();
+        let mut all_words: Vec<(String, Arc<WordDefinition>)> = Vec::new();
 
         for (dict_name, dict) in &self.user_dictionaries {
             for (name, def) in &dict.words {
-                all_user_words.push((format!("{}@{}", dict_name, name), Arc::clone(def)));
+                all_words.push((format!("{}@{}", dict_name, name), Arc::clone(def)));
             }
         }
 
-        for (module_name, module_dict) in &self.module_samples {
+        for (module_name, module_dict) in &self.module_vocabulary {
             for (name, def) in &module_dict.sample_words {
-                all_user_words.push((format!("{}@{}", module_name, name), Arc::clone(def)));
+                all_words.push((format!("{}@{}", module_name, name), Arc::clone(def)));
             }
         }
 
-        for (word_name, word_def) in &all_user_words {
+        let mut dictionary_edges: HashMap<String, HashSet<String>> = HashMap::new();
+
+        for (word_name, word_def) in &all_words {
             let mut dependencies = HashSet::new();
             for line in word_def.lines.iter() {
                 for token in line.body_tokens.iter() {
                     if let crate::types::Token::Symbol(s) = token {
                         let upper_s = s.to_uppercase();
-                        if let Some((resolved_name, resolved_def)) = self.resolve_word_entry(&upper_s) {
+                        if let Some((resolved_name, resolved_def)) =
+                            self.resolve_word_entry(&upper_s)
+                        {
                             if !resolved_def.is_builtin {
                                 dependencies.insert(resolved_name.clone());
                                 self.dependents
@@ -247,16 +298,49 @@ impl Interpreter {
                 if let Some(dict) = self.user_dictionaries.get_mut(&dict_name) {
                     if let Some(def) = dict.words.get_mut(&short_name) {
                         Arc::make_mut(def).dependencies = dependencies.clone();
-                        continue;
                     }
                 }
-                if let Some(module_dict) = self.module_samples.get_mut(&dict_name) {
+                if let Some(module_dict) = self.module_vocabulary.get_mut(&dict_name) {
                     if let Some(def) = module_dict.sample_words.get_mut(&short_name) {
-                        Arc::make_mut(def).dependencies = dependencies;
+                        Arc::make_mut(def).dependencies = dependencies.clone();
+                    }
+                }
+                let edge_set = dictionary_edges.entry(dict_name.clone()).or_default();
+                for dep in &dependencies {
+                    if let Some((dep_dict, _)) = self.split_qualified_name(dep) {
+                        if dep_dict != dict_name {
+                            edge_set.insert(dep_dict);
+                        }
                     }
                 }
             }
         }
+
+        for dict in self.user_dictionaries.keys() {
+            self.dictionary_dependencies
+                .entry(dict.clone())
+                .or_default();
+        }
+        for dict in self.module_vocabulary.keys() {
+            self.dictionary_dependencies
+                .entry(dict.clone())
+                .or_default();
+        }
+        for (from, tos) in dictionary_edges {
+            for to in tos {
+                self.dictionary_dependencies
+                    .entry(from.clone())
+                    .or_insert_with(DictionaryDependencyInfo::default)
+                    .depends_on
+                    .insert(to.clone());
+                self.dictionary_dependencies
+                    .entry(to)
+                    .or_insert_with(DictionaryDependencyInfo::default)
+                    .depended_by
+                    .insert(from.clone());
+            }
+        }
+
         self.sync_user_words_cache();
         Ok(())
     }
@@ -270,7 +354,7 @@ impl Interpreter {
                 }
             }
         }
-        for (module_name, module_dict) in &self.module_samples {
+        for (module_name, module_dict) in &self.module_vocabulary {
             for (name, def) in &module_dict.sample_words {
                 if def.dependencies.contains(word_name) {
                     result.insert(format!("{}@{}", module_name, name));

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -57,7 +57,7 @@ impl AjisaiInterpreter {
 
     pub(crate) fn collect_imported_modules_array(&self) -> JsValue {
         let arr = js_sys::Array::new();
-        for name in &self.interpreter.imported_modules {
+        for name in self.interpreter.import_table.modules.keys() {
             arr.push(&JsValue::from_str(name));
         }
         arr.into()
@@ -95,7 +95,7 @@ impl AjisaiInterpreter {
     #[wasm_bindgen]
     pub fn collect_imported_modules(&self) -> JsValue {
         let arr = js_sys::Array::new();
-        for name in &self.interpreter.imported_modules {
+        for name in self.interpreter.import_table.modules.keys() {
             arr.push(&JsValue::from_str(name));
         }
         arr.into()
@@ -107,7 +107,7 @@ impl AjisaiInterpreter {
     pub fn collect_module_sample_words_info(&self, module_name: &str) -> JsValue {
         let upper = module_name.to_uppercase();
         let arr = js_sys::Array::new();
-        if let Some(module_dict) = self.interpreter.module_samples.get(&upper) {
+        if let Some(module_dict) = self.interpreter.module_vocabulary.get(&upper) {
             for (name, def) in &module_dict.sample_words {
                 let item = js_sys::Array::new();
                 item.push(&JsValue::from_str(name));
@@ -128,10 +128,9 @@ impl AjisaiInterpreter {
     #[wasm_bindgen]
     pub fn collect_module_words_info(&self, module_name: &str) -> JsValue {
         let upper = module_name.to_uppercase();
-        let prefix = format!("{}@", upper);
         let arr = js_sys::Array::new();
-        for (name, def) in &self.interpreter.core_vocabulary {
-            if name.starts_with(&prefix) {
+        if let Some(module_dict) = self.interpreter.module_vocabulary.get(&upper) {
+            for (name, def) in &module_dict.words {
                 let item = js_sys::Array::new();
                 item.push(&JsValue::from_str(name));
                 item.push(
@@ -142,6 +141,29 @@ impl AjisaiInterpreter {
                 );
                 arr.push(&item);
             }
+        }
+        arr.into()
+    }
+
+    #[wasm_bindgen]
+    pub fn collect_dictionary_dependencies(&self) -> JsValue {
+        let arr = js_sys::Array::new();
+        for (dict_name, dep) in &self.interpreter.dictionary_dependencies {
+            let item = js_sys::Array::new();
+            item.push(&JsValue::from_str(dict_name));
+
+            let depends_on = js_sys::Array::new();
+            for name in &dep.depends_on {
+                depends_on.push(&JsValue::from_str(name));
+            }
+            item.push(&depends_on.into());
+
+            let depended_by = js_sys::Array::new();
+            for name in &dep.depended_by {
+                depended_by.push(&JsValue::from_str(name));
+            }
+            item.push(&depended_by.into());
+            arr.push(&item);
         }
         arr.into()
     }
@@ -174,7 +196,7 @@ impl AjisaiInterpreter {
             if let Some(dict) = self.interpreter.user_dictionaries.get_mut(&dict_name) {
                 dict.words.remove(&short_name);
             }
-            if let Some(dict) = self.interpreter.module_samples.get_mut(&dict_name) {
+            if let Some(dict) = self.interpreter.module_vocabulary.get_mut(&dict_name) {
                 dict.sample_words.remove(&short_name);
             }
             let _ = self.interpreter.rebuild_dependencies();
@@ -187,7 +209,7 @@ impl AjisaiInterpreter {
                 return;
             }
         }
-        for dict in self.interpreter.module_samples.values_mut() {
+        for dict in self.interpreter.module_vocabulary.values_mut() {
             if dict.sample_words.remove(&upper_name).is_some() {
                 let _ = self.interpreter.rebuild_dependencies();
                 return;


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc, compile-time `MODULE_SPECS`/`imported_modules` + `core_vocabulary` injection model with a structured runtime module registry to improve module visibility, selective imports and dictionary-level dependency tracking. 
- Make import semantics explicit so fully-qualified module words are not resolvable unless the module (or that specific word) is imported. 
- Provide an API for dictionary-level dependency information so the GUI can visualize dictionary-to-dictionary relationships derived from word dependencies.

### Description
- Introduced `ModuleDictionary.words` to hold a module's public (qualified) words and `module_vocabulary` to store per-module dictionaries, removing injection of module words into `core_vocabulary`. 
- Replaced `imported_modules: HashSet<String>` with an `ImportTable` and `ImportedModule` entries tracking `import_all_public`, `imported_words`, `imported_samples` and `imported_at` to support selective visibility. 
- Added `IMPORT-ONLY` builtin and wiring (`BuiltinExecutorKey::ImportOnly` → `modules::op_import_only`) to import selected public words (selectors as string or vector), and made `IMPORT` call `import_all_public`. 
- Updated resolver logic so short names and qualified lookups consult the `ImportTable` visibility rules (fully-qualified names do not resolve unless imported), and extended `rebuild_dependencies` to produce `dictionary_dependencies` (`depends_on` / `depended_by`) derived from word-level dependencies. 
- Adjusted module helpers and WASM bindings: moved module word/sample collectors to read from `module_vocabulary`, added `collect_dictionary_dependencies()` to `wasm-interpreter-state`, and updated TypeScript types (`collect_dictionary_dependencies`). 
- Updated `DEF`/`DEL` flows and related APIs to use `module_vocabulary` and the new import table, and added unit tests for unimported FQNs and selective import behavior.

### Testing
- Ran `cargo test dictionary_resolution_tests --manifest-path rust/Cargo.toml` and the test suite completed successfully with the targeted tests passing (`17` tests in that suite passed). 
- Ran `cargo fmt` to reformat code after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72ee2d80883269d0841353785de5a)