### PR TITLE
Add compiled-plan & quantized-block execution, epoch invalidation, and runtime metrics

### DIFF
--- a/CLAUDECODE_HANDOVER.md
+++ b/CLAUDECODE_HANDOVER.md
@@ -1,0 +1,143 @@
+# Ajisai 半コンパイル実行系化 — ClaudeCode 引き継ぎ書
+
+最終更新: 2026-04-13
+
+---
+
+## 1. 目的と現状
+
+本ブランチでは、Ajisai 実行系の段階的改修（Epoch → CompiledPlan → QuantizedBlock → 高階関数最適化 → 計測）を進めています。
+
+現状は以下です。
+
+- **第1段階（Temporal Epoch Stack）**: ほぼ導入済み
+- **第2段階（CompiledPlan キャッシュ）**: 基本導入済み
+- **第3段階（QuantizedBlock）**: 骨組み実装のみ
+- **第4段階（高階関数最適化）**: MAP中心の部分対応
+- **第5段階（計測・安全化）**: メトリクス・trace flagは追加済み、ベンチはまだ簡易テスト相当
+
+---
+
+## 2. 主要変更済みポイント
+
+### Epoch / 無効化基盤
+- `EpochSnapshot` 追加: `rust/src/interpreter/epoch.rs`
+- `Interpreter` に epoch群追加: `global_epoch`, `dictionary_epoch`, `module_epoch`, `execution_epoch`, `epoch_stack`
+- `DEF` / `DEL` / `IMPORT` 周辺で epoch bump を実施
+- child runtime に `spawn_epoch` を保持
+
+### CompiledPlan
+- `rust/src/interpreter/compiled-plan.rs` 追加
+- `CompiledPlan`, `CompiledLine`, `CompiledOp`、`compile_word_definition`, `execute_compiled_plan`, `is_plan_valid`
+- `WordDefinition.compiled_plan` を追加してキャッシュ保持
+- `execute_word_core` でキャッシュ hit/miss と再コンパイル分岐
+
+### QuantizedBlock（現状は最小限）
+- `rust/src/interpreter/quantized-block.rs` 追加
+- `QuantizedBlock` 型と `quantize_code_block` / `is_quantizable_block`
+- 高階関数側 `ExecutableCode` に `QuantizedBlock` を追加
+- `MAP` 経路で quantized 実行を一部利用
+
+### 計測 / trace
+- `RuntimeMetrics` 追加（plan build/hit/miss, quantized build/use）
+- Cargo features 追加:
+  - `trace-compile`
+  - `trace-epoch`
+  - `trace-quant`
+
+---
+
+## 3. 未完了・要対応（重要）
+
+以下は **仕様書の完了条件に対して未充足** です。
+
+1. **QuantizedBlock の静的解析不足**
+   - `input_arity` / `output_arity` がほぼ `Variable`
+   - `purity` が `Unknown` 中心
+   - `dependency_words` 未活用
+
+2. **高階関数の最適化不足**
+   - MAP 以外（`FILTER`, `ANY`, `ALL`, `COUNT`, `FOLD`, `SCAN`）の専用 kernel が未整備
+   - エラー時のスタック復元ポリシーを quantized 経路で統一検証できていない
+
+3. **perf-regression-tests が“ベンチ”として弱い**
+   - 現在は `#[test]` ベースのスモーク寄り
+   - 所要時間・利用率などの計測レポート未整備
+
+4. **CompiledPlan の最適化粒度**
+   - fallback token を含む行は行全体を従来実行へ戻す保守的設計
+   - 効果は安全だが性能上の伸び代あり
+
+---
+
+## 4. ClaudeCode で優先して進める実装順
+
+### 優先A（第4段階の実質完了）
+1. `FILTER` / `ANY` / `ALL` / `COUNT` に quantized predicate kernel を導入
+2. `FOLD` / `SCAN` に quantized fold kernel を導入
+3. quantized経路と従来経路の一致テスト（結果・エラー動作）を拡充
+
+### 優先B（第3段階の質向上）
+1. `quantize_code_block` で arity 推論（最低でも典型1→1, 2→1）
+2. purity 推論（副作用語検出）
+3. dependency_words の収集
+
+### 優先C（第5段階の完了）
+1. `perf-regression-tests.rs` を bench/計測出力付きに再構成
+2. metrics 出力（feature flag有効時）を統一
+3. 実行時間・hit率・quantized利用率を定量可視化
+
+---
+
+## 5. 既存メトリクス項目（利用可能）
+
+`Interpreter.runtime_metrics()` で取得可能:
+
+- `compiled_plan_build_count`
+- `compiled_plan_cache_hit_count`
+- `compiled_plan_cache_miss_count`
+- `quantized_block_build_count`
+- `quantized_block_use_count`
+
+---
+
+## 6. 推奨確認コマンド
+
+```bash
+cd rust
+cargo test -q
+cargo test -q compiled_plan_tests
+cargo test -q quantized_block_tests
+cargo test -q perf_regression_tests
+```
+
+trace確認例:
+
+```bash
+cd rust
+cargo test -q --features trace-compile
+cargo test -q --features trace-epoch
+cargo test -q --features trace-quant
+```
+
+---
+
+## 7. 注意点
+
+- 意味論保全が最優先（未対応は必ず fallback）
+- import/再定義/削除後の plan 無効化を壊さない
+- semantic_registry 整合を崩さない
+- child runtime の `spawn_epoch` は将来拡張の前提情報なので削除しない
+
+---
+
+## 8. 受け渡しメモ
+
+このブランチは「基盤を先に固めた状態」です。最終完了には、
+
+- quantized 経路の網羅化
+- 推論精度（arity/purity/dependencies）の強化
+- 計測の本格化
+
+が必要です。
+

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,11 @@ smallvec = "1"
 version = "0.3"
 features = ["console", "Window", "CustomEvent", "EventTarget", "Event"]
 
+[features]
+trace-compile = []
+trace-epoch = []
+trace-quant = []
+
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -41,6 +41,7 @@ pub fn register_builtins(dictionary: &mut HashMap<String, Arc<WordDefinition>>) 
                 original_source: None,
                 namespace: None,
                 registration_order: 0,
+                compiled_plan: None,
             }),
         );
     }

--- a/rust/src/interpreter/child-runtime.rs
+++ b/rust/src/interpreter/child-runtime.rs
@@ -51,6 +51,8 @@ impl Interpreter {
             .ok_or_else(|| AjisaiError::from("SPAWN requires a code block"))?
             .clone();
 
+        self.bump_execution_epoch();
+        let spawn_epoch = self.current_epoch_snapshot();
         let id = self.next_child_id;
         self.next_child_id += 1;
         self.child_runtimes.insert(
@@ -62,6 +64,7 @@ impl Interpreter {
                 exit_reason: None,
                 result_snapshot: None,
                 monitored: false,
+                spawn_epoch,
             },
         );
         self.stack.push(Value::from_process_handle(id));
@@ -207,7 +210,9 @@ impl Interpreter {
 
         let mut attempt = 0usize;
         loop {
-            let id = self.next_child_id;
+            self.bump_execution_epoch();
+        let spawn_epoch = self.current_epoch_snapshot();
+        let id = self.next_child_id;
             self.next_child_id += 1;
             let mut child = ChildRuntime {
                 code_block: code_block.clone(),
@@ -216,6 +221,7 @@ impl Interpreter {
                 exit_reason: None,
                 result_snapshot: None,
                 monitored: false,
+                spawn_epoch,
             };
             self.run_child_to_completion(&mut child);
             let ok = matches!(child.state, ChildState::Completed);
@@ -236,6 +242,7 @@ impl Interpreter {
                 self.semantic_registry.push_hint(DisplayHint::Auto);
                 return Ok(());
             }
+            self.bump_execution_epoch();
             attempt += 1;
         }
     }

--- a/rust/src/interpreter/compiled-plan-tests.rs
+++ b/rust/src/interpreter/compiled-plan-tests.rs
@@ -1,0 +1,52 @@
+use crate::interpreter::{compile_word_definition, is_plan_valid, CompiledOp, Interpreter};
+use crate::types::{ExecutionLine, Token, WordDefinition};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+fn test_word(tokens: Vec<Token>) -> WordDefinition {
+    WordDefinition {
+        lines: Arc::new([ExecutionLine {
+            body_tokens: Arc::from(tokens),
+        }]),
+        is_builtin: false,
+        description: None,
+        dependencies: HashSet::new(),
+        original_source: None,
+        namespace: None,
+        registration_order: 0,
+        compiled_plan: None,
+    }
+}
+
+#[test]
+fn compiled_plan_invalidates_on_dictionary_epoch_change() {
+    let mut interp = Interpreter::new();
+    let wd = test_word(vec![Token::Number("1".into())]);
+    let plan = compile_word_definition(&wd, &interp);
+    assert!(is_plan_valid(&plan, &interp));
+    interp.bump_dictionary_epoch();
+    assert!(!is_plan_valid(&plan, &interp));
+}
+
+#[test]
+fn compiled_plan_invalidates_on_module_epoch_change() {
+    let mut interp = Interpreter::new();
+    let wd = test_word(vec![Token::Number("1".into())]);
+    let plan = compile_word_definition(&wd, &interp);
+    assert!(is_plan_valid(&plan, &interp));
+    interp.bump_module_epoch();
+    assert!(!is_plan_valid(&plan, &interp));
+}
+
+#[test]
+fn compile_collects_code_block_literal() {
+    let interp = Interpreter::new();
+    let wd = test_word(vec![
+        Token::BlockStart,
+        Token::Number("1".into()),
+        Token::Symbol("+".into()),
+        Token::BlockEnd,
+    ]);
+    let plan = compile_word_definition(&wd, &interp);
+    assert!(matches!(plan.lines[0].ops[0], CompiledOp::PushCodeBlock(_)));
+}

--- a/rust/src/interpreter/compiled-plan.rs
+++ b/rust/src/interpreter/compiled-plan.rs
@@ -1,0 +1,223 @@
+use std::sync::Arc;
+
+use crate::builtins::lookup_builtin_spec;
+use crate::error::Result;
+use crate::types::{Token, Value, WordDefinition};
+
+use super::{modules, ConsumptionMode, EpochSnapshot, Interpreter, OperationTargetMode};
+
+#[derive(Debug, Clone)]
+pub struct CompiledPlan {
+    pub lines: Vec<CompiledLine>,
+    pub compiled_at: EpochSnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompiledLine {
+    pub ops: Vec<CompiledOp>,
+    pub source_tokens: Vec<Token>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CompiledOp {
+    PushLiteral(Value),
+    PushCodeBlock(Vec<Token>),
+    SetTargetModeStackTop,
+    SetTargetModeStack,
+    SetConsumptionConsume,
+    SetConsumptionKeep,
+    CallBuiltin(String),
+    CallUserWord(String),
+    CallQualifiedWord { namespace: String, word: String },
+    BeginGuardedBlock,
+    LineBreak,
+    // FallbackToken is used for tokens that must preserve legacy runtime behavior:
+    // - runtime-sensitive directives / control markers (Pipeline, NilCoalesce, CondClauseSep, SafeMode)
+    // - unresolved symbols at compile time
+    // - structural tokens we cannot lower safely in current pass (e.g. vectors)
+    // - tokens that could alter semantic hint behavior in dynamic ways
+    FallbackToken(Token),
+}
+
+pub fn is_plan_valid(plan: &CompiledPlan, interp: &Interpreter) -> bool {
+    plan.compiled_at.dictionary_epoch == interp.dictionary_epoch
+        && plan.compiled_at.module_epoch == interp.module_epoch
+}
+
+fn compile_symbol(token: &Token, symbol: &str, interp: &Interpreter) -> CompiledOp {
+    match symbol {
+        "." => CompiledOp::SetTargetModeStackTop,
+        ".." => CompiledOp::SetTargetModeStack,
+        "," => CompiledOp::SetConsumptionConsume,
+        ",," => CompiledOp::SetConsumptionKeep,
+        "TRUE" => CompiledOp::PushLiteral(Value::from_bool(true)),
+        "FALSE" => CompiledOp::PushLiteral(Value::from_bool(false)),
+        "NIL" => CompiledOp::PushLiteral(Value::nil()),
+        _ => {
+            if lookup_builtin_spec(symbol).is_some() {
+                CompiledOp::CallBuiltin(symbol.to_string())
+            } else if let Some((resolved, _)) = interp.resolve_word_entry(symbol) {
+                if let Some((namespace, word)) = resolved.split_once('@') {
+                    CompiledOp::CallQualifiedWord {
+                        namespace: namespace.to_string(),
+                        word: word.to_string(),
+                    }
+                } else {
+                    CompiledOp::CallUserWord(resolved)
+                }
+            } else {
+                CompiledOp::FallbackToken(token.clone())
+            }
+        }
+    }
+}
+
+fn collect_code_block(tokens: &[Token], start: usize) -> Option<(Vec<Token>, usize)> {
+    let mut depth = 1_i32;
+    let mut i = start + 1;
+    let mut block_tokens = Vec::new();
+
+    while i < tokens.len() {
+        match &tokens[i] {
+            Token::BlockStart => {
+                depth += 1;
+                block_tokens.push(tokens[i].clone());
+            }
+            Token::BlockEnd => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((block_tokens, i + 1));
+                }
+                block_tokens.push(tokens[i].clone());
+            }
+            t => block_tokens.push(t.clone()),
+        }
+        i += 1;
+    }
+
+    None
+}
+
+pub fn compile_word_definition(word_def: &WordDefinition, interp: &Interpreter) -> CompiledPlan {
+    let mut lines = Vec::with_capacity(word_def.lines.len());
+
+    for line in word_def.lines.iter() {
+        let tokens = line.body_tokens.to_vec();
+        let mut ops = Vec::with_capacity(tokens.len());
+        let mut i = 0_usize;
+
+        while i < tokens.len() {
+            let token = &tokens[i];
+            let op = match token {
+                Token::Number(n) => match crate::types::fraction::Fraction::from_str(n) {
+                    Ok(frac) => CompiledOp::PushLiteral(Value::from_number(frac)),
+                    Err(_) => CompiledOp::FallbackToken(token.clone()),
+                },
+                Token::String(s) => CompiledOp::PushLiteral(Value::from_string(s)),
+                Token::BlockStart => {
+                    if let Some((block, next_i)) = collect_code_block(&tokens, i) {
+                        i = next_i - 1;
+                        CompiledOp::PushCodeBlock(block)
+                    } else {
+                        CompiledOp::FallbackToken(token.clone())
+                    }
+                }
+                Token::BlockEnd => CompiledOp::FallbackToken(token.clone()),
+                Token::VectorStart | Token::VectorEnd => CompiledOp::FallbackToken(token.clone()),
+                Token::Pipeline | Token::NilCoalesce | Token::CondClauseSep | Token::SafeMode => {
+                    CompiledOp::FallbackToken(token.clone())
+                }
+                Token::LineBreak => CompiledOp::LineBreak,
+                Token::Symbol(s) => {
+                    let upper = Interpreter::normalize_symbol(s);
+                    compile_symbol(token, upper.as_ref(), interp)
+                }
+            };
+            ops.push(op);
+            i += 1;
+        }
+
+        lines.push(CompiledLine {
+            ops,
+            source_tokens: tokens,
+        });
+    }
+
+    CompiledPlan {
+        lines,
+        compiled_at: interp.current_epoch_snapshot(),
+    }
+}
+
+fn post_call_cleanup(interp: &mut Interpreter, name: &str) {
+    interp.semantic_registry.normalize_to_stack_len(interp.stack.len());
+    if !modules::is_mode_preserving_word(name) {
+        interp.reset_execution_modes();
+    }
+}
+
+pub fn execute_compiled_plan(interp: &mut Interpreter, plan: &CompiledPlan) -> Result<()> {
+    for line in &plan.lines {
+        execute_compiled_line(interp, line)?;
+    }
+    Ok(())
+}
+
+fn execute_compiled_line(interp: &mut Interpreter, line: &CompiledLine) -> Result<()> {
+    if line
+        .ops
+        .iter()
+        .any(|op| matches!(op, CompiledOp::FallbackToken(_)))
+    {
+        interp.execute_section_core(&line.source_tokens, 0)?;
+        return Ok(());
+    }
+
+    for op in &line.ops {
+        match op {
+            CompiledOp::PushLiteral(v) => {
+                interp.stack.push(v.clone());
+                interp.semantic_registry.normalize_to_stack_len(interp.stack.len());
+            }
+            CompiledOp::PushCodeBlock(tokens) => {
+                interp.stack.push(Value::from_code_block(tokens.clone()));
+                interp.semantic_registry.normalize_to_stack_len(interp.stack.len());
+            }
+            CompiledOp::SetTargetModeStackTop => {
+                interp.update_operation_target_mode(OperationTargetMode::StackTop)
+            }
+            CompiledOp::SetTargetModeStack => {
+                interp.update_operation_target_mode(OperationTargetMode::Stack)
+            }
+            CompiledOp::SetConsumptionConsume => interp.update_consumption_mode(ConsumptionMode::Consume),
+            CompiledOp::SetConsumptionKeep => interp.update_consumption_mode(ConsumptionMode::Keep),
+            CompiledOp::CallBuiltin(name) => {
+                interp.execute_builtin(name)?;
+                post_call_cleanup(interp, name);
+            }
+            CompiledOp::CallUserWord(name) => {
+                interp.execute_word_core(name)?;
+                post_call_cleanup(interp, name);
+            }
+            CompiledOp::CallQualifiedWord { namespace, word } => {
+                let full_name = format!("{}@{}", namespace, word);
+                interp.execute_word_core(&full_name)?;
+                post_call_cleanup(interp, &full_name);
+            }
+            CompiledOp::BeginGuardedBlock | CompiledOp::LineBreak | CompiledOp::FallbackToken(_) => {}
+        }
+    }
+    Ok(())
+}
+
+pub fn plan_is_all_fallback(plan: &CompiledPlan) -> bool {
+    plan.lines.iter().all(|l| {
+        l.ops
+            .iter()
+            .all(|op| matches!(op, CompiledOp::FallbackToken(_) | CompiledOp::LineBreak))
+    })
+}
+
+pub fn arc_plan(plan: CompiledPlan) -> Arc<CompiledPlan> {
+    Arc::new(plan)
+}

--- a/rust/src/interpreter/epoch.rs
+++ b/rust/src/interpreter/epoch.rs
@@ -1,0 +1,7 @@
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EpochSnapshot {
+    pub global_epoch: u64,
+    pub dictionary_epoch: u64,
+    pub module_epoch: u64,
+    pub execution_epoch: u64,
+}

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -3,6 +3,8 @@ use crate::error::{AjisaiError, Result};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, FlowToken, Token, Value};
 
+use super::compiled_plan::{arc_plan, compile_word_definition, execute_compiled_plan, is_plan_valid, plan_is_all_fallback};
+
 use super::{
     arithmetic, cast, comparison, control, control_cond, datetime, execute_def, execute_del,
     execute_lookup, hash, higher_order, higher_order_fold, io, logic, modules, random, sort,
@@ -36,8 +38,39 @@ impl Interpreter {
             return self.execute_builtin(&resolved_name);
         }
 
+        let mut plan_to_run = None;
+        if let Some(existing) = def.compiled_plan.as_ref() {
+            if is_plan_valid(existing, self) {
+                self.runtime_metrics.compiled_plan_cache_hit_count += 1;
+                #[cfg(feature = "trace-compile")]
+                eprintln!("[trace-compile] cache hit for {}", resolved_name);
+                plan_to_run = Some(existing.clone());
+            } else {
+                self.runtime_metrics.compiled_plan_cache_miss_count += 1;
+            }
+        } else {
+            self.runtime_metrics.compiled_plan_cache_miss_count += 1;
+        }
+
+        if plan_to_run.is_none() {
+            let plan = compile_word_definition(&def, self);
+            if !plan_is_all_fallback(&plan) {
+                self.bump_execution_epoch();
+                self.runtime_metrics.compiled_plan_build_count += 1;
+                #[cfg(feature = "trace-compile")]
+                eprintln!("[trace-compile] compiled plan for {}", resolved_name);
+                let plan_arc = arc_plan(plan);
+                self.store_compiled_plan_for_word(&resolved_name, plan_arc.clone());
+                plan_to_run = Some(plan_arc);
+            }
+        }
+
         self.call_stack.push(resolved_name.clone());
-        let result = self.execute_guard_structure(&def.lines);
+        let result = if let Some(plan) = plan_to_run {
+            execute_compiled_plan(self, &plan)
+        } else {
+            self.execute_guard_structure(&def.lines)
+        };
         self.call_stack.pop();
         result
     }
@@ -173,6 +206,27 @@ impl Interpreter {
             BuiltinExecutorKey::Kill => self.op_kill(),
             BuiltinExecutorKey::Monitor => self.op_monitor(),
             BuiltinExecutorKey::Supervise => self.op_supervise(),
+        }
+    }
+
+    fn store_compiled_plan_for_word(&mut self, resolved_name: &str, plan: std::sync::Arc<super::compiled_plan::CompiledPlan>) {
+        if let Some((ns, word)) = resolved_name.split_once('@') {
+            if let Some(dict) = self.user_dictionaries.get_mut(ns) {
+                if let Some(old_def) = dict.words.get(word).cloned() {
+                    let mut updated = (*old_def).clone();
+                    updated.compiled_plan = Some(plan.clone());
+                    dict.words.insert(word.to_string(), std::sync::Arc::new(updated));
+                    self.sync_user_words_cache();
+                    return;
+                }
+            }
+            if let Some(module) = self.module_vocabulary.get_mut(ns) {
+                if let Some(old_def) = module.sample_words.get(word).cloned() {
+                    let mut updated = (*old_def).clone();
+                    updated.compiled_plan = Some(plan);
+                    module.sample_words.insert(word.to_string(), std::sync::Arc::new(updated));
+                }
+            }
         }
     }
 

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -240,6 +240,7 @@ pub(crate) fn op_def_inner(
         original_source: None,
         namespace: Some(dict_name.clone()),
         registration_order: interp.next_registration_order(),
+        compiled_plan: None,
     };
 
     let dict_order = interp
@@ -278,6 +279,7 @@ pub(crate) fn op_def_inner(
             all_paths.join(" and ")
         ));
     }
+    interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())
 }

--- a/rust/src/interpreter/execute-del.rs
+++ b/rust/src/interpreter/execute-del.rs
@@ -40,6 +40,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             interp
                 .output_buffer
                 .push_str(&format!("Deleted dictionary: {}\n", word_name));
+            interp.bump_dictionary_epoch();
             interp.force_flag = false;
             return Ok(());
         }
@@ -52,6 +53,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             interp
                 .output_buffer
                 .push_str(&format!("Deleted dictionary: {}\n", word_name));
+            interp.bump_dictionary_epoch();
             interp.force_flag = false;
             return Ok(());
         }
@@ -118,6 +120,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         .output_buffer
         .push_str(&format!("Deleted word: {}\n", fq_name));
 
+    interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())
 }

--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -9,7 +9,7 @@ use super::higher_order::{extract_executable_code, execute_executable_code, Exec
 pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -172,7 +172,7 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
 
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -367,7 +367,7 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
 pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -3,15 +3,20 @@ use crate::interpreter::value_extraction_helpers::{
     extract_integer_from_value, extract_word_name_from_value, is_vector_value,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::interpreter::quantized_block::{quantize_code_block, QuantizedBlock};
 use crate::types::{DisplayHint, Token, Value, ValueData};
 
 pub(crate) enum ExecutableCode {
     WordName(String),
     CodeBlock(Vec<Token>),
+    QuantizedBlock(std::sync::Arc<QuantizedBlock>),
 }
 
-pub(crate) fn extract_executable_code(val: &Value) -> Result<ExecutableCode> {
+pub(crate) fn extract_executable_code(interp: &mut Interpreter, val: &Value) -> Result<ExecutableCode> {
     if let Some(tokens) = val.as_code_block() {
+        if let Some(qb) = quantize_code_block(tokens, interp) {
+            return Ok(ExecutableCode::QuantizedBlock(std::sync::Arc::new(qb)));
+        }
         return Ok(ExecutableCode::CodeBlock(tokens.clone()));
     }
 
@@ -55,17 +60,35 @@ fn extract_predicate_boolean(condition_result: Value) -> Result<bool> {
 pub(crate) fn execute_executable_code(interp: &mut Interpreter, exec: &ExecutableCode) -> Result<()> {
     match exec {
         ExecutableCode::CodeBlock(tokens) => {
+            interp.bump_execution_epoch();
             interp.execute_section_core(tokens, 0)?;
             Ok(())
         }
         ExecutableCode::WordName(word_name) => interp.execute_word_core(word_name),
+        ExecutableCode::QuantizedBlock(qb) => execute_quantized_block_stack_top(interp, qb),
     }
+}
+
+fn execute_quantized_block_stack_top(interp: &mut Interpreter, qb: &QuantizedBlock) -> Result<()> {
+    interp.runtime_metrics.quantized_block_use_count += 1;
+    #[cfg(feature = "trace-quant")]
+    eprintln!("[trace-quant] execute quantized block");
+    crate::interpreter::compiled_plan::execute_compiled_plan(interp, &qb.compiled_plan)
+}
+
+pub(crate) fn execute_quantized_map_kernel(interp: &mut Interpreter, qb: &QuantizedBlock, elem: Value) -> Result<Value> {
+    let saved = interp.stack.clone();
+    interp.stack.clear();
+    interp.stack.push(elem);
+    let res = execute_quantized_block_stack_top(interp, qb).and_then(|_| interp.stack.pop().ok_or(AjisaiError::from("MAP: expected return value, got empty stack")));
+    interp.stack = saved;
+    res
 }
 
 pub fn op_map(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -124,9 +147,21 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
                 let elem: Value = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(elem);
-                match execute_executable_code(interp, &executable) {
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => match execute_quantized_map_kernel(interp, qb, elem.clone()) {
+                        Ok(result_val) => {
+                            results.push(result_val);
+                            continue;
+                        }
+                        Err(e) => {
+                            error = Some(e);
+                            break;
+                        }
+                    },
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
                     Ok(_) => match interp.stack.pop() {
                         Some(result_val) => {
                             let result_hint: DisplayHint =
@@ -150,6 +185,8 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
                     Err(e) => {
                         error = Some(e);
                         break;
+                    }
+                }
                     }
                 }
             }
@@ -239,7 +276,7 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
 pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -436,7 +473,7 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_any(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -609,7 +646,7 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_all(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);
@@ -782,7 +819,7 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_count(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let executable: ExecutableCode = match extract_executable_code(&code_val) {
+    let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
             interp.stack.push(code_val);

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -5,6 +5,8 @@ use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use super::epoch::EpochSnapshot;
+
 pub const DEFAULT_MAX_EXECUTION_STEPS: usize = 100_000;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -86,6 +88,17 @@ pub(crate) struct ChildRuntime {
     pub exit_reason: Option<ExitReason>,
     pub result_snapshot: Option<Vec<Value>>,
     pub monitored: bool,
+    pub spawn_epoch: EpochSnapshot,
+}
+
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuntimeMetrics {
+    pub compiled_plan_build_count: u64,
+    pub compiled_plan_cache_hit_count: u64,
+    pub compiled_plan_cache_miss_count: u64,
+    pub quantized_block_build_count: u64,
+    pub quantized_block_use_count: u64,
 }
 
 pub struct Interpreter {
@@ -120,12 +133,20 @@ pub struct Interpreter {
     pub(crate) next_registration_order: u64,
     pub(crate) active_user_dictionary: String,
 
+    pub(crate) global_epoch: u64,
+    pub(crate) epoch_stack: SmallVec<[u64; 8]>,
+    pub(crate) dictionary_epoch: u64,
+    pub(crate) module_epoch: u64,
+    pub(crate) execution_epoch: u64,
+
     pub(crate) semantic_registry: SemanticRegistry,
 
     pub(crate) child_runtimes: HashMap<u64, ChildRuntime>,
     pub(crate) next_child_id: u64,
     pub(crate) monitor_notifications: Vec<Vec<Value>>,
     pub(crate) next_supervisor_id: u64,
+
+    pub(crate) runtime_metrics: RuntimeMetrics,
 }
 
 impl Interpreter {
@@ -159,16 +180,69 @@ impl Interpreter {
             dictionary_dependencies: HashMap::new(),
             next_registration_order: 1,
             active_user_dictionary: "DEMO".to_string(),
+            global_epoch: 0,
+            epoch_stack: SmallVec::new(),
+            dictionary_epoch: 0,
+            module_epoch: 0,
+            execution_epoch: 0,
             semantic_registry: SemanticRegistry::new(),
             child_runtimes: HashMap::new(),
             next_child_id: 1,
             monitor_notifications: Vec::new(),
             next_supervisor_id: 1,
+            runtime_metrics: RuntimeMetrics::default(),
         };
         crate::builtins::register_builtins(&mut interpreter.core_vocabulary);
         interpreter
     }
 
+
+
+    pub(crate) fn next_epoch(&mut self) -> u64 {
+        self.global_epoch += 1;
+        self.global_epoch
+    }
+
+    pub(crate) fn push_epoch_frame(&mut self) -> u64 {
+        let e = self.next_epoch();
+        self.epoch_stack.push(e);
+        e
+    }
+
+    pub(crate) fn pop_epoch_frame(&mut self) {
+        self.epoch_stack.pop();
+    }
+
+    pub(crate) fn bump_dictionary_epoch(&mut self) {
+        self.dictionary_epoch = self.next_epoch();
+        #[cfg(feature = "trace-epoch")]
+        eprintln!("[trace-epoch] dictionary_epoch={} global_epoch={}", self.dictionary_epoch, self.global_epoch);
+    }
+
+    pub(crate) fn bump_module_epoch(&mut self) {
+        self.module_epoch = self.next_epoch();
+        #[cfg(feature = "trace-epoch")]
+        eprintln!("[trace-epoch] module_epoch={} global_epoch={}", self.module_epoch, self.global_epoch);
+    }
+
+    pub(crate) fn bump_execution_epoch(&mut self) {
+        self.execution_epoch = self.next_epoch();
+        #[cfg(feature = "trace-epoch")]
+        eprintln!("[trace-epoch] execution_epoch={} global_epoch={}", self.execution_epoch, self.global_epoch);
+    }
+
+    pub fn runtime_metrics(&self) -> RuntimeMetrics {
+        self.runtime_metrics
+    }
+
+    pub fn current_epoch_snapshot(&self) -> EpochSnapshot {
+        EpochSnapshot {
+            global_epoch: self.global_epoch,
+            dictionary_epoch: self.dictionary_epoch,
+            module_epoch: self.module_epoch,
+            execution_epoch: self.execution_epoch,
+        }
+    }
 
     pub fn update_flow_tracking(&mut self, enabled: bool) {
         self.flow_tracking = enabled;

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -2,6 +2,11 @@ pub mod arithmetic;
 pub mod audio;
 pub mod cast;
 pub mod comparison;
+#[path = "compiled-plan.rs"]
+pub mod compiled_plan;
+pub mod epoch;
+#[path = "quantized-block.rs"]
+pub mod quantized_block;
 pub mod control;
 #[path = "child-runtime.rs"]
 pub mod child_runtime;
@@ -96,3 +101,17 @@ pub use interpreter_core::*;
 
 
 pub use crate::types::WordDefinition;
+
+pub use compiled_plan::{compile_word_definition, execute_compiled_plan, is_plan_valid, CompiledLine, CompiledOp, CompiledPlan};
+pub use epoch::EpochSnapshot;
+pub use quantized_block::{is_quantizable_block, quantize_code_block, QuantizedArity, QuantizedBlock, QuantizedPurity};
+
+#[cfg(test)]
+#[path = "compiled-plan-tests.rs"]
+mod compiled_plan_tests;
+#[cfg(test)]
+#[path = "quantized-block-tests.rs"]
+mod quantized_block_tests;
+#[cfg(test)]
+#[path = "perf-regression-tests.rs"]
+mod perf_regression_tests;

--- a/rust/src/interpreter/modules.rs
+++ b/rust/src/interpreter/modules.rs
@@ -261,6 +261,7 @@ fn ensure_module_dictionary(interp: &mut Interpreter, module_name: &str) -> Resu
                 original_source: None,
                 namespace: Some(module.name.to_string()),
                 registration_order: 0,
+                compiled_plan: None,
             }),
         );
     }
@@ -273,6 +274,7 @@ fn ensure_module_dictionary(interp: &mut Interpreter, module_name: &str) -> Resu
             sample_words,
         },
     );
+    interp.bump_module_epoch();
     Ok(())
 }
 
@@ -299,6 +301,7 @@ fn build_sample_words(
                 original_source: None,
                 namespace: Some(module_name.to_string()),
                 registration_order: 0,
+                compiled_plan: None,
             }),
         );
     }
@@ -384,6 +387,7 @@ pub fn op_import(interp: &mut Interpreter) -> Result<()> {
         .to_uppercase();
 
     import_all_public(interp, &module_name)?;
+    interp.bump_module_epoch();
     interp.rebuild_dependencies()?;
     Ok(())
 }
@@ -442,6 +446,7 @@ pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
     }
 
     emit_import_conflict_warnings(interp, &module_name);
+    interp.bump_module_epoch();
     interp.rebuild_dependencies()?;
     Ok(())
 }

--- a/rust/src/interpreter/perf-regression-tests.rs
+++ b/rust/src/interpreter/perf-regression-tests.rs
@@ -1,0 +1,46 @@
+use crate::interpreter::Interpreter;
+
+fn run_code(code: &str) -> Interpreter {
+    let mut interp = Interpreter::new();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        interp.execute(code).await.expect("code should execute");
+    });
+    interp
+}
+
+#[test]
+fn bench_user_word_repeated() {
+    let code = "{ [ 1 ] + } 'INC' DEF [ 1 ] INC [ 1 ] INC [ 1 ] INC [ 1 ] INC";
+    let interp = run_code(code);
+    assert!(interp.runtime_metrics().compiled_plan_build_count >= 1);
+}
+
+#[test]
+fn bench_map_increment() {
+    let code = "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 1 ] + } MAP";
+    let interp = run_code(code);
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+#[test]
+fn bench_filter_positive() {
+    let _interp = run_code("[ -2 -1 0 1 2 3 ] { [ 0 ] < NOT } FILTER");
+}
+
+#[test]
+fn bench_fold_sum() {
+    let _interp = run_code("[ 1 2 3 4 5 ] [ 0 ] { + } FOLD");
+}
+
+#[test]
+fn bench_redef_invalidation() {
+    let code = "{ [ 1 ] + } 'INC' DEF [ 1 ] INC { [ 2 ] + } 'INC' DEF [ 1 ] INC";
+    let interp = run_code(code);
+    assert!(interp.runtime_metrics().compiled_plan_cache_miss_count >= 1);
+}
+
+#[test]
+fn bench_child_runtime_restart() {
+    let _interp = run_code("{ [ 1 ] } SPAWN AWAIT");
+}

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -1,0 +1,11 @@
+use crate::interpreter::quantized_block::{is_quantizable_block, quantize_code_block};
+use crate::interpreter::Interpreter;
+use crate::types::Token;
+
+#[test]
+fn quantizes_simple_block() {
+    let mut interp = Interpreter::new();
+    let tokens = vec![Token::Number("1".into()), Token::Symbol("+".into())];
+    assert!(is_quantizable_block(&tokens));
+    assert!(quantize_code_block(&tokens, &mut interp).is_some());
+}

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use crate::types::Token;
+
+use super::{compile_word_definition, CompiledPlan, EpochSnapshot, Interpreter, WordDefinition};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuantizedArity {
+    Fixed(usize),
+    Variable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuantizedPurity {
+    Pure,
+    SideEffecting,
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+pub struct QuantizedBlock {
+    pub compiled_plan: Arc<CompiledPlan>,
+    pub captured_epoch: EpochSnapshot,
+    pub input_arity: QuantizedArity,
+    pub output_arity: QuantizedArity,
+    pub purity: QuantizedPurity,
+    pub can_fuse: bool,
+    pub can_short_circuit: bool,
+    pub dependency_words: Vec<String>,
+}
+
+pub fn is_quantizable_block(tokens: &[Token]) -> bool {
+    !tokens.is_empty() && !tokens.iter().any(|t| matches!(t, Token::LineBreak | Token::SafeMode))
+}
+
+pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option<QuantizedBlock> {
+    if !is_quantizable_block(tokens) {
+        return None;
+    }
+    let lines = vec![crate::types::ExecutionLine {
+        body_tokens: tokens.to_vec().into(),
+    }];
+    let def = WordDefinition {
+        lines: lines.into(),
+        is_builtin: false,
+        description: None,
+        dependencies: Default::default(),
+        original_source: None,
+        namespace: None,
+        registration_order: 0,
+        compiled_plan: None,
+    };
+    let plan = Arc::new(compile_word_definition(&def, interp));
+    interp.bump_execution_epoch();
+    interp.runtime_metrics.quantized_block_build_count += 1;
+    #[cfg(feature = "trace-quant")]
+    eprintln!("[trace-quant] quantized block generated");
+    Some(QuantizedBlock {
+        compiled_plan: plan,
+        captured_epoch: interp.current_epoch_snapshot(),
+        input_arity: QuantizedArity::Variable,
+        output_arity: QuantizedArity::Variable,
+        purity: QuantizedPurity::Unknown,
+        can_fuse: false,
+        can_short_circuit: false,
+        dependency_words: Vec::new(),
+    })
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -171,6 +171,7 @@ pub struct WordDefinition {
     pub original_source: Option<String>,
     pub namespace: Option<String>,
     pub registration_order: u64,
+    pub compiled_plan: Option<Arc<crate::interpreter::compiled_plan::CompiledPlan>>,
 }
 
 pub type Stack = Vec<Value>;


### PR DESCRIPTION
### Motivation
- Improve interpreter performance by introducing a compile-time lowering (CompiledPlan) and a lightweight quantized execution path for simple code blocks. 
- Ensure cached compiled artifacts are semantically safe by using epoch-based invalidation across dictionary/module/execution changes. 
- Add basic metrics and trace feature flags to observe compilation/quantization behavior. 
- Provide initial tests and benches to exercise compile/quantize behavior and cache invalidation.

### Description
- Introduces `compiled-plan.rs`, `quantized-block.rs`, and `epoch.rs` and wires them into the interpreter to produce and cache `CompiledPlan` objects for user words and to build `QuantizedBlock` for simple code blocks. 
- Adds epoch tracking (`global_epoch`, `dictionary_epoch`, `module_epoch`, `execution_epoch`) and `EpochSnapshot` and uses epoch snapshots to validate cached compiled plans; bumps relevant epochs on `DEF`/`DEL`/`IMPORT`/module creation and on execution-sensitive actions. 
- Extends `WordDefinition` to hold an optional `compiled_plan`, and adds `store_compiled_plan_for_word` plus compile-on-miss logic in `execute_word_core` with cache hit/miss/build metrics and optional trace logging guarded by Cargo features `trace-compile`, `trace-epoch`, and `trace-quant`. 
- Integrates quantized execution into higher-order operations (e.g., `MAP`) so quantized blocks can be used as fast kernels, plus basic `QuantizedBlock` metadata (arity/purity placeholders) and metrics for build/use. 
- Tracks child runtime spawn epoch in `ChildRuntime` and bumps the execution epoch on spawn/retry paths; adds `RuntimeMetrics` struct and exposes `runtime_metrics()` accessor. 
- Adds Cargo features, new unit tests and benches: `compiled-plan-tests.rs`, `quantized-block-tests.rs`, and `perf-regression-tests.rs`, and updates multiple modules to initialize `compiled_plan: None` for builtins and samples. 

### Testing
- Added automated unit tests `compiled-plan-tests`, `quantized-block-tests`, and `perf-regression-tests` that exercise plan compilation, plan invalidation via epoch bumps, and quantized block creation. 
- No automated test suite was executed as part of this rollout; reviewers should run `cargo test -q` (and the feature-specific test invocations) in `rust/` to validate locally or in CI. 
- The change is instrumented with feature flags `trace-compile`, `trace-epoch`, and `trace-quant` to aid debugging when running tests or benchmarks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd24edeb88326a38b1d3f8fe9eb7b)