### PR TITLE
Add debug stylesheet for visualizing div hierarchy structure

### DIFF
--- a/debug-borders.css
+++ b/debug-borders.css
@@ -1,0 +1,50 @@
+/*
+ * DEBUG: div階層ごとの枠線表示
+ * 構造確認用の一時ファイルです。確認後は下記を削除してください:
+ *   1. このファイル (debug-borders.css)
+ *   2. index.html の <link rel="stylesheet" href="debug-borders.css"> 行
+ *
+ * 色凡例:
+ *   Level 1 (赤    #FF3B30): div祖先 0個  — .container
+ *   Level 2 (橙    #FF9500): div祖先 1個  — #editor-panel, #state-panel 等
+ *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .textarea-wrapper 等
+ *   Level 4 (緑    #34C759): div祖先 3個  — .vocabulary-container, .search-wrapper 等
+ *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, #user-words-display 等
+ */
+
+/* Level 1 — div祖先 0個 */
+div {
+    outline: 2px solid #FF3B30;
+    outline-offset: -1px;
+}
+
+/* Level 2 — div祖先 1個 */
+div div {
+    outline: 2px solid #FF9500;
+    outline-offset: -1px;
+}
+
+/* Level 3 — div祖先 2個 */
+div div div {
+    outline: 2px solid #FFCC00;
+    outline-offset: -1px;
+}
+
+/* Level 4 — div祖先 3個 */
+div div div div {
+    outline: 2px solid #34C759;
+    outline-offset: -1px;
+}
+
+/* Level 5 — div祖先 4個 */
+div div div div div {
+    outline: 2px solid #007AFF;
+    outline-offset: -1px;
+}
+
+/* Level 6 — div祖先 5個以上 */
+div div div div div div {
+    outline: 2px solid #AF52DE;
+    outline-offset: -1px;
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 
     <link rel="stylesheet" href="public/ajisai-base.css?v=20260408">
     <link rel="stylesheet" href="app-interface.css?v=20260408">
+    <link rel="stylesheet" href="debug-borders.css">
 </head>
 <body>
     <a href="#code-input" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
Added a debug stylesheet to visualize the DOM hierarchy by displaying colored borders around div elements at different nesting levels. This is a temporary development tool to help verify the structure of the page layout.

## Changes
- **debug-borders.css** (new file): Created a debug stylesheet that applies colored outlines to div elements based on their nesting depth
  - Level 1 (Red #FF3B30): Root divs with no div ancestors
  - Level 2 (Orange #FF9500): Divs with 1 div ancestor
  - Level 3 (Yellow #FFCC00): Divs with 2 div ancestors
  - Level 4 (Green #34C759): Divs with 3 div ancestors
  - Level 5 (Blue #007AFF): Divs with 4 div ancestors
  - Level 6 (Purple #AF52DE): Divs with 5+ div ancestors

- **index.html**: Linked the debug stylesheet in the document head

## Notes
This is a temporary debugging file. The stylesheet and its link reference should be removed once the DOM structure verification is complete.

https://claude.ai/code/session_01KzTHCuaUi1MATzuhXNiRPt