### PR TITLE
Rename "custom word" to "user word" in test documentation

### DIFF
--- a/examples/user-word-guard-test.ajisai
+++ b/examples/user-word-guard-test.ajisai
@@ -1,16 +1,16 @@
-# Custom word behavior regression cases (canonical)
+# User word behavior regression cases (canonical)
 
-# 1) Basic custom word definition and execution
+# 1) Basic user word definition and execution
 [ '[ 1 ] [ 2 ] +' ] 'ADD12' DEF
 ADD12 PRINT
 # 期待: [ 3 ]
 
-# 2) Custom word composed from built-ins
+# 2) User word composed from built-ins
 [ '[ 1 ] +' ] 'INC' DEF
 [ 41 ] INC PRINT
 # 期待: [ 42 ]
 
-# 3) Custom word can be redefined intentionally
+# 3) User word can be redefined intentionally
 [ '[ 2 ] +' ] 'INC' DEF
 [ 40 ] INC PRINT
 # 期待: [ 42 ]


### PR DESCRIPTION
## Summary
Updated terminology in the user-word-guard-test.ajisai file to consistently use "user word" instead of "custom word" throughout the test case comments and descriptions.

## Key Changes
- Renamed file from `custom-word-guard-test.ajisai` to `user-word-guard-test.ajisai`
- Updated all comment headers and descriptions to use "user word" terminology:
  - "Custom word behavior" → "User word behavior"
  - "Custom word definition" → "User word definition"
  - "Custom word composed" → "User word composed"
  - "Custom word can be redefined" → "User word can be redefined"

## Details
This change standardizes the terminology used in the test suite to align with the preferred naming convention for user-defined words in the Ajisai language. The test cases themselves remain functionally unchanged; only the documentation and file naming have been updated for consistency.

https://claude.ai/code/session_01Js888Gcp2TmDNpnnrV14RT