### PR TITLE
Refactor header markup and logo hover styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,16 +24,16 @@
     <div class="container">
         <header role="banner">
             <div class="app-header-top">
-                <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
-                    <span class="logo-swap" aria-hidden="true">
-                        <img src="public/images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
-                        <img src="public/images/ajisai-qr.png" alt="" class="logo logo-qr">
-                    </span>
-                    <div class="app-brand-meta">
+                <div class="app-brand-meta">
+                    <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
+                        <span class="logo-swap" aria-hidden="true">
+                            <img src="public/images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
+                            <img src="public/images/ajisai-qr.png" alt="" class="logo logo-qr">
+                        </span>
                         <h1>Ajisai</h1>
-                        <span class="version">ver.202604111547</span>
-                    </div>
-                </a>
+                    </a>
+                    <span class="version">ver.202604111547</span>
+                </div>
                 <span id="offline-indicator" class="offline-indicator" style="display: none;">Offline</span>
             </div>
             <div class="header-actions">

--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -154,13 +154,13 @@ header {
     filter: brightness(0) invert(1);
 }
 
-.app-brand-block:hover .logo-default,
+.logo-swap:hover .logo-default,
 .app-brand-block:focus-visible .logo-default,
 .app-brand-block:focus-within .logo-default {
     opacity: 0;
 }
 
-.app-brand-block:hover .logo-qr,
+.logo-swap:hover .logo-qr,
 .app-brand-block:focus-visible .logo-qr,
 .app-brand-block:focus-within .logo-qr {
     opacity: 1;


### PR DESCRIPTION
## Summary
Restructured the header branding markup to improve semantic HTML organization and updated CSS selectors to match the new DOM structure.

## Key Changes
- **HTML Structure**: Reorganized the app header to move the `app-brand-meta` div outside and around the `app-brand-block` link, making the version span a sibling to the link rather than nested within it
- **CSS Selectors**: Updated logo hover/focus styles to target `.logo-swap:hover` instead of `.app-brand-block:hover`, ensuring the logo swap animation is triggered by hovering over the logo container itself rather than the entire link

## Implementation Details
The refactoring improves the semantic structure by:
- Keeping the clickable link (`app-brand-block`) focused on the logo and title
- Moving the version information outside the link, making it non-interactive
- Adjusting CSS selectors to work with the new nesting hierarchy while maintaining the same visual behavior for the logo swap animation on hover

https://claude.ai/code/session_01KUny5DpoBRACFqjcCP95qH