### PR TITLE
Add touch-based QR code display for logo

### DIFF
--- a/js/web-app-entrypoint.ts
+++ b/js/web-app-entrypoint.ts
@@ -119,4 +119,30 @@ function setupOnlineStatusMonitoring(): void {
     updateOnlineStatus();
 }
 
-document.addEventListener('DOMContentLoaded', main);
+function setupLogoTouchQR(): void {
+    const logoSwap = document.querySelector<HTMLElement>('.logo-swap');
+    if (!logoSwap) return;
+
+    let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+    logoSwap.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+
+        if (hideTimer !== null) {
+            clearTimeout(hideTimer);
+            hideTimer = null;
+        }
+
+        logoSwap.classList.add('qr-active');
+
+        hideTimer = setTimeout(() => {
+            logoSwap.classList.remove('qr-active');
+            hideTimer = null;
+        }, 3000);
+    }, { passive: false });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    setupLogoTouchQR();
+    main();
+});

--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -104,7 +104,7 @@ header {
 .app-brand-block {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 0.4rem;
     text-decoration: none;
     color: inherit;
 }
@@ -141,16 +141,17 @@ header {
 
 .logo-qr {
     opacity: 0;
-    filter: brightness(0) invert(1);
 }
 
 .logo-swap:hover .logo-default,
+.logo-swap.qr-active .logo-default,
 .app-brand-block:focus-visible .logo-default,
 .app-brand-block:focus-within .logo-default {
     opacity: 0;
 }
 
 .logo-swap:hover .logo-qr,
+.logo-swap.qr-active .logo-qr,
 .app-brand-block:focus-visible .logo-qr,
 .app-brand-block:focus-within .logo-qr {
     opacity: 1;


### PR DESCRIPTION
## Summary
Added touch interaction support to display a QR code when the logo is tapped on mobile devices, with automatic hiding after 3 seconds.

## Key Changes
- **JavaScript**: Implemented `setupLogoTouchQR()` function that:
  - Listens for `touchstart` events on the logo element
  - Toggles the `qr-active` CSS class to show/hide the QR code
  - Auto-hides the QR code after 3 seconds
  - Resets the timer if the logo is touched again while QR is visible
  - Uses `{ passive: false }` to allow `preventDefault()` on touch events

- **CSS**: Updated logo styling to:
  - Reduce gap between logo and text from `1rem` to `0.4rem`
  - Remove the `brightness(0) invert(1)` filter from `.logo-qr` for better QR code visibility
  - Add `.logo-swap.qr-active` selector to show QR code on touch, matching existing hover and focus behavior

## Implementation Details
- The touch handler prevents default behavior to avoid unwanted scrolling or selection
- Timer management ensures only one auto-hide timeout is active at a time
- The QR code display behavior is now consistent across hover, focus, and touch interactions

https://claude.ai/code/session_01UQWEYmou21tNBuwnrZdGfY