### PR TITLE
Remove gui_mode and unify boolean result handling

### DIFF
--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -3,7 +3,14 @@ use crate::interpreter::value_extraction_helpers::extract_integer_from_value;
 use crate::interpreter::tensor_ops::FlatTensor;
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
-use crate::types::{Value, ValueData};
+use crate::types::{DisplayHint, Value, ValueData};
+
+fn push_boolean_result(interp: &mut Interpreter, result: bool) {
+    interp.stack.push(Value::from_vector(vec![Value::from_bool(result)]));
+    let stack_len = interp.stack.len();
+    interp.semantic_registry.normalize_to_stack_len(stack_len);
+    interp.semantic_registry.update_hint_at(stack_len - 1, DisplayHint::Boolean);
+}
 
 fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
     match &val.data {
@@ -92,13 +99,7 @@ where
             };
 
             let result: bool = op(&a_scalar, &b_scalar);
-            if interp.gui_mode {
-                interp
-                    .stack
-                    .push(Value::from_vector(vec![Value::from_bool(result)]));
-            } else {
-                interp.stack.push(Value::from_bool(result));
-            }
+            push_boolean_result(interp, result);
             Ok(())
         }
 
@@ -134,7 +135,7 @@ where
                 }
             };
 
-            interp.stack.push(Value::from_bool(all_true));
+            push_boolean_result(interp, all_true);
             Ok(())
         }
     }
@@ -186,13 +187,7 @@ pub fn op_eq(interp: &mut Interpreter) -> Result<()> {
                     _ => false,
                 }
             };
-            if interp.gui_mode {
-                interp
-                    .stack
-                    .push(Value::from_vector(vec![Value::from_bool(result)]));
-            } else {
-                interp.stack.push(Value::from_bool(result));
-            }
+            push_boolean_result(interp, result);
             Ok(())
         }
 
@@ -218,7 +213,7 @@ pub fn op_eq(interp: &mut Interpreter) -> Result<()> {
             };
 
             let all_equal: bool = check_all_adjacent_equal(&items);
-            interp.stack.push(Value::from_bool(all_equal));
+            push_boolean_result(interp, all_equal);
             Ok(())
         }
     }

--- a/rust/src/interpreter/control-cond-tests.rs
+++ b/rust/src/interpreter/control-cond-tests.rs
@@ -157,15 +157,9 @@ mod tests {
 }
 
 #[cfg(test)]
-mod demo_word_gui_mode_tests {
+mod demo_word_tests {
     use crate::interpreter::Interpreter;
     use crate::types::ValueData;
-
-    fn create_gui_interpreter() -> Interpreter {
-        let mut interp = Interpreter::new();
-        interp.gui_mode = true;
-        interp
-    }
 
     async fn setup_demo_words(interp: &mut Interpreter) {
         interp.execute("{ 'Hello' ,, PRINT } 'SAY-HELLO' DEF").await.unwrap();
@@ -177,17 +171,17 @@ mod demo_word_gui_mode_tests {
     }
 
     #[tokio::test]
-    async fn test_cond_guard_unwraps_vector_boolean_in_gui_mode() {
-        let mut interp = create_gui_interpreter();
+    async fn test_cond_guard_handles_vector_boolean() {
+        let mut interp = Interpreter::new();
         let r = interp
             .execute("[ 1 ] { [ 1 ] = } { 'yes' } { IDLE } { 'no' } COND")
             .await;
-        assert!(r.is_ok(), "COND should handle gui-mode vector boolean: {:?}", r);
+        assert!(r.is_ok(), "COND should handle vector boolean guard result: {:?}", r);
     }
 
     #[tokio::test]
-    async fn test_greet_in_gui_mode() {
-        let mut interp = create_gui_interpreter();
+    async fn test_greet_branch_1() {
+        let mut interp = Interpreter::new();
         setup_demo_words(&mut interp).await;
 
         let r = interp.execute("[ 1 ] GREET").await;
@@ -197,8 +191,8 @@ mod demo_word_gui_mode_tests {
     }
 
     #[tokio::test]
-    async fn test_greet_branch_2_in_gui_mode() {
-        let mut interp = create_gui_interpreter();
+    async fn test_greet_branch_2() {
+        let mut interp = Interpreter::new();
         setup_demo_words(&mut interp).await;
 
         let r = interp.execute("[ 2 ] GREET").await;
@@ -208,8 +202,8 @@ mod demo_word_gui_mode_tests {
     }
 
     #[tokio::test]
-    async fn test_greet_else_branch_in_gui_mode() {
-        let mut interp = create_gui_interpreter();
+    async fn test_greet_else_branch() {
+        let mut interp = Interpreter::new();
         setup_demo_words(&mut interp).await;
 
         let r = interp.execute("[ 99 ] GREET").await;
@@ -219,8 +213,8 @@ mod demo_word_gui_mode_tests {
     }
 
     #[tokio::test]
-    async fn test_greet_all_in_gui_mode() {
-        let mut interp = create_gui_interpreter();
+    async fn test_greet_all() {
+        let mut interp = Interpreter::new();
         setup_demo_words(&mut interp).await;
 
         let r = interp.execute("[ 1 2 3 ] GREET-ALL").await;
@@ -229,7 +223,6 @@ mod demo_word_gui_mode_tests {
         assert!(output.contains("Hello"), "Expected Hello in output, got: {}", output);
         assert!(output.contains("World"), "Expected World in output, got: {}", output);
         assert!(output.contains("!"), "Expected ! in output, got: {}", output);
-
 
         assert_eq!(interp.stack.len(), 1);
         let result = &interp.stack[0];

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -116,10 +116,6 @@ pub struct Interpreter {
     pub(crate) input_buffer: String,
     pub(crate) io_output_buffer: String,
 
-
-
-    pub gui_mode: bool,
-
     pub(crate) flow_tracking: bool,
     pub(crate) active_flows: Vec<FlowToken>,
     pub(crate) flow_consumed_log: Vec<(u64, Fraction)>,
@@ -161,7 +157,6 @@ impl Interpreter {
             max_execution_steps: DEFAULT_MAX_EXECUTION_STEPS,
             input_buffer: String::new(),
             io_output_buffer: String::new(),
-            gui_mode: false,
             flow_tracking: false,
             active_flows: Vec::new(),
             flow_consumed_log: Vec::new(),

--- a/rust/src/interpreter/interpreter-execution-tests.rs
+++ b/rust/src/interpreter/interpreter-execution-tests.rs
@@ -28,9 +28,11 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(interp.stack.len(), 4);
         let val = &interp.stack[3];
-        assert_eq!(val.len(), 1, "Expected single element");
+        // Comparison returns a single-element vector boolean [ TRUE ]
+        assert_eq!(val.len(), 1, "Expected single-element vector boolean");
+        let inner = val.get_child(0).expect("Expected inner element");
         assert!(
-            !val.as_scalar().expect("Expected scalar").is_zero(),
+            !inner.as_scalar().expect("Expected scalar in result").is_zero(),
             "Expected TRUE from comparison"
         );
     }

--- a/rust/src/interpreter/interpreter-mode-tests.rs
+++ b/rust/src/interpreter/interpreter-mode-tests.rs
@@ -160,9 +160,9 @@ mod tests {
             "Safe mode should not affect normal execution: {:?}",
             result
         );
-        assert_eq!(interp.stack.len(), 1);
+        assert_eq!(interp.stack.len(), 2);
         assert!(
-            !interp.stack[0].is_nil(),
+            !interp.stack[1].is_nil(),
             "Result should not be NIL on success"
         );
     }

--- a/rust/src/interpreter/vector_ops/position.rs
+++ b/rust/src/interpreter/vector_ops/position.rs
@@ -44,13 +44,11 @@ pub fn op_get(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
     let (index_val, index) = pop_index_operand(interp)?;
 
-
-    let preserve_source = interp.gui_mode || is_keep_mode;
-
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
+            // StackTop always preserves the source vector (query semantics).
             let result_elem =
-                with_stacktop_vector_target_with_arg(interp, &index_val, preserve_source, |target_val| {
+                with_stacktop_vector_target_with_arg(interp, &index_val, true, |target_val| {
                     let len = target_val.len();
                     if len == 0 {
                         return Err(AjisaiError::IndexOutOfBounds { index, length: 0 });
@@ -86,8 +84,7 @@ pub fn op_get(interp: &mut Interpreter) -> Result<()> {
             };
 
             let result_elem = interp.stack[actual_index].clone();
-            if !preserve_source {
-
+            if !is_keep_mode {
                 interp.stack.clear();
             }
             interp.stack.push(result_elem);

--- a/rust/src/interpreter/vector_ops/quantity.rs
+++ b/rust/src/interpreter/vector_ops/quantity.rs
@@ -43,41 +43,25 @@ fn compute_take_bounds(len: usize, count: i64, target: &str) -> Result<(usize, u
 pub fn op_length(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
-    let preserve_source = interp.gui_mode || is_keep_mode;
-
     let len = match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            if preserve_source {
-                let target_val = interp.stack.last().ok_or(AjisaiError::StackUnderflow)?;
+            // StackTop always preserves the source vector (query semantics).
+            let target_val = interp.stack.last().ok_or(AjisaiError::StackUnderflow)?;
 
-                if target_val.is_nil() {
-                    0
-                } else if target_val.is_vector() {
-                    extract_vector_elements(target_val).len()
-                } else {
-                    return Err(AjisaiError::create_structure_error(
-                        "vector",
-                        "other format",
-                    ));
-                }
+            if target_val.is_nil() {
+                0
+            } else if target_val.is_vector() {
+                extract_vector_elements(target_val).len()
             } else {
-                let target_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-
-                if target_val.is_nil() {
-                    0
-                } else if target_val.is_vector() {
-                    extract_vector_elements(&target_val).len()
-                } else {
-                    interp.stack.push(target_val);
-                    return Err(AjisaiError::create_structure_error(
-                        "vector",
-                        "other format",
-                    ));
-                }
+                return Err(AjisaiError::create_structure_error(
+                    "vector",
+                    "other format",
+                ));
             }
         }
         OperationTargetMode::Stack => {
-            if preserve_source {
+            // Stack mode respects keep_mode for clearing behavior.
+            if is_keep_mode {
                 interp.stack.len()
             } else {
                 let len = interp.stack.len();

--- a/rust/src/interpreter/vector_ops/tests_modes.rs
+++ b/rust/src/interpreter/vector_ops/tests_modes.rs
@@ -95,8 +95,8 @@ async fn test_get_consume_mode() {
     assert!(result.is_ok(), "GET should succeed: {:?}", result);
     assert_eq!(
         interp.stack.len(),
-        1,
-        "GET in consume mode should leave only result"
+        2,
+        "GET in StackTop mode preserves source vector and pushes result"
     );
 }
 
@@ -125,8 +125,8 @@ async fn test_length_consume_mode() {
     assert!(result.is_ok(), "LENGTH should succeed: {:?}", result);
     assert_eq!(
         interp.stack.len(),
-        1,
-        "LENGTH in consume mode should leave only result"
+        2,
+        "LENGTH in StackTop mode preserves source vector and pushes result"
     );
 }
 

--- a/rust/src/wasm-interpreter-bindings.rs
+++ b/rust/src/wasm-interpreter-bindings.rs
@@ -28,8 +28,7 @@ pub(crate) fn set_js_prop(obj: &js_sys::Object, key: &str, value: &JsValue) {
 impl AjisaiInterpreter {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        let mut interp = Interpreter::new();
-        interp.gui_mode = true;
+        let interp = Interpreter::new();
         AjisaiInterpreter {
             interpreter: interp,
             step_tokens: Vec::new(),

--- a/rust/tests/fractional-dataflow-behavior-tests.rs
+++ b/rust/tests/fractional-dataflow-behavior-tests.rs
@@ -20,14 +20,12 @@ use num_bigint::BigInt;
 
 async fn run(code: &str) -> Result<Vec<Value>, String> {
     let mut interp = Interpreter::new();
-    interp.gui_mode = true;
     interp.execute(code).await.map_err(|e| e.to_string())?;
     Ok(interp.get_stack().clone())
 }
 
 async fn run_with_flow_tracking(code: &str) -> Result<(Vec<Value>, Interpreter), String> {
     let mut interp = Interpreter::new();
-    interp.gui_mode = true;
     interp.update_flow_tracking(true);
     interp.execute(code).await.map_err(|e| e.to_string())?;
     let stack = interp.get_stack().clone();


### PR DESCRIPTION
## Summary
This PR removes the `gui_mode` flag from the interpreter and unifies boolean result handling across all comparison and query operations. Previously, `gui_mode` controlled whether boolean results were returned as scalar booleans or single-element vector booleans. Now, all boolean results are consistently returned as single-element vector booleans with a `DisplayHint::Boolean` semantic marker.

## Key Changes

- **Removed `gui_mode` field** from `Interpreter` struct and all initialization code
- **Unified boolean result handling** by introducing `push_boolean_result()` helper function that:
  - Always wraps boolean results in a single-element vector
  - Applies `DisplayHint::Boolean` semantic hint for proper display
  - Replaces all conditional `gui_mode` checks in comparison operations
- **Simplified operation semantics**:
  - `op_length()` in StackTop mode now always preserves source (query semantics)
  - `op_get()` in StackTop mode now always preserves source (query semantics)
  - Removed `preserve_source` variable that was computed from `gui_mode || is_keep_mode`
- **Updated tests** to reflect new behavior:
  - Removed `create_gui_interpreter()` helper and `gui_mode` test setup
  - Updated test assertions to expect vector boolean results
  - Clarified test names and comments to reflect query vs. consumption semantics
  - Fixed stack length expectations in mode tests (StackTop now preserves source)
- **Removed `gui_mode` from WASM bindings** initialization

## Implementation Details

The new `push_boolean_result()` function ensures consistent handling:
```rust
fn push_boolean_result(interp: &mut Interpreter, result: bool) {
    interp.stack.push(Value::from_vector(vec![Value::from_bool(result)]));
    let stack_len = interp.stack.len();
    interp.semantic_registry.normalize_to_stack_len(stack_len);
    interp.semantic_registry.update_hint_at(stack_len - 1, DisplayHint::Boolean);
}
```

This change makes the interpreter's behavior more predictable and eliminates the need for mode-dependent logic in comparison operations.

https://claude.ai/code/session_01SKZUFCwNDLFuL6QJeMQchH