### PR TITLE
cleanup: remove DepthLimitExceeded variant and normalize call-chain test names

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -20,10 +20,6 @@ pub enum AjisaiError {
         len1: usize,
         len2: usize,
     },
-    DepthLimitExceeded {
-        depth: usize,
-        chain: String,
-    },
     ExecutionLimitExceeded {
         limit: usize,
     },
@@ -91,9 +87,6 @@ impl fmt::Display for AjisaiError {
             }
             AjisaiError::VectorLengthMismatch { len1, len2 } => {
                 write!(f, "Vector length mismatch: {} vs {}", len1, len2)
-            }
-            AjisaiError::DepthLimitExceeded { depth, chain } => {
-                write!(f, "Call depth limit ({}) exceeded: {}", depth, chain)
             }
             AjisaiError::ExecutionLimitExceeded { limit } => {
                 write!(f, "Execution step limit ({}) exceeded", limit)

--- a/rust/src/interpreter/interpreter-definition-tests.rs
+++ b/rust/src/interpreter/interpreter-definition-tests.rs
@@ -298,7 +298,7 @@ mod tests {
 
 
     #[tokio::test]
-    async fn test_call_depth_4_ok() {
+    async fn test_nested_call_chain_4_levels_ok() {
         let mut interp = Interpreter::new();
         interp.execute("{ B } 'A' DEF").await.unwrap();
         interp.execute("{ C } 'B' DEF").await.unwrap();
@@ -306,12 +306,12 @@ mod tests {
         interp.execute("{ [ 1 ] } 'D' DEF").await.unwrap();
 
         let result = interp.execute("A").await;
-        assert!(result.is_ok(), "Call depth 4 should succeed: {:?}", result);
+        assert!(result.is_ok(), "4-level nested call chain should succeed: {:?}", result);
         assert_eq!(interp.stack.len(), 1);
     }
 
     #[tokio::test]
-    async fn test_deep_call_chain_succeeds_without_depth_limit() {
+    async fn test_deep_call_chain_succeeds() {
         let mut interp = Interpreter::new();
         interp.execute("{ B } 'A' DEF").await.unwrap();
         interp.execute("{ C } 'B' DEF").await.unwrap();
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_call_depth_resets_after_completion() {
+    async fn test_call_chain_state_resets_after_completion() {
         let mut interp = Interpreter::new();
         interp.execute("{ B } 'A' DEF").await.unwrap();
         interp.execute("{ [ 1 ] } 'B' DEF").await.unwrap();


### PR DESCRIPTION
### Motivation
- Consolidate safety/error responsibilities by removing an obsolete depth-based error remnant and align test names/messages with the current execution-step-limit semantics.

### Description
- Remove the `AjisaiError::DepthLimitExceeded` variant and its `Display` branch from `rust/src/error.rs` so runtime limits are represented by `ExecutionLimitExceeded` only.
- Rename and update call-chain tests in `rust/src/interpreter/interpreter-definition-tests.rs` to avoid depth-limit terminology and to reflect current semantics and assert messages.

### Testing
- Ran `cd rust && cargo test -q nested_call_chain` and the test passed.
- Ran `cd rust && cargo test -q deep_call_chain_succeeds` and the test passed.
- Ran `cd rust && cargo test -q call_chain_state_resets_after_completion` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f27733008326ba2ce01bbea02f16)