### PR TITLE
Reference: set 3:7 split, limit header hover to logo, remove section rounding

### DIFF
--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -163,15 +163,15 @@ header {
     filter: brightness(0) invert(1);
 }
 
-.app-brand-block:hover .logo-default,
-.app-brand-block:focus-visible .logo-default,
-.app-brand-block:focus-within .logo-default {
+.logo-swap:hover .logo-default,
+.logo-swap:focus-visible .logo-default,
+.logo-swap:focus-within .logo-default {
     opacity: 0;
 }
 
-.app-brand-block:hover .logo-qr,
-.app-brand-block:focus-visible .logo-qr,
-.app-brand-block:focus-within .logo-qr {
+.logo-swap:hover .logo-qr,
+.logo-swap:focus-visible .logo-qr,
+.logo-swap:focus-within .logo-qr {
     opacity: 1;
 }
 

--- a/public/docs/css/docs-reference-styles.css
+++ b/public/docs/css/docs-reference-styles.css
@@ -7,5 +7,10 @@
 
 
 :root {
-    --col-right-flex: 1.618;
+    --col-left-flex: 3;
+    --col-right-flex: 7;
+}
+
+.main-content section {
+    border-radius: 0;
 }

--- a/public/docs/docs-navigation-script.js
+++ b/public/docs/docs-navigation-script.js
@@ -57,7 +57,10 @@ document.addEventListener('DOMContentLoaded', () => {
         headerEl.innerHTML = `
             <div class="app-header-top">
                 <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
-                    <img src="../images/ajisai-logo-thumbnail-w40.jpg" alt="Ajisai Logo" class="logo">
+                    <span class="logo-swap" aria-hidden="true">
+                        <img src="../images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
+                        <img src="../images/ajisai-qr.png" alt="" class="logo logo-qr">
+                    </span>
                     <div class="app-brand-meta">
                         <h1>${c.meta.title}</h1>
                         <span class="version">ver.202604080203</span>


### PR DESCRIPTION
### Motivation
- Make the Reference pages visually match the main app by changing the left/right split to 3:7, unify header logo behavior, and remove rounded corners from right-side sections.

### Description
- Override the Reference theme variables to `--col-left-flex: 3` and `--col-right-flex: 7` in `public/docs/css/docs-reference-styles.css` to change the layout split.
- Remove section rounding in the Reference content by adding `.main-content section { border-radius: 0; }` in `public/docs/css/docs-reference-styles.css`.
- Change Reference header markup in `public/docs/docs-navigation-script.js` to use the `logo-swap` structure (default logo + QR logo) so the header matches the main app.
- Restrict the hover/focus swap CSS to the logo mark only by updating selectors in `public/ajisai-base.css` from `.app-brand-block:hover …` to `.logo-swap:hover …`.

### Testing
- Ran the TypeScript build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e3db4624832684733cbb4e2352a2)