### PR TITLE
Add QR code to README and make header logo swap to QR on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build and Deploy Ajisai](https://github.com/masamoto1982/Ajisai/actions/workflows/build.yml/badge.svg)](https://github.com/masamoto1982/Ajisai/actions/workflows/build.yml)
 
 ![Ajisai Logo](public/images/ajisai-logo.png "Ajisai Programming Language Logo")
+![Ajisai QR Code](public/images/ajisai-qr.png "Ajisai QR Code")
 
 # Ajisai
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,10 @@
         <header role="banner">
             <div class="app-header-top">
                 <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
-                    <img src="public/images/ajisai-logo-thumbnail-w40.jpg" alt="Ajisai Logo" class="logo">
+                    <span class="logo-swap" aria-hidden="true">
+                        <img src="public/images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
+                        <img src="public/images/ajisai-qr.png" alt="" class="logo logo-qr">
+                    </span>
                     <div class="app-brand-meta">
                         <h1>Ajisai</h1>
                         <span class="version">ver.202604101205</span>

--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -140,6 +140,40 @@ header {
     object-fit: contain;
 }
 
+.logo-swap {
+    position: relative;
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+}
+
+.logo-swap .logo {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transition: opacity 0.18s ease-in-out;
+}
+
+.logo-default {
+    opacity: 1;
+}
+
+.logo-qr {
+    opacity: 0;
+}
+
+.app-brand-block:hover .logo-default,
+.app-brand-block:focus-visible .logo-default,
+.app-brand-block:focus-within .logo-default {
+    opacity: 0;
+}
+
+.app-brand-block:hover .logo-qr,
+.app-brand-block:focus-visible .logo-qr,
+.app-brand-block:focus-within .logo-qr {
+    opacity: 1;
+}
+
 header h1 {
     font-size: 1.5rem;
     color: var(--heading-h1);


### PR DESCRIPTION
### Motivation
- Make the Ajisai QR code visible in project documentation and provide a quick-access visual affordance in the web UI header.
- Provide an unobtrusive way to reveal the QR code from the header when users hover or focus the brand area.

### Description
- Added the QR image reference `![Ajisai QR Code](public/images/ajisai-qr.png "Ajisai QR Code")` to `README.md` so the QR code appears in the repo docs.
- Replaced the single header logo `img` in `index.html` with a layered `.logo-swap` span that contains `img.logo-default` (original logo) and `img.logo-qr` (QR image).
- Introduced CSS in `public/ajisai-base.css` to position the two images absolutely, and to transition `opacity` so the QR fades in on `:hover`, `:focus-visible`, and `:focus-within` of the brand area.
- No JavaScript changes were required; the behavior is implemented with markup and CSS only.

### Testing
- Ran `npm run build` (TypeScript compile) which completed successfully.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87e773f8c83269b52ff39012f7c76)