### PR TITLE
Introduce epoch snapshots and compiled/quantized execution scaffolding

### DIFF
--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -41,6 +41,7 @@ pub fn register_builtins(dictionary: &mut HashMap<String, Arc<WordDefinition>>) 
                 original_source: None,
                 namespace: None,
                 registration_order: 0,
+                compiled_plan: None,
             }),
         );
     }

--- a/rust/src/interpreter/child-runtime.rs
+++ b/rust/src/interpreter/child-runtime.rs
@@ -51,6 +51,8 @@ impl Interpreter {
             .ok_or_else(|| AjisaiError::from("SPAWN requires a code block"))?
             .clone();
 
+        self.bump_execution_epoch();
+        let spawn_epoch = self.current_epoch_snapshot();
         let id = self.next_child_id;
         self.next_child_id += 1;
         self.child_runtimes.insert(
@@ -62,6 +64,7 @@ impl Interpreter {
                 exit_reason: None,
                 result_snapshot: None,
                 monitored: false,
+                spawn_epoch,
             },
         );
         self.stack.push(Value::from_process_handle(id));
@@ -207,7 +210,9 @@ impl Interpreter {
 
         let mut attempt = 0usize;
         loop {
-            let id = self.next_child_id;
+            self.bump_execution_epoch();
+        let spawn_epoch = self.current_epoch_snapshot();
+        let id = self.next_child_id;
             self.next_child_id += 1;
             let mut child = ChildRuntime {
                 code_block: code_block.clone(),
@@ -216,6 +221,7 @@ impl Interpreter {
                 exit_reason: None,
                 result_snapshot: None,
                 monitored: false,
+                spawn_epoch,
             };
             self.run_child_to_completion(&mut child);
             let ok = matches!(child.state, ChildState::Completed);
@@ -236,6 +242,7 @@ impl Interpreter {
                 self.semantic_registry.push_hint(DisplayHint::Auto);
                 return Ok(());
             }
+            self.bump_execution_epoch();
             attempt += 1;
         }
     }

--- a/rust/src/interpreter/compiled-plan-tests.rs
+++ b/rust/src/interpreter/compiled-plan-tests.rs
@@ -1,0 +1,23 @@
+use crate::interpreter::{compile_word_definition, is_plan_valid, Interpreter};
+use crate::types::{ExecutionLine, Token, WordDefinition};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+#[test]
+fn compiled_plan_invalidates_on_dictionary_epoch_change() {
+    let mut interp = Interpreter::new();
+    let wd = WordDefinition {
+        lines: Arc::new([ExecutionLine { body_tokens: Arc::new([Token::Number("1".into())]) }]),
+        is_builtin: false,
+        description: None,
+        dependencies: HashSet::new(),
+        original_source: None,
+        namespace: None,
+        registration_order: 0,
+        compiled_plan: None,
+    };
+    let plan = compile_word_definition(&wd, &interp);
+    assert!(is_plan_valid(&plan, &interp));
+    interp.bump_dictionary_epoch();
+    assert!(!is_plan_valid(&plan, &interp));
+}

--- a/rust/src/interpreter/compiled-plan.rs
+++ b/rust/src/interpreter/compiled-plan.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use crate::builtins::lookup_builtin_spec;
+use crate::error::Result;
+use crate::types::{Token, Value, WordDefinition};
+
+use super::{ConsumptionMode, EpochSnapshot, Interpreter, OperationTargetMode};
+
+#[derive(Debug, Clone)]
+pub struct CompiledPlan {
+    pub lines: Vec<CompiledLine>,
+    pub compiled_at: EpochSnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompiledLine {
+    pub ops: Vec<CompiledOp>,
+    pub source_tokens: Vec<Token>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CompiledOp {
+    PushLiteral(Value),
+    PushCodeBlock(Vec<Token>),
+    SetTargetModeStackTop,
+    SetTargetModeStack,
+    SetConsumptionConsume,
+    SetConsumptionKeep,
+    CallBuiltin(String),
+    CallUserWord(String),
+    CallQualifiedWord { namespace: String, word: String },
+    BeginGuardedBlock,
+    LineBreak,
+    // Fallback token for unresolved/dynamic tokens that must preserve legacy execution path.
+    FallbackToken(Token),
+}
+
+pub fn is_plan_valid(plan: &CompiledPlan, interp: &Interpreter) -> bool {
+    plan.compiled_at.dictionary_epoch == interp.dictionary_epoch
+        && plan.compiled_at.module_epoch == interp.module_epoch
+}
+
+pub fn compile_word_definition(word_def: &WordDefinition, interp: &Interpreter) -> CompiledPlan {
+    let mut lines = Vec::with_capacity(word_def.lines.len());
+    for line in word_def.lines.iter() {
+        let mut ops = Vec::with_capacity(line.body_tokens.len());
+        for token in line.body_tokens.iter() {
+            let op = match token {
+                Token::Number(n) => match crate::types::fraction::Fraction::from_str(n) {
+                    Ok(frac) => CompiledOp::PushLiteral(Value::from_number(frac)),
+                    Err(_) => CompiledOp::FallbackToken(token.clone()),
+                },
+                Token::String(s) => CompiledOp::PushLiteral(Value::from_string(s)),
+                Token::BlockStart | Token::BlockEnd | Token::VectorStart | Token::VectorEnd => {
+                    // structural tokens require parser context
+                    CompiledOp::FallbackToken(token.clone())
+                }
+                Token::Pipeline | Token::NilCoalesce | Token::CondClauseSep | Token::SafeMode => {
+                    CompiledOp::FallbackToken(token.clone())
+                }
+                Token::LineBreak => CompiledOp::LineBreak,
+                Token::Symbol(s) => match s.as_ref() {
+                    "." => CompiledOp::SetTargetModeStackTop,
+                    ".." => CompiledOp::SetTargetModeStack,
+                    "," => CompiledOp::SetConsumptionConsume,
+                    ",," => CompiledOp::SetConsumptionKeep,
+                    _ => {
+                        let upper = Interpreter::normalize_symbol(s);
+                        if lookup_builtin_spec(upper.as_ref()).is_some() {
+                            CompiledOp::CallBuiltin(upper.into_owned())
+                        } else if let Some((resolved, _)) = interp.resolve_word_entry(upper.as_ref()) {
+                            if let Some((ns, word)) = resolved.split_once('@') {
+                                CompiledOp::CallQualifiedWord {
+                                    namespace: ns.to_string(),
+                                    word: word.to_string(),
+                                }
+                            } else {
+                                CompiledOp::CallUserWord(resolved)
+                            }
+                        } else {
+                            CompiledOp::FallbackToken(token.clone())
+                        }
+                    }
+                },
+            };
+            ops.push(op);
+        }
+        lines.push(CompiledLine { ops, source_tokens: line.body_tokens.to_vec() });
+    }
+
+    CompiledPlan {
+        lines,
+        compiled_at: interp.current_epoch_snapshot(),
+    }
+}
+
+pub fn execute_compiled_plan(interp: &mut Interpreter, plan: &CompiledPlan) -> Result<()> {
+    for line in &plan.lines {
+        execute_compiled_line(interp, line)?;
+    }
+    Ok(())
+}
+
+fn execute_compiled_line(interp: &mut Interpreter, line: &CompiledLine) -> Result<()> {
+    if line.ops.iter().any(|op| matches!(op, CompiledOp::FallbackToken(_))) {
+        interp.execute_section_core(&line.source_tokens, 0)?;
+        return Ok(());
+    }
+    for op in &line.ops {
+        match op {
+            CompiledOp::PushLiteral(v) => {
+                interp.stack.push(v.clone());
+                interp.semantic_registry.normalize_to_stack_len(interp.stack.len());
+            }
+            CompiledOp::PushCodeBlock(tokens) => interp.stack.push(Value::from_code_block(tokens.clone())),
+            CompiledOp::SetTargetModeStackTop => {
+                interp.update_operation_target_mode(OperationTargetMode::StackTop)
+            }
+            CompiledOp::SetTargetModeStack => {
+                interp.update_operation_target_mode(OperationTargetMode::Stack)
+            }
+            CompiledOp::SetConsumptionConsume => interp.update_consumption_mode(ConsumptionMode::Consume),
+            CompiledOp::SetConsumptionKeep => interp.update_consumption_mode(ConsumptionMode::Keep),
+            CompiledOp::CallBuiltin(name) => interp.execute_builtin(name)?,
+            CompiledOp::CallUserWord(name) => interp.execute_word_core(name)?,
+            CompiledOp::CallQualifiedWord { namespace, word } => {
+                interp.execute_word_core(&format!("{}@{}", namespace, word))?
+            }
+            CompiledOp::BeginGuardedBlock | CompiledOp::LineBreak => {}
+            CompiledOp::FallbackToken(_) => {}
+        }
+    }
+    Ok(())
+}
+
+pub fn plan_is_all_fallback(plan: &CompiledPlan) -> bool {
+    plan.lines
+        .iter()
+        .all(|l| l.ops.iter().all(|op| matches!(op, CompiledOp::FallbackToken(_) | CompiledOp::LineBreak)))
+}
+
+pub fn arc_plan(plan: CompiledPlan) -> Arc<CompiledPlan> {
+    Arc::new(plan)
+}

--- a/rust/src/interpreter/epoch.rs
+++ b/rust/src/interpreter/epoch.rs
@@ -1,0 +1,7 @@
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EpochSnapshot {
+    pub global_epoch: u64,
+    pub dictionary_epoch: u64,
+    pub module_epoch: u64,
+    pub execution_epoch: u64,
+}

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -3,6 +3,8 @@ use crate::error::{AjisaiError, Result};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, FlowToken, Token, Value};
 
+use super::compiled_plan::{arc_plan, compile_word_definition, execute_compiled_plan, is_plan_valid, plan_is_all_fallback};
+
 use super::{
     arithmetic, cast, comparison, control, control_cond, datetime, execute_def, execute_del,
     execute_lookup, hash, higher_order, higher_order_fold, io, logic, modules, random, sort,
@@ -36,8 +38,29 @@ impl Interpreter {
             return self.execute_builtin(&resolved_name);
         }
 
+        let mut plan_to_run = None;
+        if let Some(existing) = def.compiled_plan.as_ref() {
+            if is_plan_valid(existing, self) {
+                plan_to_run = Some(existing.clone());
+            }
+        }
+
+        if plan_to_run.is_none() {
+            let plan = compile_word_definition(&def, self);
+            if !plan_is_all_fallback(&plan) {
+                self.bump_execution_epoch();
+                let plan_arc = arc_plan(plan);
+                self.store_compiled_plan_for_word(&resolved_name, plan_arc.clone());
+                plan_to_run = Some(plan_arc);
+            }
+        }
+
         self.call_stack.push(resolved_name.clone());
-        let result = self.execute_guard_structure(&def.lines);
+        let result = if let Some(plan) = plan_to_run {
+            execute_compiled_plan(self, &plan)
+        } else {
+            self.execute_guard_structure(&def.lines)
+        };
         self.call_stack.pop();
         result
     }
@@ -173,6 +196,27 @@ impl Interpreter {
             BuiltinExecutorKey::Kill => self.op_kill(),
             BuiltinExecutorKey::Monitor => self.op_monitor(),
             BuiltinExecutorKey::Supervise => self.op_supervise(),
+        }
+    }
+
+    fn store_compiled_plan_for_word(&mut self, resolved_name: &str, plan: std::sync::Arc<super::compiled_plan::CompiledPlan>) {
+        if let Some((ns, word)) = resolved_name.split_once('@') {
+            if let Some(dict) = self.user_dictionaries.get_mut(ns) {
+                if let Some(old_def) = dict.words.get(word).cloned() {
+                    let mut updated = (*old_def).clone();
+                    updated.compiled_plan = Some(plan.clone());
+                    dict.words.insert(word.to_string(), std::sync::Arc::new(updated));
+                    self.sync_user_words_cache();
+                    return;
+                }
+            }
+            if let Some(module) = self.module_vocabulary.get_mut(ns) {
+                if let Some(old_def) = module.sample_words.get(word).cloned() {
+                    let mut updated = (*old_def).clone();
+                    updated.compiled_plan = Some(plan);
+                    module.sample_words.insert(word.to_string(), std::sync::Arc::new(updated));
+                }
+            }
         }
     }
 

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -240,6 +240,7 @@ pub(crate) fn op_def_inner(
         original_source: None,
         namespace: Some(dict_name.clone()),
         registration_order: interp.next_registration_order(),
+        compiled_plan: None,
     };
 
     let dict_order = interp
@@ -278,6 +279,7 @@ pub(crate) fn op_def_inner(
             all_paths.join(" and ")
         ));
     }
+    interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())
 }

--- a/rust/src/interpreter/execute-del.rs
+++ b/rust/src/interpreter/execute-del.rs
@@ -40,6 +40,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             interp
                 .output_buffer
                 .push_str(&format!("Deleted dictionary: {}\n", word_name));
+            interp.bump_dictionary_epoch();
             interp.force_flag = false;
             return Ok(());
         }
@@ -52,6 +53,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             interp
                 .output_buffer
                 .push_str(&format!("Deleted dictionary: {}\n", word_name));
+            interp.bump_dictionary_epoch();
             interp.force_flag = false;
             return Ok(());
         }
@@ -118,6 +120,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         .output_buffer
         .push_str(&format!("Deleted word: {}\n", fq_name));
 
+    interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())
 }

--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -9,7 +9,7 @@ use super::higher_order::{extract_executable_code, execute_executable_code, Exec
 pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -172,7 +172,7 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
 
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -367,7 +367,7 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
 pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -3,15 +3,20 @@ use crate::interpreter::value_extraction_helpers::{
     extract_integer_from_value, extract_word_name_from_value, is_vector_value,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::interpreter::quantized_block::{quantize_code_block, QuantizedBlock};
 use crate::types::{DisplayHint, Token, Value, ValueData};
 
 pub(crate) enum ExecutableCode {
     WordName(String),
     CodeBlock(Vec<Token>),
+    QuantizedBlock(std::sync::Arc<QuantizedBlock>),
 }
 
-pub(crate) fn extract_executable_code(val: &Value) -> Result<ExecutableCode> {
+pub(crate) fn extract_executable_code(interp: &Interpreter, val: &Value) -> Result<ExecutableCode> {
     if let Some(tokens) = val.as_code_block() {
+        if let Some(qb) = quantize_code_block(tokens, interp) {
+            return Ok(ExecutableCode::QuantizedBlock(std::sync::Arc::new(qb)));
+        }
         return Ok(ExecutableCode::CodeBlock(tokens.clone()));
     }
 
@@ -55,17 +60,32 @@ fn extract_predicate_boolean(condition_result: Value) -> Result<bool> {
 pub(crate) fn execute_executable_code(interp: &mut Interpreter, exec: &ExecutableCode) -> Result<()> {
     match exec {
         ExecutableCode::CodeBlock(tokens) => {
+            interp.bump_execution_epoch();
             interp.execute_section_core(tokens, 0)?;
             Ok(())
         }
         ExecutableCode::WordName(word_name) => interp.execute_word_core(word_name),
+        ExecutableCode::QuantizedBlock(qb) => execute_quantized_block_stack_top(interp, qb),
     }
+}
+
+fn execute_quantized_block_stack_top(interp: &mut Interpreter, qb: &QuantizedBlock) -> Result<()> {
+    crate::interpreter::compiled_plan::execute_compiled_plan(interp, &qb.compiled_plan)
+}
+
+pub(crate) fn execute_quantized_map_kernel(interp: &mut Interpreter, qb: &QuantizedBlock, elem: Value) -> Result<Value> {
+    let saved = interp.stack.clone();
+    interp.stack.clear();
+    interp.stack.push(elem);
+    let res = execute_quantized_block_stack_top(interp, qb).and_then(|_| interp.stack.pop().ok_or(AjisaiError::from("MAP: expected return value, got empty stack")));
+    interp.stack = saved;
+    res
 }
 
 pub fn op_map(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -124,9 +144,21 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
                 let elem: Value = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(elem);
-                match execute_executable_code(interp, &executable) {
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => match execute_quantized_map_kernel(interp, qb, elem.clone()) {
+                        Ok(result_val) => {
+                            results.push(result_val);
+                            continue;
+                        }
+                        Err(e) => {
+                            error = Some(e);
+                            break;
+                        }
+                    },
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
                     Ok(_) => match interp.stack.pop() {
                         Some(result_val) => {
                             let result_hint: DisplayHint =
@@ -150,6 +182,8 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
                     Err(e) => {
                         error = Some(e);
                         break;
+                    }
+                }
                     }
                 }
             }
@@ -239,7 +273,7 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
 pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -436,7 +470,7 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_any(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -609,7 +643,7 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_all(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -782,7 +816,7 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_count(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -5,6 +5,8 @@ use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use super::epoch::EpochSnapshot;
+
 pub const DEFAULT_MAX_EXECUTION_STEPS: usize = 100_000;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -86,6 +88,7 @@ pub(crate) struct ChildRuntime {
     pub exit_reason: Option<ExitReason>,
     pub result_snapshot: Option<Vec<Value>>,
     pub monitored: bool,
+    pub spawn_epoch: EpochSnapshot,
 }
 
 pub struct Interpreter {
@@ -119,6 +122,12 @@ pub struct Interpreter {
     pub(crate) dictionary_dependencies: HashMap<String, DictionaryDependencyInfo>,
     pub(crate) next_registration_order: u64,
     pub(crate) active_user_dictionary: String,
+
+    pub(crate) global_epoch: u64,
+    pub(crate) epoch_stack: SmallVec<[u64; 8]>,
+    pub(crate) dictionary_epoch: u64,
+    pub(crate) module_epoch: u64,
+    pub(crate) execution_epoch: u64,
 
     pub(crate) semantic_registry: SemanticRegistry,
 
@@ -159,6 +168,11 @@ impl Interpreter {
             dictionary_dependencies: HashMap::new(),
             next_registration_order: 1,
             active_user_dictionary: "DEMO".to_string(),
+            global_epoch: 0,
+            epoch_stack: SmallVec::new(),
+            dictionary_epoch: 0,
+            module_epoch: 0,
+            execution_epoch: 0,
             semantic_registry: SemanticRegistry::new(),
             child_runtimes: HashMap::new(),
             next_child_id: 1,
@@ -169,6 +183,43 @@ impl Interpreter {
         interpreter
     }
 
+
+
+    pub(crate) fn next_epoch(&mut self) -> u64 {
+        self.global_epoch += 1;
+        self.global_epoch
+    }
+
+    pub(crate) fn push_epoch_frame(&mut self) -> u64 {
+        let e = self.next_epoch();
+        self.epoch_stack.push(e);
+        e
+    }
+
+    pub(crate) fn pop_epoch_frame(&mut self) {
+        self.epoch_stack.pop();
+    }
+
+    pub(crate) fn bump_dictionary_epoch(&mut self) {
+        self.dictionary_epoch = self.next_epoch();
+    }
+
+    pub(crate) fn bump_module_epoch(&mut self) {
+        self.module_epoch = self.next_epoch();
+    }
+
+    pub(crate) fn bump_execution_epoch(&mut self) {
+        self.execution_epoch = self.next_epoch();
+    }
+
+    pub fn current_epoch_snapshot(&self) -> EpochSnapshot {
+        EpochSnapshot {
+            global_epoch: self.global_epoch,
+            dictionary_epoch: self.dictionary_epoch,
+            module_epoch: self.module_epoch,
+            execution_epoch: self.execution_epoch,
+        }
+    }
 
     pub fn update_flow_tracking(&mut self, enabled: bool) {
         self.flow_tracking = enabled;

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -2,6 +2,11 @@ pub mod arithmetic;
 pub mod audio;
 pub mod cast;
 pub mod comparison;
+#[path = "compiled-plan.rs"]
+pub mod compiled_plan;
+pub mod epoch;
+#[path = "quantized-block.rs"]
+pub mod quantized_block;
 pub mod control;
 #[path = "child-runtime.rs"]
 pub mod child_runtime;
@@ -96,3 +101,17 @@ pub use interpreter_core::*;
 
 
 pub use crate::types::WordDefinition;
+
+pub use compiled_plan::{compile_word_definition, execute_compiled_plan, is_plan_valid, CompiledLine, CompiledOp, CompiledPlan};
+pub use epoch::EpochSnapshot;
+pub use quantized_block::{is_quantizable_block, quantize_code_block, QuantizedArity, QuantizedBlock, QuantizedPurity};
+
+#[cfg(test)]
+#[path = "compiled-plan-tests.rs"]
+mod compiled_plan_tests;
+#[cfg(test)]
+#[path = "quantized-block-tests.rs"]
+mod quantized_block_tests;
+#[cfg(test)]
+#[path = "perf-regression-tests.rs"]
+mod perf_regression_tests;

--- a/rust/src/interpreter/modules.rs
+++ b/rust/src/interpreter/modules.rs
@@ -261,6 +261,7 @@ fn ensure_module_dictionary(interp: &mut Interpreter, module_name: &str) -> Resu
                 original_source: None,
                 namespace: Some(module.name.to_string()),
                 registration_order: 0,
+                compiled_plan: None,
             }),
         );
     }
@@ -273,6 +274,7 @@ fn ensure_module_dictionary(interp: &mut Interpreter, module_name: &str) -> Resu
             sample_words,
         },
     );
+    interp.bump_module_epoch();
     Ok(())
 }
 
@@ -299,6 +301,7 @@ fn build_sample_words(
                 original_source: None,
                 namespace: Some(module_name.to_string()),
                 registration_order: 0,
+                compiled_plan: None,
             }),
         );
     }
@@ -384,6 +387,7 @@ pub fn op_import(interp: &mut Interpreter) -> Result<()> {
         .to_uppercase();
 
     import_all_public(interp, &module_name)?;
+    interp.bump_module_epoch();
     interp.rebuild_dependencies()?;
     Ok(())
 }
@@ -442,6 +446,7 @@ pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
     }
 
     emit_import_conflict_warnings(interp, &module_name);
+    interp.bump_module_epoch();
     interp.rebuild_dependencies()?;
     Ok(())
 }

--- a/rust/src/interpreter/perf-regression-tests.rs
+++ b/rust/src/interpreter/perf-regression-tests.rs
@@ -1,0 +1,17 @@
+use crate::interpreter::Interpreter;
+
+#[test]
+fn bench_user_word_repeated() {
+    let _ = Interpreter::new();
+}
+
+#[test]
+fn bench_map_increment() { let _ = Interpreter::new(); }
+#[test]
+fn bench_filter_positive() { let _ = Interpreter::new(); }
+#[test]
+fn bench_fold_sum() { let _ = Interpreter::new(); }
+#[test]
+fn bench_redef_invalidation() { let _ = Interpreter::new(); }
+#[test]
+fn bench_child_runtime_restart() { let _ = Interpreter::new(); }

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -1,0 +1,11 @@
+use crate::interpreter::quantized_block::{is_quantizable_block, quantize_code_block};
+use crate::interpreter::Interpreter;
+use crate::types::Token;
+
+#[test]
+fn quantizes_simple_block() {
+    let interp = Interpreter::new();
+    let tokens = vec![Token::Number("1".into()), Token::Symbol("+".into())];
+    assert!(is_quantizable_block(&tokens));
+    assert!(quantize_code_block(&tokens, &interp).is_some());
+}

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use crate::types::Token;
+
+use super::{compile_word_definition, CompiledPlan, EpochSnapshot, Interpreter, WordDefinition};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuantizedArity {
+    Fixed(usize),
+    Variable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuantizedPurity {
+    Pure,
+    SideEffecting,
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+pub struct QuantizedBlock {
+    pub compiled_plan: Arc<CompiledPlan>,
+    pub captured_epoch: EpochSnapshot,
+    pub input_arity: QuantizedArity,
+    pub output_arity: QuantizedArity,
+    pub purity: QuantizedPurity,
+    pub can_fuse: bool,
+    pub can_short_circuit: bool,
+    pub dependency_words: Vec<String>,
+}
+
+pub fn is_quantizable_block(tokens: &[Token]) -> bool {
+    !tokens.is_empty() && !tokens.iter().any(|t| matches!(t, Token::LineBreak | Token::SafeMode))
+}
+
+pub fn quantize_code_block(tokens: &[Token], interp: &Interpreter) -> Option<QuantizedBlock> {
+    if !is_quantizable_block(tokens) {
+        return None;
+    }
+    let lines = vec![crate::types::ExecutionLine {
+        body_tokens: tokens.to_vec().into(),
+    }];
+    let def = WordDefinition {
+        lines: lines.into(),
+        is_builtin: false,
+        description: None,
+        dependencies: Default::default(),
+        original_source: None,
+        namespace: None,
+        registration_order: 0,
+        compiled_plan: None,
+    };
+    let plan = Arc::new(compile_word_definition(&def, interp));
+    Some(QuantizedBlock {
+        compiled_plan: plan,
+        captured_epoch: interp.current_epoch_snapshot(),
+        input_arity: QuantizedArity::Variable,
+        output_arity: QuantizedArity::Variable,
+        purity: QuantizedPurity::Unknown,
+        can_fuse: false,
+        can_short_circuit: false,
+        dependency_words: Vec::new(),
+    })
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -171,6 +171,7 @@ pub struct WordDefinition {
     pub original_source: Option<String>,
     pub namespace: Option<String>,
     pub registration_order: u64,
+    pub compiled_plan: Option<Arc<crate::interpreter::compiled_plan::CompiledPlan>>,
 }
 
 pub type Stack = Vec<Value>;


### PR DESCRIPTION
### Motivation
- Provide a safe, semantics-preserving foundation for caching and lightweight execution units so repeated token interpretation can be avoided and high-order blocks can be reused.
- Track logical changes (dictionary/module/execution) with a compact epoch snapshot so cached plans can be invalidated deterministically.
- Add a scaffolding for later quantized block optimizations while keeping a full fallback to the legacy interpreter for safety.

### Description
- Added `EpochSnapshot` and epoch counters with helper APIs on `Interpreter` (`next_epoch`, `bump_dictionary_epoch`, `bump_module_epoch`, `bump_execution_epoch`, `current_epoch_snapshot`) and recorded `spawn_epoch` on `ChildRuntime` to support future coherence checks (new file: `rust/src/interpreter/epoch.rs`; changes in `interpreter-core.rs`, `child-runtime.rs`).
- Introduced `CompiledPlan`/`CompiledLine`/`CompiledOp` types, a `compile_word_definition()` compiler and `execute_compiled_plan()` executor with per-line fallback to legacy token execution to preserve semantics (new file: `rust/src/interpreter/compiled-plan.rs`), and wired plan caching into `execute_word_core` to prefer valid compiled plans.
- Extended `WordDefinition` with an optional `compiled_plan` cache and initialized it where definitions are created or registered (changes in `rust/src/types/mod.rs`, `execute-def.rs`, module/sample/builtins initialization).
- Added `QuantizedBlock` types and simple `quantize_code_block()` / `is_quantizable_block()` APIs plus integration into high-order paths so `extract_executable_code()` will attempt quantization and `MAP` can call a quick quantized kernel when available (new file: `rust/src/interpreter/quantized-block.rs`; changes in `higher-order-operations.rs`).
- Hooked epoch bumps to events that should invalidate caches: `DEF`, `DEL`, module/import changes, child spawn/supervise and first-time plan/block generation (changes across `execute-def.rs`, `execute-del.rs`, `modules.rs`, `child-runtime.rs`, `execute-builtin.rs`).
- Added test scaffolding and unit tests for the new pieces: `compiled-plan-tests.rs`, `quantized-block-tests.rs`, and placeholder perf regression test stubs in `perf-regression-tests.rs`, and registered modules in `interpreter/mod.rs`.

### Testing
- Ran `cargo test -q` in the repository; the full test suite passed (interpreter unit tests and added tests executed successfully).
- Executed the new unit tests for `CompiledPlan` and `QuantizedBlock` (`compiled-plan-tests.rs` and `quantized-block-tests.rs`) as part of the test run and they passed.
- No regressions were observed in existing interpreter test suites after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd24edeb88326a38b1d3f8fe9eb7b)