### PR TITLE
Restore Ajisai web GUI entrypoint and assets

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -1,0 +1,872 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+.main-layout .output-area,
+.main-layout .input-area,
+.main-layout .stack-area,
+.main-layout .dictionary-area,
+.main-layout .vocabulary-container,
+.main-layout .words-area,
+.main-layout .dictionary-sheet {
+    justify-content: flex-start;
+    align-content: flex-start;
+}
+
+
+.main-layout .display-area,
+.main-layout .state-display,
+.main-layout .words-display,
+.main-layout .area-content-flow {
+    align-content: flex-start;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+
+
+
+
+
+.main-layout {
+    display: flex;
+    flex: 1;
+    gap: 0;
+    padding: 0;
+    min-height: 0;
+    border: 1px solid var(--color-border-strong, #999);
+    background: var(--gradient-child, #fff);
+}
+
+
+
+
+.area-selector {
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.area-selector select {
+    font-family: var(--font-stack-mono);
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border-strong, #999);
+    border-radius: 3px;
+    background: var(--gradient-child, #fff);
+    color: var(--color-text);
+    width: 100%;
+    cursor: pointer;
+}
+
+
+.area-selector-mobile {
+    display: none;
+}
+
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+
+
+.main-layout section {
+    margin-bottom: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    padding: 0;
+}
+
+
+#editor-panel,
+#state-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 0;
+    padding: 0.75rem;
+    overflow: hidden;
+    background: transparent;
+    position: relative;
+}
+
+
+#editor-panel { flex: var(--col-left-flex); }
+#state-panel  { flex: var(--col-right-flex); }
+
+
+#editor-panel {
+    border-right: 1px solid var(--color-border-strong, #999);
+}
+
+
+
+#editor-panel,
+#state-panel,
+.input-area,
+.output-area,
+.stack-area,
+.vocabulary-area,
+.dictionary-area {
+    min-height: 0;
+}
+
+#editor-panel .input-area,
+#editor-panel .output-area,
+#state-panel .stack-area,
+#state-panel .vocabulary-area,
+#state-panel .dictionary-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#editor-panel .input-area,
+#editor-panel .output-area,
+#state-panel .stack-area,
+#state-panel .vocabulary-area,
+.vocabulary-container,
+.words-area,
+.words-display,
+.state-display,
+.display-area {
+    min-height: 0;
+}
+
+body[data-active-area] #editor-panel,
+body[data-active-area] #state-panel {
+    padding: 0.75rem;
+}
+
+
+@media (min-width: 769px) {
+    body[data-active-area] .main-layout section {
+        margin-bottom: 0;
+        flex: 1;
+        min-height: 0;
+    }
+}
+
+@media (max-width: 768px) {
+    body[data-active-area="input"] #state-panel,
+    body[data-active-area="output"] #state-panel,
+    body[data-active-area="stack"] #editor-panel,
+    body[data-active-area="dictionary"] #editor-panel {
+        display: none;
+    }
+}
+
+
+.output-area,
+.input-area {
+    flex: 1 1 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+
+
+
+.textarea-wrapper {
+    position: relative;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+#code-input {
+    width: 100%;
+    min-height: 0;
+    padding: 0.75rem;
+    border: none;
+    font-family: var(--font-stack-mono);
+    font-size: 0.95rem;
+    resize: none;
+    flex: 1;
+    line-height: 1.5;
+    background-color: var(--code-bg);
+    color: var(--code-text);
+}
+
+#code-input:focus {
+    outline: none;
+}
+
+#code-input::placeholder {
+    color: var(--code-comment);
+}
+
+
+.inline-clear-btn {
+    position: absolute;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--code-comment);
+    font-size: 1.15rem;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.6;
+    transition: opacity 0.15s ease;
+}
+
+.inline-clear-btn:hover {
+    opacity: 1;
+}
+
+
+#clear-btn {
+    top: 0.5rem;
+    right: 0.5rem;
+}
+
+#code-input:placeholder-shown ~ #clear-btn {
+    display: none;
+}
+
+
+
+.editor-suggestions {
+    position: absolute;
+
+    min-width: 180px;
+    max-width: calc(100% - 1rem);
+    max-height: 220px;
+    overflow-y: auto;
+    background: rgba(255, 255, 255, 0.75);
+    backdrop-filter: blur(4px);
+    border: var(--border-main);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    z-index: 20;
+}
+
+.editor-suggestion-item {
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    background: transparent;
+    text-align: left;
+    padding: 0.45rem 0.6rem;
+    font-family: var(--font-stack-mono);
+    font-size: 0.78rem;
+    cursor: pointer;
+}
+
+.editor-suggestion-item:last-child {
+    border-bottom: none;
+}
+
+.editor-suggestion-item.active,
+.editor-suggestion-item:hover {
+    background: rgba(0, 0, 0, 0.06);
+}
+
+
+.json-download-link {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    color: var(--color-primary);
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: var(--font-stack-mono);
+    font-size: 0.85rem;
+}
+
+.json-download-link:hover {
+    color: var(--color-secondary);
+}
+
+
+
+
+#output-display {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+}
+
+#output-display::-webkit-scrollbar {
+    width: 10px;
+}
+
+#output-display::-webkit-scrollbar-track {
+    background: var(--color-light);
+}
+
+#output-display::-webkit-scrollbar-thumb {
+    background: var(--color-medium);
+    border-radius: 5px;
+}
+
+#output-display::-webkit-scrollbar-thumb:hover {
+    background: var(--color-secondary);
+}
+
+
+
+
+.stack-area {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+
+#stack-display {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+#stack-display.is-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+
+.vocabulary-header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin-bottom: 0.75rem;
+}
+
+
+.search-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.vocabulary-search-input {
+    padding: 0.25rem 1.75rem 0.25rem 0.5rem;
+    border: none;
+    border-radius: 0;
+    font-size: 0.85rem;
+    font-family: var(--font-stack-mono);
+    background-color: var(--code-bg);
+    color: var(--code-text);
+    min-width: 120px;
+    max-width: 200px;
+}
+
+.vocabulary-search-input:focus {
+    outline: none;
+}
+
+.vocabulary-search-input::placeholder {
+    color: var(--code-comment);
+}
+
+.vocabulary-search-clear-btn {
+    right: 0.25rem;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.vocabulary-search-input:placeholder-shown ~ .vocabulary-search-clear-btn {
+    display: none;
+}
+
+
+.no-results-message {
+    width: 100%;
+    color: var(--color-text-light);
+    font-style: italic;
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.vocabulary-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    flex: 1;
+    min-height: 0;
+}
+
+.vocabulary-actions {
+    margin-top: 0.75rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.words-area {
+    width: 100%;
+    background: var(--gradient-child);
+    padding: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.words-area .word-info-display {
+    display: block;
+    flex: 0 0 1.25rem;
+    height: 1.25rem;
+    line-height: 1.25rem;
+    max-width: 100%;
+    margin-bottom: 0.5rem;
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.words-area .word-info-display.is-placeholder {
+    color: var(--color-text-light);
+}
+
+.words-area .words-display {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    align-content: flex-start;
+    min-height: 7rem;
+    overflow-y: auto;
+    background-color: rgba(0, 0, 0, 0.06);
+    border-radius: 6px;
+    padding: 4px;
+    cursor: pointer;
+}
+
+.words-area .words-display.is-empty {
+    align-items: center;
+    align-content: center;
+    justify-content: center;
+}
+
+.empty-words-message {
+    width: 100%;
+    padding: 0.75rem;
+    text-align: center;
+    color: var(--color-text-light);
+    font-style: italic;
+}
+
+
+
+.state-display {
+    color: var(--color-text);
+}
+
+.state-display:empty::before,
+.state-display:has(> :only-child:contains("(empty)")) {
+    color: var(--color-text-light);
+}
+
+
+
+
+.area-content-flow {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+    align-content: flex-start;
+    width: 100%;
+
+
+
+
+}
+
+
+
+#stack-display .stack-content-flow {
+    flex-wrap: wrap-reverse;
+    align-content: flex-end;
+    align-items: center;
+}
+
+
+
+
+.dictionary-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.dictionary-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 0 0.5rem 0;
+    flex-shrink: 0;
+}
+
+
+.dictionary-sheet-selector {
+    flex: 1.618 1 0%;
+}
+
+
+
+.words-area .dictionary-sheet-selector {
+    flex: 0 0 auto;
+    padding: 0 0 0.5rem 0;
+}
+
+
+
+.words-area .dictionary-sheet-selector select:focus-visible {
+    outline-offset: -2px;
+    box-shadow: none;
+}
+
+.dictionary-sheet-selector select {
+    font-family: var(--font-stack-mono);
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border-strong, #999);
+    border-radius: 3px;
+    background: var(--gradient-child, #fff);
+    color: var(--color-text);
+    width: 100%;
+    cursor: pointer;
+}
+
+.dictionary-toolbar .search-wrapper {
+    flex: 1 1 0%;
+    min-width: 0;
+}
+
+.dictionary-toolbar .vocabulary-search-input {
+    width: 100%;
+    max-width: none;
+}
+
+.dictionary-sheet {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.dictionary-sheet:not(.active) {
+    display: none;
+}
+
+
+
+
+.word-button {
+    margin: 2px;
+    padding: 0.2rem 0.4rem;
+    background-color: rgba(255, 255, 255, 0.5);
+    color: var(--color-text);
+    border: var(--border-main);
+    font-family: var(--font-stack-mono);
+    font-size: 0.75rem;
+    font-weight: 400;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.word-button:hover {
+    background: var(--color-light);
+}
+
+
+.word-button.core {
+    border-color: var(--color-core);
+    background: #fff;
+    color: var(--color-core);
+    box-shadow: 0 2px 0 var(--color-medium);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.word-button.core:hover {
+    transform: translateY(2px);
+    box-shadow: 0 0 0 var(--color-medium);
+}
+
+
+.word-button.dependency {
+    border-color: var(--color-dependency);
+    background: #fff;
+    color: var(--color-dependency);
+    box-shadow: 0 2px 0 var(--color-medium);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.word-button.dependency:hover {
+    transform: translateY(2px);
+    box-shadow: 0 0 0 var(--color-medium);
+}
+
+
+.word-button.non-dependency {
+    border-color: var(--color-non-dependency);
+    background: #fff;
+    color: var(--color-non-dependency);
+    box-shadow: 0 2px 0 var(--color-medium);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.word-button.non-dependency:hover {
+    transform: translateY(2px);
+    box-shadow: 0 0 0 var(--color-medium);
+}
+
+
+.word-button.module {
+    border-color: var(--color-module, #0277BD);
+    background: #fff;
+    color: var(--color-module, #0277BD);
+    box-shadow: 0 2px 0 var(--color-medium);
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.word-button.module:hover {
+    transform: translateY(2px);
+    box-shadow: 0 0 0 var(--color-medium);
+}
+
+
+.word-button.signature-map {
+    background: var(--color-signature-map);
+}
+
+.word-button.signature-form {
+    background: var(--color-signature-form);
+}
+
+.word-button.signature-fold {
+    background: var(--color-signature-fold);
+}
+
+
+
+
+.stack-item {
+    font-family: var(--font-stack-mono);
+    font-size: 0.75rem;
+    display: inline;
+    margin: 2px;
+    padding: 2px 4px;
+    border-radius: 6px;
+    background-color: transparent;
+    color: var(--color-stack);
+    border: none;
+    word-break: break-word;
+}
+
+.stack-node {
+    display: inline;
+    border-radius: 6px;
+    line-height: 1.6;
+}
+
+.stack-node-vector {
+    display: inline;
+}
+
+
+.stack-bracket {
+    font-weight: bold;
+    font-size: 1.1em;
+    line-height: 1;
+}
+
+
+.stack-node-vector {
+    background-color: transparent;
+    color: var(--color-stack);
+}
+
+
+.stack-item:last-child {
+    font-weight: bold;
+}
+
+
+#stack-display.highlight-all .stack-item .stack-node[data-depth="1"],
+#stack-display.blink-all .stack-item .stack-node[data-depth="1"] {
+    background-color: #DDDDDD;
+    font-weight: bold;
+    padding: 2px 5px;
+    border-radius: 4px;
+}
+
+
+#stack-display.highlight-top .stack-item:last-child .stack-node[data-depth="1"],
+#stack-display.blink-top .stack-item:last-child .stack-node[data-depth="1"] {
+    background-color: #DDDDDD;
+    padding: 2px 5px;
+    border-radius: 4px;
+}
+
+
+
+
+
+@media (max-width: 768px) {
+
+
+    html,
+    body {
+        height: 100%;
+        overflow: hidden;
+    }
+
+    .container {
+        height: 100vh;
+        height: 100dvh;
+        min-height: 0;
+    }
+
+
+    .area-selector-left,
+    .area-selector-right {
+        display: none;
+    }
+
+    .area-selector-mobile {
+        display: block;
+        padding: 0.75rem 0.75rem 0;
+    }
+
+    .main-layout {
+        flex: 1;
+        flex-direction: column;
+        padding: 0;
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    #editor-panel,
+    #state-panel {
+        flex: 1 1 auto;
+        width: 100%;
+        min-height: 0;
+        overflow: hidden;
+        padding: 0.75rem;
+        gap: 0;
+    }
+
+
+    #editor-panel {
+        border-right: none;
+    }
+
+    #state-panel {
+        margin-bottom: 0;
+    }
+
+
+    #editor-panel .input-area,
+    #editor-panel .output-area,
+    #state-panel .stack-area,
+    #state-panel .vocabulary-area,
+    #state-panel .dictionary-area {
+        flex: 1;
+        min-height: 0;
+    }
+
+    #code-input {
+        min-height: 180px;
+        max-height: none;
+    }
+
+    .display-area,
+    .state-display,
+    .words-display {
+        min-height: 80px;
+    }
+
+    .words-area .words-display {
+        cursor: default;
+    }
+
+    .stack-area {
+        cursor: pointer;
+    }
+
+    .output-area,
+    .stack-area {
+        cursor: pointer;
+        position: relative;
+    }
+
+    .input-area,
+    .vocabulary-area {
+        cursor: default;
+    }
+}
+
+
+@media (min-width: 769px) and (max-width: 1024px) {
+    .main-layout {
+        gap: 0;
+        padding: 0;
+    }
+
+    #editor-panel {
+        padding: 0.75rem 0.375rem 0.75rem 0.75rem;
+    }
+
+    #state-panel {
+        padding: 0.75rem 0.75rem 0.75rem 0.375rem;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,16 +1,176 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ja">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ajisai</title>
-  <link rel="stylesheet" href="/ajisai-base.css" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Ajisai - A stack-based programming language inspired by FORTH">
+    <meta name="theme-color" content="#007bff">
+
+
+    <link rel="manifest" href="./manifest.json">
+    <link rel="apple-touch-icon" href="./images/icon-192.png">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-title" content="Ajisai">
+
+    <title>Ajisai</title>
+
+
+    <script src="/ajisai-config.js?v=20260408"></script>
+    <script src="/ajisai-theme.js?v=20260408"></script>
+    <style id="theme-vars"></style>
+    <script>
+
+        if (typeof AjisaiTheme !== 'undefined') {
+            const vars = AjisaiTheme.getAll();
+            let css = ':root {';
+            for (const [key, value] of Object.entries(vars)) {
+                css += `${key}: ${value};`;
+            }
+            css += '}';
+            document.getElementById('theme-vars').textContent = css;
+        }
+    </script>
+
+    <link rel="stylesheet" href="public/ajisai-base.css?v=20260408">
+    <link rel="stylesheet" href="app-interface.css?v=20260408">
 </head>
 <body>
-  <main style="max-width: 840px; margin: 48px auto; padding: 0 16px;">
-    <h1>Ajisai</h1>
-    <p>Referenceページは削除されました。最新情報はGitHubリポジトリをご確認ください。</p>
-    <p><a href="https://github.com/masamoto1982/Ajisai">https://github.com/masamoto1982/Ajisai</a></p>
-  </main>
+    <a href="#code-input" class="skip-link">Skip to main content</a>
+    <div class="container">
+        <header role="banner">
+            <div class="app-header-top">
+                <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
+                    <span class="logo-swap" aria-hidden="true">
+                        <img src="public/images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
+                        <img src="public/images/ajisai-qr.png" alt="" class="logo logo-qr">
+                    </span>
+                    <div class="app-brand-meta">
+                        <h1>Ajisai</h1>
+                        <span class="version">ver.202604110853</span>
+                    </div>
+                </a>
+                <span id="offline-indicator" class="offline-indicator" style="display: none;">Offline</span>
+            </div>
+            <div class="header-actions">
+                <a href="docs/index.html" class="reference-btn" target="_blank">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M9 9h6v6M15 9l-6 6M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z"/>
+                    </svg>
+                    Reference
+                </a>
+                <button id="test-btn" class="test-btn" type="button">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    </svg>
+                    Test
+                </button>
+            </div>
+        </header>
+
+        <main class="main-layout">
+            <div class="area-selector area-selector-mobile">
+                <label for="mobile-panel-select" class="visually-hidden">Select panel</label>
+                <select id="mobile-panel-select">
+                    <option value="input">Input</option>
+                    <option value="output">Output</option>
+                    <option value="stack">Stack</option>
+                    <option value="dictionary">Dictionary</option>
+                </select>
+            </div>
+
+            <div id="editor-panel" class="panel">
+                <div class="area-selector area-selector-left">
+                    <label for="left-panel-select" class="visually-hidden">Select left panel</label>
+                    <select id="left-panel-select">
+                        <option value="input">Input</option>
+                        <option value="output">Output</option>
+                    </select>
+                </div>
+                <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0">
+                    <h2 class="visually-hidden">Output</h2>
+                    <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
+                    <div class="vocabulary-actions">
+                        <button id="copy-output-btn" class="header-btn" type="button" aria-label="Copy output to clipboard">Copy</button>
+                    </div>
+                </section>
+                <section id="input-panel" class="input-area" role="region" aria-label="Input" tabindex="0">
+                    <h2 class="visually-hidden">Input</h2>
+                    <div class="textarea-wrapper">
+                        <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
+                        <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
+                    </div>
+                    <div class="vocabulary-actions">
+                        <button id="run-btn" type="button">Run</button>
+                    </div>
+                </section>
+            </div>
+
+            <div id="state-panel" class="panel">
+                <div class="area-selector area-selector-right">
+                    <label for="right-panel-select" class="visually-hidden">Select right panel</label>
+                    <select id="right-panel-select">
+                        <option value="stack">Stack</option>
+                        <option value="dictionary">Dictionary</option>
+                    </select>
+                </div>
+                <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
+                    <h2 class="visually-hidden">Stack</h2>
+                    <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
+                    <div class="vocabulary-actions"></div>
+                </section>
+
+                <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
+                    <div class="dictionary-toolbar">
+                        <div class="dictionary-sheet-selector">
+                            <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
+                            <select id="dictionary-sheet-select">
+                                <option value="core">Core word</option>
+                                <option value="user">User word</option>
+                            </select>
+                        </div>
+                        <div class="search-wrapper">
+                            <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
+                            <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
+                        </div>
+                    </div>
+                    <div id="dictionary-sheet-core" class="dictionary-sheet active">
+                        <div class="vocabulary-container">
+                            <div class="words-area">
+                                <span id="core-word-info" class="word-info-display"></span>
+                                <div id="core-words-display" class="words-display"></div>
+                            </div>
+                        </div>
+                        <div class="vocabulary-actions"></div>
+                    </div>
+                    <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
+                        <div class="vocabulary-container">
+                            <div class="words-area">
+                                <div class="dictionary-sheet-selector">
+                                    <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                                    <select id="user-dictionary-select">
+                                        <option value="DEMO">Demonstration word</option>
+                                    </select>
+                                </div>
+                                <span id="user-word-info" class="word-info-display"></span>
+                                <div id="user-words-display" class="words-display"></div>
+                            </div>
+                        </div>
+                        <div class="vocabulary-actions">
+                            <button id="export-btn" class="header-btn" type="button">Export</button>
+                            <button id="import-btn" class="header-btn" type="button">Import</button>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span>&copy; <span id="footer-year"></span> masamoto yamashiro</span>
+            <a href="https://github.com/masamoto1982/Ajisai" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </footer>
+        <script>document.getElementById('footer-year').textContent = new Date().getFullYear();</script>
+    </div>
+
+    <script type="module" src="js/web-app-entrypoint.ts"></script>
 </body>
 </html>

--- a/js/gui/code-input-editor.ts
+++ b/js/gui/code-input-editor.ts
@@ -1,0 +1,329 @@
+
+
+export interface EditorCallbacks {
+    readonly onContentChange?: (content: string) => void;
+    readonly onSwitchToInputMode?: () => void;
+    readonly onRequestSuggestions?: (prefix: string) => string[];
+}
+
+export interface Editor {
+    readonly extractValue: () => string;
+    readonly updateValue: (value: string) => void;
+    readonly clear: (switchView?: boolean) => void;
+    readonly insertWord: (word: string) => void;
+    readonly insertText: (text: string) => void;
+    readonly removeLastWord: () => void;
+    readonly focus: () => void;
+    readonly registerContentChangeCallback: (callback: (content: string) => void) => void;
+}
+
+const insertAt = (
+    text: string,
+    start: number,
+    end: number,
+    insertion: string
+): string => text.substring(0, start) + insertion + text.substring(end);
+
+const locateInnerBracketPosition = (text: string): number | null => {
+    const pos = text.lastIndexOf('[ ]');
+    return pos !== -1 ? pos + 2 : null;
+};
+
+const computeCursorPosition = (
+    basePosition: number,
+    insertedText: string,
+    preferInnerBracket: boolean
+): number => {
+    if (preferInnerBracket) {
+        const innerPos = locateInnerBracketPosition(insertedText);
+        if (innerPos !== null) {
+            return basePosition + innerPos;
+        }
+    }
+    return basePosition + insertedText.length;
+};
+
+const updateElementValue = (element: HTMLTextAreaElement, value: string): void => {
+    element.value = value;
+};
+
+const focusElement = (element: HTMLTextAreaElement): void => {
+    element.focus();
+};
+
+const updateSelectionRange = (
+    element: HTMLTextAreaElement,
+    start: number,
+    end: number
+): void => {
+    element.selectionStart = start;
+    element.selectionEnd = end;
+};
+
+const lookupSelectionRange = (element: HTMLTextAreaElement): { start: number; end: number } => ({
+    start: element.selectionStart,
+    end: element.selectionEnd
+});
+
+const MOBILE_BREAKPOINT = 768;
+const MAX_SUGGESTIONS = 10;
+const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
+
+const extractToken = (
+    text: string,
+    cursorPosition: number
+): { token: string; start: number; end: number } => {
+    const safeCursor = Math.max(0, Math.min(cursorPosition, text.length));
+    const left = text.slice(0, safeCursor);
+    const right = text.slice(safeCursor);
+    const leftMatch = left.match(/[A-Za-z0-9_?!+\-*/<>=]+$/);
+    const rightMatch = right.match(/^[A-Za-z0-9_?!+\-*/<>=]*/);
+
+    const tokenLeft = leftMatch?.[0] ?? '';
+    const tokenRight = rightMatch?.[0] ?? '';
+
+    return {
+        token: `${tokenLeft}${tokenRight}`,
+        start: safeCursor - tokenLeft.length,
+        end: safeCursor + tokenRight.length
+    };
+};
+
+export const createEditor = (
+    element: HTMLTextAreaElement,
+    callbacks: EditorCallbacks = {}
+): Editor => {
+    let onContentChangeCallback = callbacks.onContentChange;
+    const switchToInputMode = callbacks.onSwitchToInputMode ?? (() => {});
+    const requestSuggestions = callbacks.onRequestSuggestions ?? (() => []);
+
+    let currentSuggestions: string[] = [];
+    let selectedSuggestionIndex = 0;
+
+    const textareaWrapper = element.closest('.textarea-wrapper');
+    const suggestionPanel = document.createElement('div');
+    suggestionPanel.className = 'editor-suggestions';
+    suggestionPanel.style.display = 'none';
+    textareaWrapper?.appendChild(suggestionPanel);
+
+    const emitContentChange = (): void => {
+        if (onContentChangeCallback) {
+            onContentChangeCallback(element.value);
+        }
+    };
+
+    const hideSuggestions = (): void => {
+        suggestionPanel.style.display = 'none';
+        currentSuggestions = [];
+        selectedSuggestionIndex = 0;
+    };
+
+    const computeCursorCoords = (el: HTMLTextAreaElement): { top: number; left: number } => {
+        const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
+        const paddingTop = parseFloat(getComputedStyle(el).paddingTop) || 0;
+        const text = el.value.substring(0, el.selectionStart);
+        const lines = text.split('\n');
+        const lineIndex = lines.length - 1;
+        const top = paddingTop + lineIndex * lineHeight + lineHeight;
+        const left = 0;
+        return { top, left };
+    };
+
+    const renderSuggestions = (): void => {
+        if (currentSuggestions.length === 0) {
+            hideSuggestions();
+            return;
+        }
+
+        const { top, left } = computeCursorCoords(element);
+        suggestionPanel.style.top = `${top}px`;
+        suggestionPanel.style.left = `${left + 8}px`;
+        suggestionPanel.style.bottom = 'auto';
+
+        suggestionPanel.innerHTML = '';
+        currentSuggestions.forEach((suggestion, index) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `editor-suggestion-item${index === selectedSuggestionIndex ? ' active' : ''}`;
+            button.textContent = suggestion;
+            button.addEventListener('mousedown', (e) => {
+                e.preventDefault();
+                applySuggestion(suggestion);
+            });
+            suggestionPanel.appendChild(button);
+        });
+
+        suggestionPanel.style.display = 'block';
+    };
+
+    const refreshSuggestions = (forceShow = false): void => {
+        const { token } = extractToken(element.value, element.selectionStart);
+        if (!forceShow && token.length < 1) {
+            hideSuggestions();
+            return;
+        }
+
+        const suggestions = requestSuggestions(token)
+            .filter(word => token.length === 0 || word.toLowerCase().startsWith(token.toLowerCase()))
+            .slice(0, MAX_SUGGESTIONS);
+
+        currentSuggestions = suggestions;
+        selectedSuggestionIndex = 0;
+        renderSuggestions();
+    };
+
+    const applySuggestion = (suggestion: string): void => {
+        const { start, end } = extractToken(element.value, element.selectionStart);
+        const newText = insertAt(element.value, start, end, suggestion);
+        updateElementValue(element, newText);
+        const newPos = start + suggestion.length;
+        updateSelectionRange(element, newPos, newPos);
+        hideSuggestions();
+        emitContentChange();
+    };
+
+    const registerEventListeners = (): void => {
+        element.addEventListener('focus', () => {
+            switchToInputMode();
+            refreshSuggestions();
+        });
+
+        element.addEventListener('blur', () => {
+            setTimeout(hideSuggestions, 100);
+        });
+
+        element.addEventListener('input', () => {
+            emitContentChange();
+            refreshSuggestions();
+        });
+
+        element.addEventListener('keydown', (e) => {
+            if (e.key === ' ' && e.ctrlKey) {
+                e.preventDefault();
+                refreshSuggestions(true);
+                return;
+            }
+
+            if (currentSuggestions.length === 0) return;
+
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                selectedSuggestionIndex = (selectedSuggestionIndex + 1) % currentSuggestions.length;
+                renderSuggestions();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                selectedSuggestionIndex = (selectedSuggestionIndex - 1 + currentSuggestions.length) % currentSuggestions.length;
+                renderSuggestions();
+            } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.altKey)) {
+                e.preventDefault();
+                applySuggestion(currentSuggestions[selectedSuggestionIndex]!);
+            } else if (e.key === 'Escape') {
+                hideSuggestions();
+            }
+        });
+    };
+
+    if (element.value.trim() === '') {
+        updateElementValue(element, '');
+    }
+    registerEventListeners();
+
+    const extractValue = (): string => element.value.trim();
+
+    const updateValue = (value: string): void => {
+        updateElementValue(element, value);
+        hideSuggestions();
+        emitContentChange();
+        switchToInputMode();
+    };
+
+    const clear = (switchView = true): void => {
+        updateElementValue(element, '');
+        if (!checkIsMobile()) {
+            focusElement(element);
+        }
+        hideSuggestions();
+        emitContentChange();
+        if (switchView) {
+            switchToInputMode();
+        }
+    };
+
+    const insertWord = (word: string): void => {
+        const { start, end } = lookupSelectionRange(element);
+        const newText = insertAt(element.value, start, end, word);
+
+        updateElementValue(element, newText);
+
+        const newPos = start + word.length;
+        updateSelectionRange(element, newPos, newPos);
+
+        if (!checkIsMobile()) {
+            focusElement(element);
+        }
+        hideSuggestions();
+        emitContentChange();
+    };
+
+    const insertText = (text: string): void => {
+        const { start, end } = lookupSelectionRange(element);
+        const newText = insertAt(element.value, start, end, text);
+
+        updateElementValue(element, newText);
+
+        const cursorPos = computeCursorPosition(start, text, true);
+        updateSelectionRange(element, cursorPos, cursorPos);
+
+        if (!checkIsMobile()) {
+            focusElement(element);
+        }
+        hideSuggestions();
+        emitContentChange();
+    };
+
+    const removeLastWord = (): void => {
+        const { start } = lookupSelectionRange(element);
+        const before = element.value.substring(0, start);
+        const after = element.value.substring(start);
+
+        const trimmed = before.replace(/\S+\s*$/, '');
+        const newText = trimmed + after;
+
+        updateElementValue(element, newText);
+        updateSelectionRange(element, trimmed.length, trimmed.length);
+
+        if (!checkIsMobile()) {
+            focusElement(element);
+        }
+        hideSuggestions();
+        emitContentChange();
+    };
+
+    const focus = (): void => {
+        focusElement(element);
+        switchToInputMode();
+        refreshSuggestions();
+    };
+
+    const registerContentChangeCallback = (callback: (content: string) => void): void => {
+        onContentChangeCallback = callback;
+    };
+
+    return {
+        extractValue,
+        updateValue,
+        clear,
+        insertWord,
+        insertText,
+        removeLastWord,
+        focus,
+        registerContentChangeCallback
+    };
+};
+
+export const editorUtils = {
+    insertAt,
+    locateInnerBracketPosition,
+    computeCursorPosition,
+    extractToken
+};

--- a/js/gui/demo-words.ts
+++ b/js/gui/demo-words.ts
@@ -1,0 +1,33 @@
+import type { UserWord } from '../wasm-interpreter-types';
+
+
+
+export const DEMO_WORDS_VERSION = 8;
+
+export const DEMO_USER_WORDS: UserWord[] = [
+    {
+        name: 'SAY-HELLO',
+        definition: "'Hello' ,, PRINT",
+        description: 'Map型: スタックトップを保持しつつOutputに「Hello」を出力する。入力: 任意、出力: 入力そのまま',
+    },
+    {
+        name: 'SAY-WORLD',
+        definition: "'World' ,, PRINT",
+        description: 'Map型: スタックトップを保持しつつOutputに「World」を出力する。入力: 任意、出力: 入力そのまま',
+    },
+    {
+        name: 'SAY-BANG',
+        definition: "'!' ,, PRINT",
+        description: 'Map型: スタックトップを保持しつつOutputに「!」を出力する。入力: 任意、出力: 入力そのまま',
+    },
+    {
+        name: 'GREET',
+        definition: "{ [ 1 ] = } { SAY-HELLO } { [ 2 ] = } { SAY-WORLD } { IDLE } { SAY-BANG } COND",
+        description: 'Form型: 入力値に応じてHello/World/!を分岐出力する（CONDパターン例）。入力: Scalar(1|2|other)、出力: 入力そのまま',
+    },
+    {
+        name: 'GREET-ALL',
+        definition: '{ GREET } MAP',
+        description: 'Form型: Vectorの各要素にGREETを適用する（MAPパターン例）。入力: Vector、出力: Vector',
+    },
+];

--- a/js/gui/dictionary-element-builders.ts
+++ b/js/gui/dictionary-element-builders.ts
@@ -1,0 +1,90 @@
+export const compareWordName = (a: string, b: string): number => {
+    const aIsAlpha = /^[A-Za-z]/.test(a);
+    const bIsAlpha = /^[A-Za-z]/.test(b);
+
+    if (!aIsAlpha && bIsAlpha) return -1;
+    if (aIsAlpha && !bIsAlpha) return 1;
+
+    return a.localeCompare(b);
+};
+
+export const checkWordMatchesFilter = (wordName: string, filter: string): boolean => {
+    if (!filter) return true;
+    return wordName.toLowerCase().includes(filter.toLowerCase());
+};
+
+export const createNoResultsElement = (): HTMLElement => {
+    const message = document.createElement('div');
+    message.className = 'no-results-message';
+    message.textContent = 'No matching words found';
+    return message;
+};
+
+export const createEmptyWordsElement = (text: string): HTMLElement => {
+    const message = document.createElement('div');
+    message.className = 'empty-words-message';
+    message.textContent = text;
+    return message;
+};
+
+export const registerBackgroundClickListeners = (
+    container: HTMLElement,
+    onBackgroundClick?: () => void,
+    onBackgroundDoubleClick?: () => void
+): void => {
+    const isBackgroundClick = (e: MouseEvent): boolean => {
+        const target = e.target as HTMLElement;
+        return !target.closest('.word-button');
+    };
+
+    let clickTimer: ReturnType<typeof setTimeout> | null = null;
+
+    if (onBackgroundClick) {
+        container.addEventListener('click', (e) => {
+            if (!isBackgroundClick(e as MouseEvent)) return;
+            if (clickTimer) clearTimeout(clickTimer);
+            clickTimer = setTimeout(() => {
+                onBackgroundClick();
+                clickTimer = null;
+            }, 200);
+        });
+    }
+
+    if (onBackgroundDoubleClick) {
+        container.addEventListener('dblclick', (e) => {
+            if (!isBackgroundClick(e as MouseEvent)) return;
+            if (clickTimer) {
+                clearTimeout(clickTimer);
+                clickTimer = null;
+            }
+            onBackgroundDoubleClick();
+        });
+    }
+};
+
+export const createWordButtonElement = (
+    text: string,
+    title: string,
+    className: string,
+    onClick: () => void,
+    onHover?: () => void,
+    onLeave?: () => void,
+    onContextMenu?: (event: MouseEvent) => void
+): HTMLButtonElement => {
+    const button = document.createElement('button');
+    button.textContent = text;
+    button.className = className;
+    button.title = title;
+    button.addEventListener('click', onClick);
+
+    if (onHover) button.addEventListener('mouseenter', onHover);
+    if (onLeave) button.addEventListener('mouseleave', onLeave);
+    if (onContextMenu) {
+        button.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            onContextMenu(e);
+        });
+    }
+
+    return button;
+};

--- a/js/gui/execution-controller.ts
+++ b/js/gui/execution-controller.ts
@@ -1,0 +1,214 @@
+import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import {
+    applyInterpreterSnapshot,
+    createInterpreterSnapshot,
+    type InterpreterSnapshot
+} from '../workers/interpreter-snapshot';
+import type { AjisaiInterpreter, ExecuteResult, UserWord } from '../wasm-interpreter-types';
+import { createStepExecutor, StepExecutor } from './step-executor';
+import type { ViewMode } from './mobile-view-switcher';
+
+export interface ExecutionCallbacks {
+    readonly extractEditorValue: () => string;
+    readonly clearEditor: (switchView?: boolean) => void;
+    readonly updateEditorValue: (value: string) => void;
+    readonly insertEditorText: (text: string) => void;
+    readonly showInfo: (text: string, append: boolean) => void;
+    readonly showError: (error: Error | string) => void;
+    readonly showExecutionResult: (result: ExecuteResult) => void;
+    readonly updateDisplays: () => void;
+    readonly saveState: () => Promise<void>;
+    readonly fullReset: () => Promise<void>;
+    readonly updateView: (mode: ViewMode) => void;
+}
+
+export interface ExecutionController {
+    readonly executeCode: (code: string) => Promise<void>;
+    readonly executeReset: () => Promise<void>;
+    readonly executeStep: () => Promise<void>;
+    readonly checkIsStepModeActive: () => boolean;
+    readonly abortExecution: () => void;
+}
+
+const mapWordDataToUserWord = (
+    interpreter: AjisaiInterpreter,
+    wordData: [string, string, string | null, boolean]
+): UserWord => ({
+    dictionary: wordData[0],
+    name: wordData[1],
+    definition: interpreter.lookup_word_definition(`${wordData[0]}@${wordData[1]}`),
+    description: wordData[2]
+});
+
+const collectUserWords = (interpreter: AjisaiInterpreter): UserWord[] => {
+    const userWordsInfo = interpreter.collect_user_words_info();
+    return userWordsInfo.map(wordData => mapWordDataToUserWord(interpreter, wordData));
+};
+
+const restoreInterpreterState = (
+    interpreter: AjisaiInterpreter,
+    result: ExecuteResult
+): void => {
+    if (!result || result.error) return;
+
+    applyInterpreterSnapshot(interpreter, {
+        stack: result.stack,
+        userWords: result.userWords,
+        importedModules: result.importedModules
+    });
+};
+
+const checkIsResetCommand = (code: string): boolean =>
+    code.trim().toUpperCase() === 'RESET';
+
+const isAbortError = (error: Error): boolean =>
+    error.message.includes('aborted');
+
+const createExecutionSnapshot = (interpreter: AjisaiInterpreter): InterpreterSnapshot =>
+    createInterpreterSnapshot({
+        stack: interpreter.collect_stack(),
+        userWords: collectUserWords(interpreter),
+        importedModules: interpreter.collect_imported_modules()
+    });
+
+const resolveExecutionException = (
+    error: unknown,
+    showInfo: (text: string, append: boolean) => void,
+    showError: (error: Error | string) => void
+): void => {
+    console.error('[ExecController] Code execution failed:', error);
+    if (error instanceof Error && isAbortError(error)) {
+        showInfo('Execution aborted', true);
+        return;
+    }
+    showError(error as Error);
+};
+
+export const createExecutionController = (
+    interpreter: AjisaiInterpreter,
+    callbacks: ExecutionCallbacks
+): ExecutionController => {
+    const {
+        extractEditorValue,
+        clearEditor,
+        updateEditorValue,
+        insertEditorText,
+        showInfo,
+        showError,
+        showExecutionResult,
+        updateDisplays,
+        saveState,
+        fullReset,
+        updateView
+    } = callbacks;
+
+    const stepExecutor: StepExecutor = createStepExecutor(interpreter, {
+        extractEditorValue,
+        showInfo,
+        showError,
+        showExecutionResult,
+        updateDisplays,
+        saveState
+    });
+
+    const applyExecutionResult = (result: ExecuteResult, code: string): void => {
+        if (result.inputHelper) {
+            clearEditor(false);
+            insertEditorText(result.inputHelper);
+            showInfo('Input helper inserted', false);
+            updateView('input');
+        } else if (result.definition_to_load) {
+            updateEditorValue(result.definition_to_load);
+            const wordName = code.replace("?", "").trim();
+            showInfo(`Showing definition: ${wordName}`, false);
+            updateView('input');
+        } else if (result.status === 'OK' && !result.error) {
+            showExecutionResult(result);
+            clearEditor(false);
+        } else {
+            showError(result.message || 'Unknown error');
+        }
+    };
+
+    const executeCode = async (code: string): Promise<void> => {
+        if (!code) return;
+
+        stepExecutor.reset();
+
+        if (checkIsResetCommand(code)) {
+            await executeReset();
+            return;
+        }
+
+        try {
+            updateView('output');
+            showInfo('Executing...', false);
+
+            const currentState = createExecutionSnapshot(interpreter);
+            const result = await WORKER_MANAGER.execute(code, currentState);
+
+            try {
+                restoreInterpreterState(interpreter, result);
+            } catch (error) {
+                console.error('[ExecController] Failed to sync state:', error);
+                showError(error as Error);
+            }
+
+            applyExecutionResult(result, code);
+
+        } catch (error) {
+            resolveExecutionException(error, showInfo, showError);
+        }
+
+        updateDisplays();
+        await saveState();
+    };
+
+    const executeReset = async (): Promise<void> => {
+        try {
+            console.log('[ExecController] Executing full reset');
+            stepExecutor.reset();
+            await WORKER_MANAGER.resetAllWorkers();
+            const result = interpreter.reset();
+
+            if (result.status === 'OK' && !result.error) {
+                clearEditor(true);
+                await fullReset();
+
+                updateView('input');
+            } else {
+                showError(result.message || 'RESET execution failed');
+            }
+        } catch (error) {
+            console.error('[ExecController] Reset failed:', error);
+            showError(error as Error);
+        }
+    };
+
+    const executeStep = async (): Promise<void> => {
+        await stepExecutor.executeStep();
+    };
+
+    const checkIsStepModeActive = (): boolean => stepExecutor.isActive();
+
+    const abortExecution = (): void => {
+        stepExecutor.abort();
+    };
+
+    return {
+        executeCode,
+        executeReset,
+        executeStep,
+        checkIsStepModeActive,
+        abortExecution
+    };
+};
+
+export const executionControllerUtils = {
+    collectUserWords,
+    restoreInterpreterState,
+    checkIsResetCommand,
+    isAbortError,
+    createExecutionSnapshot,
+    resolveExecutionException
+};

--- a/js/gui/functional-result-helpers.ts
+++ b/js/gui/functional-result-helpers.ts
@@ -1,0 +1,24 @@
+
+
+
+
+
+
+export function pipe<A>(value: A): A;
+export function pipe<A, B>(value: A, fn1: (a: A) => B): B;
+export function pipe<A, B, C>(value: A, fn1: (a: A) => B, fn2: (b: B) => C): C;
+export function pipe<A, B, C, D>(value: A, fn1: (a: A) => B, fn2: (b: B) => C, fn3: (c: C) => D): D;
+export function pipe<A, B, C, D, E>(value: A, fn1: (a: A) => B, fn2: (b: B) => C, fn3: (c: C) => D, fn4: (d: D) => E): E;
+export function pipe(value: unknown, ...fns: Array<(arg: unknown) => unknown>): unknown {
+    return fns.reduce((acc, fn) => fn(acc), value);
+}
+
+
+
+
+export type Result<T, E = Error> =
+    | { ok: true; value: T }
+    | { ok: false; error: E };
+
+export const ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
+export const err = <E>(error: E): Result<never, E> => ({ ok: false, error });

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -1,0 +1,385 @@
+import { createDisplay, Display } from './output-display-renderer';
+import { createVocabularyManager, VocabularyManager } from './vocabulary-state-controller';
+import { createEditor, Editor } from './code-input-editor';
+import { createMobileHandler, MobileHandler, ViewMode } from './mobile-view-switcher';
+import { createModuleTabManager, ModuleTabManager } from './module-selector-sheets';
+import { createPersistence, Persistence } from './interpreter-state-persistence';
+import { createExecutionController, ExecutionController } from './execution-controller';
+import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import type { AjisaiInterpreter } from '../wasm-interpreter-types';
+import {
+    GUIElements,
+    cacheElements,
+    extractDisplayElements,
+    extractVocabularyElements,
+    extractMobileElements
+} from './gui-dom-cache';
+import {
+    createLayoutState,
+    applyAreaState,
+    updateHighlights,
+    updateEditorPlaceholder,
+    checkStackHighlightAll,
+    checkStackHighlightTop,
+    LayoutState
+} from './gui-layout-state';
+import { switchDictionarySheet } from './gui-dictionary-sheet';
+
+declare global {
+    interface Window {
+        ajisaiInterpreter: AjisaiInterpreter;
+    }
+}
+
+export type { GUIElements };
+
+export interface GUI {
+    readonly init: () => Promise<void>;
+    readonly updateAllDisplays: () => void;
+    readonly extractElements: () => GUIElements;
+    readonly extractDisplay: () => Display;
+    readonly extractEditor: () => Editor;
+    readonly extractVocabulary: () => VocabularyManager;
+    readonly extractMobile: () => MobileHandler;
+    readonly extractPersistence: () => Persistence;
+    readonly extractExecutionController: () => ExecutionController;
+}
+
+const collectAutocompleteWords = (): string[] => {
+    if (!window.ajisaiInterpreter) return [];
+
+    const coreWordsInfo = window.ajisaiInterpreter.collect_core_words_info();
+    const coreWords: string[] = coreWordsInfo.map(word => word[0]).filter((w): w is string => w !== undefined);
+
+    const userWordsInfo = window.ajisaiInterpreter.collect_user_words_info();
+    const userWords: string[] = userWordsInfo.flatMap(word => [
+        word[1],
+        `${word[0]}@${word[1]}`
+    ]);
+
+    const moduleWords: string[] = [];
+    try {
+        const importedModules: string[] = window.ajisaiInterpreter.collect_imported_modules();
+        for (const moduleName of importedModules) {
+            const words = window.ajisaiInterpreter.collect_module_words_info(moduleName);
+            const prefix: string = `${moduleName}@`;
+            for (const word of words) {
+                const name: string = word[0] ?? '';
+                moduleWords.push(name.startsWith(prefix) ? name.slice(prefix.length) : name);
+            }
+            const sampleWords = window.ajisaiInterpreter.collect_module_sample_words_info(moduleName);
+            for (const word of sampleWords) {
+                const sampleName: string = word[0] ?? '';
+                moduleWords.push(sampleName);
+            }
+        }
+    } catch {  }
+
+    const allWords: Set<string> = new Set([...coreWords, ...userWords, ...moduleWords]);
+    return Array.from(allWords).sort((a: string, b: string) => a.localeCompare(b));
+};
+
+export const createGUI = (): GUI => {
+    let elements: GUIElements;
+    let display: Display;
+    let editor: Editor;
+    let vocabulary: VocabularyManager;
+    let mobile: MobileHandler;
+    let persistence: Persistence;
+    let executionController: ExecutionController;
+    let moduleTabManager: ModuleTabManager;
+    let layoutState: LayoutState;
+
+    const doSwitchDictionarySheet = (sheetId: string): void => {
+        switchDictionarySheet(elements.dictionaryArea, sheetId);
+    };
+
+    const switchArea = (mode: ViewMode): void => {
+        layoutState.currentMode = mode;
+        applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, mode);
+    };
+
+    const updateAllDisplays = (): void => {
+        if (!window.ajisaiInterpreter) return;
+
+        try {
+            display.renderStack(window.ajisaiInterpreter.collect_stack());
+            vocabulary.updateUserWords(window.ajisaiInterpreter.collect_user_words_info());
+
+            const newSheetIds: string[] = moduleTabManager.syncModuleTabs();
+
+            if (newSheetIds.length > 0) {
+                const lastSheetId: string = newSheetIds[newSheetIds.length - 1]!;
+                if (layoutState.currentRightMode !== 'dictionary' || (mobile.isMobile() && layoutState.currentMode !== 'dictionary')) {
+                    switchArea('dictionary');
+                }
+                elements.dictionarySheetSelect.value = lastSheetId;
+                doSwitchDictionarySheet(lastSheetId);
+            }
+
+            updateHighlights(elements, elements.codeInput.value);
+        } catch (error) {
+            console.error('Failed to update display:', error);
+            display.renderError(new Error('Failed to update display.'));
+        }
+    };
+
+    const initializeWorkers = async (): Promise<void> => {
+        try {
+            display.renderInfo('Initializing...', false);
+            await WORKER_MANAGER.init();
+            display.renderInfo('Ready', true);
+        } catch (error) {
+            console.error('[GUI] Failed to initialize workers:', error);
+            display.renderError(new Error(`Failed to initialize parallel execution: ${error}`));
+        }
+    };
+
+    const debounce = <T extends (...args: unknown[]) => void>(
+        fn: T,
+        delay: number
+    ): ((...args: Parameters<T>) => void) => {
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
+        return (...args: Parameters<T>) => {
+            if (timeoutId) clearTimeout(timeoutId);
+            timeoutId = setTimeout(() => fn(...args), delay);
+        };
+    };
+
+    const setupEventListeners = (): void => {
+        elements.runBtn.addEventListener('click', () => {
+            executionController.executeCode(editor.extractValue());
+        });
+
+        const applySearchFilter = (filter: string): void => {
+            elements.dictionarySearch.value = filter;
+            vocabulary.updateSearchFilter(filter);
+            moduleTabManager.updateSearchFilter(filter);
+        };
+
+        const applySearchInput = debounce(() => {
+            applySearchFilter(elements.dictionarySearch.value);
+        }, 150);
+
+        elements.dictionarySearch.addEventListener('input', applySearchInput);
+
+        elements.dictionarySearchClearBtn.addEventListener('click', () => {
+            applySearchFilter('');
+        });
+
+        elements.clearBtn.addEventListener('click', () => {
+            editor.clear();
+        });
+
+        elements.leftPanelSelect.addEventListener('change', () => {
+            switchArea(elements.leftPanelSelect.value as ViewMode);
+        });
+        elements.rightPanelSelect.addEventListener('change', () => {
+            switchArea(elements.rightPanelSelect.value as ViewMode);
+        });
+        elements.mobilePanelSelect.addEventListener('change', () => {
+            switchArea(elements.mobilePanelSelect.value as ViewMode);
+        });
+
+        elements.dictionarySheetSelect.addEventListener('change', () => {
+            const selectedValue = elements.dictionarySheetSelect.value;
+            doSwitchDictionarySheet(selectedValue);
+        });
+
+        elements.testBtn?.addEventListener('click', async () => {
+            switchArea('output');
+            const { createTestRunner } = await import('./gui-test-runner');
+            const testRunner = createTestRunner({
+                showInfo: (text: string, append: boolean) => display.renderInfo(text, append),
+                showError: (error: Error | string) => display.renderError(error),
+                updateDisplays: updateAllDisplays
+            });
+            testRunner.runAllTests();
+        });
+
+        elements.outputArea.addEventListener('click', (e: MouseEvent) => {
+            if ((e.target as HTMLElement).closest('button, a')) return;
+            if (!mobile.isMobile() && layoutState.currentLeftMode === 'output') {
+                switchArea('input');
+            }
+        });
+
+        elements.copyOutputBtn.addEventListener('click', (e: MouseEvent) => {
+            e.stopPropagation();
+            const text = display.extractState().mainOutput;
+            navigator.clipboard.writeText(text).then(() => {
+                const btn = elements.copyOutputBtn;
+                const original = btn.textContent;
+                btn.textContent = 'Copied!';
+                setTimeout(() => { btn.textContent = original; }, 1500);
+            });
+        });
+
+        elements.exportBtn?.addEventListener('click', () => persistence.exportUserWords());
+        elements.importBtn?.addEventListener('click', () => persistence.importUserWords());
+
+        elements.codeInput.addEventListener('keydown', (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && e.shiftKey) {
+                e.preventDefault();
+                executionController.executeCode(editor.extractValue());
+            }
+            if (e.key === 'Enter' && e.ctrlKey && !e.altKey && !e.shiftKey) {
+                e.preventDefault();
+                executionController.executeStep();
+            }
+        });
+
+        window.addEventListener('resize', () => {
+            applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, layoutState.currentMode);
+            updateEditorPlaceholder(elements, mobile);
+        });
+
+        window.addEventListener('keydown', (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                WORKER_MANAGER.abortAll();
+                executionController.abortExecution();
+                e.preventDefault();
+                e.stopImmediatePropagation();
+            }
+            if (e.key === 'Enter' && e.ctrlKey && e.altKey) {
+                if (confirm('Are you sure you want to reset the system?')) {
+                    executionController.executeReset();
+                }
+                e.preventDefault();
+                e.stopImmediatePropagation();
+            }
+        }, true);
+    };
+
+    const init = async (): Promise<void> => {
+        console.log('[GUI] Initializing GUI...');
+
+        elements = cacheElements();
+        layoutState = createLayoutState();
+        mobile = createMobileHandler(extractMobileElements(elements), {
+            onModeChange: (mode) => switchArea(mode)
+        });
+        display = createDisplay(extractDisplayElements(elements));
+        display.init();
+        updateEditorPlaceholder(elements, mobile);
+
+        moduleTabManager = createModuleTabManager({
+            selectEl: elements.dictionarySheetSelect,
+            sheetContainerEl: elements.dictionaryArea,
+            onWordClick: (word: string) => {
+                if (!mobile.isMobile()) {
+                    editor.insertWord(word);
+                }
+            },
+            onBackgroundClick: () => {
+                if (!mobile.isMobile()) {
+                    editor.insertWord(' ');
+                }
+            },
+            onBackgroundDoubleClick: () => {
+                if (!mobile.isMobile()) {
+                    editor.removeLastWord();
+                }
+            },
+            onSheetChange: (sheetId: string) => doSwitchDictionarySheet(sheetId),
+            onSearchInput: (filter: string) => {
+                elements.dictionarySearch.value = filter;
+                vocabulary.updateSearchFilter(filter);
+                moduleTabManager.updateSearchFilter(filter);
+            },
+            onUpdateDisplays: () => updateAllDisplays(),
+            onSaveState: () => persistence.saveCurrentState(),
+            showInfo: (text: string, append: boolean) => display.renderInfo(text, append),
+            moduleActions: {
+                IO: [{
+                    label: 'JSON',
+                    className: 'btn-primary',
+                    ariaLabel: 'Import JSON as vector',
+                    onClick: () => persistence.importJsonAsVector(),
+                }],
+            },
+        });
+
+        persistence = createPersistence({
+            showError: (error) => display.renderError(error),
+            updateDisplays: updateAllDisplays,
+            showInfo: (text, append) => display.renderInfo(text, append)
+        });
+        await persistence.init();
+
+        editor = createEditor(elements.codeInput, {
+            onContentChange: (content) => updateHighlights(elements, content),
+            onSwitchToInputMode: () => switchArea('input'),
+            onRequestSuggestions: () => collectAutocompleteWords()
+        });
+
+        vocabulary = createVocabularyManager(extractVocabularyElements(elements), {
+            onWordClick: (word) => {
+                if (!mobile.isMobile()) {
+                    editor.insertWord(word);
+                }
+            },
+            onBackgroundClick: () => {
+                if (!mobile.isMobile()) {
+                    editor.insertWord(' ');
+                }
+            },
+            onBackgroundDoubleClick: () => {
+                if (!mobile.isMobile()) {
+                    editor.removeLastWord();
+                }
+            },
+            onUpdateDisplays: updateAllDisplays,
+            onSaveState: () => persistence.saveCurrentState(),
+            showInfo: (text, append) => display.renderInfo(text, append)
+        });
+
+        executionController = createExecutionController(window.ajisaiInterpreter, {
+            extractEditorValue: () => editor.extractValue(),
+            clearEditor: (switchView) => { editor.clear(switchView); },
+            updateEditorValue: (value) => editor.updateValue(value),
+            insertEditorText: (text) => editor.insertText(text),
+            showInfo: (text, append) => display.renderInfo(text, append),
+            showError: (error) => display.renderError(error),
+            showExecutionResult: (result) => display.renderExecutionResult(result),
+            updateDisplays: updateAllDisplays,
+            saveState: () => persistence.saveCurrentState(),
+            fullReset: () => persistence.fullReset(),
+            updateView: (mode) => switchArea(mode)
+        });
+
+        setupEventListeners();
+        vocabulary.renderBuiltInWords();
+        updateAllDisplays();
+        switchArea('input');
+
+        await persistence.loadDatabaseData();
+        updateAllDisplays();
+        await initializeWorkers();
+
+        console.log('[GUI] GUI initialization completed');
+    };
+
+    return {
+        init,
+        updateAllDisplays,
+        extractElements: () => elements,
+        extractDisplay: () => display,
+        extractEditor: () => editor,
+        extractVocabulary: () => vocabulary,
+        extractMobile: () => mobile,
+        extractPersistence: () => persistence,
+        extractExecutionController: () => executionController
+    };
+};
+
+export const GUI_INSTANCE = createGUI();
+
+export const guiUtils = {
+    cacheElements,
+    extractDisplayElements,
+    extractVocabularyElements,
+    extractMobileElements,
+    checkStackHighlightAll,
+    checkStackHighlightTop
+};

--- a/js/gui/gui-dictionary-sheet.ts
+++ b/js/gui/gui-dictionary-sheet.ts
@@ -1,0 +1,13 @@
+export const switchDictionarySheet = (containerEl: HTMLElement, sheetId: string): void => {
+    const allSheets = containerEl.querySelectorAll('.dictionary-sheet');
+    allSheets.forEach(sheet => {
+        (sheet as HTMLElement).hidden = true;
+        sheet.classList.remove('active');
+    });
+
+    const target = document.getElementById(`dictionary-sheet-${sheetId}`);
+    if (target) {
+        target.hidden = false;
+        target.classList.add('active');
+    }
+};

--- a/js/gui/gui-dom-cache.ts
+++ b/js/gui/gui-dom-cache.ts
@@ -1,0 +1,81 @@
+import type { DisplayElements } from './output-display-renderer';
+import type { VocabularyElements } from './vocabulary-state-controller';
+import type { MobileElements } from './mobile-view-switcher';
+
+export interface GUIElements {
+    readonly codeInput: HTMLTextAreaElement;
+    readonly runBtn: HTMLButtonElement;
+    readonly clearBtn: HTMLButtonElement;
+    readonly testBtn: HTMLButtonElement;
+    readonly exportBtn: HTMLButtonElement;
+    readonly importBtn: HTMLButtonElement;
+    readonly outputDisplay: HTMLElement;
+    readonly stackDisplay: HTMLElement;
+    readonly builtInWordsDisplay: HTMLElement;
+    readonly userWordsDisplay: HTMLElement;
+    readonly builtInWordInfo: HTMLElement;
+    readonly userWordInfo: HTMLElement;
+    readonly userDictionarySelect: HTMLSelectElement;
+    readonly dictionarySearch: HTMLInputElement;
+    readonly dictionarySearchClearBtn: HTMLButtonElement;
+    readonly dictionarySheetSelect: HTMLSelectElement;
+    readonly inputArea: HTMLElement;
+    readonly outputArea: HTMLElement;
+    readonly stackArea: HTMLElement;
+    readonly dictionaryArea: HTMLElement;
+    readonly editorPanel: HTMLElement;
+    readonly statePanel: HTMLElement;
+    readonly leftPanelSelect: HTMLSelectElement;
+    readonly rightPanelSelect: HTMLSelectElement;
+    readonly mobilePanelSelect: HTMLSelectElement;
+    readonly copyOutputBtn: HTMLButtonElement;
+}
+
+export const cacheElements = (): GUIElements => ({
+    codeInput: document.getElementById('code-input') as HTMLTextAreaElement,
+    runBtn: document.getElementById('run-btn') as HTMLButtonElement,
+    clearBtn: document.getElementById('clear-btn') as HTMLButtonElement,
+    testBtn: document.getElementById('test-btn') as HTMLButtonElement,
+    exportBtn: document.getElementById('export-btn') as HTMLButtonElement,
+    importBtn: document.getElementById('import-btn') as HTMLButtonElement,
+    outputDisplay: document.getElementById('output-display')!,
+    stackDisplay: document.getElementById('stack-display')!,
+    builtInWordsDisplay: document.getElementById('core-words-display')!,
+    userWordsDisplay: document.getElementById('user-words-display')!,
+    builtInWordInfo: document.getElementById('core-word-info')!,
+    userWordInfo: document.getElementById('user-word-info')!,
+    userDictionarySelect: document.getElementById('user-dictionary-select') as HTMLSelectElement,
+    dictionarySearch: document.getElementById('dictionary-search') as HTMLInputElement,
+    dictionarySearchClearBtn: document.getElementById('dictionary-search-clear-btn') as HTMLButtonElement,
+    dictionarySheetSelect: document.getElementById('dictionary-sheet-select') as HTMLSelectElement,
+    inputArea: document.querySelector('.input-area')!,
+    outputArea: document.querySelector('.output-area')!,
+    stackArea: document.querySelector('.stack-area')!,
+    dictionaryArea: document.getElementById('dictionary-panel')!,
+    editorPanel: document.getElementById('editor-panel')!,
+    statePanel: document.getElementById('state-panel')!,
+    leftPanelSelect: document.getElementById('left-panel-select') as HTMLSelectElement,
+    rightPanelSelect: document.getElementById('right-panel-select') as HTMLSelectElement,
+    mobilePanelSelect: document.getElementById('mobile-panel-select') as HTMLSelectElement,
+    copyOutputBtn: document.getElementById('copy-output-btn') as HTMLButtonElement
+});
+
+export const extractDisplayElements = (elements: GUIElements): DisplayElements => ({
+    outputDisplay: elements.outputDisplay,
+    stackDisplay: elements.stackDisplay
+});
+
+export const extractVocabularyElements = (elements: GUIElements): VocabularyElements => ({
+    builtInWordsDisplay: elements.builtInWordsDisplay,
+    userWordsDisplay: elements.userWordsDisplay,
+    builtInWordInfo: elements.builtInWordInfo,
+    userWordInfo: elements.userWordInfo,
+    userDictionarySelect: elements.userDictionarySelect
+});
+
+export const extractMobileElements = (elements: GUIElements): MobileElements => ({
+    inputArea: elements.inputArea,
+    outputArea: elements.outputArea,
+    stackArea: elements.stackArea,
+    dictionaryArea: elements.dictionaryArea
+});

--- a/js/gui/gui-interpreter-test-cases.ts
+++ b/js/gui/gui-interpreter-test-cases.ts
@@ -1,0 +1,664 @@
+
+
+import type { Value } from '../wasm-interpreter-types';
+
+export interface TestCase {
+    name: string;
+    code: string;
+    expectedStack?: Value[];
+    expectedOutput?: string;
+    expectError?: boolean;
+    category?: string;
+}
+
+
+export function createNumber(numerator: string, denominator: string = '1'): Value {
+    return { type: 'number', value: { numerator, denominator } };
+}
+
+export function createVector(elements: Value[]): Value {
+    return { type: 'vector', value: elements };
+}
+
+export function createString(value: string): Value {
+    return { type: 'string', value };
+}
+
+export function createBoolean(value: boolean): Value {
+    return { type: 'boolean', value };
+}
+
+export function createNil(): Value {
+    return { type: 'nil', value: null };
+}
+
+
+export const TEST_CASES: TestCase[] = [
+
+
+
+    {
+        name: "Number - integer",
+        code: "[ 42 ]",
+        expectedStack: [createVector([createNumber('42')])],
+        category: "Basic Types"
+    },
+    {
+        name: "Number - negative",
+        code: "[ -17 ]",
+        expectedStack: [createVector([createNumber('-17')])],
+        category: "Basic Types"
+    },
+    {
+        name: "Number - fraction",
+        code: "[ 3/4 ]",
+        expectedStack: [createVector([createNumber('3', '4')])],
+        category: "Basic Types"
+    },
+    {
+        name: "Number - decimal converts to fraction",
+        code: "[ 0.5 ]",
+        expectedStack: [createVector([createNumber('1', '2')])],
+        category: "Basic Types"
+    },
+    {
+        name: "String - simple",
+        code: "[ 'hello' ]",
+        expectedStack: [createVector([createString('hello')])],
+        category: "Basic Types"
+    },
+    {
+        name: "String - with spaces",
+        code: "[ 'hello world' ]",
+        expectedStack: [createVector([createString('hello world')])],
+        category: "Basic Types"
+    },
+    {
+        name: "Boolean - TRUE",
+        code: "[ TRUE ]",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Basic Types"
+    },
+    {
+        name: "Boolean - FALSE",
+        code: "[ FALSE ]",
+        expectedStack: [createVector([createBoolean(false)])],
+        category: "Basic Types"
+    },
+    {
+        name: "NIL",
+        code: "[ NIL ]",
+        expectedStack: [createVector([createNil()])],
+        category: "Basic Types"
+    },
+
+
+
+
+    {
+        name: "Addition - integers",
+        code: "[ 2 ] [ 3 ] +",
+        expectedStack: [createVector([createNumber('5')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Addition - fractions",
+        code: "[ 1/2 ] [ 1/3 ] +",
+        expectedStack: [createVector([createNumber('5', '6')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Subtraction",
+        code: "[ 10 ] [ 3 ] -",
+        expectedStack: [createVector([createNumber('7')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Multiplication",
+        code: "[ 4 ] [ 5 ] *",
+        expectedStack: [createVector([createNumber('20')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Division",
+        code: "[ 10 ] [ 4 ] /",
+        expectedStack: [createVector([createNumber('5', '2')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Division by zero - error",
+        code: "[ 1 ] [ 0 ] /",
+        expectError: true,
+        category: "Arithmetic"
+    },
+    {
+        name: "Modulo",
+        code: "[ 7 ] [ 3 ] MOD",
+        expectedStack: [createVector([createNumber('1')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Floor",
+        code: "[ 7/3 ] FLOOR",
+        expectedStack: [createVector([createNumber('2')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Ceil",
+        code: "[ 7/3 ] CEIL",
+        expectedStack: [createVector([createNumber('3')])],
+        category: "Arithmetic"
+    },
+    {
+        name: "Round",
+        code: "[ 5/2 ] ROUND",
+        expectedStack: [createVector([createNumber('3')])],
+        category: "Arithmetic"
+    },
+
+
+
+
+
+    {
+        name: "Less than - true",
+        code: "[ 3 ] [ 5 ] <",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Comparison"
+    },
+    {
+        name: "Less than - false",
+        code: "[ 5 ] [ 3 ] <",
+        expectedStack: [createVector([createBoolean(false)])],
+        category: "Comparison"
+    },
+    {
+        name: "Greater than (via <= NOT)",
+        code: "[ 5 ] [ 3 ] <= NOT",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Comparison"
+    },
+    {
+        name: "Less than or equal",
+        code: "[ 3 ] [ 3 ] <=",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Comparison"
+    },
+    {
+        name: "Greater than or equal (via < NOT)",
+        code: "[ 3 ] [ 3 ] < NOT",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Comparison"
+    },
+    {
+        name: "Equal - numbers",
+        code: "[ 5 ] [ 5 ] =",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Comparison"
+    },
+    {
+        name: "Equal - fraction auto-reduction",
+        code: "[ 1/2 ] [ 2/4 ] =",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Comparison"
+    },
+
+
+
+
+    {
+        name: "AND - true && true",
+        code: "[ TRUE ] [ TRUE ] AND",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Logic"
+    },
+    {
+        name: "AND - true && false",
+        code: "[ TRUE ] [ FALSE ] AND",
+        expectedStack: [createVector([createBoolean(false)])],
+        category: "Logic"
+    },
+    {
+        name: "OR - false || true",
+        code: "[ FALSE ] [ TRUE ] OR",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Logic"
+    },
+    {
+        name: "NOT - true",
+        code: "[ TRUE ] NOT",
+        expectedStack: [createVector([createBoolean(false)])],
+        category: "Logic"
+    },
+    {
+        name: "NOT - false",
+        code: "[ FALSE ] NOT",
+        expectedStack: [createVector([createBoolean(true)])],
+        category: "Logic"
+    },
+
+
+
+
+    {
+        name: "COND - basic branch",
+        code: "[ -1 ] { [ 0 ] < } { 'negative' } { IDLE } { 'positive' } COND",
+        expectedStack: [createString('negative')],
+        category: "Conditional"
+    },
+    {
+        name: "COND - else branch",
+        code: "[ 7 ] { [ 0 ] < } { 'negative' } { IDLE } { 'positive' } COND",
+        expectedStack: [createString('positive')],
+        category: "Conditional"
+    },
+    {
+        name: "COND - exhausted error",
+        code: "[ 7 ] { [ 0 ] < } { 'negative' } COND",
+        expectError: true,
+        category: "Conditional"
+    },
+
+
+
+
+    {
+        name: "LENGTH",
+        code: "[ 1 2 3 4 5 ] LENGTH",
+        expectedStack: [
+            createVector([createNumber('1'), createNumber('2'), createNumber('3'), createNumber('4'), createNumber('5')]),
+            createNumber('5')
+        ],
+        category: "Vector Operations"
+    },
+    {
+        name: "GET - first element",
+        code: "[ 10 20 30 ] [ 0 ] GET",
+        expectedStack: [
+            createVector([createNumber('10'), createNumber('20'), createNumber('30')]),
+            createNumber('10')
+        ],
+        category: "Vector Operations"
+    },
+    {
+        name: "GET - negative index",
+        code: "[ 10 20 30 ] [ -1 ] GET",
+        expectedStack: [
+            createVector([createNumber('10'), createNumber('20'), createNumber('30')]),
+            createNumber('30')
+        ],
+        category: "Vector Operations"
+    },
+    {
+        name: "TAKE - positive",
+        code: "[ 1 2 3 4 5 ] [ 3 ] TAKE",
+        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3')])],
+        category: "Vector Operations"
+    },
+    {
+        name: "TAKE - negative",
+        code: "[ 1 2 3 4 5 ] [ -2 ] TAKE",
+        expectedStack: [createVector([createNumber('4'), createNumber('5')])],
+        category: "Vector Operations"
+    },
+    {
+        name: "REVERSE",
+        code: "[ 1 2 3 ] REVERSE",
+        expectedStack: [createVector([createNumber('3'), createNumber('2'), createNumber('1')])],
+        category: "Vector Operations"
+    },
+    {
+        name: "CONCAT",
+        code: "[ 1 2 ] [ 3 4 ] CONCAT",
+        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3'), createNumber('4')])],
+        category: "Vector Operations"
+    },
+    {
+
+        name: "INSERT",
+        code: "[ 1 3 ] [ 1 2 ] INSERT",
+        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3')])],
+        category: "Vector Operations"
+    },
+    {
+
+        name: "REPLACE",
+        code: "[ 1 2 3 ] [ 1 9 ] REPLACE",
+        expectedStack: [createVector([createNumber('1'), createNumber('9'), createNumber('3')])],
+        category: "Vector Operations"
+    },
+    {
+        name: "REMOVE",
+        code: "[ 1 2 3 ] [ 1 ] REMOVE",
+        expectedStack: [createVector([createNumber('1'), createNumber('3')])],
+        category: "Vector Operations"
+    },
+
+
+
+
+    {
+
+        name: "SHAPE - 1D",
+        code: "[ 1 2 3 ] SHAPE",
+        expectedStack: [
+            createVector([createNumber('3')])
+        ],
+        category: "Tensor Operations"
+    },
+    {
+        name: "SHAPE - 2D",
+        code: "[ [ 1 2 3 ] [ 4 5 6 ] ] SHAPE",
+        expectedStack: [
+            createVector([createNumber('2'), createNumber('3')])
+        ],
+        category: "Tensor Operations"
+    },
+    {
+
+        name: "RANK - 1D",
+        code: "[ 1 2 3 ] RANK",
+        expectedStack: [
+            createNumber('1')
+        ],
+        category: "Tensor Operations"
+    },
+    {
+        name: "RANK - 2D",
+        code: "[ [ 1 2 ] [ 3 4 ] ] RANK",
+        expectedStack: [
+            createNumber('2')
+        ],
+        category: "Tensor Operations"
+    },
+    {
+        name: "TRANSPOSE",
+        code: "[ [ 1 2 3 ] [ 4 5 6 ] ] TRANSPOSE",
+        expectedStack: [
+            createVector([
+                createVector([createNumber('1'), createNumber('4')]),
+                createVector([createNumber('2'), createNumber('5')]),
+                createVector([createNumber('3'), createNumber('6')])
+            ])
+        ],
+        category: "Tensor Operations"
+    },
+    {
+        name: "RESHAPE",
+        code: "[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE",
+        expectedStack: [
+            createVector([
+                createVector([createNumber('1'), createNumber('2'), createNumber('3')]),
+                createVector([createNumber('4'), createNumber('5'), createNumber('6')])
+            ])
+        ],
+        category: "Tensor Operations"
+    },
+
+
+
+
+    {
+        name: "Broadcast - scalar + vector",
+        code: "[ 10 ] [ 1 2 3 ] +",
+        expectedStack: [createVector([createNumber('11'), createNumber('12'), createNumber('13')])],
+        category: "Broadcasting"
+    },
+    {
+        name: "Broadcast - vector * scalar",
+        code: "[ 1 2 3 ] [ 2 ] *",
+        expectedStack: [createVector([createNumber('2'), createNumber('4'), createNumber('6')])],
+        category: "Broadcasting"
+    },
+    {
+        name: "Broadcast - vector + vector (same length)",
+        code: "[ 1 2 3 ] [ 10 20 30 ] +",
+        expectedStack: [createVector([createNumber('11'), createNumber('22'), createNumber('33')])],
+        category: "Broadcasting"
+    },
+
+
+
+
+
+    {
+        name: "MAP - double",
+        code: "{ [ 2 ] * } 'DBL' DEF\n[ 1 2 3 ] 'DBL' MAP",
+        expectedStack: [createVector([createNumber('2'), createNumber('4'), createNumber('6')])],
+        category: "Higher-Order Functions"
+    },
+    {
+
+        name: "FILTER - positive",
+        code: "{ [ 0 ] <= NOT } 'POS' DEF\n[ -2 -1 0 1 2 ] 'POS' FILTER",
+        expectedStack: [createVector([createNumber('1'), createNumber('2')])],
+        category: "Higher-Order Functions"
+    },
+    {
+        name: "FOLD - sum",
+        code: "[ 1 2 3 4 ] [ 0 ] '+' FOLD",
+        expectedStack: [createVector([createNumber('10')])],
+        category: "Higher-Order Functions"
+    },
+    {
+        name: "UNFOLD - basic",
+        code: "[ 1 ] { { [ 1 ] = } { [ 1 2 ] } { [ 2 ] = } { [ 2 3 ] } { [ 3 ] = } { [ 3 NIL ] } { IDLE } { NIL } COND } UNFOLD",
+        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3'), createNumber('4')])],
+        category: "Higher-Order Functions"
+    },
+    {
+        name: "ANY - basic",
+        code: "[ 1 3 5 8 ] { [ 2 ] MOD [ 0 ] = } ANY",
+        expectedStack: [createBoolean(true)],
+        category: "Higher-Order Functions"
+    },
+    {
+        name: "ALL - basic",
+        code: "[ 2 4 6 8 ] { [ 2 ] MOD [ 0 ] = } ALL",
+        expectedStack: [createBoolean(true)],
+        category: "Higher-Order Functions"
+    },
+    {
+        name: "COUNT - basic",
+        code: "[ 1 2 3 4 5 6 ] { [ 2 ] MOD [ 0 ] = } COUNT",
+        expectedStack: [createVector([createNumber('3')])],
+        category: "Higher-Order Functions"
+    },
+    {
+        name: "SCAN - prefix sum",
+        code: "[ 1 2 3 4 ] [ 0 ] '+' SCAN",
+        expectedStack: [createVector([createNumber('1'), createNumber('3'), createNumber('6'), createNumber('10')])],
+        category: "Higher-Order Functions"
+    },
+
+
+
+
+
+    {
+        name: "STR - number to string",
+        code: "[ 42 ] STR",
+        expectedStack: [createString('42')],
+        category: "Type Conversion"
+    },
+    {
+        name: "STR - fraction to string",
+        code: "[ 3/4 ] STR",
+        expectedStack: [createString('3/4')],
+        category: "Type Conversion"
+    },
+    {
+
+
+        name: "NUM - string to number",
+        code: "'42' NUM",
+        expectedStack: [createNumber('42')],
+        category: "Type Conversion"
+    },
+    {
+
+
+        name: "BOOL - 1 to true",
+        code: "1 BOOL",
+        expectedStack: [createBoolean(true)],
+        category: "Type Conversion"
+    },
+    {
+        name: "BOOL - 0 to false",
+        code: "0 BOOL",
+        expectedStack: [createBoolean(false)],
+        category: "Type Conversion"
+    },
+
+
+
+
+
+    {
+        name: "CHARS - split string",
+        code: "'hello' CHARS",
+        expectedStack: [createVector([
+            createString('h'),
+            createString('e'),
+            createString('l'),
+            createString('l'),
+            createString('o')
+        ])],
+        category: "String Operations"
+    },
+    {
+
+        name: "JOIN - join strings",
+        code: "[ 'h' 'e' 'l' 'l' 'o' ] JOIN",
+        expectedStack: [createString('hello')],
+        category: "String Operations"
+    },
+
+
+
+
+    {
+        name: "Stack mode - LENGTH",
+        code: "[ 1 ] [ 2 ] [ 3 ] .. LENGTH",
+        expectedStack: [
+            createVector([createNumber('1')]),
+            createVector([createNumber('2')]),
+            createVector([createNumber('3')]),
+            createNumber('3')
+        ],
+        category: "Stack Mode"
+    },
+    {
+        name: "Stack mode - GET",
+        code: "[ 'a' ] [ 'b' ] [ 'c' ] [ 1 ] .. GET",
+        expectedStack: [
+            createVector([createString('a')]),
+            createVector([createString('b')]),
+            createVector([createString('c')]),
+            createVector([createString('b')])
+        ],
+        category: "Stack Mode"
+    },
+    {
+        name: "Stack mode - REVERSE",
+        code: "[ 1 ] [ 2 ] [ 3 ] .. REVERSE",
+        expectedStack: [
+            createVector([createNumber('3')]),
+            createVector([createNumber('2')]),
+            createVector([createNumber('1')])
+        ],
+        category: "Stack Mode"
+    },
+
+
+
+
+
+    {
+        name: "DEF and call",
+        code: "{ [ 2 ] * } 'DOUBLE' DEF\n[ 5 ] DOUBLE",
+        expectedStack: [createVector([createNumber('10')])],
+        category: "User Words"
+    },
+    {
+        name: "DEL - delete user word",
+        code: "{ [ 2 ] * } 'TEMP' DEF\n'TEMP' DEL\nTEMP",
+        expectError: true,
+        category: "User Words"
+    },
+
+
+
+
+    {
+
+        name: "FILL",
+        code: "[ 3 7 ] FILL",
+        expectedStack: [createVector([
+            createNumber('7'),
+            createNumber('7'),
+            createNumber('7')
+        ])],
+        category: "Tensor Generation"
+    },
+
+
+
+
+    {
+
+        name: "Nil Coalescing - NIL case",
+        code: "NIL => [ 0 ]",
+        expectedStack: [createVector([createNumber('0')])],
+        category: "NIL Safety"
+    },
+    {
+        name: "Nil Coalescing - non-NIL case",
+        code: "[ 42 ] => [ 0 ]",
+        expectedStack: [createVector([createNumber('42')])],
+        category: "NIL Safety"
+    },
+
+
+
+
+    {
+        name: "Error - stack underflow",
+        code: "+",
+        expectError: true,
+        category: "Error Cases"
+    },
+    {
+        name: "Error - unknown word",
+        code: "UNKNOWNWORD",
+        expectError: true,
+        category: "Error Cases"
+    },
+    {
+        name: "Error - index out of bounds",
+        code: "[ 1 2 3 ] [ 10 ] GET",
+        expectError: true,
+        category: "Error Cases"
+    },
+    {
+
+        name: "Error - incompatible shapes",
+        code: "[ 1 2 3 ] [ 1 2 ] +",
+        expectError: true,
+        category: "Error Cases"
+    },
+    {
+
+        name: "Error - empty vector",
+        code: "[ ]",
+        expectError: true,
+        category: "Error Cases"
+    },
+    {
+
+        name: "Sort already sorted succeeds",
+        code: "[ 1 2 3 ] SORT",
+        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3')])],
+        category: "Vector Operations"
+    }
+];

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -1,0 +1,124 @@
+import type { ViewMode } from './mobile-view-switcher';
+import type { MobileHandler } from './mobile-view-switcher';
+import type { GUIElements } from './gui-dom-cache';
+import type { ModuleTabManager } from './module-selector-sheets';
+
+export const LEFT_TAB_MODES: ViewMode[] = ['input', 'output'];
+export const RIGHT_TAB_MODES: ViewMode[] = ['stack', 'dictionary'];
+
+export const checkStackHighlightAll = (content: string): boolean => /(\s|^)\.\.(\s|$)/.test(content);
+export const checkStackHighlightTop = (content: string): boolean => /(\s|^)\.(\s|$)/.test(content);
+
+export const DESKTOP_EDITOR_PLACEHOLDER = [
+    'Enter code here',
+    '',
+    'Run → Shift+Enter',
+    'Step → Ctrl+Enter',
+    'Abort → Escape',
+    'Reset → Ctrl+Alt+Enter',
+    'Autocomplete → Ctrl+Space / Tab / ↑↓'
+].join('\n');
+
+export const MOBILE_EDITOR_PLACEHOLDER = [
+    'Enter code here',
+    '',
+    'Run → Tap the Run button',
+    'Autocomplete → Tap suggestions while typing'
+].join('\n');
+
+export interface LayoutState {
+    currentMode: ViewMode;
+    currentLeftMode: ViewMode;
+    currentRightMode: ViewMode;
+}
+
+export const createLayoutState = (): LayoutState => ({
+    currentMode: 'input',
+    currentLeftMode: 'input',
+    currentRightMode: 'stack'
+});
+
+export const syncSelectorState = (elements: GUIElements, leftMode: ViewMode, rightMode: ViewMode): void => {
+    elements.leftPanelSelect.value = leftMode;
+    elements.rightPanelSelect.value = rightMode;
+};
+
+export const syncMobileSelectorState = (elements: GUIElements, mode: ViewMode): void => {
+    elements.mobilePanelSelect.value = mode;
+};
+
+export const syncDesktopLayout = (elements: GUIElements, state: LayoutState): void => {
+    elements.editorPanel.hidden = false;
+    elements.statePanel.hidden = false;
+    elements.inputArea.hidden = state.currentLeftMode !== 'input';
+    elements.outputArea.hidden = state.currentLeftMode !== 'output';
+    elements.stackArea.hidden = state.currentRightMode !== 'stack';
+    elements.dictionaryArea.hidden = state.currentRightMode !== 'dictionary';
+};
+
+export const updateDesktopModes = (state: LayoutState, mode: ViewMode): void => {
+    if (LEFT_TAB_MODES.includes(mode)) {
+        state.currentLeftMode = mode;
+    }
+    if (RIGHT_TAB_MODES.includes(mode)) {
+        state.currentRightMode = mode;
+        if (mode === 'dictionary') {
+            state.currentLeftMode = 'input';
+        }
+    }
+};
+
+export const applyAreaState = (
+    elements: GUIElements,
+    state: LayoutState,
+    mobile: MobileHandler,
+    moduleTabManager: ModuleTabManager,
+    switchDictionarySheet: (sheetId: string) => void,
+    mode: ViewMode
+): void => {
+    if (mobile.isMobile()) {
+        mobile.updateView(mode);
+        document.body.dataset.activeArea = mode;
+        syncMobileSelectorState(elements, mode);
+        return;
+    }
+
+    updateDesktopModes(state, mode);
+
+    const currentSheet = elements.dictionarySheetSelect?.value;
+    if (currentSheet?.startsWith('module-') && !moduleTabManager.lookupModuleArea(currentSheet)) {
+        elements.dictionarySheetSelect.value = 'core';
+        switchDictionarySheet('core');
+    }
+
+    syncDesktopLayout(elements, state);
+    document.body.dataset.activeArea = state.currentRightMode;
+    syncSelectorState(elements, state.currentLeftMode, state.currentRightMode);
+};
+
+export const updateHighlights = (elements: GUIElements, content: string): void => {
+    const hasStackAllWord = checkStackHighlightAll(content);
+    const hasStackTopWord = checkStackHighlightTop(content) || !hasStackAllWord;
+
+    if (hasStackAllWord) {
+        elements.stackDisplay.classList.add('highlight-all');
+    } else {
+        elements.stackDisplay.classList.remove('highlight-all');
+    }
+
+    if (hasStackTopWord && !hasStackAllWord) {
+        elements.stackDisplay.classList.add('highlight-top');
+    } else {
+        elements.stackDisplay.classList.remove('highlight-top');
+    }
+
+    elements.stackDisplay.classList.remove('blink-all');
+    elements.stackDisplay.classList.remove('blink-top');
+};
+
+export const updateEditorPlaceholder = (elements: GUIElements, mobile: MobileHandler): void => {
+    if (!elements?.codeInput) return;
+    elements.codeInput.placeholder = mobile.isMobile()
+        ? MOBILE_EDITOR_PLACEHOLDER
+        : DESKTOP_EDITOR_PLACEHOLDER;
+};

--- a/js/gui/gui-test-runner.ts
+++ b/js/gui/gui-test-runner.ts
@@ -1,0 +1,419 @@
+
+
+import type { Value } from '../wasm-interpreter-types';
+import { TEST_CASES, type TestCase } from './gui-interpreter-test-cases';
+import { formatStack, formatValueSimple, compareStack, compareValue } from './value-formatter';
+
+
+
+
+
+export interface TestResult {
+    readonly passed: boolean;
+    readonly actualStack?: Value[];
+    readonly actualOutput?: string;
+    readonly errorMessage?: string;
+    readonly reason?: string;
+}
+
+export interface TestSummary {
+    readonly totalPassed: number;
+    readonly totalFailed: number;
+    readonly failedTests: readonly string[];
+}
+
+export interface TestRunnerCallbacks {
+    readonly showInfo: (text: string, append: boolean) => void;
+    readonly showError: (error: Error | string) => void;
+    readonly updateDisplays: () => void;
+}
+
+export interface TestRunner {
+    readonly runAllTests: () => Promise<TestSummary>;
+}
+
+type InfoType = 'success' | 'error' | 'info';
+
+
+
+
+
+
+
+
+const groupByCategory = (testCases: TestCase[]): Map<string, TestCase[]> => {
+    const groups = new Map<string, TestCase[]>();
+
+    testCases.forEach(test => {
+        const category = test.category || 'Other';
+        const existing = groups.get(category) || [];
+        groups.set(category, [...existing, test]);
+    });
+
+    return groups;
+};
+
+
+
+
+const checkIsTestPassed = (result: TestResult): boolean => result.passed;
+
+
+
+
+const calculateStackDifference = (
+    expected: Value[],
+    actual: Value[]
+): Array<{ index: number; type: 'extra' | 'missing' | 'mismatch'; expected?: Value; actual?: Value }> => {
+    const differences: Array<{ index: number; type: 'extra' | 'missing' | 'mismatch'; expected?: Value; actual?: Value }> = [];
+
+    const maxLen = Math.max(expected.length, actual.length);
+
+    for (let i = 0; i < maxLen; i++) {
+        const exp = expected[i];
+        const act = actual[i];
+
+        if (exp === undefined) {
+            differences.push({ index: i, type: 'extra', actual: act });
+        } else if (act === undefined) {
+            differences.push({ index: i, type: 'missing', expected: exp });
+        } else if (!compareValue(exp, act)) {
+            differences.push({ index: i, type: 'mismatch', expected: exp, actual: act });
+        }
+    }
+
+    return differences;
+};
+
+
+
+
+
+export const createTestRunner = (_callbacks: TestRunnerCallbacks): TestRunner => {
+
+    const lookupOutputElement = (): HTMLElement | null =>
+        document.getElementById('output-display');
+
+
+    const showColoredInfo = (text: string, type: InfoType): void => {
+        const outputElement = lookupOutputElement();
+        if (!outputElement) return;
+
+        const span = document.createElement('span');
+        span.textContent = text + '\n';
+
+        switch (type) {
+            case 'success':
+                span.style.color = '#28a745';
+                span.style.fontWeight = 'bold';
+                break;
+            case 'error':
+                span.style.color = '#dc3545';
+                span.style.fontWeight = 'bold';
+                break;
+            case 'info':
+                span.style.color = '#333';
+                break;
+        }
+
+        outputElement.appendChild(span);
+    };
+
+
+    const resetInterpreter = async (): Promise<void> => {
+        if (!window.ajisaiInterpreter) return;
+
+        const outputElement = lookupOutputElement();
+        const currentOutput = outputElement?.innerHTML || '';
+
+        await window.ajisaiInterpreter.reset();
+
+        if (outputElement) {
+            outputElement.innerHTML = currentOutput;
+        }
+    };
+
+
+    const checkExpectations = async (testCase: TestCase): Promise<TestResult> => {
+        if (testCase.expectedStack) {
+            const stack = window.ajisaiInterpreter.collect_stack();
+            const matches = compareStack(stack, testCase.expectedStack);
+            return {
+                passed: matches,
+                actualStack: stack,
+                reason: matches ? 'Stack matches expected' : 'Stack mismatch'
+            };
+        }
+
+        if (testCase.expectedOutput) {
+            await resetInterpreter();
+            const result = await window.ajisaiInterpreter.execute(testCase.code);
+            const matches = result.output?.trim() === testCase.expectedOutput.trim();
+            return {
+                passed: matches,
+                actualOutput: result.output,
+                reason: matches ? 'Output matches expected' : 'Output mismatch'
+            };
+        }
+
+        return { passed: true, reason: 'Test completed successfully' };
+    };
+
+
+    const executeWithDef = async (testCase: TestCase): Promise<TestResult> => {
+        const lines = testCase.code.split('\n');
+
+
+        let defEndIndex = -1;
+        for (let i = lines.length - 1; i >= 0; i--) {
+            if (lines[i]?.trim().includes(' DEF')) {
+                defEndIndex = i;
+                break;
+            }
+        }
+
+        if (defEndIndex < 0) {
+            return { passed: false, reason: 'DEF not found' };
+        }
+
+
+        const defPart = lines.slice(0, defEndIndex + 1).join('\n');
+        const defResult = await window.ajisaiInterpreter.execute(defPart);
+
+        if (defResult.status === 'ERROR') {
+            return {
+                passed: testCase.expectError === true,
+                errorMessage: defResult.message,
+                reason: 'Error during word definition'
+            };
+        }
+
+
+        if (defEndIndex + 1 < lines.length) {
+            const execPart = lines.slice(defEndIndex + 1)
+                .map(line => line.trim())
+                .filter(line => line.length > 0)
+                .join('\n');
+
+            if (execPart) {
+                const execResult = await window.ajisaiInterpreter.execute(execPart);
+
+                if (testCase.expectError) {
+                    return {
+                        passed: execResult.status === 'ERROR',
+                        errorMessage: execResult.message,
+                        reason: execResult.status === 'ERROR'
+                            ? 'Expected error occurred'
+                            : 'Expected error but execution succeeded'
+                    };
+                }
+
+                if (execResult.status === 'ERROR') {
+                    return {
+                        passed: false,
+                        errorMessage: execResult.message,
+                        reason: 'Unexpected error during execution'
+                    };
+                }
+            }
+        }
+
+        return checkExpectations(testCase);
+    };
+
+
+    const runSingleTest = async (testCase: TestCase): Promise<TestResult> => {
+        await resetInterpreter();
+
+
+        if (testCase.code.includes(' DEF')) {
+            return executeWithDef(testCase);
+        }
+
+
+        const result = await window.ajisaiInterpreter.execute(testCase.code);
+
+        if (testCase.expectError) {
+            return {
+                passed: result.status === 'ERROR',
+                errorMessage: result.message,
+                reason: result.status === 'ERROR'
+                    ? 'Expected error occurred'
+                    : 'Expected error but execution succeeded'
+            };
+        }
+
+        if (result.status === 'ERROR') {
+            return {
+                passed: false,
+                errorMessage: result.message,
+                reason: 'Unexpected error during execution'
+            };
+        }
+
+        return checkExpectations(testCase);
+    };
+
+
+    const showStackDifference = (expected: Value[], actual: Value[]): void => {
+        if (expected.length !== actual.length) {
+            showColoredInfo(
+                `  Stack length mismatch → expected ${expected.length}, got ${actual.length}`,
+                'error'
+            );
+        }
+
+        const differences = calculateStackDifference(expected, actual);
+
+        differences.forEach(diff => {
+            switch (diff.type) {
+                case 'extra':
+                    showColoredInfo(`  [${diff.index}] Extra → ${formatValueSimple(diff.actual!)}`, 'error');
+                    break;
+                case 'missing':
+                    showColoredInfo(`  [${diff.index}] Missing → ${formatValueSimple(diff.expected!)}`, 'error');
+                    break;
+                case 'mismatch':
+                    showColoredInfo(`  [${diff.index}] Expected → ${formatValueSimple(diff.expected!)}`, 'error');
+                    showColoredInfo(`  [${diff.index}] Got      → ${formatValueSimple(diff.actual!)}`, 'error');
+                    break;
+            }
+        });
+    };
+
+
+    const showTestResult = (testCase: TestCase, result: TestResult, passed: boolean): void => {
+        const statusIcon = passed ? '[OK]' : '[NG]';
+        const statusText = passed ? 'PASS' : 'FAIL';
+        const statusColor: InfoType = passed ? 'success' : 'error';
+
+        console.log(`${statusIcon} ${statusText} → ${testCase.name}`);
+        showColoredInfo(`${statusIcon} ${statusText} → ${testCase.name}`, statusColor);
+
+
+        const codeLines = testCase.code.split('\n');
+        if (codeLines.length === 1) {
+            showColoredInfo(`  Code → ${testCase.code}`, 'info');
+        } else {
+            showColoredInfo(`  Code →`, 'info');
+            codeLines.forEach((line, index) => {
+                showColoredInfo(`    Step${index + 1}. ${line}`, 'info');
+            });
+        }
+
+
+        if (testCase.expectError) {
+            showColoredInfo(`  Expected → Error should occur`, 'info');
+            if (result.errorMessage) {
+                showColoredInfo(`  Actual error → ${result.errorMessage}`, 'info');
+            } else {
+                showColoredInfo(`  Actual → No error occurred`, passed ? 'info' : 'error');
+            }
+        } else if (testCase.expectedStack !== undefined) {
+            showColoredInfo(`  Expected stack → ${formatStack(testCase.expectedStack)}`, 'info');
+            if (result.actualStack !== undefined) {
+                showColoredInfo(
+                    `  Actual stack   → ${formatStack(result.actualStack)}`,
+                    passed ? 'info' : 'error'
+                );
+                if (!passed) {
+                    showStackDifference(testCase.expectedStack, result.actualStack);
+                }
+            } else {
+                showColoredInfo(`  Actual stack → (not captured)`, 'error');
+            }
+        } else if (testCase.expectedOutput !== undefined) {
+            showColoredInfo(`  Expected output → "${testCase.expectedOutput}"`, 'info');
+            if (result.actualOutput !== undefined) {
+                showColoredInfo(
+                    `  Actual output   → "${result.actualOutput}"`,
+                    passed ? 'info' : 'error'
+                );
+            } else {
+                showColoredInfo(`  Actual output → (not captured)`, 'error');
+            }
+        }
+
+        if (result.reason) {
+            showColoredInfo(`  Reason → ${result.reason}`, passed ? 'info' : 'error');
+        }
+
+        if (!passed && result.errorMessage) {
+            showColoredInfo(`  Error → ${result.errorMessage}`, 'error');
+        }
+
+        showColoredInfo('', 'info');
+    };
+
+
+    const showTestError = (testCase: TestCase, error: unknown): void => {
+        showColoredInfo(`[NG] ERROR → ${testCase.name}`, 'error');
+        showColoredInfo(`  Code → ${testCase.code}`, 'info');
+        showColoredInfo(`  Error → ${error}`, 'error');
+        showColoredInfo('', 'info');
+    };
+
+
+    const runAllTests = async (): Promise<TestSummary> => {
+        let totalPassed = 0;
+        let totalFailed = 0;
+        const failedTests: string[] = [];
+
+        const outputElement = lookupOutputElement();
+        if (outputElement) {
+            outputElement.innerHTML = '';
+        }
+
+        showColoredInfo('=== Ajisai Comprehensive Test Suite ===', 'info');
+        showColoredInfo(`Running ${TEST_CASES.length} test cases...`, 'info');
+
+        const categoryGroups = groupByCategory(TEST_CASES);
+        const categories = [...categoryGroups.keys()].sort();
+
+        for (const category of categories) {
+            showColoredInfo(`\n--- ${category} Tests ---`, 'info');
+            const categoryTests = categoryGroups.get(category) || [];
+
+            for (const testCase of categoryTests) {
+                try {
+                    const result = await runSingleTest(testCase);
+                    const passed = checkIsTestPassed(result);
+
+                    if (passed) {
+                        totalPassed++;
+                    } else {
+                        totalFailed++;
+                        failedTests.push(testCase.name);
+                    }
+
+                    showTestResult(testCase, result, passed);
+                } catch (error) {
+                    totalFailed++;
+                    failedTests.push(testCase.name);
+                    showTestError(testCase, error);
+                }
+            }
+        }
+
+        showColoredInfo(`\n=== Final Results ===`, 'info');
+        showColoredInfo(`Total Passed → ${totalPassed}`, 'success');
+
+        if (totalFailed > 0) {
+            showColoredInfo(`Total Failed → ${totalFailed}`, 'error');
+            showColoredInfo(`Failed tests → ${failedTests.join(', ')}`, 'error');
+        } else {
+            showColoredInfo('All tests passed!', 'success');
+        }
+
+        return { totalPassed, totalFailed, failedTests };
+    };
+
+    return { runAllTests };
+};
+
+
+export const testUtils = {
+    groupByCategory,
+    checkIsTestPassed,
+    calculateStackDifference
+};

--- a/js/gui/interpreter-state-persistence.ts
+++ b/js/gui/interpreter-state-persistence.ts
@@ -1,0 +1,371 @@
+
+
+import type { AjisaiInterpreter, Value, UserWord } from '../wasm-interpreter-types';
+import type DB from '../indexeddb-user-word-store';
+import { DEMO_USER_WORDS, DEMO_WORDS_VERSION } from './demo-words';
+import { Result, ok, err } from './functional-result-helpers';
+
+export interface InterpreterState {
+    readonly stack: Value[];
+    readonly userWords: UserWord[];
+    readonly demoWordsVersion?: number;
+}
+
+export interface PersistenceCallbacks {
+    readonly showError?: (error: Error) => void;
+    readonly updateDisplays?: () => void;
+    readonly showInfo?: (text: string, append: boolean) => void;
+}
+
+export interface Persistence {
+    readonly init: () => Promise<void>;
+    readonly saveCurrentState: () => Promise<void>;
+    readonly loadDatabaseData: () => Promise<void>;
+    readonly fullReset: () => Promise<void>;
+    readonly exportUserWords: () => void;
+    readonly importUserWords: () => void;
+    readonly importJsonAsVector: () => void;
+}
+
+declare global {
+    interface Window {
+        ajisaiInterpreter: AjisaiInterpreter;
+        AjisaiDB: typeof DB;
+    }
+}
+
+const toUserWord = (
+    wordData: [string, string, string | null, boolean],
+    getDefinition: (name: string) => string | null
+): UserWord => ({
+    dictionary: wordData[0],
+    name: wordData[1],
+    description: wordData[2],
+    definition: getDefinition(`${wordData[0]}@${wordData[1]}`)
+});
+
+const collectCurrentState = (interpreter: AjisaiInterpreter): InterpreterState => {
+    const userWordsInfo = interpreter.collect_user_words_info();
+    const userWords: UserWord[] = userWordsInfo.map(wordData =>
+        toUserWord(wordData, name => interpreter.lookup_word_definition(name))
+    );
+
+    return {
+        stack: interpreter.collect_stack(),
+        userWords,
+        demoWordsVersion: DEMO_WORDS_VERSION
+    };
+};
+
+const createExportData = (interpreter: AjisaiInterpreter, dictionaryName: string): UserWord[] => {
+    const userWordsInfo = interpreter.collect_user_words_info();
+    return userWordsInfo
+        .filter(([dictionary]) => dictionary === dictionaryName)
+        .map(wordData => ({
+            dictionary: wordData[0],
+            name: wordData[1],
+            description: wordData[2],
+            definition: interpreter.lookup_word_definition(`${wordData[0]}@${wordData[1]}`)
+        }));
+};
+
+const buildExportFilename = (name: string): string => `${name}.json`;
+
+const downloadJson = (data: unknown, filename: string): void => {
+    const jsonString = JSON.stringify(data, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};
+
+const openFileDialog = (
+    accept: string,
+    onFileSelected: (file: File) => void
+): void => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = accept;
+
+    input.onchange = (e) => {
+        const file = (e.target as HTMLInputElement).files?.[0];
+        if (file) {
+            onFileSelected(file);
+        }
+    };
+
+    input.click();
+};
+
+const readFileAsText = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            const result = event.target?.result;
+            if (typeof result === 'string') {
+                resolve(result);
+            } else {
+                reject(new Error('Failed to read file'));
+            }
+        };
+        reader.onerror = () => reject(new Error('Failed to read file'));
+        reader.readAsText(file);
+    });
+
+const parseUserWords = (jsonString: string): Result<UserWord[], Error> => {
+    try {
+        const parsed = JSON.parse(jsonString);
+        if (!Array.isArray(parsed)) {
+            return err(new Error('Invalid file format. Expected an array of words.'));
+        }
+        return ok(parsed as UserWord[]);
+    } catch (e) {
+        return err(e instanceof Error ? e : new Error(String(e)));
+    }
+};
+
+export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persistence => {
+    const { showError, updateDisplays, showInfo } = callbacks;
+    let dbInitialized = false;
+    const MAX_RETRY_COUNT = 3;
+    const RETRY_DELAY_MS = 1000;
+
+    const sleep = (ms: number): Promise<void> =>
+        new Promise(resolve => setTimeout(resolve, ms));
+
+    const init = async (): Promise<void> => {
+        for (let attempt = 1; attempt <= MAX_RETRY_COUNT; attempt++) {
+            try {
+                await window.AjisaiDB.open();
+                dbInitialized = true;
+                console.log('Database initialized successfully for Persistence.');
+                return;
+            } catch (error) {
+                console.error(`Failed to initialize persistence database (attempt ${attempt}/${MAX_RETRY_COUNT}):`, error);
+                if (attempt < MAX_RETRY_COUNT) {
+                    await sleep(RETRY_DELAY_MS * attempt);
+                }
+            }
+        }
+
+        console.warn('Persistence database initialization failed after all retries. Data will not be persisted.');
+        showError?.(new Error('Failed to initialize database. Changes will not be saved.'));
+    };
+
+    const saveCurrentState = async (): Promise<void> => {
+        if (!window.ajisaiInterpreter) return;
+        if (!dbInitialized) {
+            console.warn('Database not initialized, skipping state save.');
+            return;
+        }
+
+        try {
+            const state = collectCurrentState(window.ajisaiInterpreter);
+            await window.AjisaiDB.saveInterpreterState(state);
+            console.log('State saved automatically.');
+        } catch (error) {
+            console.error('Failed to auto-save state:', error);
+        }
+    };
+
+    const loadDemoWords = async (): Promise<void> => {
+        try {
+            await window.ajisaiInterpreter.restore_user_words(DEMO_USER_WORDS);
+            await saveCurrentState();
+            console.log('Demo user words loaded.');
+
+            const wordNames = DEMO_USER_WORDS.map(w => w.name).join(', ');
+            showInfo?.(`Sample words loaded: ${wordNames}`, false);
+        } catch (error) {
+            console.error('Failed to load sample words:', error);
+        }
+    };
+
+    const loadDatabaseData = async (): Promise<void> => {
+        if (!window.ajisaiInterpreter) return;
+        if (!dbInitialized) {
+            console.warn('Database not initialized, loading sample words instead.');
+            await loadDemoWords();
+            return;
+        }
+
+        try {
+            const state = await window.AjisaiDB.loadInterpreterState();
+
+            if (state) {
+                if (state.stack) {
+                    window.ajisaiInterpreter.restore_stack(state.stack);
+                }
+
+                if (state.userWords && state.userWords.length > 0) {
+
+                    const savedVersion = state.demoWordsVersion || 0;
+                    let wordsToRestore = state.userWords;
+
+                    if (savedVersion < DEMO_WORDS_VERSION) {
+
+                        const oldSampleNames = new Set([
+
+                            'C4', 'D4', 'E4', 'F4', 'G4', 'A4', 'B4', 'C5',
+
+                            'GREETING', 'WORLD', 'HELLO-WORLD',
+                        ]);
+                        const newSampleWordNames = new Set(
+                            DEMO_USER_WORDS.map(w => w.name.toUpperCase())
+                        );
+
+
+                        const userWords = state.userWords.filter(
+                            (w: UserWord) =>
+                                !oldSampleNames.has(w.name.toUpperCase()) &&
+                                !newSampleWordNames.has(w.name.toUpperCase())
+                        );
+                        wordsToRestore = [...DEMO_USER_WORDS, ...userWords];
+                        console.log(`Sample words migrated: v${savedVersion} → v${DEMO_WORDS_VERSION}`);
+                    }
+
+                    await window.ajisaiInterpreter.restore_user_words(wordsToRestore);
+
+
+
+
+                    const savedWordNames = new Set(wordsToRestore.map((w: UserWord) => w.name.toUpperCase()));
+                    const currentWords = window.ajisaiInterpreter.collect_user_words_info();
+                    for (const [name] of currentWords) {
+                        if (!savedWordNames.has(name.toUpperCase())) {
+                            window.ajisaiInterpreter.remove_word(name);
+                        }
+                    }
+
+
+                    if (savedVersion < DEMO_WORDS_VERSION) {
+                        await saveCurrentState();
+                    }
+
+                    console.log('Interpreter state restored.');
+                } else {
+                    await loadDemoWords();
+                }
+            } else {
+                await loadDemoWords();
+            }
+        } catch (error) {
+            console.error('Failed to load database data:', error);
+            showError?.(error as Error);
+        }
+    };
+
+    const exportUserWords = (): void => {
+        if (!window.ajisaiInterpreter) {
+            showError?.(new Error('Interpreter not available'));
+            return;
+        }
+
+        const selectedDictionary = (document.getElementById('user-dictionary-select') as HTMLSelectElement | null)?.value || 'DEMO';
+        const suggestedName = selectedDictionary.toLowerCase();
+        const requestedName = window.prompt('Export file name', suggestedName)?.trim();
+        if (!requestedName) {
+            return;
+        }
+        const exportData = createExportData(window.ajisaiInterpreter, selectedDictionary);
+        const filename = buildExportFilename(requestedName);
+
+        downloadJson(exportData, filename);
+        showInfo?.(`User words exported as ${filename}`, true);
+    };
+
+    const importUserWords = (): void => {
+        openFileDialog('.json', async (file) => {
+            try {
+                const jsonString = await readFileAsText(file);
+                const parseResult = parseUserWords(jsonString);
+
+                if (!parseResult.ok) {
+                    showError?.(parseResult.error);
+                    return;
+                }
+
+                const importedWords = parseResult.value.map(word => ({
+                    ...word,
+                    dictionary: (word.dictionary || file.name.replace(/\.json$/i, '')).toUpperCase()
+                }));
+                await window.ajisaiInterpreter.restore_user_words(importedWords);
+
+                updateDisplays?.();
+                await saveCurrentState();
+                showInfo?.(`${importedWords.length} user words imported and saved`, true);
+
+            } catch (error) {
+                showError?.(error as Error);
+            }
+        });
+    };
+
+    const importJsonAsVector = (): void => {
+        openFileDialog('.json', async (file) => {
+            try {
+                const jsonString = await readFileAsText(file);
+
+
+                try {
+                    JSON.parse(jsonString);
+                } catch {
+                    showError?.(new Error('Invalid JSON file.'));
+                    return;
+                }
+
+                const result = window.ajisaiInterpreter.push_json_string(jsonString);
+
+                if (result.status === 'OK') {
+                    updateDisplays?.();
+                    await saveCurrentState();
+                    showInfo?.(`JSON loaded from ${file.name}`, true);
+                } else {
+                    showError?.(new Error(result.message || 'Failed to parse JSON'));
+                }
+            } catch (error) {
+                showError?.(error as Error);
+            }
+        });
+    };
+
+    const fullReset = async (): Promise<void> => {
+        try {
+            if (dbInitialized) {
+                await window.AjisaiDB.clearAll();
+                console.log('IndexedDB cleared.');
+            } else {
+                console.warn('Database not initialized, skipping clear operation.');
+            }
+            await loadDemoWords();
+            updateDisplays?.();
+        } catch (error) {
+            console.error('Failed to perform full reset:', error);
+            showError?.(error as Error);
+        }
+    };
+
+    return {
+        init,
+        saveCurrentState,
+        loadDatabaseData,
+        fullReset,
+        exportUserWords,
+        importUserWords,
+        importJsonAsVector
+    };
+};
+
+export const persistenceUtils = {
+    toUserWord,
+    collectCurrentState,
+    createExportData,
+    buildExportFilename,
+    parseUserWords
+};

--- a/js/gui/mobile-view-switcher.ts
+++ b/js/gui/mobile-view-switcher.ts
@@ -1,0 +1,136 @@
+
+
+export interface MobileElements {
+    readonly inputArea: HTMLElement;
+    readonly outputArea: HTMLElement;
+    readonly stackArea: HTMLElement;
+    readonly dictionaryArea: HTMLElement;
+}
+
+export type ViewMode = 'input' | 'output' | 'stack' | 'dictionary';
+
+export interface MobileHandler {
+    readonly isMobile: () => boolean;
+    readonly extractCurrentMode: () => ViewMode;
+    readonly updateView: (mode: ViewMode) => void;
+}
+
+export interface MobileHandlerOptions {
+    readonly onModeChange?: (mode: ViewMode) => void;
+}
+
+const MOBILE_BREAKPOINT = 768;
+const SWIPE_THRESHOLD = 50;
+const VIEW_ORDER: ViewMode[] = ['input', 'output', 'stack', 'dictionary'];
+
+const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
+
+const detectSwipeDirection = (
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number
+): 'left' | 'right' | 'up' | 'down' | null => {
+    const deltaX = endX - startX;
+    const deltaY = endY - startY;
+
+    if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > SWIPE_THRESHOLD) {
+        return deltaX > 0 ? 'right' : 'left';
+    }
+
+    if (Math.abs(deltaY) > Math.abs(deltaX) && Math.abs(deltaY) > SWIPE_THRESHOLD) {
+        return deltaY > 0 ? 'down' : 'up';
+    }
+
+    return null;
+};
+
+const resolveNextViewMode = (currentMode: ViewMode, direction: 'left' | 'right'): ViewMode => {
+    const currentIndex = VIEW_ORDER.indexOf(currentMode);
+    const nextIndex = direction === 'left'
+        ? (currentIndex + 1) % VIEW_ORDER.length
+        : (currentIndex - 1 + VIEW_ORDER.length) % VIEW_ORDER.length;
+    return VIEW_ORDER[nextIndex]!;
+};
+
+const lookupVisibilityForMode = (mode: ViewMode): Record<keyof MobileElements, boolean> => {
+    const modeMap: Record<ViewMode, Record<keyof MobileElements, boolean>> = {
+        input: { inputArea: false, outputArea: true, stackArea: true, dictionaryArea: true },
+        output: { inputArea: true, outputArea: false, stackArea: true, dictionaryArea: true },
+        stack: { inputArea: true, outputArea: true, stackArea: false, dictionaryArea: true },
+        dictionary: { inputArea: true, outputArea: true, stackArea: true, dictionaryArea: false },
+    };
+    return modeMap[mode];
+};
+
+const applyVisibility = (
+    elements: MobileElements,
+    visibility: Record<keyof MobileElements, boolean>
+): void => {
+    (Object.keys(visibility) as Array<keyof MobileElements>).forEach(key => {
+        elements[key].hidden = visibility[key];
+    });
+};
+
+export const createMobileHandler = (
+    elements: MobileElements,
+    options: MobileHandlerOptions = {}
+): MobileHandler => {
+    let currentMode: ViewMode = 'input';
+    let touchStartX = 0;
+    let touchStartY = 0;
+
+    const updateView = (mode: ViewMode): void => {
+        currentMode = mode;
+        const visibility = lookupVisibilityForMode(mode);
+        applyVisibility(elements, visibility);
+    };
+
+    const resolveSwipeGesture = (endX: number, endY: number): void => {
+        const direction = detectSwipeDirection(touchStartX, touchStartY, endX, endY);
+
+        if (direction === 'left' || direction === 'right') {
+            const newMode = resolveNextViewMode(currentMode, direction);
+            updateView(newMode);
+            options.onModeChange?.(newMode);
+        }
+    };
+
+    const setupSwipeGestures = (): void => {
+        const container = document.body;
+
+        container.addEventListener('touchstart', (e: TouchEvent) => {
+            const touch = e.changedTouches[0];
+            if (touch) {
+                touchStartX = touch.screenX;
+                touchStartY = touch.screenY;
+            }
+        }, { passive: true });
+
+        container.addEventListener('touchend', (e: TouchEvent) => {
+            if (!checkIsMobile()) return;
+            const touch = e.changedTouches[0];
+            if (touch) {
+                resolveSwipeGesture(touch.screenX, touch.screenY);
+            }
+        }, { passive: true });
+    };
+
+    setupSwipeGestures();
+
+    return {
+        isMobile: () => checkIsMobile(),
+        extractCurrentMode: () => currentMode,
+        updateView
+    };
+};
+
+export const mobileUtils = {
+    checkIsMobile,
+    detectSwipeDirection,
+    resolveNextViewMode,
+    lookupVisibilityForMode,
+    VIEW_ORDER,
+    MOBILE_BREAKPOINT,
+    SWIPE_THRESHOLD
+};

--- a/js/gui/module-selector-sheets.ts
+++ b/js/gui/module-selector-sheets.ts
@@ -1,0 +1,242 @@
+
+
+import {
+    createEmptyWordsElement,
+    createNoResultsElement,
+    createWordButtonElement,
+    checkWordMatchesFilter,
+    registerBackgroundClickListeners,
+    compareWordName,
+} from './dictionary-element-builders';
+import { formatDictionaryTabName } from './vocabulary-state-controller';
+
+export interface ModuleSheet {
+    readonly moduleName: string;
+    readonly sheetId: string;
+    readonly optionEl: HTMLOptionElement;
+    readonly sheetEl: HTMLElement;
+}
+
+export interface ModuleTabManager {
+    readonly syncModuleTabs: () => string[];
+    readonly clearModuleTabs: () => void;
+    readonly lookupModuleArea: (sheetId: string) => HTMLElement | null;
+    readonly collectSheets: () => ModuleSheet[];
+    readonly updateSearchFilter: (filter: string) => void;
+}
+
+export interface ModuleActionConfig {
+    readonly label: string;
+    readonly className: string;
+    readonly ariaLabel: string;
+    readonly onClick: () => void;
+}
+
+export interface ModuleTabManagerOptions {
+    readonly selectEl: HTMLSelectElement;
+    readonly sheetContainerEl: HTMLElement;
+    readonly onWordClick: (word: string) => void;
+    readonly onBackgroundClick: () => void;
+    readonly onBackgroundDoubleClick: () => void;
+    readonly onSheetChange: (sheetId: string) => void;
+    readonly onSearchInput: (filter: string) => void;
+    readonly onUpdateDisplays?: () => void;
+    readonly onSaveState?: () => Promise<void>;
+    readonly showInfo?: (msg: string, clear: boolean) => void;
+    readonly moduleActions?: Record<string, readonly ModuleActionConfig[]>;
+}
+
+export const createModuleTabManager = (
+    options: ModuleTabManagerOptions
+): ModuleTabManager => {
+    const {
+        selectEl,
+        sheetContainerEl,
+        onWordClick,
+        onBackgroundClick,
+        onBackgroundDoubleClick,
+    } = options;
+
+    const sheets: ModuleSheet[] = [];
+    let searchFilter = '';
+
+    const createOptionElement = (moduleName: string, sheetId: string): HTMLOptionElement => {
+        const option = document.createElement('option');
+        option.value = sheetId;
+        option.textContent = formatDictionaryTabName(moduleName);
+        return option;
+    };
+
+    const createSheetElement = (sheetId: string, moduleName: string): HTMLElement => {
+        const sheet = document.createElement('div');
+        sheet.className = 'dictionary-sheet';
+        sheet.id = `dictionary-sheet-${sheetId}`;
+        sheet.hidden = true;
+
+        const wordInfoDisplay = document.createElement('span');
+        wordInfoDisplay.className = 'word-info-display module-word-info';
+
+        const wordsArea = document.createElement('div');
+        wordsArea.className = 'words-area';
+        wordsArea.appendChild(wordInfoDisplay);
+
+        const wordsDisplay = document.createElement('div');
+        wordsDisplay.className = 'words-display module-words-display';
+        wordsArea.appendChild(wordsDisplay);
+        registerBackgroundClickListeners(wordsDisplay, onBackgroundClick, onBackgroundDoubleClick);
+
+        const container = document.createElement('div');
+        container.className = 'vocabulary-container';
+        container.appendChild(wordsArea);
+
+        sheet.appendChild(container);
+
+        const actionsDiv = document.createElement('div');
+        actionsDiv.className = 'vocabulary-actions';
+
+        const actions = options.moduleActions?.[moduleName];
+        if (actions) {
+            for (const action of actions) {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = `header-btn ${action.className}`;
+                btn.setAttribute('aria-label', action.ariaLabel);
+                btn.textContent = action.label;
+                btn.addEventListener('click', action.onClick);
+                actionsDiv.appendChild(btn);
+            }
+        }
+
+        sheet.appendChild(actionsDiv);
+
+        return sheet;
+    };
+
+    const renderModuleWords = (moduleSheet: ModuleSheet): void => {
+        if (!window.ajisaiInterpreter) return;
+
+        const wordsDisplay = moduleSheet.sheetEl.querySelector('.module-words-display');
+        const wordInfo = moduleSheet.sheetEl.querySelector('.module-word-info');
+        if (!wordsDisplay || !wordInfo) return;
+
+        wordsDisplay.innerHTML = '';
+
+        try {
+            const moduleWords: Array<[string, string | null]> =
+                window.ajisaiInterpreter.collect_module_words_info(moduleSheet.moduleName);
+
+            const sorted = [...moduleWords].sort((a, b) => compareWordName(a[0], b[0]));
+            const matched = sorted.filter(wd => checkWordMatchesFilter(wd[0], searchFilter));
+            const prefix = `${moduleSheet.moduleName}@`;
+
+            matched.forEach(wordData => {
+                const name = wordData[0];
+                const shortName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
+                const description = wordData[1] || name;
+
+                const button = createWordButtonElement(
+                    shortName,
+                    description,
+                    'word-button module',
+                    () => onWordClick(shortName),
+                    () => { (wordInfo as HTMLElement).textContent = description; },
+                    () => { (wordInfo as HTMLElement).textContent = ''; }
+                );
+
+                wordsDisplay.appendChild(button);
+            });
+
+            if (searchFilter && matched.length === 0) {
+                wordsDisplay.classList.add('is-empty');
+                wordsDisplay.appendChild(createNoResultsElement());
+                return;
+            }
+
+            if (!searchFilter && sorted.length === 0) {
+                wordsDisplay.classList.add('is-empty');
+                wordsDisplay.appendChild(createEmptyWordsElement('No words available in this module.'));
+                return;
+            }
+
+            wordsDisplay.classList.toggle('is-empty', matched.length === 0);
+        } catch (error) {
+            console.error(`Failed to render module words for ${moduleSheet.moduleName}:`, error);
+        }
+    };
+
+    const findSheet = (moduleName: string): ModuleSheet | undefined =>
+        sheets.find(s => s.moduleName === moduleName);
+
+    const syncModuleTabs = (): string[] => {
+        if (!window.ajisaiInterpreter) return [];
+
+        const newSheetIds: string[] = [];
+
+        try {
+            const importedModules: string[] = window.ajisaiInterpreter.collect_imported_modules();
+            const importedSet = new Set(importedModules);
+
+            for (let i = sheets.length - 1; i >= 0; i--) {
+                const sheet = sheets[i]!;
+                if (!importedSet.has(sheet.moduleName)) {
+                    sheet.optionEl.remove();
+                    sheet.sheetEl.remove();
+                    sheets.splice(i, 1);
+                }
+            }
+
+            for (const moduleName of importedModules) {
+                if (!findSheet(moduleName)) {
+                    const sheetId = `module-${moduleName}`;
+                    const optionEl = createOptionElement(moduleName, sheetId);
+                    const sheetEl = createSheetElement(sheetId, moduleName);
+
+                    selectEl.appendChild(optionEl);
+                    sheetContainerEl.appendChild(sheetEl);
+
+                    const moduleSheet: ModuleSheet = { moduleName, sheetId, optionEl, sheetEl };
+                    sheets.push(moduleSheet);
+                    newSheetIds.push(sheetId);
+                }
+            }
+
+            for (const sheet of sheets) {
+                renderModuleWords(sheet);
+            }
+        } catch (error) {
+            console.error('Failed to sync module sheets:', error);
+        }
+
+        return newSheetIds;
+    };
+
+    const clearModuleTabs = (): void => {
+        for (const sheet of sheets) {
+            sheet.optionEl.remove();
+            sheet.sheetEl.remove();
+        }
+        sheets.length = 0;
+    };
+
+    const lookupModuleSheet = (sheetId: string): HTMLElement | null => {
+        const sheet = sheets.find(s => s.sheetId === sheetId);
+        return sheet?.sheetEl ?? null;
+    };
+
+    const collectSheets = (): ModuleSheet[] => sheets;
+
+    const updateSearchFilter = (filter: string): void => {
+        searchFilter = filter.trim();
+        for (const sheet of sheets) {
+            renderModuleWords(sheet);
+        }
+    };
+
+    return {
+        syncModuleTabs,
+        clearModuleTabs,
+        lookupModuleArea: lookupModuleSheet,
+        collectSheets,
+        updateSearchFilter,
+    };
+};

--- a/js/gui/output-display-renderer.ts
+++ b/js/gui/output-display-renderer.ts
@@ -1,0 +1,559 @@
+import type { Value, ExecuteResult } from '../wasm-interpreter-types';
+import { AUDIO_ENGINE } from '../audio/audio-engine';
+import { formatFractionScientific } from './value-formatter';
+import { pipe } from './functional-result-helpers';
+
+export interface DisplayElements {
+    outputDisplay: HTMLElement;
+    stackDisplay: HTMLElement;
+}
+
+export interface DisplayState {
+    readonly mainOutput: string;
+}
+
+export interface Display {
+    readonly init: () => void;
+    readonly renderExecutionResult: (result: ExecuteResult) => void;
+    readonly appendExecutionResult: (result: ExecuteResult) => void;
+    readonly renderOutput: (text: string) => void;
+    readonly renderError: (error: Error | { message?: string } | string) => void;
+    readonly renderInfo: (text: string, append?: boolean) => void;
+    readonly renderStack: (stack: Value[]) => void;
+    readonly extractState: () => DisplayState;
+}
+
+const lookupBracketsAtDepth = (_depth: number): [string, string] => ['[', ']'];
+
+
+const BRACKET_DEPTH_COLORS: readonly string[] = [
+    '#332288',
+    '#88CCEE',
+    '#44AA99',
+    '#117733',
+    '#999933',
+    '#DDCC77',
+    '#CC6677',
+    '#882255',
+    '#AA4499',
+] as const;
+
+const lookupBracketColor = (depth: number): string =>
+    BRACKET_DEPTH_COLORS[depth - 1] ?? '#332288';
+
+const createBracketSpan = (bracket: string, depth: number): HTMLSpanElement => {
+    const span = document.createElement('span');
+    span.className = 'stack-bracket';
+    span.style.color = lookupBracketColor(depth);
+    span.textContent = bracket;
+    return span;
+};
+
+
+const checkFractionObject = (value: unknown): Record<string, unknown> | null => {
+    if (!value || typeof value !== 'object') return null;
+    const candidate = value as Record<string, unknown>;
+    if (!('numerator' in candidate) || !('denominator' in candidate)) return null;
+    return candidate;
+};
+
+const formatFractionToText = (fraction: Record<string, unknown>): string => {
+    const numerator = String(fraction.numerator);
+    const denominator = String(fraction.denominator);
+    return denominator === '1' ? numerator : `${numerator}/${denominator}`;
+};
+
+const parseFractionToNumber = (fraction: Record<string, unknown>): number | null => {
+    const numerator = parseInt(String(fraction.numerator || '0'), 10);
+    const denominator = parseInt(String(fraction.denominator || '1'), 10);
+    if (Number.isNaN(numerator) || Number.isNaN(denominator) || denominator === 0) return null;
+    return denominator === 1 ? numerator : Math.floor(numerator / denominator);
+};
+
+const formatNumber = (value: unknown): string => {
+    const fraction = checkFractionObject(value);
+    if (!fraction) return '?';
+    return formatFractionScientific(String(fraction.numerator), String(fraction.denominator));
+};
+
+const formatFraction = (frac: unknown): string => {
+    const fraction = checkFractionObject(frac);
+    if (!fraction) return '?';
+    return formatFractionScientific(String(fraction.numerator), String(fraction.denominator));
+};
+
+const formatDateTime = (value: unknown): string => {
+    const fraction = checkFractionObject(value);
+    if (!fraction) return '@?';
+
+    try {
+        const numer = BigInt(String(fraction.numerator));
+        const denom = BigInt(String(fraction.denominator));
+        const timestampMs = Number((numer * 1000n) / denom);
+        const date = new Date(timestampMs);
+
+        if (isNaN(date.getTime())) {
+            return `@${formatFractionToText(fraction)}`;
+        }
+
+        const pad = (n: number) => String(n).padStart(2, '0');
+        const year = date.getFullYear();
+        const month = pad(date.getMonth() + 1);
+        const day = pad(date.getDate());
+        const hours = pad(date.getHours());
+        const minutes = pad(date.getMinutes());
+        const seconds = pad(date.getSeconds());
+        const ms = date.getMilliseconds();
+
+        const dateStr = `@${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+        return ms > 0 ? `${dateStr}.${String(ms).padStart(3, '0')}` : dateStr;
+    } catch {
+        return `@${formatFractionToText(fraction)}`;
+    }
+};
+
+const extractByteFromFraction = (frac: unknown): number | null => {
+    const fraction: Record<string, unknown> | null = checkFractionObject(frac);
+    if (!fraction) return null;
+    return parseFractionToNumber(fraction);
+};
+
+const deserializeBytesToString = (data: unknown[]): string => {
+    const bytes: number[] = data
+        .map(extractByteFromFraction)
+        .filter((value): value is number => value !== null && value >= 0 && value <= 255);
+
+    try {
+        return new TextDecoder('utf-8').decode(new Uint8Array(bytes));
+    } catch {
+        return bytes.map(b => String.fromCharCode(b)).join('');
+    }
+};
+
+const formatTensorRecursive = (shape: number[], data: unknown[], depth: number, displayHint?: string): string => {
+    const [open, close] = lookupBracketsAtDepth(depth);
+
+    if (shape.length === 0) {
+        if (data.length === 0) return `${open}${close}`;
+        return `${open} ${formatFraction(data[0])} ${close}`;
+    }
+
+    if (shape.length === 1) {
+        if (data.length === 0) return `${open}${close}`;
+        if (displayHint === 'string') {
+            const str = deserializeBytesToString(data);
+            return `'${str}'`;
+        }
+        const elements: string = data.map(frac => formatFraction(frac)).join(' ');
+        return `${open} ${elements} ${close}`;
+    }
+
+    const outerSize: number = shape[0] ?? 0;
+    const innerShape: number[] = shape.slice(1);
+    const innerSize: number = innerShape.reduce((a: number, b: number) => a * b, 1);
+
+    const parts: string[] = [];
+    for (let i = 0; i < outerSize; i++) {
+        const innerData = data.slice(i * innerSize, (i + 1) * innerSize);
+        parts.push(formatTensorRecursive(innerShape, innerData, depth + 1, displayHint));
+    }
+
+    return `${open} ${parts.join(' ')} ${close}`;
+};
+
+const formatTensor = (value: unknown, depth: number): string => {
+    if (!value || typeof value !== 'object') return '?';
+    const v = value as Record<string, unknown>;
+    if (!('shape' in v) || !('data' in v)) return '?';
+    const displayHint = v.displayHint as string | undefined;
+    return formatTensorRecursive(v.shape as number[], v.data as unknown[], depth, displayHint);
+};
+
+const formatVector = (value: unknown, depth: number): string => {
+    const [open, close] = lookupBracketsAtDepth(depth);
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return `${open}${close}`;
+        }
+        const formatSingleElement = (v: Value): string => {
+            try { return formatValue(v, depth + 1); } catch { return '?'; }
+        };
+        const elements: string = value.map(formatSingleElement).join(' ');
+        return `${open} ${elements} ${close}`;
+    }
+    return `${open}${close}`;
+};
+
+
+
+
+
+const renderStackValueNode = (item: Value, depth: number): HTMLElement => {
+    const node = document.createElement('span');
+    node.className = 'stack-node';
+
+    if (item.type === 'vector' && Array.isArray(item.value)) {
+        node.classList.add('stack-node-vector');
+        node.dataset.depth = String(depth);
+        node.appendChild(createBracketSpan('[', depth));
+        item.value.forEach((child, index) => {
+            if (index > 0) node.append(' ');
+            node.appendChild(renderStackValueNode(child, depth + 1));
+        });
+        node.appendChild(createBracketSpan(']', depth));
+        return node;
+    }
+
+    if (item.type === 'tensor' && item.value && typeof item.value === 'object') {
+        const tensor = item.value as { shape?: number[]; data?: unknown[]; displayHint?: string };
+        const shape = Array.isArray(tensor.shape) ? tensor.shape : [];
+        const data = Array.isArray(tensor.data) ? tensor.data : [];
+
+        const renderTensorNode = (tensorShape: number[], tensorData: unknown[], tensorDepth: number): HTMLElement => {
+            const tensorNode = document.createElement('span');
+            tensorNode.className = 'stack-node stack-node-vector';
+            tensorNode.dataset.depth = String(tensorDepth);
+
+            if (tensorShape.length === 0) {
+                tensorNode.appendChild(createBracketSpan('[', tensorDepth));
+                tensorNode.appendChild(createBracketSpan(']', tensorDepth));
+                return tensorNode;
+            }
+
+            if (tensorShape.length === 1) {
+                if ((tensor.displayHint ?? '').toLowerCase() === 'string') {
+                    tensorNode.append(deserializeBytesToString(tensorData));
+                } else {
+                    tensorNode.appendChild(createBracketSpan('[', tensorDepth));
+                    tensorData.forEach((frac, index) => {
+                        if (index > 0) tensorNode.append(' ');
+                        tensorNode.append(formatFraction(frac));
+                    });
+                    tensorNode.appendChild(createBracketSpan(']', tensorDepth));
+                }
+                return tensorNode;
+            }
+
+            tensorNode.appendChild(createBracketSpan('[', tensorDepth));
+            const outerSize = tensorShape[0] ?? 0;
+            const innerShape = tensorShape.slice(1);
+            const innerSize = innerShape.reduce((a, b) => a * b, 1);
+            for (let i = 0; i < outerSize; i++) {
+                if (i > 0) tensorNode.append(' ');
+                const innerData = tensorData.slice(i * innerSize, (i + 1) * innerSize);
+                tensorNode.appendChild(renderTensorNode(innerShape, innerData, tensorDepth + 1));
+            }
+            tensorNode.appendChild(createBracketSpan(']', tensorDepth));
+            return tensorNode;
+        };
+
+        return renderTensorNode(shape, data, depth);
+    }
+
+    if (depth === 1) {
+        node.dataset.depth = String(depth);
+    }
+    node.textContent = formatValue(item, depth);
+    return node;
+};
+
+const formatValue = (item: Value, depth: number): string => {
+    if (!item || !item.type) return 'unknown';
+
+    switch (item.type) {
+        case 'number':
+            return formatNumber(item.value);
+        case 'datetime':
+            return formatDateTime(item.value);
+        case 'tensor':
+            return formatTensor(item.value, depth);
+        case 'string':
+            return `'${item.value}'`;
+        case 'symbol':
+            return String(item.value);
+        case 'boolean':
+            return item.value ? 'TRUE' : 'FALSE';
+        case 'vector':
+            return formatVector(item.value, depth);
+        case 'nil':
+            return 'NIL';
+        case 'block': {
+            const source = (item as unknown as { source: string }).source || '';
+            return `"${source}"`;
+        }
+        default:
+            return JSON.stringify(item.value);
+    }
+};
+
+
+const extractAudioCommands = (output: string): string[] =>
+    output.split('\n')
+        .filter(line => line.startsWith('AUDIO:'))
+        .map(line => line.substring(6));
+
+const extractConfigCommands = (output: string): string[] =>
+    output.split('\n')
+        .filter(line => line.startsWith('CONFIG:'))
+        .map(line => line.substring(7));
+
+const extractEffectCommands = (output: string): string[] =>
+    output.split('\n')
+        .filter(line => line.startsWith('EFFECT:'))
+        .map(line => line.substring(7));
+
+const extractJsonExportCommands = (output: string): string[] =>
+    output.split('\n')
+        .filter(line => line.startsWith('JSONEXPORT:'))
+        .map(line => line.substring(11));
+
+const checkIsSpecialCommand = (line: string): boolean =>
+    line.startsWith('AUDIO:') || line.startsWith('CONFIG:') ||
+    line.startsWith('EFFECT:') || line.startsWith('JSONEXPORT:');
+
+const removeSpecialCommandLines = (output: string): string =>
+    output.split('\n')
+        .filter(line => !checkIsSpecialCommand(line))
+        .join('\n');
+
+const formatExecutionOutput = (result: ExecuteResult): { debug: string; program: string } => ({
+    debug: (result.debugOutput || '').trim(),
+    program: pipe(
+        (result.output || '').trim(),
+        removeSpecialCommandLines
+    )
+});
+
+const formatErrorMessage = (error: Error | { message?: string } | string): string =>
+    typeof error === 'string'
+        ? `Error: ${error}`
+        : `Error: ${(error as Error).message || error}`;
+
+const createSpanElement = (text: string, color: string): HTMLSpanElement => {
+    const span = document.createElement('span');
+    span.style.color = color;
+    span.textContent = text;
+    return span;
+};
+
+const clearElement = (element: HTMLElement): void => {
+    element.innerHTML = '';
+};
+
+const appendToElement = (parent: HTMLElement, child: HTMLElement): void => {
+    parent.appendChild(child);
+};
+
+const applyEffectCommands = (output: string): void => {
+    extractEffectCommands(output).forEach(commandStr => {
+        try {
+            const effect = JSON.parse(commandStr);
+            if (effect.gain !== undefined) {
+                AUDIO_ENGINE.updateGain(effect.gain);
+            }
+            if (effect.pan !== undefined) {
+                AUDIO_ENGINE.updatePan(effect.pan);
+            }
+        } catch {
+            console.error('Failed to parse EFFECT command:', commandStr);
+        }
+    });
+};
+
+const applyConfigCommands = (output: string): void => {
+    extractConfigCommands(output).forEach(commandStr => {
+        try {
+            const config = JSON.parse(commandStr);
+            if (config.slot_duration !== undefined) {
+                AUDIO_ENGINE.updateSlotDuration(config.slot_duration);
+                console.log(`Slot duration set to ${config.slot_duration}s`);
+            }
+        } catch {
+            console.error('Failed to parse CONFIG command');
+        }
+    });
+};
+
+const executeAudioCommands = (output: string): void => {
+    applyEffectCommands(output);
+    applyConfigCommands(output);
+
+    extractAudioCommands(output).forEach(commandStr => {
+        try {
+            const audioCommand = JSON.parse(commandStr);
+            AUDIO_ENGINE.playAudioCommand(audioCommand).catch(console.error);
+        } catch {
+            console.error('Failed to parse audio command');
+        }
+    });
+};
+
+const createJsonDownloadLinkElement = (jsonCompact: string): HTMLAnchorElement => {
+    let prettyJson: string;
+    try {
+        prettyJson = JSON.stringify(JSON.parse(jsonCompact), null, 2);
+    } catch {
+        prettyJson = jsonCompact;
+    }
+
+    const blob = new Blob([prettyJson], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `ajisai_export_${timestamp}.json`;
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.className = 'json-download-link';
+    a.textContent = `Download: ${filename}`;
+    return a;
+};
+
+const renderJsonExportLinks = (output: string, outputDisplay: HTMLElement): void => {
+    extractJsonExportCommands(output).forEach(jsonCompact => {
+        const link = createJsonDownloadLinkElement(jsonCompact);
+        appendToElement(outputDisplay, document.createElement('br'));
+        appendToElement(outputDisplay, link);
+    });
+};
+
+export const createDisplay = (elements: DisplayElements): Display => {
+    let mainOutput = '';
+
+    const init = (): void => {
+        elements.outputDisplay.style.whiteSpace = 'pre-wrap';
+        AUDIO_ENGINE.init().catch(console.error);
+    };
+
+    const appendSpan = (text: string, color: string): HTMLSpanElement => {
+        const span = createSpanElement(text.replace(/\\n/g, '\n'), color);
+        appendToElement(elements.outputDisplay, span);
+        return span;
+    };
+
+    const renderExecutionResult = (result: ExecuteResult): void => {
+        const { debug, program } = formatExecutionOutput(result);
+        const rawOutput = result.output || '';
+        executeAudioCommands(rawOutput);
+
+        mainOutput = `${debug}\n${program}`;
+        clearElement(elements.outputDisplay);
+
+        if (debug) {
+            appendSpan(debug, '#333');
+        }
+
+        if (debug && program) {
+            appendToElement(elements.outputDisplay, document.createElement('br'));
+        }
+
+        if (program) {
+            appendSpan(program, '#4DC4FF');
+        }
+
+        renderJsonExportLinks(rawOutput, elements.outputDisplay);
+
+        if (!debug && !program && !extractJsonExportCommands(rawOutput).length && result.status === 'OK') {
+            appendSpan('OK', '#333');
+        }
+    };
+
+    const appendExecutionResult = (result: ExecuteResult): void => {
+        const programOutput = (result.output || '').trim();
+        executeAudioCommands(programOutput);
+        const filteredOutput = removeSpecialCommandLines(programOutput);
+
+        if (filteredOutput) {
+            appendSpan(filteredOutput, '#4DC4FF');
+        }
+    };
+
+    const renderOutput = (text: string): void => {
+        executeAudioCommands(text);
+        const filteredText = removeSpecialCommandLines(text);
+
+        mainOutput = filteredText;
+        clearElement(elements.outputDisplay);
+        appendSpan(filteredText, '#4DC4FF');
+    };
+
+    const renderError = (error: Error | { message?: string } | string): void => {
+        const errorMessage = formatErrorMessage(error);
+
+        mainOutput = errorMessage;
+        clearElement(elements.outputDisplay);
+
+        const span = appendSpan(errorMessage, '#dc3545');
+        span.style.fontWeight = 'bold';
+    };
+
+    const renderInfo = (text: string, append = false): void => {
+        if (append && elements.outputDisplay.innerHTML.trim() !== '') {
+            mainOutput = `${mainOutput}\n${text}`;
+            appendSpan('\n' + text, '#666');
+        } else {
+            mainOutput = text;
+            clearElement(elements.outputDisplay);
+            appendSpan(text, '#666');
+        }
+    };
+
+    const renderStack = (stack: Value[]): void => {
+        const display = elements.stackDisplay;
+        clearElement(display);
+
+        if (!Array.isArray(stack) || stack.length === 0) {
+            display.classList.add('is-empty');
+            const message = document.createElement('div');
+            message.className = 'empty-words-message';
+            message.textContent = 'No values on the stack yet.';
+            display.appendChild(message);
+            return;
+        }
+
+        display.classList.remove('is-empty');
+
+        const container = document.createElement('div');
+        container.className = 'area-content-flow stack-content-flow';
+
+        stack.forEach((item, index) => {
+            const elem = document.createElement('span');
+            elem.className = 'stack-item';
+            try {
+                elem.appendChild(renderStackValueNode(item, 1));
+            } catch {
+                console.error(`Error formatting item ${index}`);
+                elem.textContent = 'ERROR';
+            }
+            appendToElement(container, elem);
+        });
+
+        appendToElement(display, container);
+    };
+
+    const extractState = (): DisplayState => ({ mainOutput });
+
+    return {
+        init,
+        renderExecutionResult,
+        appendExecutionResult,
+        renderOutput,
+        renderError,
+        renderInfo,
+        renderStack,
+        extractState
+    };
+};
+
+export const displayUtils = {
+    formatValue,
+    formatNumber,
+    formatDateTime,
+    formatTensor,
+    formatVector,
+    lookupBracketsAtDepth,
+    removeSpecialCommandLines,
+    formatErrorMessage
+};

--- a/js/gui/step-executor.ts
+++ b/js/gui/step-executor.ts
@@ -1,0 +1,233 @@
+
+
+import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import type { AjisaiInterpreter, UserWord, ExecuteResult } from '../wasm-interpreter-types';
+import {
+    applyInterpreterSnapshot,
+    createInterpreterSnapshot,
+    type InterpreterSnapshot
+} from '../workers/interpreter-snapshot';
+
+export interface StepState {
+    readonly active: boolean;
+    readonly tokens: readonly string[];
+    readonly currentIndex: number;
+}
+
+export interface StepExecutorCallbacks {
+    readonly extractEditorValue: () => string;
+    readonly showInfo: (text: string, append: boolean) => void;
+    readonly showError: (error: Error | string) => void;
+    readonly showExecutionResult: (result: ExecuteResult) => void;
+    readonly updateDisplays: () => void;
+    readonly saveState: () => Promise<void>;
+}
+
+export interface StepExecutor {
+    readonly isActive: () => boolean;
+    readonly reset: () => void;
+    readonly executeStep: () => Promise<void>;
+    readonly abort: () => void;
+    readonly extractState: () => StepState;
+}
+
+const createInitialState = (): StepState => ({
+    active: false,
+    tokens: [],
+    currentIndex: 0
+});
+
+const tokenize = (code: string): string[] =>
+    code.split(/\s+/).filter(token => token.length > 0);
+
+const createActiveState = (tokens: string[]): StepState => ({
+    active: true,
+    tokens,
+    currentIndex: 0
+});
+
+const advanceState = (state: StepState): StepState => ({
+    ...state,
+    currentIndex: state.currentIndex + 1
+});
+
+const formatStepMessage = (
+    currentIndex: number,
+    totalTokens: number,
+    token: string
+): string => {
+    const remaining = totalTokens - currentIndex - 1;
+    return `[>] Step ${currentIndex + 1}/${totalTokens}: "${token}" (${remaining} remaining)`;
+};
+
+const collectUserWords = (interpreter: AjisaiInterpreter): UserWord[] => {
+    const userWordsInfo = interpreter.collect_user_words_info();
+    return userWordsInfo.map(wordData => ({
+        dictionary: wordData[0],
+        name: wordData[1],
+        definition: interpreter.lookup_word_definition(`${wordData[0]}@${wordData[1]}`),
+        description: wordData[2]
+    }));
+};
+
+const createStepExecutionSnapshot = (
+    interpreter: AjisaiInterpreter
+): InterpreterSnapshot =>
+    createInterpreterSnapshot({
+        stack: interpreter.collect_stack(),
+        userWords: collectUserWords(interpreter),
+        importedModules: interpreter.collect_imported_modules()
+    });
+
+const resolveStepExecutionException = (
+    error: unknown,
+    showInfo: (text: string, append: boolean) => void,
+    showError: (error: Error | string) => void
+): void => {
+    console.error('[StepExecutor] Step execution failed:', error);
+    if (error instanceof Error && error.message.includes('aborted')) {
+        showInfo('Step execution aborted', true);
+        return;
+    }
+    showError(error as Error);
+};
+
+const syncInterpreterState = (
+    interpreter: AjisaiInterpreter,
+    result: ExecuteResult
+): void => {
+    if (!result || result.error) return;
+
+    applyInterpreterSnapshot(interpreter, {
+        stack: result.stack,
+        userWords: result.userWords,
+        importedModules: result.importedModules
+    });
+};
+
+export const createStepExecutor = (
+    interpreter: AjisaiInterpreter,
+    callbacks: StepExecutorCallbacks
+): StepExecutor => {
+    const {
+        extractEditorValue,
+        showInfo,
+        showError,
+        showExecutionResult,
+        updateDisplays,
+        saveState
+    } = callbacks;
+
+    let state = createInitialState();
+
+    const isActive = (): boolean => state.active;
+
+    const reset = (): void => {
+        state = createInitialState();
+    };
+
+    const abort = (): void => {
+        if (state.active) {
+            reset();
+            showInfo('Step mode aborted', true);
+        }
+    };
+
+    const extractState = (): StepState => ({ ...state });
+
+    const startStepMode = async (): Promise<void> => {
+        const code = extractEditorValue();
+        if (!code) return;
+
+        const tokens = tokenize(code);
+
+        if (tokens.length === 0) {
+            showInfo('No code', true);
+            return;
+        }
+
+        state = createActiveState(tokens);
+
+        showInfo(`[STEP] Step mode: ${tokens.length} tokens (Ctrl+Enter to continue)`, true);
+
+        await executeNextToken();
+    };
+
+    const executeNextToken = async (): Promise<void> => {
+        if (state.currentIndex >= state.tokens.length) {
+            showInfo('[DONE] Step mode completed', true);
+            reset();
+            return;
+        }
+
+        const token = state.tokens[state.currentIndex]!;
+
+        try {
+            showInfo(
+                formatStepMessage(state.currentIndex, state.tokens.length, token),
+                false
+            );
+
+            const currentState = createStepExecutionSnapshot(interpreter);
+            const result = await WORKER_MANAGER.execute(token, currentState);
+
+            try {
+                syncInterpreterState(interpreter, result);
+            } catch (error) {
+                console.error('[StepExecutor] Failed to sync state:', error);
+                showError(error as Error);
+            }
+
+            if (result.status === 'OK' && !result.error) {
+                showExecutionResult(result);
+            } else {
+                showError(result.message || 'Unknown error');
+                reset();
+                updateDisplays();
+                await saveState();
+                return;
+            }
+
+            state = advanceState(state);
+
+            if (state.currentIndex >= state.tokens.length) {
+                showInfo('[DONE] Step mode completed', true);
+                reset();
+            }
+
+        } catch (error) {
+            resolveStepExecutionException(error, showInfo, showError);
+            reset();
+        }
+
+        updateDisplays();
+        await saveState();
+    };
+
+    const executeStep = async (): Promise<void> => {
+        if (!state.active) {
+            await startStepMode();
+        } else {
+            await executeNextToken();
+        }
+    };
+
+    return {
+        isActive,
+        reset,
+        executeStep,
+        abort,
+        extractState
+    };
+};
+
+export const stepExecutorUtils = {
+    createInitialState,
+    tokenize,
+    createActiveState,
+    advanceState,
+    formatStepMessage,
+    collectUserWords,
+    createStepExecutionSnapshot,
+    resolveStepExecutionException
+};

--- a/js/gui/value-formatter.ts
+++ b/js/gui/value-formatter.ts
@@ -1,0 +1,179 @@
+
+
+import type { Value, Fraction } from '../wasm-interpreter-types';
+
+
+const SCIENTIFIC_THRESHOLD = 10;
+const MANTISSA_PRECISION = 6;
+
+
+
+
+export function formatIntegerScientific(numStr: string): string {
+    const isNegative = numStr.startsWith('-');
+    const absNumStr = isNegative ? numStr.substring(1) : numStr;
+
+    if (absNumStr.length < SCIENTIFIC_THRESHOLD) {
+        return numStr;
+    }
+
+    const firstDigit = absNumStr[0];
+    const remainingDigits = absNumStr.substring(1);
+    const exponent = remainingDigits.length;
+
+    let mantissa = firstDigit!;
+    if (remainingDigits.length > 0) {
+        const fractionalDigits = Math.min(MANTISSA_PRECISION - 1, remainingDigits.length);
+        if (fractionalDigits > 0) {
+            mantissa += '.' + remainingDigits.substring(0, fractionalDigits);
+        }
+    }
+
+    mantissa = mantissa.replace(/\.?0+$/, '');
+    if (isNegative) mantissa = '-' + mantissa;
+
+    return `${mantissa}e${exponent}`;
+}
+
+
+
+
+export function formatFractionScientific(numerStr: string, denomStr: string): string {
+    if (denomStr === '1') {
+        return formatIntegerScientific(numerStr);
+    }
+
+    const numSci = formatIntegerScientific(numerStr);
+    const denSci = formatIntegerScientific(denomStr);
+
+    if (numSci.includes('e') && denSci.includes('e')) {
+        const numMatch = numSci.match(/^([+-]?\d+\.?\d*)e([+-]?\d+)$/);
+        const denMatch = denSci.match(/^([+-]?\d+\.?\d*)e([+-]?\d+)$/);
+
+        if (numMatch && denMatch) {
+            const numMantissa = parseFloat(numMatch[1]!);
+            const numExponent = parseInt(numMatch[2]!);
+            const denMantissa = parseFloat(denMatch[1]!);
+            const denExponent = parseInt(denMatch[2]!);
+
+            let resultMantissa = numMantissa / denMantissa;
+            let resultExponent = numExponent - denExponent;
+
+            while (Math.abs(resultMantissa) >= 10) {
+                resultMantissa /= 10;
+                resultExponent += 1;
+            }
+            while (Math.abs(resultMantissa) < 1 && resultMantissa !== 0) {
+                resultMantissa *= 10;
+                resultExponent -= 1;
+            }
+
+            const rounded = resultMantissa.toPrecision(MANTISSA_PRECISION);
+            return resultExponent === 0 ? rounded : `${rounded}e${resultExponent}`;
+        }
+    }
+
+    return `${numSci}/${denSci}`;
+}
+
+
+
+
+export function formatFraction(frac: Fraction): string {
+    const denomStr = String(frac.denominator);
+    const numerStr = String(frac.numerator);
+    return formatFractionScientific(numerStr, denomStr);
+}
+
+
+
+
+export function formatValueSimple(value: Value): string {
+    switch (value.type) {
+        case 'number': {
+            const frac = value.value as Fraction;
+            if (frac.denominator === '1') {
+                return frac.numerator;
+            }
+            return `${frac.numerator}/${frac.denominator}`;
+        }
+        case 'string':
+            return `'${value.value}'`;
+        case 'boolean':
+            return value.value ? 'TRUE' : 'FALSE';
+        case 'nil':
+            return 'NIL';
+        case 'vector':
+            if (Array.isArray(value.value)) {
+                const elements = value.value.map(v => formatValueSimple(v)).join(' ');
+                return `[${elements ? ' ' + elements + ' ' : ''}]`;
+            }
+            return '[]';
+        case 'process_handle':
+            return `<process:${value.value}>`;
+        case 'supervisor_handle':
+            return `<supervisor:${value.value}>`;
+        default:
+            return JSON.stringify(value.value);
+    }
+}
+
+
+
+
+export function formatStack(stack: Value[]): string {
+    if (stack.length === 0) {
+        return '[]';
+    }
+    const formatted = stack.map(v => formatValueSimple(v)).join(', ');
+    return `[${formatted}]`;
+}
+
+
+
+
+export function compareValue(actual: Value, expected: Value): boolean {
+    if (actual.type !== expected.type) {
+        return false;
+    }
+
+    switch (actual.type) {
+        case 'number': {
+            const actualFrac = actual.value as Fraction;
+            const expectedFrac = expected.value as Fraction;
+            return actualFrac.numerator === expectedFrac.numerator &&
+                   actualFrac.denominator === expectedFrac.denominator;
+        }
+        case 'vector':
+            if (!Array.isArray(actual.value) || !Array.isArray(expected.value)) {
+                return false;
+            }
+            return compareStack(actual.value, expected.value);
+        case 'string':
+        case 'boolean':
+            return JSON.stringify(actual.value) === JSON.stringify(expected.value);
+        case 'nil':
+            return true;
+        default:
+            return JSON.stringify(actual.value) === JSON.stringify(expected.value);
+    }
+}
+
+
+
+
+export function compareStack(actual: Value[], expected: Value[]): boolean {
+    if (actual.length !== expected.length) {
+        return false;
+    }
+
+    for (let i = 0; i < actual.length; i++) {
+        const a = actual[i];
+        const e = expected[i];
+        if (!a || !e || !compareValue(a, e)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -1,0 +1,403 @@
+
+
+import {
+    checkWordMatchesFilter,
+    compareWordName,
+    createEmptyWordsElement,
+    createNoResultsElement,
+    createWordButtonElement,
+    registerBackgroundClickListeners,
+} from './dictionary-element-builders';
+
+export interface WordInfo {
+    readonly dictionary: string;
+    readonly name: string;
+    readonly description?: string | null;
+    readonly protected?: boolean;
+}
+
+export interface VocabularyElements {
+    readonly builtInWordsDisplay: HTMLElement;
+    readonly userWordsDisplay: HTMLElement;
+    readonly builtInWordInfo: HTMLElement;
+    readonly userWordInfo: HTMLElement;
+    readonly userDictionarySelect: HTMLSelectElement;
+}
+
+export interface VocabularyCallbacks {
+    readonly onWordClick: (word: string) => void;
+    readonly onBackgroundClick?: () => void;
+    readonly onBackgroundDoubleClick?: () => void;
+    readonly onUpdateDisplays?: () => void;
+    readonly onSaveState?: () => Promise<void>;
+    readonly showInfo?: (text: string, append: boolean) => void;
+}
+
+export interface VocabularyManager {
+    readonly renderBuiltInWords: () => void;
+    readonly updateUserWords: (userWordsInfo: Array<[string, string, string | null, boolean]>) => void;
+    readonly updateSearchFilter: (filter: string) => void;
+}
+
+const DICTIONARY_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.freeze({
+    'DEMO': 'Demonstration',
+});
+
+export const formatDictionaryTabName = (pathName: string): string => {
+    const displayName = DICTIONARY_DISPLAY_NAMES[pathName]
+        ?? pathName.charAt(0).toUpperCase() + pathName.slice(1).toLowerCase();
+    return `${displayName} word`;
+};
+
+const SYMBOL_MAP: Readonly<Record<string, string>> = Object.freeze({
+    'VSTART': '[', 'VEND': ']', 'BSTART': '{', 'BEND': '}',
+    'NIL': 'nil', 'ADD': '+', 'SUB': '-', 'MUL': '*', 'DIV': '/',
+    'LT': '<', 'LE': '<=', 'GT': '>', 'GE': '>=', 'EQ': '=',
+    'AND': 'and', 'OR': 'or', 'NOT': 'not',
+});
+
+const deserializeWordName = (name: string): string | null => {
+    if (name.match(/^W_[0-9A-F]+$/)) return null;
+    if (!name.includes('_')) return null;
+
+    const decoded = name.split('_').map(part => {
+        if (part.startsWith('STR_')) {
+            return `"${part.substring(4).replace(/_/g, ' ')}"`;
+        }
+        return SYMBOL_MAP[part] ?? part.toLowerCase();
+    }).join(' ');
+
+    return `≈ ${decoded}`;
+};
+
+const createWordInfoFromTuple = (wordData: [string, string, string | null, boolean]): WordInfo => ({
+    dictionary: wordData[0],
+    name: wordData[1],
+    description: wordData[2] || deserializeWordName(wordData[1]) || wordData[1],
+    protected: wordData[3] || false
+});
+
+
+const clearElement = (element: HTMLElement): void => {
+    element.innerHTML = '';
+};
+
+const DEFAULT_WORD_INFO_MESSAGE = 'Hover over a word button to view its usage.';
+
+const resolveDisplayDescription = (wordInfo: WordInfo): string | null => {
+    const desc = wordInfo.description;
+    if (!desc || desc === wordInfo.name) return null;
+    return desc;
+};
+
+const renderWordInfo = (element: HTMLElement, text: string, isPlaceholder = false): void => {
+    element.textContent = text;
+    element.classList.toggle('is-placeholder', isPlaceholder);
+};
+
+const resetWordInfoDisplay = (element: HTMLElement): void => {
+    renderWordInfo(element, DEFAULT_WORD_INFO_MESSAGE, true);
+};
+
+const DEPENDENCY_DELETE_ERROR = 'Cannot delete';
+
+const createDeleteContextMenuElement = (
+    onDelete: () => void
+): HTMLDivElement => {
+    const menu = document.createElement('div');
+    menu.hidden = true;
+    Object.assign(menu.style, {
+        position: 'fixed',
+        zIndex: '1000',
+        minWidth: '7rem',
+        padding: '0.125rem',
+        backgroundColor: '#ffffff',
+        border: '1px solid #c0c0c0',
+        boxShadow: '0 2px 6px rgba(0, 0, 0, 0.15)'
+    } satisfies Partial<CSSStyleDeclaration>);
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.textContent = 'Delete';
+    Object.assign(deleteButton.style, {
+        display: 'block',
+        width: '100%',
+        padding: '0.375rem 0.75rem',
+        backgroundColor: 'transparent',
+        color: '#000000',
+        border: 'none',
+        textAlign: 'left',
+        cursor: 'pointer'
+    } satisfies Partial<CSSStyleDeclaration>);
+    deleteButton.addEventListener('mouseenter', () => {
+        deleteButton.style.backgroundColor = '#e8e8e8';
+    });
+    deleteButton.addEventListener('mouseleave', () => {
+        deleteButton.style.backgroundColor = 'transparent';
+    });
+    deleteButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        onDelete();
+    });
+
+    menu.appendChild(deleteButton);
+    document.body.appendChild(menu);
+
+    return menu;
+};
+
+export const createVocabularyManager = (
+    elements: VocabularyElements,
+    callbacks: VocabularyCallbacks
+): VocabularyManager => {
+    const { onWordClick, onBackgroundClick, onBackgroundDoubleClick, onUpdateDisplays, onSaveState, showInfo } = callbacks;
+    const deleteContextMenu = createDeleteContextMenuElement(() => {
+        if (!activeContextWordName) {
+            return;
+        }
+
+        const selectedWordName = activeContextWordName;
+        hideDeleteContextMenu();
+        void confirmAndDeleteWord(selectedWordName);
+    });
+    let activeContextWordName: string | null = null;
+
+    const hideDeleteContextMenu = (): void => {
+        deleteContextMenu.hidden = true;
+        activeContextWordName = null;
+    };
+
+    const renderDeleteContextMenu = (event: MouseEvent, wordName: string): void => {
+        activeContextWordName = wordName;
+        deleteContextMenu.hidden = false;
+        deleteContextMenu.style.left = `${event.clientX}px`;
+        deleteContextMenu.style.top = `${event.clientY}px`;
+    };
+
+    document.addEventListener('click', () => {
+        hideDeleteContextMenu();
+    });
+    document.addEventListener('contextmenu', (event) => {
+        if (!(event.target instanceof HTMLElement) || !event.target.closest('.word-button')) {
+            hideDeleteContextMenu();
+        }
+    });
+    window.addEventListener('blur', hideDeleteContextMenu);
+
+    [elements.builtInWordsDisplay, elements.userWordsDisplay].forEach(container => {
+        registerBackgroundClickListeners(container, onBackgroundClick, onBackgroundDoubleClick);
+    });
+
+    [elements.builtInWordInfo, elements.userWordInfo].forEach(resetWordInfoDisplay);
+
+
+    let searchFilter = '';
+    let cachedUserWords: Array<[string, string, string | null, boolean]> = [];
+    let selectedDictionary = 'DEMO';
+
+    const deleteWord = async (wordName: string, forceDelete: boolean): Promise<boolean> => {
+        const deleteCode = forceDelete
+            ? `! '${wordName}' DEL`
+            : `'${wordName}' DEL`;
+
+        try {
+            const result = await window.ajisaiInterpreter.execute(deleteCode);
+            if (result.status === 'ERROR') {
+                if (!forceDelete && result.message?.includes(DEPENDENCY_DELETE_ERROR)) {
+                    const confirmed = confirm(
+                        `Word '${wordName}' is referenced by other user words. Force delete with ! ?`
+                    );
+
+                    if (confirmed) {
+                        return deleteWord(wordName, true);
+                    }
+
+                    return false;
+                }
+
+                alert(`Failed to delete word: ${result.message}`);
+                return false;
+            }
+
+            onUpdateDisplays?.();
+            await onSaveState?.();
+            showInfo?.(`Word '${wordName}' deleted`, true);
+            return true;
+        } catch (error) {
+            alert(`Error deleting word: ${error}`);
+            return false;
+        }
+    };
+
+    const confirmAndDeleteWord = async (wordName: string): Promise<void> => {
+        await deleteWord(wordName, false);
+    };
+
+    const renderBuiltInWordsSorted = (
+        container: HTMLElement,
+        coreWords: unknown[][]
+    ): void => {
+        clearElement(container);
+
+
+        const filtered = coreWords.filter(
+            (wd): wd is unknown[] =>
+                Array.isArray(wd) && wd[0] !== ';' && wd[0] !== '"'
+        );
+
+
+        const sorted = [...filtered].sort((a, b) =>
+            compareWordName(a[0] as string, b[0] as string)
+        );
+
+
+        const matched = sorted.filter(wd =>
+            checkWordMatchesFilter(wd[0] as string, searchFilter)
+        );
+
+
+        matched.forEach(wordData => {
+            const name = wordData[0] as string;
+            const description = (wordData[1] as string) || name;
+            const syntaxExample = (wordData[2] as string) || '';
+            const signatureType = (wordData[3] as string) || 'none';
+            const sigClass = signatureType !== 'none' ? ` signature-${signatureType}` : '';
+
+            const button = createWordButtonElement(
+                name,
+                description,
+                `word-button core${sigClass}`,
+                () => onWordClick(name),
+                () => { renderWordInfo(elements.builtInWordInfo, syntaxExample || DEFAULT_WORD_INFO_MESSAGE, !syntaxExample); },
+                () => { resetWordInfoDisplay(elements.builtInWordInfo); }
+            );
+
+            container.appendChild(button);
+        });
+
+        if (searchFilter && matched.length === 0) {
+            container.appendChild(createNoResultsElement());
+        }
+    };
+
+    const renderUserWordButtons = (
+        container: HTMLElement,
+        words: WordInfo[]
+    ): void => {
+        clearElement(container);
+
+
+        const filteredWords = words.filter(wordInfo =>
+            checkWordMatchesFilter(wordInfo.name, searchFilter)
+        );
+
+
+        const sortedFiltered = [...filteredWords].sort((a, b) =>
+            compareWordName(a.name, b.name)
+        );
+
+        sortedFiltered.forEach(wordInfo => {
+            const className = wordInfo.protected
+                ? 'word-button dependency'
+                : 'word-button non-dependency';
+
+            const button = createWordButtonElement(
+                wordInfo.name,
+                wordInfo.description || '',
+                className,
+                () => onWordClick(wordInfo.dictionary === 'DEMO' ? wordInfo.name : `${wordInfo.dictionary}@${wordInfo.name}`),
+                () => {
+                    const lookupName = `${wordInfo.dictionary}@${wordInfo.name}`;
+                    const definition = window.ajisaiInterpreter?.lookup_word_definition(lookupName);
+                    const desc = resolveDisplayDescription(wordInfo);
+                    const displayText = desc
+                        ? `${desc}\n\n${definition ?? ''}`.trim()
+                        : (definition ?? '');
+                    renderWordInfo(
+                        elements.userWordInfo,
+                        displayText || DEFAULT_WORD_INFO_MESSAGE,
+                        !displayText
+                    );
+                },
+                () => { resetWordInfoDisplay(elements.userWordInfo); },
+                (event) => renderDeleteContextMenu(event, `${wordInfo.dictionary}@${wordInfo.name}`)
+            );
+
+            container.appendChild(button);
+        });
+
+
+
+        if (searchFilter && words.length > 0 && filteredWords.length === 0) {
+            container.classList.add('is-empty');
+            container.appendChild(createNoResultsElement());
+            return;
+        }
+
+        if (!searchFilter && words.length === 0) {
+            container.classList.add('is-empty');
+            container.appendChild(createEmptyWordsElement('No user words defined yet.'));
+            return;
+        }
+
+        container.classList.toggle('is-empty', sortedFiltered.length === 0);
+    };
+
+    const renderBuiltInWords = (): void => {
+        if (!window.ajisaiInterpreter) return;
+
+        try {
+            const coreWords = window.ajisaiInterpreter.collect_core_words_info();
+            renderBuiltInWordsSorted(elements.builtInWordsDisplay, coreWords);
+        } catch (error) {
+            console.error('Failed to render core words:', error);
+        }
+    };
+
+    const updateUserWords = (
+        userWordsInfo: Array<[string, string, string | null, boolean]>
+    ): void => {
+
+        cachedUserWords = userWordsInfo || [];
+        const dictionaries = Array.from(new Set(cachedUserWords.map(([dictionary]) => dictionary))).sort();
+        elements.userDictionarySelect.innerHTML = '';
+        for (const dictionary of dictionaries.length > 0 ? dictionaries : ['DEMO']) {
+            const option = document.createElement('option');
+            option.value = dictionary;
+            option.textContent = formatDictionaryTabName(dictionary);
+            elements.userDictionarySelect.appendChild(option);
+        }
+        if (!dictionaries.includes(selectedDictionary)) {
+            selectedDictionary = dictionaries.includes('DEMO') ? 'DEMO' : (dictionaries[0] || 'DEMO');
+        }
+        elements.userDictionarySelect.value = selectedDictionary;
+        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
+        renderUserWordButtons(elements.userWordsDisplay, words);
+    };
+
+    const updateSearchFilter = (filter: string): void => {
+        searchFilter = filter.trim();
+
+        renderBuiltInWords();
+        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
+        renderUserWordButtons(elements.userWordsDisplay, words);
+    };
+
+    elements.userDictionarySelect.addEventListener('change', () => {
+        selectedDictionary = elements.userDictionarySelect.value;
+        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
+        renderUserWordButtons(elements.userWordsDisplay, words);
+    });
+
+    return {
+        renderBuiltInWords,
+        updateUserWords,
+        updateSearchFilter
+    };
+};
+
+export const dictionaryUtils = {
+    deserializeWordName,
+    createWordInfoFromTuple,
+    SYMBOL_MAP
+};

--- a/js/web-app-entrypoint.ts
+++ b/js/web-app-entrypoint.ts
@@ -1,0 +1,122 @@
+
+
+import { GUI_INSTANCE } from './gui/gui-application';
+import { initWasm } from './wasm-module-loader';
+import './indexeddb-user-word-store';
+import type { WasmModule, AjisaiInterpreter } from './wasm-interpreter-types';
+
+declare global {
+    interface Window {
+        AjisaiWasm: WasmModule;
+        ajisaiInterpreter: AjisaiInterpreter;
+    }
+}
+
+async function main(): Promise<void> {
+    console.log('[Main] Starting Ajisai application...');
+
+    try {
+        console.log('[Main] Initializing WASM...');
+        const wasm = await initWasm();
+        if (!wasm) {
+            throw new Error('WASM initialization failed. Application cannot start.');
+        }
+        window.AjisaiWasm = wasm;
+
+        console.log('[Main] Creating main thread interpreter...');
+        window.ajisaiInterpreter = new window.AjisaiWasm.AjisaiInterpreter();
+
+        console.log('[Main] Initializing GUI...');
+        await GUI_INSTANCE.init();
+
+        GUI_INSTANCE.updateAllDisplays();
+
+
+        setupOnlineStatusMonitoring();
+
+        console.log('[Main] Application initialization completed successfully');
+
+    } catch (error) {
+        console.error('[Main] Application startup failed:', error);
+        const outputDisplay = document.getElementById('output-display');
+        if (outputDisplay) {
+            outputDisplay.innerHTML = `
+                <span style="color: #dc3545; font-weight: bold;">
+                    Application startup failed: ${(error as Error).message}
+                </span>
+            `;
+        }
+    }
+}
+
+
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./service-worker.js')
+            .then(registration => {
+                console.log('[Main] Service Worker registered:', registration.scope);
+
+
+                registration.addEventListener('updatefound', () => {
+                    const newWorker = registration.installing;
+                    console.log('[Main] New service worker found');
+
+                    newWorker?.addEventListener('statechange', () => {
+                        if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+
+                            console.log('[Main] New version available');
+                            try {
+                                const display = GUI_INSTANCE.extractDisplay();
+                                display.renderInfo('New version available. Please reload.', true);
+                            } catch {
+
+                            }
+                        }
+                    });
+                });
+            })
+            .catch(error => {
+                console.error('[Main] Service Worker registration failed:', error);
+            });
+    });
+}
+
+
+function setupOnlineStatusMonitoring(): void {
+    const offlineIndicator = document.getElementById('offline-indicator');
+    let isInitialCheck = true;
+
+    function updateOnlineStatus() {
+        if (navigator.onLine) {
+            console.log('[Main] Online');
+            if (offlineIndicator) offlineIndicator.style.display = 'none';
+
+            if (!isInitialCheck) {
+                try {
+                    const display = GUI_INSTANCE.extractDisplay();
+                    display.renderInfo('Online mode', true);
+                } catch {
+
+                }
+            }
+        } else {
+            console.log('[Main] Offline');
+            if (offlineIndicator) offlineIndicator.style.display = 'inline';
+            try {
+                const display = GUI_INSTANCE.extractDisplay();
+                display.renderInfo('Offline mode', true);
+            } catch {
+
+            }
+        }
+        isInitialCheck = false;
+    }
+
+    window.addEventListener('online', updateOnlineStatus);
+    window.addEventListener('offline', updateOnlineStatus);
+
+
+    updateOnlineStatus();
+}
+
+document.addEventListener('DOMContentLoaded', main);


### PR DESCRIPTION
### Motivation
- The site was left as a static placeholder after the Reference-page removal, which replaced the original app shell and prevented the Ajisai GUI from initializing. 
- The intent is to restore the browser app entry so the WASM-backed interpreter and GUI load on page visit. 

### Description
- Restored a full application HTML shell in `index.html` that references the app assets, theme/config scripts, manifest, and the module entry `js/web-app-entrypoint.ts`.
- Reintroduced the GUI bootstrap and app lifecycle code in `js/web-app-entrypoint.ts` which initializes WASM, creates `window.ajisaiInterpreter`, registers the service worker, and sets up online/offline monitoring.
- Recovered the GUI implementation and supporting modules under `js/gui/` (including `gui-application.ts`, `output-display-renderer.ts`, `vocabulary-state-controller.ts`, `interpreter-state-persistence.ts`, `execution-controller.ts`, `step-executor.ts`, editor, layout, module-sheet, test-runner, and related utilities) to provide the runtime UI, persistence, and test tooling.
- Restored styling by adding `app-interface.css` and demo/user-word data in `js/gui/demo-words.ts` so the layout and sample words load correctly in the UI.

### Testing
- Ran TypeScript type-checks with `npm run check` (executes `tsc --noEmit`) and it completed successfully. 
- Built the TypeScript sources with `npm run build` (executes `tsc`) and the build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99b1165048326ad6786610e722046)