### PR TITLE
fix: ブランドエリアの縦揃えをbaselineからcenterに変更

### DIFF
--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -121,7 +121,7 @@ header {
 
 .app-brand-meta {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 0.5rem;
 }
 


### PR DESCRIPTION
align-items: baselineはテキスト下端基準のため下詰めに見えていた。
centerに変更することでロゴ・h1・バージョン番号を縦軸中央で揃える。

https://claude.ai/code/session_01KUny5DpoBRACFqjcCP95qH