### PR TITLE
Unify app/reference header version and enable header rendering in Tauri

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
     <script src="/ajisai-config.js?v=20260408"></script>
     <script src="/ajisai-theme.js?v=20260408"></script>
-    <script src="/shared/ajisai-shared-ui.js?v=20260410"></script>
+    <script src="/shared/ajisai-shared-ui.js?v=20260411"></script>
     <style id="theme-vars"></style>
     <script>
 

--- a/js/entrypoints/tauri-app-entrypoint.ts
+++ b/js/entrypoints/tauri-app-entrypoint.ts
@@ -2,6 +2,20 @@ import '../indexeddb-user-word-store';
 import { createAjisaiRuntimeFromWasm } from '../core/ajisai-runtime-factory';
 import { createGUI } from '../gui/gui-application';
 import { createTauriPlatformServices } from '../platform/tauri/create-tauri-platform-services';
+import { AJISAI_APP_VERSION } from '../ui/shared/app-version';
+
+declare global {
+    interface Window {
+        AjisaiSharedUI?: {
+            renderHeader: (root: HTMLElement, options: {
+                mode: 'web' | 'reference';
+                version: string;
+                assetsPath: string;
+                referenceHref: string;
+            }) => void;
+        };
+    }
+}
 
 const renderStartupError = (error: unknown): void => {
     const outputDisplay = document.getElementById('output-display');
@@ -18,6 +32,16 @@ export async function startTauriApp(): Promise<void> {
     console.log('[Main] Starting Ajisai Tauri application...');
 
     try {
+        const headerEl = document.getElementById('js-header');
+        if (headerEl instanceof HTMLElement && window.AjisaiSharedUI?.renderHeader) {
+            window.AjisaiSharedUI.renderHeader(headerEl, {
+                mode: 'web',
+                version: AJISAI_APP_VERSION,
+                assetsPath: './public/images',
+                referenceHref: 'docs/index.html'
+            });
+        }
+
         const runtime = await createAjisaiRuntimeFromWasm();
         const platform = createTauriPlatformServices();
         const gui = createGUI({ runtime, root: document, platform });

--- a/js/entrypoints/web-app-entrypoint.ts
+++ b/js/entrypoints/web-app-entrypoint.ts
@@ -4,6 +4,7 @@ import { createGUI } from '../gui/gui-application';
 import { monitorWebOnlineStatus } from '../infrastructure/web/web-online-status';
 import { registerWebServiceWorker } from '../infrastructure/web/web-service-worker';
 import { createWebPlatformServices } from '../platform/web/create-web-platform-services';
+import { AJISAI_APP_VERSION } from '../ui/shared/app-version';
 
 declare global {
     interface Window {
@@ -37,7 +38,7 @@ export async function startWebApp(): Promise<void> {
         if (headerEl instanceof HTMLElement && window.AjisaiSharedUI?.renderHeader) {
             window.AjisaiSharedUI.renderHeader(headerEl, {
                 mode: 'web',
-                version: '202604102001',
+                version: AJISAI_APP_VERSION,
                 assetsPath: './public/images',
                 referenceHref: 'docs/index.html'
             });

--- a/js/ui/shared/ajisai-shell.ts
+++ b/js/ui/shared/ajisai-shell.ts
@@ -1,4 +1,5 @@
 import { renderAjisaiHeader } from './header-view';
+import { AJISAI_APP_VERSION } from './app-version';
 
 export interface NavItem {
     readonly label: string;
@@ -41,7 +42,7 @@ const defaultConfig: DocsShellConfig = {
         github: { url: 'https://github.com/masamoto1982/Ajisai', label: 'GitHub' },
         demo: { url: 'https://masamoto1982.github.io/Ajisai/', label: 'Try Demo' }
     },
-    version: '202604080203'
+    version: AJISAI_APP_VERSION
 };
 
 export const renderDocsShell = (root: ParentNode, config: DocsShellConfig = defaultConfig): void => {

--- a/js/ui/shared/app-version.ts
+++ b/js/ui/shared/app-version.ts
@@ -1,0 +1,1 @@
+export const AJISAI_APP_VERSION = '202604102001';

--- a/public/docs/about.html
+++ b/public/docs/about.html
@@ -6,7 +6,7 @@
   <title>Ajisai | About</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/control.html
+++ b/public/docs/control.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Control</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/docs-navigation-script.js
+++ b/public/docs/docs-navigation-script.js
@@ -19,7 +19,7 @@
             { label: 'GitHub', link: 'https://github.com/masamoto1982/Ajisai' },
             { label: 'Demo', link: 'https://masamoto1982.github.io/Ajisai/' }
         ],
-        version: '202604080203'
+        version: '202604102001'
     });
 
     const renderDocsShell = (root, config) => {

--- a/public/docs/examples.html
+++ b/public/docs/examples.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Examples</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/higher-order.html
+++ b/public/docs/higher-order.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Higher-Order</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Vector-oriented Fractional Dataflow Language</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/philosophy.html
+++ b/public/docs/philosophy.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Philosophy</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/syntax.html
+++ b/public/docs/syntax.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Syntax</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/tutorial.html
+++ b/public/docs/tutorial.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Tutorial</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/types.html
+++ b/public/docs/types.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Types</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/public/docs/words.html
+++ b/public/docs/words.html
@@ -6,7 +6,7 @@
   <title>Ajisai | Words</title>
   <script src="../ajisai-config.js?v=20260408"></script>
   <script src="../ajisai-theme.js?v=20260408"></script>
-  <script src="../shared/ajisai-shared-ui.js?v=20260410"></script>
+  <script src="../shared/ajisai-shared-ui.js?v=20260411"></script>
   <style id="theme-vars"></style>
   <script>
     if (typeof AjisaiTheme !== 'undefined') {
@@ -40,6 +40,6 @@
 
     <footer id="js-footer"></footer>
   </div>
-  <script src="docs-navigation-script.js?v=20260408"></script>
+  <script src="docs-navigation-script.js?v=20260411"></script>
 </body>
 </html>

--- a/tauri.html
+++ b/tauri.html
@@ -18,7 +18,7 @@
 
     <script src="/ajisai-config.js?v=20260408"></script>
     <script src="/ajisai-theme.js?v=20260408"></script>
-    <script src="/shared/ajisai-shared-ui.js?v=20260410"></script>
+    <script src="/shared/ajisai-shared-ui.js?v=20260411"></script>
     <style id="theme-vars"></style>
     <script>
 


### PR DESCRIPTION
### Motivation
- Ensure the header version shown in the app UI and the reference/docs site is consistent and avoid out-of-sync updates.
- Make the Tauri desktop app render the same shared header as the web app so desktop and web UIs match.

### Description
- Introduced a single shared constant `AJISAI_APP_VERSION` in `js/ui/shared/app-version.ts` and used it where header version strings were previously hard-coded. 
- Updated `js/entrypoints/web-app-entrypoint.ts` and `js/ui/shared/ajisai-shell.ts` to read the version from `AJISAI_APP_VERSION`. 
- Added header rendering to `js/entrypoints/tauri-app-entrypoint.ts` so Tauri now calls `AjisaiSharedUI.renderHeader(...)` with the same contract as the web app. 
- Synced the docs script version in `public/docs/docs-navigation-script.js` to the app version and bumped cache-busting query params for `ajisai-shared-ui.js` and `docs-navigation-script.js` across `index.html`, `tauri.html`, and `public/docs/*.html` so updates are reflected reliably.

### Testing
- Ran `npm run check` (TypeScript type check) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90c5c59a48326a23c77cb4bd32b57)