### PR TITLE
Introduce isolated child runtimes and supervision builtins (SPAWN/AWAIT/STATUS/KILL/MONITOR/SUPERVISE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 Ajisai is an AI-first, vector-oriented, fractional-dataflow language with a Rust (WASM) core and TypeScript GUI/runtime shell.
 
 - Playground: https://masamoto1982.github.io/Ajisai/
+- Runtime model includes local safe-mode (`~`) plus isolated child-runtime lifecycle words (`SPAWN`, `AWAIT`, `STATUS`, `KILL`, `MONITOR`, `SUPERVISE`) for Ajisai-style let-it-crash execution.
 
 ## Documentation Authority
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -66,6 +66,8 @@ Canonical runtime values:
 - Record
 - NIL
 - Code block
+- Process handle
+- Supervisor handle
 
 Strings/booleans/datetime-like representations are encoded over core value forms and may be accompanied by semantic hints.
 
@@ -106,6 +108,12 @@ Canonical boundary: FlowToken fields (ID, remaining mass, parent/child links, ra
 
 ### 6.3 Safety mode
 - `~`: safe mode (errors become NIL where defined)
+
+### 6.4 Let-it-crash runtime model
+- `~` is local error absorption for a single operation.
+- Child runtime words (`SPAWN`, `AWAIT`, `STATUS`, `KILL`, `MONITOR`, `SUPERVISE`) provide isolated execution lifecycle control.
+- Child runtimes are isolated from parent stack/user-word mutation during execution.
+- Child failures are observed as exit values (`ok` / `exit` / `killed` / `timeout`) and do not immediately crash the parent interpreter.
 
 Mode composition must be explicit and mechanically testable.
 

--- a/js/gui/value-formatter.ts
+++ b/js/gui/value-formatter.ts
@@ -109,6 +109,10 @@ export function formatValueSimple(value: Value): string {
                 return `[${elements ? ' ' + elements + ' ' : ''}]`;
             }
             return '[]';
+        case 'process_handle':
+            return `<process:${value.value}>`;
+        case 'supervisor_handle':
+            return `<supervisor:${value.value}>`;
         default:
             return JSON.stringify(value.value);
     }

--- a/js/wasm-interpreter-types.ts
+++ b/js/wasm-interpreter-types.ts
@@ -57,6 +57,16 @@ export interface Value {
     displayHint?: 'auto' | 'number' | 'string' | 'boolean' | 'datetime' | 'nil';
 }
 
+export interface ProcessHandleValue extends Value {
+    type: 'process_handle';
+    value: number;
+}
+
+export interface SupervisorHandleValue extends Value {
+    type: 'supervisor_handle';
+    value: number;
+}
+
 export interface WasmModule {
     AjisaiInterpreter: AjisaiInterpreterClass;
     default?: () => Promise<any>;

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -81,6 +81,12 @@ pub enum BuiltinExecutorKey {
     Timestamp,
     Csprng,
     Hash,
+    Spawn,
+    Await,
+    Status,
+    Kill,
+    Monitor,
+    Supervise,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -774,6 +780,60 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         "none",
         BuiltinDetailGroup::IoModule,
         Some(BuiltinExecutorKey::ImportOnly)
+    ),
+    builtin_spec!(
+        "SPAWN",
+        "control",
+        "Spawn an isolated child runtime from a code block. Block -> ProcessHandle",
+        "{ [ 1 ] [ 0 ] / } SPAWN",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Spawn)
+    ),
+    builtin_spec!(
+        "AWAIT",
+        "control",
+        "Run/wait a child runtime and return exit tuple.",
+        "{ ... } SPAWN AWAIT → [ 'ok' [ ... ] ] / [ 'exit' 'Reason' ]",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Await)
+    ),
+    builtin_spec!(
+        "STATUS",
+        "control",
+        "Read child status. ProcessHandle -> String",
+        "{ ... } SPAWN STATUS → 'running'|'ok'|'exit'|'killed'|'timeout'",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Status)
+    ),
+    builtin_spec!(
+        "KILL",
+        "control",
+        "Force child termination. ProcessHandle -> 'killed'",
+        "{ ... } SPAWN KILL",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Kill)
+    ),
+    builtin_spec!(
+        "MONITOR",
+        "control",
+        "Register monitor on a child handle.",
+        "{ ... } SPAWN MONITOR",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Monitor)
+    ),
+    builtin_spec!(
+        "SUPERVISE",
+        "control",
+        "Run block under one_for_one restart policy.",
+        "{ unstable } [ 3 ] SUPERVISE",
+        "none",
+        BuiltinDetailGroup::ControlHigherOrder,
+        Some(BuiltinExecutorKey::Supervise)
     ),
 ];
 

--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -16,7 +16,7 @@ fn extract_scalar_from_value(val: &Value) -> Option<&Fraction> {
         ValueData::Vector(_) => None,
         ValueData::Nil => None,
         ValueData::Record { .. } => None,
-        ValueData::CodeBlock(_) => None,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
     }
 }
 

--- a/rust/src/interpreter/cast-value-helpers.rs
+++ b/rust/src/interpreter/cast-value-helpers.rs
@@ -20,7 +20,7 @@ pub(crate) fn is_string_value_with_hint(val: &Value, hint: DisplayHint) -> bool 
         ValueData::Scalar(_) => return false,
         ValueData::Nil => return false,
         ValueData::Record { .. } => return false,
-        ValueData::CodeBlock(_) => return false,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return false,
     };
     children.iter().all(|child| check_char_scalar(child))
 }
@@ -31,7 +31,7 @@ fn check_char_scalar(child: &Value) -> bool {
         ValueData::Vector(_) => return false,
         ValueData::Nil => return false,
         ValueData::Record { .. } => return false,
-        ValueData::CodeBlock(_) => return false,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return false,
     };
     let n: i64 = match f.to_i64() {
         Some(n) if n >= 0 && n <= 0x10FFFF => n,
@@ -182,7 +182,7 @@ pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_fractions(c)).collect(),
-            ValueData::CodeBlock(_) => vec!["<code>".to_string()],
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec!["<code>".to_string()],
         }
     }
 

--- a/rust/src/interpreter/child-runtime-tests.rs
+++ b/rust/src/interpreter/child-runtime-tests.rs
@@ -1,0 +1,57 @@
+#[cfg(test)]
+mod tests {
+    use crate::interpreter::Interpreter;
+    use crate::types::ValueData;
+
+    #[tokio::test]
+    async fn spawn_and_await_ok() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("{ [ 1 ] [ 2 ] + } SPAWN AWAIT").await;
+        assert!(result.is_ok());
+        let top = interp.stack.last().expect("expected await result");
+        let ValueData::Vector(values) = &top.data else {
+            panic!("await result should be vector");
+        };
+        assert_eq!(values[0].to_string(), "'ok'");
+    }
+
+    #[tokio::test]
+    async fn child_failure_does_not_crash_parent() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("{ [ 1 ] [ 0 ] / } SPAWN AWAIT [ 5 ]").await;
+        assert!(result.is_ok());
+        assert!(!interp.stack.is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_and_kill_work() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("{ [ 1 ] } SPAWN STATUS").await;
+        assert!(result.is_ok());
+        assert_eq!(interp.stack.last().unwrap().to_string(), "'running'");
+
+        let result = interp.execute("{ [ 1 ] } SPAWN KILL").await;
+        assert!(result.is_ok());
+        assert_eq!(interp.stack.last().unwrap().to_string(), "'killed'");
+    }
+
+    #[tokio::test]
+    async fn monitor_registration() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("{ [ 1 ] [ 0 ] / } SPAWN MONITOR AWAIT").await;
+        assert!(result.is_ok());
+        assert_eq!(interp.monitor_notifications.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn supervise_restarts_and_fails() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("{ [ 1 ] [ 0 ] / } [ 1 ] SUPERVISE").await;
+        assert!(result.is_ok());
+        let top = interp.stack.last().unwrap();
+        let ValueData::Vector(values) = &top.data else {
+            panic!("supervise result should be vector");
+        };
+        assert!(!values.is_empty());
+    }
+}

--- a/rust/src/interpreter/child-runtime.rs
+++ b/rust/src/interpreter/child-runtime.rs
@@ -1,0 +1,248 @@
+use crate::error::AjisaiError;
+use crate::types::{DisplayHint, Value};
+
+use super::interpreter_core::{
+    ChildRuntime, ChildState, ExitReason, RuntimeDictionarySnapshot,
+};
+use super::value_extraction_helpers::extract_integer_from_value;
+use super::Interpreter;
+
+impl Interpreter {
+    fn capture_runtime_snapshot(&self) -> RuntimeDictionarySnapshot {
+        RuntimeDictionarySnapshot {
+            user_words: self.user_words.clone(),
+            user_dictionaries: self.user_dictionaries.clone(),
+            dependents: self.dependents.clone(),
+            import_table: self.import_table.clone(),
+            module_vocabulary: self.module_vocabulary.clone(),
+            dictionary_dependencies: self.dictionary_dependencies.clone(),
+            next_registration_order: self.next_registration_order,
+            active_user_dictionary: self.active_user_dictionary.clone(),
+        }
+    }
+
+    fn build_exit_result(reason: ExitReason, stack: Option<Vec<Value>>) -> Vec<Value> {
+        match reason {
+            ExitReason::Normal => vec![
+                Value::from_string("ok"),
+                Value::from_vector(stack.unwrap_or_default()),
+            ],
+            ExitReason::Killed => vec![Value::from_string("killed")],
+            ExitReason::Timeout => vec![Value::from_string("timeout")],
+            ExitReason::Error(reason) => vec![Value::from_string("exit"), Value::from_string(&reason)],
+        }
+    }
+
+    fn map_error_to_exit_reason(error: AjisaiError) -> ExitReason {
+        match error {
+            AjisaiError::ExecutionLimitExceeded { .. } => ExitReason::Timeout,
+            AjisaiError::DivisionByZero => ExitReason::Error("DivisionByZero".to_string()),
+            AjisaiError::StackUnderflow => ExitReason::Error("StackUnderflow".to_string()),
+            AjisaiError::UnknownWord(_) => ExitReason::Error("UnknownWord".to_string()),
+            other => ExitReason::Error(other.to_string()),
+        }
+    }
+
+    pub(crate) fn op_spawn(&mut self) -> crate::error::Result<()> {
+        let block = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let code_block = block
+            .as_code_block()
+            .ok_or_else(|| AjisaiError::from("SPAWN requires a code block"))?
+            .clone();
+
+        let id = self.next_child_id;
+        self.next_child_id += 1;
+        self.child_runtimes.insert(
+            id,
+            ChildRuntime {
+                id,
+                code_block,
+                dictionary_snapshot: self.capture_runtime_snapshot(),
+                state: ChildState::Running,
+                exit_reason: None,
+                result_snapshot: None,
+                restart_count: 0,
+                supervisor_id: None,
+                monitored: false,
+            },
+        );
+        self.stack.push(Value::from_process_handle(id));
+        self.semantic_registry.push_hint(DisplayHint::Auto);
+        Ok(())
+    }
+
+    pub(crate) fn op_status(&mut self) -> crate::error::Result<()> {
+        let handle = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let id = handle
+            .as_process_handle()
+            .ok_or_else(|| AjisaiError::from("STATUS requires a process handle"))?;
+        let child = self
+            .child_runtimes
+            .get(&id)
+            .ok_or_else(|| AjisaiError::from("Unknown process handle"))?;
+        let status = match child.state {
+            ChildState::Running => "running",
+            ChildState::Completed => "ok",
+            ChildState::Failed => "exit",
+            ChildState::Killed => "killed",
+            ChildState::Timeout => "timeout",
+        };
+        self.stack.push(Value::from_string(status));
+        self.semantic_registry.push_hint(DisplayHint::String);
+        Ok(())
+    }
+
+    pub(crate) fn op_kill(&mut self) -> crate::error::Result<()> {
+        let handle = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let id = handle
+            .as_process_handle()
+            .ok_or_else(|| AjisaiError::from("KILL requires a process handle"))?;
+        let child = self
+            .child_runtimes
+            .get_mut(&id)
+            .ok_or_else(|| AjisaiError::from("Unknown process handle"))?;
+        child.state = ChildState::Killed;
+        child.exit_reason = Some(ExitReason::Killed);
+        child.result_snapshot = Some(Self::build_exit_result(ExitReason::Killed, None));
+        self.stack.push(Value::from_string("killed"));
+        self.semantic_registry.push_hint(DisplayHint::String);
+        Ok(())
+    }
+
+    fn run_child_to_completion(&self, child: &mut ChildRuntime) {
+        if !matches!(child.state, ChildState::Running) {
+            return;
+        }
+
+        let mut child_interpreter = Interpreter::new();
+        child_interpreter.user_words = child.dictionary_snapshot.user_words.clone();
+        child_interpreter.user_dictionaries = child.dictionary_snapshot.user_dictionaries.clone();
+        child_interpreter.dependents = child.dictionary_snapshot.dependents.clone();
+        child_interpreter.import_table = child.dictionary_snapshot.import_table.clone();
+        child_interpreter.module_vocabulary = child.dictionary_snapshot.module_vocabulary.clone();
+        child_interpreter.dictionary_dependencies =
+            child.dictionary_snapshot.dictionary_dependencies.clone();
+        child_interpreter.next_registration_order = child.dictionary_snapshot.next_registration_order;
+        child_interpreter.active_user_dictionary = child.dictionary_snapshot.active_user_dictionary.clone();
+        child_interpreter.max_execution_steps = self.max_execution_steps;
+
+        let lines = vec![crate::types::ExecutionLine {
+            body_tokens: child.code_block.clone().into(),
+        }];
+
+        match child_interpreter.execute_guard_structure_sync(&lines) {
+            Ok(()) => {
+                child.state = ChildState::Completed;
+                child.exit_reason = Some(ExitReason::Normal);
+                let stack = child_interpreter.stack.clone();
+                child.result_snapshot = Some(Self::build_exit_result(ExitReason::Normal, Some(stack)));
+            }
+            Err(err) => {
+                let exit_reason = Self::map_error_to_exit_reason(err);
+                child.state = match exit_reason {
+                    ExitReason::Timeout => ChildState::Timeout,
+                    _ => ChildState::Failed,
+                };
+                child.exit_reason = Some(exit_reason.clone());
+                child.result_snapshot = Some(Self::build_exit_result(exit_reason, None));
+            }
+        }
+    }
+
+    pub(crate) fn op_await(&mut self) -> crate::error::Result<()> {
+        let handle = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let id = handle
+            .as_process_handle()
+            .ok_or_else(|| AjisaiError::from("AWAIT requires a process handle"))?;
+        let mut child = self
+            .child_runtimes
+            .remove(&id)
+            .ok_or_else(|| AjisaiError::from("Unknown process handle"))?;
+
+        self.run_child_to_completion(&mut child);
+        let result = child
+            .result_snapshot
+            .clone()
+            .unwrap_or_else(|| vec![Value::from_string("exit"), Value::from_string("Unknown")]);
+
+        if child.monitored {
+            self.monitor_notifications.push(result.clone());
+        }
+        self.child_runtimes.insert(id, child);
+        self.stack.push(Value::from_vector(result));
+        self.semantic_registry.push_hint(DisplayHint::Auto);
+        Ok(())
+    }
+
+    pub(crate) fn op_monitor(&mut self) -> crate::error::Result<()> {
+        let handle = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let id = handle
+            .as_process_handle()
+            .ok_or_else(|| AjisaiError::from("MONITOR requires a process handle"))?;
+        let child = self
+            .child_runtimes
+            .get_mut(&id)
+            .ok_or_else(|| AjisaiError::from("Unknown process handle"))?;
+        child.monitored = true;
+        self.stack.push(Value::from_process_handle(id));
+        self.semantic_registry.push_hint(DisplayHint::Auto);
+        Ok(())
+    }
+
+    pub(crate) fn op_supervise(&mut self) -> crate::error::Result<()> {
+        let retry_value = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let block = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        self.semantic_registry.pop_hint();
+        let max_restarts = extract_integer_from_value(&retry_value)?.max(0) as usize;
+        let code_block = block
+            .as_code_block()
+            .ok_or_else(|| AjisaiError::from("SUPERVISE requires a code block"))?
+            .clone();
+
+        let supervisor_id = self.next_supervisor_id;
+        self.next_supervisor_id += 1;
+
+        let mut attempt = 0usize;
+        loop {
+            let id = self.next_child_id;
+            self.next_child_id += 1;
+            let mut child = ChildRuntime {
+                id,
+                code_block: code_block.clone(),
+                dictionary_snapshot: self.capture_runtime_snapshot(),
+                state: ChildState::Running,
+                exit_reason: None,
+                result_snapshot: None,
+                restart_count: attempt,
+                supervisor_id: Some(supervisor_id),
+                monitored: false,
+            };
+            self.run_child_to_completion(&mut child);
+            let ok = matches!(child.state, ChildState::Completed);
+            let result = child.result_snapshot.clone().unwrap_or_default();
+            self.child_runtimes.insert(id, child);
+
+            if ok {
+                self.stack.push(Value::from_vector(result));
+                self.semantic_registry.push_hint(DisplayHint::Auto);
+                return Ok(());
+            }
+            if attempt >= max_restarts {
+                self.stack.push(Value::from_vector(vec![
+                    Value::from_string("exit"),
+                    Value::from_string("SupervisorRestartLimitExceeded"),
+                    Value::from_supervisor_handle(supervisor_id),
+                ]));
+                self.semantic_registry.push_hint(DisplayHint::Auto);
+                return Ok(());
+            }
+            attempt += 1;
+        }
+    }
+}

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -22,7 +22,7 @@ fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
             "scalar value",
             "non-scalar value",
         )),
-        ValueData::CodeBlock(_) => Err(AjisaiError::create_structure_error(
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::create_structure_error(
             "scalar value",
             "non-scalar value",
         )),

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -167,6 +167,12 @@ impl Interpreter {
             BuiltinExecutorKey::Timestamp => datetime::op_timestamp(self),
             BuiltinExecutorKey::Csprng => random::op_csprng(self),
             BuiltinExecutorKey::Hash => hash::op_hash(self),
+            BuiltinExecutorKey::Spawn => self.op_spawn(),
+            BuiltinExecutorKey::Await => self.op_await(),
+            BuiltinExecutorKey::Status => self.op_status(),
+            BuiltinExecutorKey::Kill => self.op_kill(),
+            BuiltinExecutorKey::Monitor => self.op_monitor(),
+            BuiltinExecutorKey::Supervise => self.op_supervise(),
         }
     }
 

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -25,7 +25,7 @@ fn extract_string_from_value(val: &Value) -> Result<String> {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_chars(c)).collect(),
-            ValueData::CodeBlock(_) => vec![],
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec![],
         }
     }
 
@@ -50,7 +50,7 @@ fn is_string_like(val: &Value) -> bool {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().all(|c| check_codepoints(c)),
-            ValueData::CodeBlock(_) => false,
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => false,
         }
     }
 

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -51,6 +51,48 @@ pub(crate) struct DictionaryDependencyInfo {
     pub depended_by: HashSet<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum ChildState {
+    Running,
+    Completed,
+    Failed,
+    Killed,
+    Timeout,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ExitReason {
+    Normal,
+    Error(String),
+    Killed,
+    Timeout,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeDictionarySnapshot {
+    pub user_words: HashMap<String, Arc<WordDefinition>>,
+    pub user_dictionaries: HashMap<String, UserDictionary>,
+    pub dependents: HashMap<String, HashSet<String>>,
+    pub import_table: ImportTable,
+    pub module_vocabulary: HashMap<String, ModuleDictionary>,
+    pub dictionary_dependencies: HashMap<String, DictionaryDependencyInfo>,
+    pub next_registration_order: u64,
+    pub active_user_dictionary: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ChildRuntime {
+    pub id: u64,
+    pub code_block: Vec<Token>,
+    pub dictionary_snapshot: RuntimeDictionarySnapshot,
+    pub state: ChildState,
+    pub exit_reason: Option<ExitReason>,
+    pub result_snapshot: Option<Vec<Value>>,
+    pub restart_count: usize,
+    pub supervisor_id: Option<u64>,
+    pub monitored: bool,
+}
+
 pub struct Interpreter {
     pub(crate) stack: Stack,
     pub(crate) core_vocabulary: HashMap<String, Arc<WordDefinition>>,
@@ -88,6 +130,11 @@ pub struct Interpreter {
     pub(crate) active_user_dictionary: String,
 
     pub(crate) semantic_registry: SemanticRegistry,
+
+    pub(crate) child_runtimes: HashMap<u64, ChildRuntime>,
+    pub(crate) next_child_id: u64,
+    pub(crate) monitor_notifications: Vec<Vec<Value>>,
+    pub(crate) next_supervisor_id: u64,
 }
 
 impl Interpreter {
@@ -123,6 +170,10 @@ impl Interpreter {
             next_registration_order: 1,
             active_user_dictionary: "DEMO".to_string(),
             semantic_registry: SemanticRegistry::new(),
+            child_runtimes: HashMap::new(),
+            next_child_id: 1,
+            monitor_notifications: Vec::new(),
+            next_supervisor_id: 1,
         };
         crate::builtins::register_builtins(&mut interpreter.core_vocabulary);
         interpreter
@@ -257,6 +308,10 @@ impl Interpreter {
         self.next_registration_order = 1;
         self.active_user_dictionary = "DEMO".to_string();
         self.semantic_registry.clear();
+        self.child_runtimes.clear();
+        self.next_child_id = 1;
+        self.monitor_notifications.clear();
+        self.next_supervisor_id = 1;
         crate::builtins::register_builtins(&mut self.core_vocabulary);
         Ok(())
     }

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -9,7 +9,7 @@ fn check_value_has_truthy(val: &Value) -> bool {
     match &val.data {
         ValueData::Nil => false,
         ValueData::Scalar(f) => !f.is_zero(),
-        ValueData::CodeBlock(_) => true,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => true,
         ValueData::Vector(_) | ValueData::Record { .. } => {
             if let Ok(tensor) = FlatTensor::from_value(val) {
                 tensor.data.iter().any(|f| !f.is_zero())

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -3,6 +3,8 @@ pub mod audio;
 pub mod cast;
 pub mod comparison;
 pub mod control;
+#[path = "child-runtime.rs"]
+pub mod child_runtime;
 #[path = "control-cond.rs"]
 pub mod control_cond;
 pub mod datetime;
@@ -86,6 +88,9 @@ mod hash_tests;
 #[cfg(test)]
 #[path = "higher-order-fold-tests.rs"]
 mod higher_order_fold_tests;
+#[cfg(test)]
+#[path = "child-runtime-tests.rs"]
+mod child_runtime_tests;
 
 pub use interpreter_core::*;
 

--- a/rust/src/interpreter/simd-vector-operations.rs
+++ b/rust/src/interpreter/simd-vector-operations.rs
@@ -8,7 +8,7 @@ pub fn extract_integer_vector(val: &Value) -> Option<Vec<i64>> {
         ValueData::Scalar(_)
         | ValueData::Record { .. }
         | ValueData::Nil
-        | ValueData::CodeBlock(_) => return None,
+        | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
     };
 
     if children.len() < SIMD_THRESHOLD {
@@ -26,7 +26,7 @@ pub fn extract_integer_vector(val: &Value) -> Option<Vec<i64>> {
             | ValueData::Vector(_)
             | ValueData::Record { .. }
             | ValueData::Nil
-            | ValueData::CodeBlock(_) => return None,
+            | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
         }
     }
     Some(result)
@@ -44,7 +44,7 @@ fn extract_integer_scalar(value: &Value) -> Option<i64> {
         | ValueData::Vector(_)
         | ValueData::Record { .. }
         | ValueData::Nil
-        | ValueData::CodeBlock(_) => None,
+        | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
     }
 }
 

--- a/rust/src/interpreter/sort.rs
+++ b/rust/src/interpreter/sort.rs
@@ -33,7 +33,7 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                 ValueData::Record {
                     pairs: children, ..
                 } => children,
-                ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => {
+                ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
                     if !is_keep_mode {
                         interp.stack.push(val);
                     }

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -33,7 +33,7 @@ impl FlatTensor {
                     strides,
                 })
             }
-            ValueData::CodeBlock(_) => Err(AjisaiError::from(
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::from(
                 "Tensor conversion requires scalar or vector",
             )),
         }

--- a/rust/src/interpreter/value-extraction-helpers.rs
+++ b/rust/src/interpreter/value-extraction-helpers.rs
@@ -35,7 +35,7 @@ pub(crate) fn value_as_string(val: &Value) -> Option<String> {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_chars(c)).collect(),
-            ValueData::CodeBlock(_) => vec![],
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec![],
         }
     }
 
@@ -67,7 +67,7 @@ fn extract_integer_bigint(value: &Value) -> Result<BigInt> {
             "single-element value with integer",
             "multi-element vector",
         )),
-        ValueData::CodeBlock(_) => Err(AjisaiError::create_structure_error(
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::create_structure_error(
             "single-element value with integer",
             "code block",
         )),

--- a/rust/src/interpreter/vector-execution-operations.rs
+++ b/rust/src/interpreter/vector-execution-operations.rs
@@ -41,6 +41,8 @@ fn format_value_to_source_inner(val: &Value, depth: usize) -> Result<String> {
             let token_strs: Vec<String> = tokens.iter().map(format_token_to_source).collect();
             Ok(token_strs.join(" "))
         }
+        ValueData::ProcessHandle(id) => Ok(format!("<process:{}>", id)),
+        ValueData::SupervisorHandle(id) => Ok(format!("<supervisor:{}>", id)),
         ValueData::Vector(children)
         | ValueData::Record {
             pairs: children, ..

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -37,6 +37,8 @@ fn format_value_auto(data: &ValueData) -> String {
             format_value_recursive(data, 0)
         }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
+        ValueData::ProcessHandle(id) => format!("<process:{}>", id),
+        ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
 }
 
@@ -84,6 +86,8 @@ fn format_value_recursive(data: &ValueData, depth: usize) -> String {
             format!("{} {} {}", open, inner.join(" "), close)
         }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
+        ValueData::ProcessHandle(id) => format!("<process:{}>", id),
+        ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
 }
 
@@ -158,6 +162,8 @@ fn format_as_string(data: &ValueData) -> String {
             format!("'{}'", chars)
         }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
+        ValueData::ProcessHandle(id) => format!("<process:{}>", id),
+        ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
 }
 
@@ -204,11 +210,14 @@ fn format_as_boolean(data: &ValueData) -> String {
                         }
                     }
                     ValueData::CodeBlock(_) => "TRUE",
+                    ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => "TRUE",
                 })
                 .collect();
             format!("{{ {} }}", inner.join(" "))
         }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
+        ValueData::ProcessHandle(id) => format!("<process:{}>", id),
+        ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
 }
 
@@ -225,5 +234,7 @@ fn format_as_datetime(data: &ValueData) -> String {
         }
         ValueData::Vector(_) | ValueData::Record { .. } => format_value_recursive(data, 0),
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
+        ValueData::ProcessHandle(id) => format!("<process:{}>", id),
+        ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
 }

--- a/rust/src/types/flow-token.rs
+++ b/rust/src/types/flow-token.rs
@@ -53,7 +53,7 @@ impl FlowToken {
                 }
                 acc
             }
-            ValueData::CodeBlock(_) => Fraction::from(0),
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Fraction::from(0),
         }
     }
 

--- a/rust/src/types/json.rs
+++ b/rust/src/types/json.rs
@@ -131,7 +131,7 @@ pub fn serialize_value_to_json(val: &Value) -> serde_json::Value {
             serde_json::Value::Array(arr)
         }
 
-        ValueData::CodeBlock(_) => serde_json::Value::Null,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => serde_json::Value::Null,
     }
 }
 

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -49,6 +49,8 @@ pub enum ValueData {
     },
     Nil,
     CodeBlock(Vec<Token>),
+    ProcessHandle(u64),
+    SupervisorHandle(u64),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -95,7 +95,7 @@ impl Value {
             ValueData::Scalar(_) | ValueData::Nil => true,
             ValueData::Vector(rc) => Rc::strong_count(rc) == 1,
             ValueData::Record { pairs, .. } => Rc::strong_count(pairs) == 1,
-            ValueData::CodeBlock(_) => false,
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => false,
         }
     }
 
@@ -107,7 +107,7 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 !v.is_empty() && !v.iter().all(|c| !c.is_truthy())
             }
-            ValueData::CodeBlock(_) => true,
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => true,
         }
     }
 
@@ -118,6 +118,7 @@ impl Value {
             ValueData::Scalar(_) => 1,
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.len(),
             ValueData::CodeBlock(tokens) => tokens.len(),
+            ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => 1,
         }
     }
 
@@ -130,7 +131,7 @@ impl Value {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.get(index),
             ValueData::Scalar(_) if index == 0 => Some(self),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -139,7 +140,7 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 Rc::make_mut(v).get_mut(index)
             }
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -154,7 +155,7 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.last(),
             ValueData::Scalar(_) => Some(self),
             ValueData::Nil => None,
-            ValueData::CodeBlock(_) => None,
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -170,21 +171,21 @@ impl Value {
                 let old = Value::from_fraction(f.clone());
                 self.data = ValueData::Vector(Rc::new(vec![old, child]));
             }
-            ValueData::CodeBlock(_) => {}
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {}
         }
     }
 
     pub fn pop_child(&mut self) -> Option<Value> {
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v).pop(),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
     pub fn insert_child(&mut self, index: usize, child: Value) {
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => return,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return,
         };
         if index <= v.len() {
             v.insert(index, child);
@@ -194,7 +195,7 @@ impl Value {
     pub fn remove_child(&mut self, index: usize) -> Option<Value> {
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => return None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
         };
         if index < v.len() {
             Some(v.remove(index))
@@ -206,7 +207,7 @@ impl Value {
     pub fn replace_child(&mut self, index: usize, child: Value) -> Option<Value> {
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => return None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
         };
         if index < v.len() {
             Some(std::mem::replace(&mut v[index], child))
@@ -219,7 +220,7 @@ impl Value {
     pub fn as_scalar(&self) -> Option<&Fraction> {
         match &self.data {
             ValueData::Scalar(f) => Some(f),
-            ValueData::Vector(_) | ValueData::Record { .. } | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Vector(_) | ValueData::Record { .. } | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -227,7 +228,7 @@ impl Value {
     pub fn as_scalar_mut(&mut self) -> Option<&mut Fraction> {
         match &mut self.data {
             ValueData::Scalar(f) => Some(f),
-            ValueData::Vector(_) | ValueData::Record { .. } | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Vector(_) | ValueData::Record { .. } | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -245,7 +246,7 @@ impl Value {
     pub fn as_vector(&self) -> Option<&Vec<Value>> {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Some(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -253,7 +254,7 @@ impl Value {
     pub fn as_vector_mut(&mut self) -> Option<&mut Vec<Value>> {
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Some(Rc::make_mut(v)),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) => None,
+            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -272,7 +273,7 @@ impl Value {
                     child.collect_fractions_flat_into(buf);
                 }
             }
-            ValueData::CodeBlock(_) => {}
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {}
         }
     }
 
@@ -283,7 +284,7 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 v.iter().map(|c| c.count_fractions()).sum()
             }
-            ValueData::CodeBlock(_) => 0,
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => 0,
         }
     }
 
@@ -306,7 +307,7 @@ impl Value {
                     }
                 }
             }
-            ValueData::CodeBlock(_) => vec![],
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec![],
         }
     }
 
@@ -329,12 +330,31 @@ impl Value {
         }
     }
 
+    pub fn from_process_handle(id: u64) -> Self {
+        Self {
+            data: ValueData::ProcessHandle(id),
+        }
+    }
+
+    pub fn as_process_handle(&self) -> Option<u64> {
+        match self.data {
+            ValueData::ProcessHandle(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    pub fn from_supervisor_handle(id: u64) -> Self {
+        Self {
+            data: ValueData::SupervisorHandle(id),
+        }
+    }
+
     pub fn resolve_default_hint(&self) -> DisplayHint {
         match &self.data {
             ValueData::Nil => DisplayHint::Nil,
             ValueData::Scalar(_) => DisplayHint::Number,
             ValueData::Vector(_) | ValueData::Record { .. } => DisplayHint::Auto,
-            ValueData::CodeBlock(_) => DisplayHint::Auto,
+            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => DisplayHint::Auto,
         }
     }
 }

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -191,6 +191,14 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
             Ok(Value::from_children(children))
         }
         "nil" => Ok(Value::nil()),
+        "process_handle" => {
+            let id = value_js.as_f64().ok_or("Process handle id is not number")? as u64;
+            Ok(Value::from_process_handle(id))
+        }
+        "supervisor_handle" => {
+            let id = value_js.as_f64().ok_or("Supervisor handle id is not number")? as u64;
+            Ok(Value::from_supervisor_handle(id))
+        }
         _ => Err(format!("Unknown type: {}", type_str)),
     }
 }
@@ -257,6 +265,10 @@ pub(crate) fn value_to_js_value_with_hint(value: &Value, hint: DisplayHint) -> J
                 "vector"
             } else if value.is_scalar() {
                 "number"
+            } else if matches!(value.data, ValueData::ProcessHandle(_)) {
+                "process_handle"
+            } else if matches!(value.data, ValueData::SupervisorHandle(_)) {
+                "supervisor_handle"
             } else {
                 "nil"
             }
@@ -312,6 +324,16 @@ pub(crate) fn value_to_js_value_with_hint(value: &Value, hint: DisplayHint) -> J
                 }
             }
             js_sys::Reflect::set(&obj, &"value".into(), &js_array).unwrap();
+        }
+        "process_handle" => {
+            if let ValueData::ProcessHandle(id) = value.data {
+                js_sys::Reflect::set(&obj, &"value".into(), &(id as f64).into()).unwrap();
+            }
+        }
+        "supervisor_handle" => {
+            if let ValueData::SupervisorHandle(id) = value.data {
+                js_sys::Reflect::set(&obj, &"value".into(), &(id as f64).into()).unwrap();
+            }
         }
         _ => {}
     };


### PR DESCRIPTION
### Motivation
- Provide an Ajisai-language-level let-it-crash model by adding isolated child runtimes that do not share parent stack or mutable user-word state and whose termination is observable to the parent. 
- Enable monitoring and basic supervision (one_for_one with restart limit) so unstable code blocks can be restarted without crashing the parent interpreter. 
- Surface process/supervisor handles safely through the WASM/TS boundary and GUI so new runtime handles do not break front-end formatting. 

### Description
- Added `ProcessHandle` and `SupervisorHandle` value variants and display/JS conversion/TS typings and GUI formatting so handles are human-readable (Rust: `rust/src/types/*`, WASM: `rust/src/wasm-value-conversion.rs`, TS: `js/wasm-interpreter-types.ts`, `js/gui/value-formatter.ts`).
- Implemented child runtime model and types (`ChildRuntime`, `ChildState`, `ExitReason`, `RuntimeDictionarySnapshot`) and interpreter management fields (`child_runtimes`, `next_child_id`, `monitor_notifications`, `next_supervisor_id`) in the core interpreter (Rust: `rust/src/interpreter/interpreter-core.rs`).
- Added synchronous execution primitives and builtin dispatch for `SPAWN`, `AWAIT`, `STATUS`, `KILL`, `MONITOR`, and `SUPERVISE` with one_for_one restart semantics and restart-limit handling (Rust: `rust/src/interpreter/child-runtime.rs`, `rust/src/interpreter/execute-builtin.rs`, `rust/src/builtins/builtin-word-definitions.rs`).
- Kept existing semantics intact by capturing minimal dictionary snapshots for children, converting `AjisaiError` into structured `ExitReason`, and returning human-friendly exit tuples; updated various value-handling code paths to account for the new value kinds. 
- Added tests covering spawn/await success, child failure isolation, status/kill/monitor behavior and supervise restart/limit scenarios (Rust: `rust/src/interpreter/child-runtime-tests.rs`) and updated SPECIFICATION.md / README.md with the let-it-crash model description.

### Testing
- Ran `cd rust && cargo test -q` (unit/integration test suite); all Rust tests passed (470 passed after fixes). 
- Ran focused failing test locally during development (`cargo test --lib child_runtime` and the supervise test) while iterating and resolved issues; final run succeeded. 
- Ran front-end checks (`cd /workspace/Ajisai && npm run -s check`) and confirmed no type/formatting regressions in the GUI/WASM boundary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d98a77b52883268037c6d48848f4e0)