### PR TITLE
Update Ajisai description tagline in metadata files

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Ajisai - A stack-based programming language inspired by FORTH">
+    <meta name="description" content="Ajisai - An AI-first, vector-oriented, fractional-dataflow programming language.">
     <meta name="theme-color" content="#007bff">
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ajisai",
   "version": "1.0.0",
-  "description": "Ajisai - A stack-based programming language",
+  "description": "Ajisai - An AI-first, vector-oriented, fractional-dataflow programming language.",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Ajisai Programming Language",
   "short_name": "Ajisai",
-  "description": "A stack-based programming language inspired by FORTH",
+  "description": "Ajisai - An AI-first, vector-oriented, fractional-dataflow programming language.",
   "start_url": "./",
   "scope": "./",
   "display": "standalone",


### PR DESCRIPTION
### Motivation
- Project identity was updated and the public-facing tagline needed to be replaced across site metadata and package manifests.
- The goal was to perform exact, case-sensitive replacements of the old tagline with the new one to keep wording consistent in SEO and packaging metadata.
- Only metadata fields and HTML meta description tags were targeted to avoid structural changes to files.

### Description
- Replaced the exact string `Ajisai - A stack-based programming language inspired by FORTH` with `Ajisai - An AI-first, vector-oriented, fractional-dataflow programming language.` in `index.html` by updating the `<meta name="description">` `content` attribute.
- Updated the `"description"` property in `package.json` to the new tagline string and updated the `"description"` in `public/manifest.json` to the new tagline string.
- Searched `language-reference-playground.html` and all files under `public/docs/*.html` and found no `meta name="description"` entries to replace, so those files were left unchanged.

### Testing
- Ran exact-match searches with `rg` to find occurrences of the old and new tagline, using commands like `rg -n "Ajisai - A stack-based programming language inspired by FORTH"` and `rg -n "Ajisai - An AI-first, vector-oriented, fractional-dataflow programming language\."`, and confirmed expected matches and replacements; these searches succeeded.
- Executed the replacement script (Python) that performs case-sensitive `str.replace` substitutions across the target files and printed which files were updated; the script ran and reported updates for `index.html`, `package.json`, and `public/manifest.json`.
- Verified updated file contents with `nl` (to inspect the top lines) and re-ran `rg` to ensure no remaining occurrences of the old tagline; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e030f29c832699472e2b7a4b687c)