### PR TITLE
Introduce COND `$` clause syntax and remove legacy `|`/`&` tokenizer noise

### DIFF
--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -499,8 +499,8 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
     builtin_spec!(
         "COND",
         "control",
-        "Form: Evaluate guard/body pairs, execute first match. Any, ...CodeBlock pairs -> Any",
-        "value { guard1 } { body1 } { IDLE } { else_body } COND",
+        "Form: Evaluate guard/body clauses, execute first match. Any, ...CodeBlock clauses -> Any",
+        "value { guard1 $ body1 } { IDLE $ else_body } COND",
         "form",
         BuiltinDetailGroup::Cond,
         Some(BuiltinExecutorKey::Cond)

--- a/rust/src/builtins/detail-lookup-cond.rs
+++ b/rust/src/builtins/detail-lookup-cond.rs
@@ -8,16 +8,27 @@ pub(crate) fn lookup_detail_cond(name: &str) -> Option<String> {
 
 ## 使用法
 value { guard1 } { body1 } { guard2 } { body2 } ... COND
+value { guard1 $ body1 } { guard2 $ body2 } ... COND
 
 ## 使用例
 [ 42 ]
+  { [ 0 ] < $ 'negative' }
+  { [ 0 ] = $ 'zero' }
+  { IDLE    $ 'positive' }
+  COND
+
+## 旧構文と等価な例
+[ 42 ]
   { [ 0 ] < }   { 'negative' }
+  { [ 0 ] = }   { 'zero' }
   { IDLE }      { 'positive' }
   COND
 
 ## 注意
-- ガード/本体は必ずペアで指定します
-- else節は `{ IDLE }` ガードで表現します
+- `$` を使う場合は `{ guard $ body }` を1節として書きます
+- `$` 節は1行に1節のみです（同一行に複数節は禁止）
+- 旧構文 `{ guard } { body }` と `$` 構文の混在は禁止です
+- else節は `{ IDLE }` または `{ IDLE $ body }` で表現します
 - 一致なし・elseなしはエラーになります"#
         }
         _ => return None,

--- a/rust/src/interpreter/control-cond-tests.rs
+++ b/rust/src/interpreter/control-cond-tests.rs
@@ -81,6 +81,79 @@ mod tests {
             message
         );
     }
+
+    #[tokio::test]
+    async fn test_cond_new_clause_style_multiple_branches() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("[ 0 ]\n{ [ 0 ] < $ 'negative' }\n{ [ 0 ] = $ 'zero' }\n{ IDLE $ 'positive' }\nCOND")
+            .await;
+        assert!(result.is_ok(), "COND new style should succeed: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_cond_new_clause_style_else_branch() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("[ 42 ]\n{ [ 0 ] < $ 'negative' }\n{ IDLE $ 'positive' }\nCOND")
+            .await;
+        assert!(result.is_ok(), "COND new-style else should succeed: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_cond_mixed_clause_styles_error() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("[ 42 ] { [ 0 ] < $ 'negative' } { IDLE } { 'positive' } COND")
+            .await;
+        assert!(result.is_err(), "mixed clause styles should fail");
+        let message = result.err().unwrap().to_string();
+        assert!(message.contains("mixed clause styles are not allowed"), "unexpected error: {}", message);
+    }
+
+    #[tokio::test]
+    async fn test_cond_clause_requires_exactly_one_separator() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("[ 42 ] { [ 0 ] < $ 'a' $ 'b' } COND")
+            .await;
+        assert!(result.is_err(), "multiple separators should fail");
+        let message = result.err().unwrap().to_string();
+        assert!(message.contains("exactly one '$' separator"), "unexpected error: {}", message);
+    }
+
+    #[tokio::test]
+    async fn test_cond_clause_separator_left_side_required() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("[ 42 ] { $ 'positive' } COND").await;
+        assert!(result.is_err(), "empty guard should fail");
+        let message = result.err().unwrap().to_string();
+        assert!(message.contains("both guard and body are required around '$'"), "unexpected error: {}", message);
+    }
+
+    #[tokio::test]
+    async fn test_cond_clause_separator_right_side_required() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("[ 42 ] { IDLE $ } COND").await;
+        assert!(result.is_err(), "empty body should fail");
+        let message = result.err().unwrap().to_string();
+        assert!(message.contains("both guard and body are required around '$'"), "unexpected error: {}", message);
+    }
+
+    #[tokio::test]
+    async fn test_cond_new_clause_requires_one_clause_per_line() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("[ 42 ] { [ 0 ] < $ 'negative' } { IDLE $ 'positive' } COND")
+            .await;
+        assert!(result.is_err(), "same-line multiple $ clauses should fail");
+        let message = result.err().unwrap().to_string();
+        assert!(
+            message.contains("COND: $ clauses must be written one clause per line"),
+            "unexpected error: {}",
+            message
+        );
+    }
 }
 
 #[cfg(test)]
@@ -170,4 +243,3 @@ mod demo_word_gui_mode_tests {
         );
     }
 }
-

--- a/rust/src/interpreter/control-cond.rs
+++ b/rust/src/interpreter/control-cond.rs
@@ -45,15 +45,43 @@ fn collect_cond_pairs_from_stack(interp: &mut Interpreter) -> Result<Vec<(Vec<To
         break;
     }
 
-    if collected_blocks.is_empty() || collected_blocks.len() % 2 != 0 {
+    collected_blocks.reverse();
+
+    if collected_blocks.is_empty() {
+        return Err(AjisaiError::from(
+            "COND: expected guard/body clauses, got 0 code blocks",
+        ));
+    }
+
+    let has_sep_flags: Vec<bool> = collected_blocks
+        .iter()
+        .map(|block| block.iter().any(|token| matches!(token, Token::CondClauseSep)))
+        .collect();
+    let all_with_sep: bool = has_sep_flags.iter().all(|has_sep| *has_sep);
+    let none_with_sep: bool = has_sep_flags.iter().all(|has_sep| !*has_sep);
+
+    if !all_with_sep && !none_with_sep {
+        return Err(AjisaiError::from(
+            "COND: mixed clause styles are not allowed; use either {guard}{body} pairs or {guard $ body} clauses consistently",
+        ));
+    }
+
+    let mut pairs: Vec<(Vec<Token>, Vec<Token>)> = Vec::new();
+    if all_with_sep {
+        for block in &collected_blocks {
+            let (guard_tokens, body_tokens) = split_cond_clause_block(block)?;
+            pairs.push((guard_tokens, body_tokens));
+        }
+        return Ok(pairs);
+    }
+
+    if collected_blocks.len() % 2 != 0 {
         return Err(AjisaiError::from(format!(
             "COND: expected even number of code blocks (guard/body pairs), got {}",
             collected_blocks.len()
         )));
     }
 
-    collected_blocks.reverse();
-    let mut pairs: Vec<(Vec<Token>, Vec<Token>)> = Vec::new();
     let mut i: usize = 0;
     while i < collected_blocks.len() {
         let guard_tokens: Vec<Token> = collected_blocks[i].clone();
@@ -61,7 +89,33 @@ fn collect_cond_pairs_from_stack(interp: &mut Interpreter) -> Result<Vec<(Vec<To
         pairs.push((guard_tokens, body_tokens));
         i += 2;
     }
+
     Ok(pairs)
+}
+
+fn split_cond_clause_block(tokens: &[Token]) -> Result<(Vec<Token>, Vec<Token>)> {
+    let separator_indexes: Vec<usize> = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(i, token)| matches!(token, Token::CondClauseSep).then_some(i))
+        .collect();
+
+    if separator_indexes.len() != 1 {
+        return Err(AjisaiError::from(
+            "COND: a $ clause must contain exactly one '$' separator",
+        ));
+    }
+
+    let separator_index: usize = separator_indexes[0];
+    if separator_index == 0 || separator_index + 1 >= tokens.len() {
+        return Err(AjisaiError::from(
+            "COND: both guard and body are required around '$'",
+        ));
+    }
+
+    let guard_tokens = tokens[..separator_index].to_vec();
+    let body_tokens = tokens[(separator_index + 1)..].to_vec();
+    Ok((guard_tokens, body_tokens))
 }
 
 fn evaluate_guard_with_value(interp: &mut Interpreter, guard_tokens: &[Token], value: &Value) -> Result<bool> {

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -181,6 +181,7 @@ impl Interpreter {
             Token::BlockEnd => "}".to_string(),
             Token::Pipeline => "==".to_string(),
             Token::NilCoalesce => "=>".to_string(),
+            Token::CondClauseSep => "$".to_string(),
             Token::SafeMode => "~".to_string(),
             Token::LineBreak => "\n".to_string(),
         }

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -124,6 +124,7 @@ pub fn op_def(interp: &mut Interpreter) -> Result<()> {
                 Token::BlockEnd => "}".to_string(),
                 Token::Pipeline => "==".to_string(),
                 Token::NilCoalesce => "=>".to_string(),
+                Token::CondClauseSep => "$".to_string(),
                 Token::SafeMode => "~".to_string(),
                 Token::LineBreak => "\n".to_string(),
             })

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -139,6 +139,11 @@ impl Interpreter {
                     }
                     i += 1;
                 }
+                Token::CondClauseSep => {
+                    return Err(AjisaiError::from(
+                        "Unexpected '$' separator outside COND clause parsing",
+                    ));
+                }
                 _ => {
                     i += 1;
                 }
@@ -306,6 +311,11 @@ impl Interpreter {
                 }
                 Token::SafeMode => {
                     self.safe_mode = true;
+                }
+                Token::CondClauseSep => {
+                    return Err(AjisaiError::from(
+                        "Unexpected '$' separator outside COND clause parsing",
+                    ));
                 }
 
                 Token::LineBreak => {}

--- a/rust/src/interpreter/vector-execution-operations.rs
+++ b/rust/src/interpreter/vector-execution-operations.rs
@@ -27,6 +27,7 @@ fn format_token_to_source(token: &Token) -> String {
         Token::BlockEnd => "}".to_string(),
         Token::Pipeline => "==".to_string(),
         Token::NilCoalesce => "=>".to_string(),
+        Token::CondClauseSep => "$".to_string(),
         Token::SafeMode => "~".to_string(),
         Token::LineBreak => "\n".to_string(),
     }

--- a/rust/src/tokenizer-regression-tests-2.rs
+++ b/rust/src/tokenizer-regression-tests-2.rs
@@ -339,12 +339,12 @@ mod tokenizer_regression_tests_2 {
     }
 
     #[test]
-    fn test_pipe_character_removed_error() {
-        let result = tokenize("[ 2 ] * | 'DOUBLE' DEF");
+    fn test_multiple_dollar_clauses_in_single_line_error() {
+        let result = tokenize("{ [ 0 ] < $ 'negative' } { IDLE $ 'positive' }");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
-            .contains("'|' (block separator) has been removed"));
+            .contains("COND: $ clauses must be written one clause per line"));
     }
 
 

--- a/rust/src/tokenizer-regression-tests.rs
+++ b/rust/src/tokenizer-regression-tests.rs
@@ -376,17 +376,24 @@ mod tokenizer_regression_tests {
 
 
     #[test]
-    fn test_removed_dollar_branch_guard() {
-        let result = tokenize("[ 1 ] $ { TRUE } { [ 2 ] }");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("'$' (branch guard) has been removed"));
+    fn test_dollar_tokenized_as_cond_clause_separator() {
+        let result = tokenize("{ IDLE $ 'ok' }").unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::BlockStart,
+                Token::Symbol("IDLE".into()),
+                Token::CondClauseSep,
+                Token::String("ok".into()),
+                Token::BlockEnd,
+            ]
+        );
     }
 
     #[test]
-    fn test_removed_ampersand_loop_guard() {
-        let result = tokenize("[ 0 ] & { ,, [ 5 ] < } { [ 1 ] + }");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("'&' (loop guard) has been removed"));
+    fn test_ampersand_is_treated_as_symbol() {
+        let result = tokenize("&").unwrap();
+        assert_eq!(result, vec![Token::Symbol("&".into())]);
     }
 
     #[test]

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -38,17 +38,6 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
         if chars[i] == ';' {
             return Err("';' (code block end) has been removed. Use '{' and '}' or '(' and ')' for code blocks.".to_string());
         }
-        if chars[i] == '|' {
-            return Err("'|' (block separator) has been removed. Use '{' and '}' or '(' and ')' for code blocks.".to_string());
-        }
-        if chars[i] == '$' {
-            return Err("'$' (branch guard) has been removed. Use COND for conditional branching.".to_string());
-        }
-        if chars[i] == '&' {
-            return Err("'&' (loop guard) has been removed. Use FOLD, UNFOLD, or recursive COND for iteration.".to_string());
-        }
-
-
         if let Some((token, consumed)) = parse_token_from_single_char(chars[i]) {
             tokens.push(token);
             i += consumed;
@@ -155,6 +144,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
 
     check_bracket_matching(input)?;
     check_single_line_block_constraint(&tokens)?;
+    check_cond_clause_per_line_constraint(&tokens)?;
     Ok(tokens)
 }
 
@@ -163,7 +153,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
 fn is_special_char(c: char) -> bool {
     matches!(
         c,
-        '[' | ']' | '{' | '}' | '(' | ')' | '#' | '\'' | '>' | '=' | '~'
+        '[' | ']' | '{' | '}' | '(' | ')' | '#' | '\'' | '>' | '=' | '~' | '$'
     )
 }
 
@@ -174,6 +164,7 @@ fn parse_token_from_single_char(c: char) -> Option<(Token, usize)> {
         '{' | '(' => Some((Token::BlockStart, 1)),
         '}' | ')' => Some((Token::BlockEnd, 1)),
 
+        '$' => Some((Token::CondClauseSep, 1)),
         '~' => Some((Token::SafeMode, 1)),
 
         _ => None,
@@ -304,6 +295,48 @@ fn check_single_line_block_constraint(tokens: &[Token]) -> Result<(), String> {
                 );
             }
             _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn check_cond_clause_per_line_constraint(tokens: &[Token]) -> Result<(), String> {
+    let mut i: usize = 0;
+    let mut cond_clause_blocks_in_line: usize = 0;
+
+    while i < tokens.len() {
+        match &tokens[i] {
+            Token::LineBreak => {
+                cond_clause_blocks_in_line = 0;
+                i += 1;
+            }
+            Token::BlockStart => {
+                let mut depth: i32 = 1;
+                let mut j: usize = i + 1;
+                let mut has_clause_sep: bool = false;
+                while j < tokens.len() && depth > 0 {
+                    match &tokens[j] {
+                        Token::BlockStart => depth += 1,
+                        Token::BlockEnd => depth -= 1,
+                        Token::CondClauseSep if depth == 1 => has_clause_sep = true,
+                        _ => {}
+                    }
+                    j += 1;
+                }
+
+                if has_clause_sep {
+                    cond_clause_blocks_in_line += 1;
+                    if cond_clause_blocks_in_line > 1 {
+                        return Err("COND: $ clauses must be written one clause per line".to_string());
+                    }
+                }
+
+                i = j;
+            }
+            _ => {
+                i += 1;
+            }
         }
     }
 

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -101,6 +101,7 @@ fn format_code_block(tokens: &[super::Token]) -> String {
             Token::BlockEnd => "}".to_string(),
             Token::Pipeline => "==".to_string(),
             Token::NilCoalesce => "=>".to_string(),
+            Token::CondClauseSep => "$".to_string(),
             Token::SafeMode => "~".to_string(),
             Token::LineBreak => "\n".to_string(),
         })

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -150,6 +150,7 @@ pub enum Token {
     BlockEnd,
     Pipeline,
     NilCoalesce,
+    CondClauseSep,
     SafeMode,
     LineBreak,
 }
@@ -171,4 +172,3 @@ pub struct WordDefinition {
 }
 
 pub type Stack = Vec<Value>;
-


### PR DESCRIPTION
### Motivation

- Improve readability of `COND` by adding `{ guard $ body }` as syntax sugar while preserving existing `{ guard } { body }` semantics.
- Remove leftover noise related to legacy `|` / `&` handling in the tokenizer and error messages to reduce future confusion.
- Enforce the intended formatting rules for `$` clauses (single-line, one clause per line, no mixing with old style) to keep parsing simple and predictable.

### Description

- Added a dedicated token `Token::CondClauseSep` to represent `$` and updated token rendering/format helpers to emit `$` where appropriate. 
- Updated the tokenizer to emit `$` as `CondClauseSep`, removed legacy `|`/`&` removed-feature branches, and added `check_cond_clause_per_line_constraint` to ensure one `$`-clause per line. 
- Extended `COND` clause collection (`collect_cond_pairs_from_stack`) to accept either all old-style `{ guard } { body }` pairs or all new-style `{ guard $ body }` clauses, with explicit mixed-style rejection and validations (exactly one `$`, non-empty guard/body). 
- Added guarding errors for unexpected `CondClauseSep` outside `COND` parsing, updated `COND` docs/examples, and added/updated tests covering new success and failure cases. 

### Testing

- Ran `cargo test control_cond -- --nocapture` and the `control_cond` test suite passed (new-style and mixed-style tests included). 
- Ran `cargo test tokenizer_regression -- --nocapture` and the tokenizer regression tests passed (including new `$` tokenization and single-line clause checks). 
- All modified and newly added unit tests related to `COND` and tokenizer behavior passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d848a0213483268c090750050b3162)