### PR TITLE
Introduce Tauri 2 desktop foundation with platform abstraction

### DIFF
--- a/js/entrypoints/electron-renderer-entrypoint.ts
+++ b/js/entrypoints/electron-renderer-entrypoint.ts
@@ -1,13 +1,15 @@
 import type { AjisaiRuntime } from '../core/ajisai-runtime-types';
 import { createGUI } from '../gui/gui-application';
+import type { PlatformServices } from '../platform/platform-services';
 
 export interface ElectronRendererBootstrap {
     readonly runtime: AjisaiRuntime;
     readonly root: ParentNode;
+    readonly platform: PlatformServices;
 }
 
-export const startElectronRenderer = async ({ runtime, root }: ElectronRendererBootstrap): Promise<void> => {
-    const gui = createGUI({ runtime, root });
+export const startElectronRenderer = async ({ runtime, root, platform }: ElectronRendererBootstrap): Promise<void> => {
+    const gui = createGUI({ runtime, root, platform });
     await gui.init();
     gui.updateAllDisplays();
 };

--- a/js/entrypoints/tauri-app-entrypoint.ts
+++ b/js/entrypoints/tauri-app-entrypoint.ts
@@ -1,0 +1,33 @@
+import '../indexeddb-user-word-store';
+import { createAjisaiRuntimeFromWasm } from '../core/ajisai-runtime-factory';
+import { createGUI } from '../gui/gui-application';
+import { createTauriPlatformServices } from '../platform/tauri/create-tauri-platform-services';
+
+const renderStartupError = (error: unknown): void => {
+    const outputDisplay = document.getElementById('output-display');
+    if (!outputDisplay) return;
+
+    outputDisplay.innerHTML = `
+        <span style="color: #dc3545; font-weight: bold;">
+            Application startup failed: ${(error as Error).message}
+        </span>
+    `;
+};
+
+export async function startTauriApp(): Promise<void> {
+    console.log('[Main] Starting Ajisai Tauri application...');
+
+    try {
+        const runtime = await createAjisaiRuntimeFromWasm();
+        const platform = createTauriPlatformServices();
+        const gui = createGUI({ runtime, root: document, platform });
+
+        await gui.init();
+        gui.updateAllDisplays();
+
+        console.log('[Main] Tauri application initialization completed successfully');
+    } catch (error) {
+        console.error('[Main] Tauri application startup failed:', error);
+        renderStartupError(error);
+    }
+}

--- a/js/entrypoints/web-app-entrypoint.ts
+++ b/js/entrypoints/web-app-entrypoint.ts
@@ -3,6 +3,7 @@ import { createAjisaiRuntimeFromWasm } from '../core/ajisai-runtime-factory';
 import { createGUI } from '../gui/gui-application';
 import { monitorWebOnlineStatus } from '../infrastructure/web/web-online-status';
 import { registerWebServiceWorker } from '../infrastructure/web/web-service-worker';
+import { createWebPlatformServices } from '../platform/web/create-web-platform-services';
 
 declare global {
     interface Window {
@@ -43,7 +44,8 @@ export async function startWebApp(): Promise<void> {
         }
 
         const runtime = await createAjisaiRuntimeFromWasm();
-        const gui = createGUI({ runtime, root: document });
+        const platform = createWebPlatformServices();
+        const gui = createGUI({ runtime, root: document, platform });
 
         await gui.init();
         gui.updateAllDisplays();

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -5,7 +5,8 @@ import { createMobileHandler, MobileHandler, ViewMode } from './mobile-view-swit
 import { createModuleTabManager, ModuleTabManager } from './module-selector-sheets';
 import { createPersistence, Persistence } from './interpreter-state-persistence';
 import { createExecutionController, ExecutionController } from './execution-controller';
-import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import { createWorkerManager, WorkerManager } from '../workers/execution-worker-manager';
+import type { PlatformServices } from '../platform/platform-services';
 import type { AjisaiRuntime } from '../core/ajisai-runtime-types';
 import {
     GUIElements,
@@ -74,9 +75,10 @@ const collectAutocompleteWords = (runtime: AjisaiRuntime): string[] => {
 export interface GUIOptions {
     readonly runtime: AjisaiRuntime;
     readonly root?: ParentNode;
+    readonly platform: PlatformServices;
 }
 
-export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
+export const createGUI = ({ runtime, root = document, platform }: GUIOptions): GUI => {
     let elements: GUIElements;
     let display: Display;
     let editor: Editor;
@@ -86,6 +88,7 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
     let executionController: ExecutionController;
     let moduleTabManager: ModuleTabManager;
     let layoutState: LayoutState;
+    let workerManager: WorkerManager;
 
     const doSwitchDictionarySheet = (sheetId: string): void => {
         switchDictionarySheet(elements.dictionaryArea, sheetId);
@@ -122,7 +125,7 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
     const initializeWorkers = async (): Promise<void> => {
         try {
             display.renderInfo('Initializing...', false);
-            await WORKER_MANAGER.init();
+            await workerManager.init();
             display.renderInfo('Ready', true);
         } catch (error) {
             console.error('[GUI] Failed to initialize workers:', error);
@@ -204,7 +207,7 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
         elements.copyOutputBtn.addEventListener('click', (e: MouseEvent) => {
             e.stopPropagation();
             const text = display.extractState().mainOutput;
-            navigator.clipboard.writeText(text).then(() => {
+            void platform.clipboard.writeText(text).then(() => {
                 const btn = elements.copyOutputBtn;
                 const original = btn.textContent;
                 btn.textContent = 'Copied!';
@@ -226,20 +229,20 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
             }
         });
 
-        window.addEventListener('resize', () => {
+        platform.windowEnv.addWindowEventListener('resize', () => {
             applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, layoutState.currentMode);
             updateEditorPlaceholder(elements, mobile);
         });
 
-        window.addEventListener('keydown', (e: KeyboardEvent) => {
+        platform.windowEnv.addWindowEventListener('keydown', async (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
-                WORKER_MANAGER.abortAll();
+                workerManager.abortAll();
                 executionController.abortExecution();
                 e.preventDefault();
                 e.stopImmediatePropagation();
             }
             if (e.key === 'Enter' && e.ctrlKey && e.altKey) {
-                if (confirm('Are you sure you want to reset the system?')) {
+                if (await platform.dialogs.confirm('Are you sure you want to reset the system?')) {
                     executionController.executeReset();
                 }
                 e.preventDefault();
@@ -254,7 +257,8 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
         elements = cacheElements(root);
         layoutState = createLayoutState();
         mobile = createMobileHandler(extractMobileElements(elements), {
-            onModeChange: (mode) => switchArea(mode)
+            onModeChange: (mode) => switchArea(mode),
+            windowEnv: platform.windowEnv
         });
         display = createDisplay(extractDisplayElements(elements));
         display.init();
@@ -301,6 +305,8 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
         persistence = createPersistence({
             runtime,
             root,
+            files: platform.files,
+            storage: platform.storage,
             showError: (error) => display.renderError(error),
             updateDisplays: updateAllDisplays,
             showInfo: (text, append) => display.renderInfo(text, append)
@@ -315,6 +321,8 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
 
         vocabulary = createVocabularyManager(extractVocabularyElements(elements), {
             runtime,
+            dialogs: platform.dialogs,
+            windowEnv: platform.windowEnv,
             onWordClick: (word) => {
                 if (!mobile.isMobile()) {
                     editor.insertWord(word);
@@ -349,6 +357,7 @@ export const createGUI = ({ runtime, root = document }: GUIOptions): GUI => {
             updateView: (mode) => switchArea(mode)
         });
 
+        workerManager = createWorkerManager(platform.windowEnv);
         setupEventListeners();
         vocabulary.renderBuiltInWords();
         updateAllDisplays();

--- a/js/gui/interpreter-state-persistence.ts
+++ b/js/gui/interpreter-state-persistence.ts
@@ -1,10 +1,10 @@
 
-
 import type { AjisaiInterpreter, Value, UserWord } from '../wasm-interpreter-types';
-import type DB from '../indexeddb-user-word-store';
 import { DEMO_USER_WORDS, DEMO_WORDS_VERSION } from './demo-words';
 import { Result, ok, err } from './functional-result-helpers';
 import type { AjisaiRuntime } from '../core/ajisai-runtime-types';
+import type { FilePort } from '../platform/file-port';
+import type { StoragePort } from '../platform/storage-port';
 
 export interface InterpreterState {
     readonly stack: Value[];
@@ -15,6 +15,8 @@ export interface InterpreterState {
 export interface PersistenceCallbacks {
     readonly runtime: AjisaiRuntime;
     readonly root?: ParentNode;
+    readonly files: FilePort;
+    readonly storage: StoragePort;
     readonly showError?: (error: Error) => void;
     readonly updateDisplays?: () => void;
     readonly showInfo?: (text: string, append: boolean) => void;
@@ -25,16 +27,9 @@ export interface Persistence {
     readonly saveCurrentState: () => Promise<void>;
     readonly loadDatabaseData: () => Promise<void>;
     readonly fullReset: () => Promise<void>;
-    readonly exportUserWords: () => void;
-    readonly importUserWords: () => void;
-    readonly importJsonAsVector: () => void;
-}
-
-declare global {
-    interface Window {
-        ajisaiInterpreter: AjisaiInterpreter;
-        AjisaiDB: typeof DB;
-    }
+    readonly exportUserWords: () => Promise<void>;
+    readonly importUserWords: () => Promise<void>;
+    readonly importJsonAsVector: () => Promise<void>;
 }
 
 const toUserWord = (
@@ -74,53 +69,6 @@ const createExportData = (interpreter: AjisaiInterpreter, dictionaryName: string
 
 const buildExportFilename = (name: string): string => `${name}.json`;
 
-const downloadJson = (data: unknown, filename: string): void => {
-    const jsonString = JSON.stringify(data, null, 2);
-    const blob = new Blob([jsonString], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-};
-
-const openFileDialog = (
-    accept: string,
-    onFileSelected: (file: File) => void
-): void => {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = accept;
-
-    input.onchange = (e) => {
-        const file = (e.target as HTMLInputElement).files?.[0];
-        if (file) {
-            onFileSelected(file);
-        }
-    };
-
-    input.click();
-};
-
-const readFileAsText = (file: File): Promise<string> =>
-    new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = (event) => {
-            const result = event.target?.result;
-            if (typeof result === 'string') {
-                resolve(result);
-            } else {
-                reject(new Error('Failed to read file'));
-            }
-        };
-        reader.onerror = () => reject(new Error('Failed to read file'));
-        reader.readAsText(file);
-    });
-
 const parseUserWords = (jsonString: string): Result<UserWord[], Error> => {
     try {
         const parsed = JSON.parse(jsonString);
@@ -134,7 +82,7 @@ const parseUserWords = (jsonString: string): Result<UserWord[], Error> => {
 };
 
 export const createPersistence = (callbacks: PersistenceCallbacks): Persistence => {
-    const { runtime, root = document, showError, updateDisplays, showInfo } = callbacks;
+    const { runtime, root = document, files, storage, showError, updateDisplays, showInfo } = callbacks;
     let dbInitialized = false;
     const MAX_RETRY_COUNT = 3;
     const RETRY_DELAY_MS = 1000;
@@ -145,7 +93,7 @@ export const createPersistence = (callbacks: PersistenceCallbacks): Persistence 
     const init = async (): Promise<void> => {
         for (let attempt = 1; attempt <= MAX_RETRY_COUNT; attempt++) {
             try {
-                await window.AjisaiDB.open();
+                await storage.open();
                 dbInitialized = true;
                 console.log('Database initialized successfully for Persistence.');
                 return;
@@ -173,7 +121,7 @@ export const createPersistence = (callbacks: PersistenceCallbacks): Persistence 
                 lookup_word_definition: runtime.lookupWordDefinition,
                 collect_stack: runtime.collectStack
             } as AjisaiInterpreter);
-            await window.AjisaiDB.saveInterpreterState(state);
+            await storage.saveInterpreterState(state);
             console.log('State saved automatically.');
         } catch (error) {
             console.error('Failed to auto-save state:', error);
@@ -201,7 +149,7 @@ export const createPersistence = (callbacks: PersistenceCallbacks): Persistence 
         }
 
         try {
-            const state = await window.AjisaiDB.loadInterpreterState();
+            const state = await storage.loadInterpreterState();
 
             if (state) {
                 if (state.stack) {
@@ -266,82 +214,96 @@ export const createPersistence = (callbacks: PersistenceCallbacks): Persistence 
         }
     };
 
-    const exportUserWords = (): void => {
+    const exportUserWords = async (): Promise<void> => {
         const selectedDictionary = (root.querySelector('#user-dictionary-select') as HTMLSelectElement | null)?.value || 'DEMO';
-        const suggestedName = selectedDictionary.toLowerCase();
-        const requestedName = window.prompt('Export file name', suggestedName)?.trim();
-        if (!requestedName) {
-            return;
-        }
         const exportData = createExportData({
             collect_user_words_info: runtime.collectUserWordsInfo,
             lookup_word_definition: runtime.lookupWordDefinition
         } as AjisaiInterpreter, selectedDictionary);
-        const filename = buildExportFilename(requestedName);
+        const filename = buildExportFilename(selectedDictionary.toLowerCase());
 
-        downloadJson(exportData, filename);
+        const saved = await files.saveTextFile({
+            suggestedName: filename,
+            text: JSON.stringify(exportData, null, 2),
+            title: 'Export user words'
+        });
+
+        if (!saved) {
+            return;
+        }
         showInfo?.(`User words exported as ${filename}`, true);
     };
 
-    const importUserWords = (): void => {
-        openFileDialog('.json', async (file) => {
-            try {
-                const jsonString = await readFileAsText(file);
-                const parseResult = parseUserWords(jsonString);
-
-                if (!parseResult.ok) {
-                    showError?.(parseResult.error);
-                    return;
-                }
-
-                const importedWords = parseResult.value.map(word => ({
-                    ...word,
-                    dictionary: (word.dictionary || file.name.replace(/\.json$/i, '')).toUpperCase()
-                }));
-                await runtime.restoreUserWords(importedWords);
-
-                updateDisplays?.();
-                await saveCurrentState();
-                showInfo?.(`${importedWords.length} user words imported and saved`, true);
-
-            } catch (error) {
-                showError?.(error as Error);
-            }
+    const importUserWords = async (): Promise<void> => {
+        const fileResult = await files.pickTextFile({
+            accept: '.json',
+            title: 'Import user words JSON'
         });
+
+        if (!fileResult) {
+            return;
+        }
+
+        try {
+            const parseResult = parseUserWords(fileResult.text);
+
+            if (!parseResult.ok) {
+                showError?.(parseResult.error);
+                return;
+            }
+
+            const inferredDictionary = fileResult.name?.replace(/\.json$/i, '') ?? 'IMPORTED';
+            const importedWords = parseResult.value.map(word => ({
+                ...word,
+                dictionary: (word.dictionary || inferredDictionary).toUpperCase()
+            }));
+            await runtime.restoreUserWords(importedWords);
+
+            updateDisplays?.();
+            await saveCurrentState();
+            showInfo?.(`${importedWords.length} user words imported and saved`, true);
+
+        } catch (error) {
+            showError?.(error as Error);
+        }
     };
 
-    const importJsonAsVector = (): void => {
-        openFileDialog('.json', async (file) => {
-            try {
-                const jsonString = await readFileAsText(file);
-
-
-                try {
-                    JSON.parse(jsonString);
-                } catch {
-                    showError?.(new Error('Invalid JSON file.'));
-                    return;
-                }
-
-                const result = runtime.pushJsonString(jsonString);
-
-                if (result.status === 'OK') {
-                    updateDisplays?.();
-                    await saveCurrentState();
-                    showInfo?.(`JSON loaded from ${file.name}`, true);
-                } else {
-                    showError?.(new Error(result.message || 'Failed to parse JSON'));
-                }
-            } catch (error) {
-                showError?.(error as Error);
-            }
+    const importJsonAsVector = async (): Promise<void> => {
+        const fileResult = await files.pickTextFile({
+            accept: '.json',
+            title: 'Import JSON as vector'
         });
+
+        if (!fileResult) {
+            return;
+        }
+
+        try {
+            try {
+                JSON.parse(fileResult.text);
+            } catch {
+                showError?.(new Error('Invalid JSON file.'));
+                return;
+            }
+
+            const result = runtime.pushJsonString(fileResult.text);
+
+            if (result.status === 'OK') {
+                updateDisplays?.();
+                await saveCurrentState();
+                showInfo?.(`JSON loaded from ${fileResult.name ?? 'selected file'}`, true);
+            } else {
+                showError?.(new Error(result.message || 'Failed to parse JSON'));
+            }
+        } catch (error) {
+            showError?.(error as Error);
+        }
     };
 
     const fullReset = async (): Promise<void> => {
         try {
             if (dbInitialized) {
-                await window.AjisaiDB.clearAll();
+                await storage.clearAll();
                 console.log('IndexedDB cleared.');
             } else {
                 console.warn('Database not initialized, skipping clear operation.');

--- a/js/gui/mobile-view-switcher.ts
+++ b/js/gui/mobile-view-switcher.ts
@@ -1,4 +1,5 @@
 
+import type { WindowPort } from '../platform/window-port';
 
 export interface MobileElements {
     readonly inputArea: HTMLElement;
@@ -17,13 +18,12 @@ export interface MobileHandler {
 
 export interface MobileHandlerOptions {
     readonly onModeChange?: (mode: ViewMode) => void;
+    readonly windowEnv: WindowPort;
 }
 
 const MOBILE_BREAKPOINT = 768;
 const SWIPE_THRESHOLD = 50;
 const VIEW_ORDER: ViewMode[] = ['input', 'output', 'stack', 'dictionary'];
-
-const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
 
 const detectSwipeDirection = (
     startX: number,
@@ -74,11 +74,13 @@ const applyVisibility = (
 
 export const createMobileHandler = (
     elements: MobileElements,
-    options: MobileHandlerOptions = {}
+    options: MobileHandlerOptions
 ): MobileHandler => {
     let currentMode: ViewMode = 'input';
     let touchStartX = 0;
     let touchStartY = 0;
+
+    const isMobile = (): boolean => options.windowEnv.getInnerWidth() <= MOBILE_BREAKPOINT;
 
     const updateView = (mode: ViewMode): void => {
         currentMode = mode;
@@ -97,7 +99,7 @@ export const createMobileHandler = (
     };
 
     const setupSwipeGestures = (): void => {
-        const container = document.body;
+        const container = options.windowEnv.getBody();
 
         container.addEventListener('touchstart', (e: TouchEvent) => {
             const touch = e.changedTouches[0];
@@ -108,7 +110,7 @@ export const createMobileHandler = (
         }, { passive: true });
 
         container.addEventListener('touchend', (e: TouchEvent) => {
-            if (!checkIsMobile()) return;
+            if (!isMobile()) return;
             const touch = e.changedTouches[0];
             if (touch) {
                 resolveSwipeGesture(touch.screenX, touch.screenY);
@@ -119,14 +121,13 @@ export const createMobileHandler = (
     setupSwipeGestures();
 
     return {
-        isMobile: () => checkIsMobile(),
+        isMobile,
         extractCurrentMode: () => currentMode,
         updateView
     };
 };
 
 export const mobileUtils = {
-    checkIsMobile,
     detectSwipeDirection,
     resolveNextViewMode,
     lookupVisibilityForMode,

--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -9,6 +9,8 @@ import {
     registerBackgroundClickListeners,
 } from './dictionary-element-builders';
 import type { AjisaiRuntime } from '../core/ajisai-runtime-types';
+import type { DialogPort } from '../platform/dialog-port';
+import type { WindowPort } from '../platform/window-port';
 
 export interface WordInfo {
     readonly dictionary: string;
@@ -33,6 +35,8 @@ export interface VocabularyCallbacks {
     readonly onUpdateDisplays?: () => void;
     readonly onSaveState?: () => Promise<void>;
     readonly showInfo?: (text: string, append: boolean) => void;
+    readonly dialogs: DialogPort;
+    readonly windowEnv: WindowPort;
 }
 
 export interface VocabularyManager {
@@ -104,6 +108,7 @@ const resetWordInfoDisplay = (element: HTMLElement): void => {
 const DEPENDENCY_DELETE_ERROR = 'Cannot delete';
 
 const createDeleteContextMenuElement = (
+    body: HTMLElement,
     onDelete: () => void
 ): HTMLDivElement => {
     const menu = document.createElement('div');
@@ -143,7 +148,7 @@ const createDeleteContextMenuElement = (
     });
 
     menu.appendChild(deleteButton);
-    document.body.appendChild(menu);
+    body.appendChild(menu);
 
     return menu;
 };
@@ -152,8 +157,8 @@ export const createVocabularyManager = (
     elements: VocabularyElements,
     callbacks: VocabularyCallbacks
 ): VocabularyManager => {
-    const { runtime, onWordClick, onBackgroundClick, onBackgroundDoubleClick, onUpdateDisplays, onSaveState, showInfo } = callbacks;
-    const deleteContextMenu = createDeleteContextMenuElement(() => {
+    const { runtime, onWordClick, onBackgroundClick, onBackgroundDoubleClick, onUpdateDisplays, onSaveState, showInfo, dialogs, windowEnv } = callbacks;
+    const deleteContextMenu = createDeleteContextMenuElement(windowEnv.getBody(), () => {
         if (!activeContextWordName) {
             return;
         }
@@ -176,15 +181,15 @@ export const createVocabularyManager = (
         deleteContextMenu.style.top = `${event.clientY}px`;
     };
 
-    document.addEventListener('click', () => {
+    windowEnv.addDocumentEventListener('click', () => {
         hideDeleteContextMenu();
     });
-    document.addEventListener('contextmenu', (event) => {
+    windowEnv.addDocumentEventListener('contextmenu', (event) => {
         if (!(event.target instanceof HTMLElement) || !event.target.closest('.word-button')) {
             hideDeleteContextMenu();
         }
     });
-    window.addEventListener('blur', hideDeleteContextMenu);
+    windowEnv.addWindowEventListener('blur', hideDeleteContextMenu);
 
     [elements.builtInWordsDisplay, elements.userWordsDisplay].forEach(container => {
         registerBackgroundClickListeners(container, onBackgroundClick, onBackgroundDoubleClick);
@@ -206,7 +211,7 @@ export const createVocabularyManager = (
             const result = await runtime.execute(deleteCode);
             if (result.status === 'ERROR') {
                 if (!forceDelete && result.message?.includes(DEPENDENCY_DELETE_ERROR)) {
-                    const confirmed = confirm(
+                    const confirmed = await dialogs.confirm(
                         `Word '${wordName}' is referenced by other user words. Force delete with ! ?`
                     );
 
@@ -217,7 +222,7 @@ export const createVocabularyManager = (
                     return false;
                 }
 
-                alert(`Failed to delete word: ${result.message}`);
+                await dialogs.alert(`Failed to delete word: ${result.message}`);
                 return false;
             }
 
@@ -226,7 +231,7 @@ export const createVocabularyManager = (
             showInfo?.(`Word '${wordName}' deleted`, true);
             return true;
         } catch (error) {
-            alert(`Error deleting word: ${error}`);
+            await dialogs.alert(`Error deleting word: ${error}`);
             return false;
         }
     };

--- a/js/platform/clipboard-port.ts
+++ b/js/platform/clipboard-port.ts
@@ -1,0 +1,3 @@
+export interface ClipboardPort {
+    writeText(text: string): Promise<void>;
+}

--- a/js/platform/dialog-port.ts
+++ b/js/platform/dialog-port.ts
@@ -1,0 +1,4 @@
+export interface DialogPort {
+    confirm(message: string, options?: { title?: string; okLabel?: string; cancelLabel?: string }): Promise<boolean>;
+    alert(message: string, options?: { title?: string; kind?: 'info' | 'warning' | 'error'; okLabel?: string }): Promise<void>;
+}

--- a/js/platform/file-port.ts
+++ b/js/platform/file-port.ts
@@ -1,0 +1,17 @@
+export interface PickTextFileResult {
+    readonly path?: string;
+    readonly name?: string;
+    readonly text: string;
+}
+
+export interface FilePort {
+    pickTextFile(options?: {
+        accept?: string;
+        title?: string;
+    }): Promise<PickTextFileResult | null>;
+    saveTextFile(options: {
+        suggestedName: string;
+        text: string;
+        title?: string;
+    }): Promise<boolean>;
+}

--- a/js/platform/platform-services.ts
+++ b/js/platform/platform-services.ts
@@ -1,0 +1,13 @@
+import type { ClipboardPort } from './clipboard-port';
+import type { DialogPort } from './dialog-port';
+import type { FilePort } from './file-port';
+import type { StoragePort } from './storage-port';
+import type { WindowPort } from './window-port';
+
+export interface PlatformServices {
+    readonly dialogs: DialogPort;
+    readonly files: FilePort;
+    readonly storage: StoragePort;
+    readonly clipboard: ClipboardPort;
+    readonly windowEnv: WindowPort;
+}

--- a/js/platform/storage-port.ts
+++ b/js/platform/storage-port.ts
@@ -1,0 +1,8 @@
+import type { InterpreterState } from '../gui/interpreter-state-persistence';
+
+export interface StoragePort {
+    open(): Promise<void>;
+    saveInterpreterState(state: InterpreterState): Promise<void>;
+    loadInterpreterState(): Promise<InterpreterState | null>;
+    clearAll(): Promise<void>;
+}

--- a/js/platform/tauri/create-tauri-platform-services.ts
+++ b/js/platform/tauri/create-tauri-platform-services.ts
@@ -1,0 +1,14 @@
+import type { PlatformServices } from '../platform-services';
+import { TAURI_CLIPBOARD_PORT } from './tauri-clipboard-port';
+import { TAURI_DIALOG_PORT } from './tauri-dialog-port';
+import { TAURI_FILE_PORT } from './tauri-file-port';
+import { TAURI_STORAGE_PORT } from './tauri-storage-port';
+import { TAURI_WINDOW_PORT } from './tauri-window-port';
+
+export const createTauriPlatformServices = (): PlatformServices => ({
+    dialogs: TAURI_DIALOG_PORT,
+    files: TAURI_FILE_PORT,
+    storage: TAURI_STORAGE_PORT,
+    clipboard: TAURI_CLIPBOARD_PORT,
+    windowEnv: TAURI_WINDOW_PORT
+});

--- a/js/platform/tauri/tauri-clipboard-port.ts
+++ b/js/platform/tauri/tauri-clipboard-port.ts
@@ -1,0 +1,4 @@
+import type { ClipboardPort } from '../clipboard-port';
+import { WEB_CLIPBOARD_PORT } from '../web/web-clipboard-port';
+
+export const TAURI_CLIPBOARD_PORT: ClipboardPort = WEB_CLIPBOARD_PORT;

--- a/js/platform/tauri/tauri-dialog-port.ts
+++ b/js/platform/tauri/tauri-dialog-port.ts
@@ -1,0 +1,19 @@
+import { confirm, message } from '@tauri-apps/plugin-dialog';
+import type { DialogPort } from '../dialog-port';
+
+export const TAURI_DIALOG_PORT: DialogPort = {
+    async confirm(messageText: string, options): Promise<boolean> {
+        return await confirm(messageText, {
+            title: options?.title,
+            okLabel: options?.okLabel,
+            cancelLabel: options?.cancelLabel
+        });
+    },
+    async alert(messageText: string, options): Promise<void> {
+        await message(messageText, {
+            title: options?.title,
+            kind: options?.kind,
+            okLabel: options?.okLabel
+        });
+    }
+};

--- a/js/platform/tauri/tauri-file-port.ts
+++ b/js/platform/tauri/tauri-file-port.ts
@@ -1,0 +1,41 @@
+import { open, save } from '@tauri-apps/plugin-dialog';
+import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+import type { FilePort, PickTextFileResult } from '../file-port';
+
+const resolveNameFromPath = (path: string): string => path.split(/[\\/]/).pop() ?? path;
+
+export const TAURI_FILE_PORT: FilePort = {
+    async pickTextFile(options): Promise<PickTextFileResult | null> {
+        const selected = await open({
+            title: options?.title ?? 'Select file',
+            multiple: false,
+            filters: [{ name: 'JSON', extensions: ['json'] }]
+        });
+
+        if (!selected || Array.isArray(selected)) {
+            return null;
+        }
+
+        const text = await readTextFile(selected);
+        return {
+            path: selected,
+            name: resolveNameFromPath(selected),
+            text
+        };
+    },
+
+    async saveTextFile(options): Promise<boolean> {
+        const selected = await save({
+            title: options.title ?? 'Save file',
+            defaultPath: options.suggestedName,
+            filters: [{ name: 'JSON', extensions: ['json'] }]
+        });
+
+        if (!selected) {
+            return false;
+        }
+
+        await writeTextFile(selected, options.text);
+        return true;
+    }
+};

--- a/js/platform/tauri/tauri-storage-port.ts
+++ b/js/platform/tauri/tauri-storage-port.ts
@@ -1,0 +1,4 @@
+import type { StoragePort } from '../storage-port';
+import { WEB_STORAGE_PORT } from '../web/web-storage-port';
+
+export const TAURI_STORAGE_PORT: StoragePort = WEB_STORAGE_PORT;

--- a/js/platform/tauri/tauri-window-port.ts
+++ b/js/platform/tauri/tauri-window-port.ts
@@ -1,0 +1,4 @@
+import type { WindowPort } from '../window-port';
+import { WEB_WINDOW_PORT } from '../web/web-window-port';
+
+export const TAURI_WINDOW_PORT: WindowPort = WEB_WINDOW_PORT;

--- a/js/platform/web/create-web-platform-services.ts
+++ b/js/platform/web/create-web-platform-services.ts
@@ -1,0 +1,14 @@
+import type { PlatformServices } from '../platform-services';
+import { WEB_CLIPBOARD_PORT } from './web-clipboard-port';
+import { WEB_DIALOG_PORT } from './web-dialog-port';
+import { WEB_FILE_PORT } from './web-file-port';
+import { WEB_STORAGE_PORT } from './web-storage-port';
+import { WEB_WINDOW_PORT } from './web-window-port';
+
+export const createWebPlatformServices = (): PlatformServices => ({
+    dialogs: WEB_DIALOG_PORT,
+    files: WEB_FILE_PORT,
+    storage: WEB_STORAGE_PORT,
+    clipboard: WEB_CLIPBOARD_PORT,
+    windowEnv: WEB_WINDOW_PORT
+});

--- a/js/platform/web/web-clipboard-port.ts
+++ b/js/platform/web/web-clipboard-port.ts
@@ -1,0 +1,7 @@
+import type { ClipboardPort } from '../clipboard-port';
+
+export const WEB_CLIPBOARD_PORT: ClipboardPort = {
+    async writeText(text: string): Promise<void> {
+        await navigator.clipboard.writeText(text);
+    }
+};

--- a/js/platform/web/web-dialog-port.ts
+++ b/js/platform/web/web-dialog-port.ts
@@ -1,0 +1,10 @@
+import type { DialogPort } from '../dialog-port';
+
+export const WEB_DIALOG_PORT: DialogPort = {
+    async confirm(message: string): Promise<boolean> {
+        return window.confirm(message);
+    },
+    async alert(message: string): Promise<void> {
+        window.alert(message);
+    }
+};

--- a/js/platform/web/web-file-port.ts
+++ b/js/platform/web/web-file-port.ts
@@ -1,0 +1,48 @@
+import type { FilePort, PickTextFileResult } from '../file-port';
+
+const readFileAsText = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            const result = event.target?.result;
+            if (typeof result === 'string') {
+                resolve(result);
+            } else {
+                reject(new Error('Failed to read file'));
+            }
+        };
+        reader.onerror = () => reject(new Error('Failed to read file'));
+        reader.readAsText(file);
+    });
+
+const pickFile = (accept: string): Promise<File | null> =>
+    new Promise((resolve) => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = accept;
+        input.onchange = (e) => resolve((e.target as HTMLInputElement).files?.[0] ?? null);
+        input.click();
+    });
+
+export const WEB_FILE_PORT: FilePort = {
+    async pickTextFile(options): Promise<PickTextFileResult | null> {
+        const file = await pickFile(options?.accept ?? '.json,text/plain,application/json');
+        if (!file) return null;
+        const text = await readFileAsText(file);
+        return { name: file.name, text };
+    },
+
+    async saveTextFile(options): Promise<boolean> {
+        const blob = new Blob([options.text], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = options.suggestedName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        return true;
+    }
+};

--- a/js/platform/web/web-storage-port.ts
+++ b/js/platform/web/web-storage-port.ts
@@ -1,0 +1,24 @@
+import type DB from '../../indexeddb-user-word-store';
+import type { InterpreterState } from '../../gui/interpreter-state-persistence';
+import type { StoragePort } from '../storage-port';
+
+declare global {
+    interface Window {
+        AjisaiDB: typeof DB;
+    }
+}
+
+export const WEB_STORAGE_PORT: StoragePort = {
+    async open(): Promise<void> {
+        await window.AjisaiDB.open();
+    },
+    async saveInterpreterState(state: InterpreterState): Promise<void> {
+        await window.AjisaiDB.saveInterpreterState(state);
+    },
+    async loadInterpreterState(): Promise<InterpreterState | null> {
+        return await window.AjisaiDB.loadInterpreterState();
+    },
+    async clearAll(): Promise<void> {
+        await window.AjisaiDB.clearAll();
+    }
+};

--- a/js/platform/web/web-window-port.ts
+++ b/js/platform/web/web-window-port.ts
@@ -1,0 +1,19 @@
+import type { WindowPort } from '../window-port';
+
+export const WEB_WINDOW_PORT: WindowPort = {
+    getInnerWidth(): number {
+        return window.innerWidth;
+    },
+    getHardwareConcurrency(): number {
+        return navigator.hardwareConcurrency || 4;
+    },
+    addWindowEventListener(type, listener, options): void {
+        window.addEventListener(type, listener as EventListener, options);
+    },
+    addDocumentEventListener(type, listener, options): void {
+        document.addEventListener(type, listener as EventListener, options);
+    },
+    getBody(): HTMLElement {
+        return document.body;
+    }
+};

--- a/js/platform/window-port.ts
+++ b/js/platform/window-port.ts
@@ -1,0 +1,15 @@
+export interface WindowPort {
+    getInnerWidth(): number;
+    getHardwareConcurrency(): number;
+    addWindowEventListener<K extends keyof WindowEventMap>(
+        type: K,
+        listener: (event: WindowEventMap[K]) => void,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    addDocumentEventListener<K extends keyof DocumentEventMap>(
+        type: K,
+        listener: (event: DocumentEventMap[K]) => void,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    getBody(): HTMLElement;
+}

--- a/js/tauri-app-entrypoint.ts
+++ b/js/tauri-app-entrypoint.ts
@@ -1,0 +1,5 @@
+import { startTauriApp } from './entrypoints/tauri-app-entrypoint';
+
+document.addEventListener('DOMContentLoaded', () => {
+    void startTauriApp();
+});

--- a/js/types/tauri-plugin-shims.d.ts
+++ b/js/types/tauri-plugin-shims.d.ts
@@ -1,0 +1,25 @@
+declare module '@tauri-apps/plugin-dialog' {
+  export function confirm(
+    message: string,
+    options?: { title?: string; okLabel?: string; cancelLabel?: string }
+  ): Promise<boolean>;
+  export function message(
+    message: string,
+    options?: { title?: string; kind?: 'info' | 'warning' | 'error'; okLabel?: string }
+  ): Promise<void>;
+  export function open(options?: {
+    title?: string;
+    multiple?: boolean;
+    filters?: Array<{ name: string; extensions: string[] }>;
+  }): Promise<string | string[] | null>;
+  export function save(options?: {
+    title?: string;
+    defaultPath?: string;
+    filters?: Array<{ name: string; extensions: string[] }>;
+  }): Promise<string | null>;
+}
+
+declare module '@tauri-apps/plugin-fs' {
+  export function readTextFile(path: string): Promise<string>;
+  export function writeTextFile(path: string, contents: string): Promise<void>;
+}

--- a/js/workers/execution-worker-manager.ts
+++ b/js/workers/execution-worker-manager.ts
@@ -1,8 +1,8 @@
-
-
 import type { ExecuteResult } from '../wasm-interpreter-types';
 import type { InterpreterSnapshot } from './interpreter-snapshot';
 import { extractCompiledWasmModule } from '../wasm-module-loader';
+import type { WindowPort } from '../platform/window-port';
+import { WEB_WINDOW_PORT } from '../platform/web/web-window-port';
 
 interface WorkerTask {
     id: string;
@@ -21,29 +21,31 @@ interface WorkerInstance {
 const MOBILE_BREAKPOINT = 768;
 const MAX_MOBILE_WORKERS = 2;
 
+const resolveMaxWorkers = (windowEnv: WindowPort): number => {
+    const hardware = Math.max(windowEnv.getHardwareConcurrency(), 1);
+    if (windowEnv.getInnerWidth() <= MOBILE_BREAKPOINT) {
+        return Math.min(hardware, MAX_MOBILE_WORKERS);
+    }
+    return Math.min(hardware, 8);
+};
+
 export class WorkerManager {
     private workers: WorkerInstance[] = [];
     private taskQueue: WorkerTask[] = [];
     private activeTasks = new Map<string, WorkerTask>();
     private compiledModule: WebAssembly.Module | null = null;
-    private maxWorkers = window.innerWidth <= MOBILE_BREAKPOINT
-        ? Math.min(navigator.hardwareConcurrency || 2, MAX_MOBILE_WORKERS)
-        : navigator.hardwareConcurrency || 4;
+
+    constructor(private readonly maxWorkers: number) {}
 
     async init(): Promise<void> {
         console.log('[WorkerManager] Initializing worker pool...');
         this.workers = [];
-
-
 
         this.compiledModule = extractCompiledWasmModule();
 
         if (!this.compiledModule) {
             console.warn('[WorkerManager] Compiled WASM module not available; workers will init independently');
         }
-
-
-
 
         for (let i = 0; i < this.maxWorkers; i++) {
             this.createWorker();
@@ -57,16 +59,12 @@ export class WorkerManager {
         worker.onmessage = (event) => this.resolveWorkerMessage(instance, event.data);
         worker.onerror = (error) => this.resolveWorkerError(instance, error);
 
-
-
-
         if (this.compiledModule) {
             worker.postMessage({ type: 'init', wasmModule: this.compiledModule });
         }
 
         this.workers.push(instance);
     }
-
 
     private ensureWorkers(): void {
         if (this.workers.length > 0) return;
@@ -136,7 +134,6 @@ export class WorkerManager {
     }
 
     private createTaskId(): string {
-
         if (typeof crypto !== 'undefined' && crypto.randomUUID) {
             return crypto.randomUUID();
         }
@@ -162,13 +159,11 @@ export class WorkerManager {
     abortAll(): void {
         console.log('[WorkerManager] Aborting all tasks...');
 
-
         const abortError = new Error('Execution aborted');
         for (const task of this.taskQueue) {
             task.reject(abortError);
         }
         this.taskQueue = [];
-
 
         for (const id of this.activeTasks.keys()) {
             const worker = this.workers.find(w => w.currentTaskId === id)?.worker;
@@ -185,4 +180,8 @@ export class WorkerManager {
     }
 }
 
-export const WORKER_MANAGER = new WorkerManager();
+export const createWorkerManager = (windowEnv: WindowPort): WorkerManager =>
+    new WorkerManager(resolveMaxWorkers(windowEnv));
+
+
+export const WORKER_MANAGER = createWorkerManager(WEB_WINDOW_PORT);

--- a/package.json
+++ b/package.json
@@ -9,11 +9,20 @@
     "dev": "vite",
     "preview": "vite preview",
     "check": "tsc --noEmit",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rm -rf dist node_modules",
+    "build:web": "vite build",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build",
+    "build:tauri": "npm run build:web && tauri build"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "@tauri-apps/cli": "^2.0.0"
+  },
+  "dependencies": {
+    "@tauri-apps/plugin-dialog": "^2.0.0",
+    "@tauri-apps/plugin-fs": "^2.0.0"
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ajisai-tauri"
+version = "0.1.0"
+description = "Ajisai desktop app"
+authors = ["Ajisai"]
+edition = "2021"
+
+[lib]
+name = "ajisai_tauri_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
+
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/src-tauri/capabilities/main-capability.json
+++ b/src-tauri/capabilities/main-capability.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Permissions for Ajisai desktop main window",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "dialog:allow-open",
+    "dialog:allow-save",
+    "dialog:allow-message",
+    "dialog:allow-confirm",
+    "fs:allow-read-text-file",
+    "fs:allow-write-text-file"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    ajisai_tauri_lib::run();
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Ajisai",
+  "version": "1.0.0",
+  "identifier": "com.ajisai.app",
+  "build": {
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build:web",
+    "devUrl": "http://localhost:3000/tauri.html",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Ajisai",
+        "width": 1280,
+        "height": 820,
+        "resizable": true,
+        "url": "tauri.html"
+      }
+    ],
+    "security": {
+      "capabilities": [
+        "main-capability"
+      ]
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "../public/images/icon-192.png",
+      "../public/images/icon-512.png"
+    ]
+  }
+}

--- a/tauri.html
+++ b/tauri.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Ajisai - An AI-first, vector-oriented, fractional-dataflow programming language.">
+    <meta name="theme-color" content="#007bff">
+
+
+    <link rel="manifest" href="./manifest.json">
+    <link rel="apple-touch-icon" href="./images/icon-192.png">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-title" content="Ajisai">
+
+    <title>Ajisai</title>
+
+
+    <script src="/ajisai-config.js?v=20260408"></script>
+    <script src="/ajisai-theme.js?v=20260408"></script>
+    <script src="/shared/ajisai-shared-ui.js?v=20260410"></script>
+    <style id="theme-vars"></style>
+    <script>
+
+        if (typeof AjisaiTheme !== 'undefined') {
+            const vars = AjisaiTheme.getAll();
+            let css = ':root {';
+            for (const [key, value] of Object.entries(vars)) {
+                css += `${key}: ${value};`;
+            }
+            css += '}';
+            document.getElementById('theme-vars').textContent = css;
+        }
+    </script>
+
+    <link rel="stylesheet" href="public/ajisai-base.css?v=20260408">
+    <link rel="stylesheet" href="app-interface.css?v=20260408">
+</head>
+<body>
+    <a href="#code-input" class="skip-link">Skip to main content</a>
+    <div class="container">
+        <header id="js-header" role="banner"></header>
+
+        <main class="main-layout">
+            <div class="area-selector area-selector-mobile">
+                <label for="mobile-panel-select" class="visually-hidden">Select panel</label>
+                <select id="mobile-panel-select">
+                    <option value="input">Input</option>
+                    <option value="output">Output</option>
+                    <option value="stack">Stack</option>
+                    <option value="dictionary">Dictionary</option>
+                </select>
+            </div>
+
+            <div id="editor-panel" class="panel">
+                <div class="area-selector area-selector-left">
+                    <label for="left-panel-select" class="visually-hidden">Select left panel</label>
+                    <select id="left-panel-select">
+                        <option value="input">Input</option>
+                        <option value="output">Output</option>
+                    </select>
+                </div>
+                <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0">
+                    <h2 class="visually-hidden">Output</h2>
+                    <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
+                    <div class="vocabulary-actions">
+                        <button id="copy-output-btn" class="header-btn" type="button" aria-label="Copy output to clipboard">Copy</button>
+                    </div>
+                </section>
+                <section id="input-panel" class="input-area" role="region" aria-label="Input" tabindex="0">
+                    <h2 class="visually-hidden">Input</h2>
+                    <div class="textarea-wrapper">
+                        <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
+                        <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
+                    </div>
+                    <div class="vocabulary-actions">
+                        <button id="run-btn" type="button">Run</button>
+                    </div>
+                </section>
+            </div>
+
+            <div id="state-panel" class="panel">
+                <div class="area-selector area-selector-right">
+                    <label for="right-panel-select" class="visually-hidden">Select right panel</label>
+                    <select id="right-panel-select">
+                        <option value="stack">Stack</option>
+                        <option value="dictionary">Dictionary</option>
+                    </select>
+                </div>
+                <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
+                    <h2 class="visually-hidden">Stack</h2>
+                    <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
+                    <div class="vocabulary-actions"></div>
+                </section>
+
+                <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
+                    <div class="dictionary-toolbar">
+                        <div class="dictionary-sheet-selector">
+                            <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
+                            <select id="dictionary-sheet-select">
+                                <option value="core">Core word</option>
+                                <option value="user">User word</option>
+                            </select>
+                        </div>
+                        <div class="search-wrapper">
+                            <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
+                            <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
+                        </div>
+                    </div>
+                    <div id="dictionary-sheet-core" class="dictionary-sheet active">
+                        <div class="vocabulary-container">
+                            <div class="words-area">
+                                <span id="core-word-info" class="word-info-display"></span>
+                                <div id="core-words-display" class="words-display"></div>
+                            </div>
+                        </div>
+                        <div class="vocabulary-actions"></div>
+                    </div>
+                    <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
+                        <div class="vocabulary-container">
+                            <div class="words-area">
+                                <div class="dictionary-sheet-selector">
+                                    <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                                    <select id="user-dictionary-select">
+                                        <option value="DEMO">Demonstration word</option>
+                                    </select>
+                                </div>
+                                <span id="user-word-info" class="word-info-display"></span>
+                                <div id="user-words-display" class="words-display"></div>
+                            </div>
+                        </div>
+                        <div class="vocabulary-actions">
+                            <button id="export-btn" class="header-btn" type="button">Export</button>
+                            <button id="import-btn" class="header-btn" type="button">Import</button>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span>&copy; <span id="footer-year"></span> masamoto yamashiro</span>
+            <a href="https://github.com/masamoto1982/Ajisai" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </footer>
+        <script>document.getElementById('footer-year').textContent = new Date().getFullYear();</script>
+    </div>
+
+    <script type="module" src="js/tauri-app-entrypoint.ts"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a minimal Tauri 2 desktop execution path while preserving the existing Web UX and not redesigning the GUI. 
- Isolate browser-dependent APIs behind a `platform` abstraction to allow both Web and Tauri implementations to coexist. 
- Replace direct usage of globals (file input/reader/blob, `window.AjisaiDB`, `confirm`/`alert`, clipboard, `window.innerWidth`/`document.body`) so desktop integration can use official Tauri `dialog`/`fs` plugins. 

### Description
- Introduced a `js/platform/` abstraction layer and interfaces: `DialogPort`, `FilePort`, `StoragePort`, `ClipboardPort`, `WindowPort`, and `PlatformServices`, plus Web and Tauri adapters under `js/platform/web/` and `js/platform/tauri/` respectively. 
- Refactored `createGUI` to accept `platform` services (`createGUI({ runtime, root, platform })`) and updated callers (`web-app-entrypoint`, `electron-renderer-entrypoint`, added `tauri-app-entrypoint`) to supply `createWebPlatformServices` or `createTauriPlatformServices`. 
- Reworked persistence and I/O: `js/gui/interpreter-state-persistence.ts` now uses `FilePort`/`StoragePort` (removing `prompt`/hidden file input/Blob/download and direct `window.AjisaiDB` calls) and maintains demo-words migration and compatibility semantics. 
- Replaced direct browser calls in other modules: `vocabulary-state-controller` uses `DialogPort` and `WindowPort` for confirmations/alerts/context menu, `mobile-view-switcher` uses `WindowPort` for viewport/touch container, and the worker manager became a `createWorkerManager(windowEnv)` factory using `WindowPort` to determine worker count. 
- Added a minimal Tauri scaffold under `src-tauri/` (Rust glue with `tauri_plugin_dialog` and `tauri_plugin_fs` initialized) and an app capability file with minimal permissions for dialog/fs; added `tauri.html` and npm scripts (`tauri:dev`, `tauri:build`, `build:web`). 
- Added TypeScript shims for Tauri plugin imports and kept all Web behavior (service worker and online/offline monitoring) unchanged for the Web path. 

### Testing
- Ran TypeScript checks with `npm run check` and it passed (`tsc --noEmit`).
- Built the Web distribution with `npm run build:web` and the Vite build succeeded producing `dist/` assets. 
- Attempted `npm run tauri:build` but the `tauri` CLI was not available because `npm install` of `@tauri-apps/cli` was blocked by the environment (registry 403), so full Tauri build could not be completed here. 
- Ran `cargo check` in `src-tauri/` but dependency fetch failed due to network/crates.io access restrictions (CONNECT 403), so Rust-side validation is pending in a network-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9072223dc8326a928fc8165455dc6)