### PR TITLE
Add tap-to-focus gesture for stack display on mobile

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -202,6 +202,36 @@ export const createGUI = (): GUI => {
             }
         });
 
+        {
+            const TAP_MOVEMENT_LIMIT = 10;
+            let tapStartX = 0;
+            let tapStartY = 0;
+
+            elements.stackDisplay.addEventListener('touchstart', (e: TouchEvent) => {
+                const touch = e.changedTouches[0];
+                if (touch) {
+                    tapStartX = touch.screenX;
+                    tapStartY = touch.screenY;
+                }
+            }, { passive: true });
+
+            elements.stackDisplay.addEventListener('touchend', (e: TouchEvent) => {
+                if (!mobile.isMobile()) return;
+                if (layoutState.currentMode !== 'stack') return;
+
+                const touch = e.changedTouches[0];
+                if (!touch) return;
+
+                const deltaX = Math.abs(touch.screenX - tapStartX);
+                const deltaY = Math.abs(touch.screenY - tapStartY);
+
+                if (deltaX < TAP_MOVEMENT_LIMIT && deltaY < TAP_MOVEMENT_LIMIT) {
+                    if ((e.target as HTMLElement).closest('button, a')) return;
+                    switchArea('input');
+                }
+            }, { passive: true });
+        }
+
         elements.copyOutputBtn.addEventListener('click', (e: MouseEvent) => {
             e.stopPropagation();
             const text = display.extractState().mainOutput;


### PR DESCRIPTION
## Summary
Added touch event handling to the stack display that allows users to tap (without significant movement) to switch focus to the input area on mobile devices.

## Key Changes
- Added `touchstart` and `touchend` event listeners to the stack display element
- Implemented tap detection with a 10-pixel movement threshold to distinguish taps from swipes
- On valid tap gestures, automatically switches the active area to 'input' for improved mobile UX
- Added guards to prevent triggering on button/link clicks and when not in stack layout mode
- Used passive event listeners for better scroll performance

## Implementation Details
- Tracks initial touch position on `touchstart` and compares against final position on `touchend`
- Only triggers the area switch when:
  - Device is in mobile mode
  - Current layout mode is 'stack'
  - Touch movement is within the 10-pixel limit (TAP_MOVEMENT_LIMIT)
  - The touched element is not a button or anchor tag
- Event listeners are marked as passive to allow browser optimizations

https://claude.ai/code/session_016ubzmSACEnRxbwojtiQfQ6