### PR TITLE
Fix string literal parsing to treat adjacent quotes as literal characters

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -64,7 +64,18 @@ All numeric literals are parsed as exact rational numbers.
 
 ### 3.3 String literals
 
-Text enclosed in single quotes: `'hello'`. Consecutive string tokens are merged automatically: `'hel''lo'` is equivalent to `'hello'`.
+A string literal begins with `'` and ends with the last `'` before a token boundary. A token boundary is whitespace, end of input, or any special character other than `'` (such as `[`, `]`, `{`, `}`, `(`, `)`, `#`, `=`, `~`, `$`).
+
+Any `'` that appears before a non-boundary character is a literal quote character in the string content.
+
+Examples:
+
+| Source | String value |
+|--------|-------------|
+| `'hello'` | `hello` |
+| `'it's'` | `it's` |
+| `'hel''lo'` | `hel''lo` |
+| `'これは'テスト'です'` | `これは'テスト'です` |
 
 ### 3.4 Code blocks
 

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -289,15 +289,6 @@ pub(crate) fn parse_definition_body(tokens: &[Token]) -> Result<Vec<ExecutionLin
     let mut i = 0;
     while i < tokens.len() {
         match &tokens[i] {
-            Token::String(s) if s.starts_with('\'') && s.ends_with('\'') => {
-                let inner = &s[1..s.len() - 1];
-
-                let inner_tokens = crate::tokenizer::tokenize(inner)
-                    .map_err(|e| AjisaiError::from(format!("Error tokenizing quotation: {}", e)))?;
-                processed_tokens.push(Token::VectorStart);
-                processed_tokens.extend(inner_tokens);
-                processed_tokens.push(Token::VectorEnd);
-            }
             Token::LineBreak => {
                 if !processed_tokens.is_empty() {
                     let execution_line = ExecutionLine {

--- a/rust/src/tokenizer-regression-tests.rs
+++ b/rust/src/tokenizer-regression-tests.rs
@@ -77,6 +77,30 @@ mod tokenizer_regression_tests {
     }
 
     #[test]
+    fn test_adjacent_quotes_are_literal() {
+        let result = tokenize("'hel''lo'").unwrap();
+        assert_eq!(result, vec![Token::String("hel''lo".into()),]);
+    }
+
+    #[test]
+    fn test_multiple_inner_quotes() {
+        let result = tokenize("'a'b'c'").unwrap();
+        assert_eq!(result, vec![Token::String("a'b'c".into()),]);
+    }
+
+    #[test]
+    fn test_adjacent_quotes_followed_by_space() {
+        let result = tokenize("'hel''lo' 'world'").unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::String("hel''lo".into()),
+                Token::String("world".into()),
+            ]
+        );
+    }
+
+    #[test]
     fn test_flexible_quotes_single_with_double_inside() {
         let result = tokenize("'He\"llo'").unwrap();
         assert_eq!(result, vec![Token::String("He\"llo".into()),]);

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -200,7 +200,7 @@ fn check_bracket_matching(input: &str) -> Result<(), String> {
         if c == '\'' {
             if in_string {
 
-                if i + 1 >= chars.len() || chars[i + 1].is_whitespace() || is_special_char(chars[i + 1]) {
+                if i + 1 >= chars.len() || is_string_close_delimiter(chars[i + 1]) {
                     in_string = false;
                 }
             } else {
@@ -378,7 +378,7 @@ fn parse_token_from_string_literal(chars: &[char]) -> QuoteParseResult {
     while i < chars.len() {
         if chars[i] == '\'' {
 
-            if i + 1 >= chars.len() || is_delimiter(chars[i + 1]) {
+            if i + 1 >= chars.len() || is_string_close_delimiter(chars[i + 1]) {
                 return QuoteParseResult::StringSuccess(Token::String(string.into()), i + 1);
             } else {
 
@@ -398,6 +398,10 @@ fn parse_token_from_string_literal(chars: &[char]) -> QuoteParseResult {
 
 fn is_delimiter(c: char) -> bool {
     c.is_whitespace() || is_special_char(c)
+}
+
+fn is_string_close_delimiter(c: char) -> bool {
+    c.is_whitespace() || (is_special_char(c) && c != '\'')
 }
 
 


### PR DESCRIPTION
## Summary
This PR fixes the string literal parsing behavior to correctly handle adjacent single quotes as literal quote characters within the string content, rather than treating them as string delimiters or requiring automatic merging of consecutive string tokens.

## Key Changes

- **Updated string literal specification** in SPECIFICATION.md to clarify that a string literal ends at the last `'` before a token boundary (whitespace, end of input, or special characters other than `'`). Any `'` appearing before a non-boundary character is treated as a literal quote character in the string content.

- **Refactored quote delimiter detection** by introducing a new `is_string_close_delimiter()` function that distinguishes between string-closing delimiters (whitespace or special characters excluding `'`) and other characters. This allows adjacent quotes to be treated as literal characters.

- **Updated tokenizer logic** in `tokenizer.rs` to use the new delimiter function in both `check_bracket_matching()` and `parse_token_from_string_literal()`, ensuring consistent behavior.

- **Removed automatic string merging logic** from `execute-def.rs` that was previously handling the old behavior of merging consecutive quoted strings.

- **Added comprehensive test cases** covering:
  - Adjacent quotes within a string (`'hel''lo'` → `hel''lo`)
  - Multiple inner quotes (`'a'b'c'` → `a'b'c`)
  - Adjacent quotes followed by whitespace (`'hel''lo' 'world'` → two separate strings)

## Implementation Details

The key insight is that a single quote only closes a string if it's followed by a token boundary character. If followed by any other character (including another quote), it's treated as a literal character within the string. This simplifies the parsing logic and makes the behavior more intuitive and consistent with common string literal conventions.

https://claude.ai/code/session_01FaRrNocQ7iTCaHucsLT6p8