### PR TITLE
Implement static arity and purity analysis for quantized blocks

### DIFF
--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -4,7 +4,7 @@ use crate::interpreter::value_extraction_helpers::{
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::Value;
-use super::higher_order::{extract_executable_code, execute_executable_code, ExecutableCode};
+use super::higher_order::{extract_executable_code, execute_executable_code, execute_quantized_fold_kernel, ExecutableCode};
 
 pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
@@ -75,25 +75,39 @@ pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
                 let elem: Value = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(accumulator.clone());
-                interp.stack.push(elem);
-
-                match execute_executable_code(interp, &executable) {
-                    Ok(_) => match interp.stack.pop() {
-                        Some(result) => {
-                            accumulator = result;
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => {
+                        match execute_quantized_fold_kernel(interp, qb, accumulator.clone(), elem) {
+                            Ok(result) => {
+                                accumulator = result;
+                            }
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
                         }
-                        None => {
-                            error = Some(AjisaiError::from(
-                                "FOLD: expected return value, got empty stack",
-                            ));
-                            break;
+                    }
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(accumulator.clone());
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
+                            Ok(_) => match interp.stack.pop() {
+                                Some(result) => {
+                                    accumulator = result;
+                                }
+                                None => {
+                                    error = Some(AjisaiError::from(
+                                        "FOLD: expected return value, got empty stack",
+                                    ));
+                                    break;
+                                }
+                            },
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
                         }
-                    },
-                    Err(e) => {
-                        error = Some(e);
-                        break;
                     }
                 }
             }
@@ -428,26 +442,41 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
                 let elem: Value = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(accumulator.clone());
-                interp.stack.push(elem);
-
-                match execute_executable_code(interp, &executable) {
-                    Ok(_) => match interp.stack.pop() {
-                        Some(result) => {
-                            accumulator = result;
-                            results.push(accumulator.clone());
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => {
+                        match execute_quantized_fold_kernel(interp, qb, accumulator.clone(), elem) {
+                            Ok(result) => {
+                                accumulator = result;
+                                results.push(accumulator.clone());
+                            }
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
                         }
-                        None => {
-                            error = Some(AjisaiError::from(
-                                "SCAN: expected return value, got empty stack",
-                            ));
-                            break;
+                    }
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(accumulator.clone());
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
+                            Ok(_) => match interp.stack.pop() {
+                                Some(result) => {
+                                    accumulator = result;
+                                    results.push(accumulator.clone());
+                                }
+                                None => {
+                                    error = Some(AjisaiError::from(
+                                        "SCAN: expected return value, got empty stack",
+                                    ));
+                                    break;
+                                }
+                            },
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
                         }
-                    },
-                    Err(e) => {
-                        error = Some(e);
-                        break;
                     }
                 }
             }

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -36,7 +36,7 @@ fn is_truthy_boolean(val: &Value) -> bool {
     false
 }
 
-fn extract_predicate_boolean(condition_result: Value) -> Result<bool> {
+pub(crate) fn extract_predicate_boolean(condition_result: Value) -> Result<bool> {
     if let Some(f) = condition_result.as_scalar() {
         return Ok(!f.is_zero());
     }
@@ -81,6 +81,50 @@ pub(crate) fn execute_quantized_map_kernel(interp: &mut Interpreter, qb: &Quanti
     interp.stack.clear();
     interp.stack.push(elem);
     let res = execute_quantized_block_stack_top(interp, qb).and_then(|_| interp.stack.pop().ok_or(AjisaiError::from("MAP: expected return value, got empty stack")));
+    interp.stack = saved;
+    res
+}
+
+/// Execute a predicate quantized block with a single element.
+/// Saves/restores the outer stack, pushes `elem`, runs the block, and
+/// interprets the top-of-stack result as a boolean.
+pub(crate) fn execute_quantized_predicate_kernel(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    elem: Value,
+) -> Result<bool> {
+    let saved = interp.stack.clone();
+    interp.stack.clear();
+    interp.stack.push(elem);
+    let res = execute_quantized_block_stack_top(interp, qb).and_then(|_| {
+        interp
+            .stack
+            .pop()
+            .ok_or_else(|| AjisaiError::from("predicate: expected boolean value from quantized block, got empty stack"))
+            .and_then(extract_predicate_boolean)
+    });
+    interp.stack = saved;
+    res
+}
+
+/// Execute a fold quantized block: pushes `(acc, elem)`, runs the block,
+/// and returns the new accumulator from top-of-stack.
+pub(crate) fn execute_quantized_fold_kernel(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    acc: Value,
+    elem: Value,
+) -> Result<Value> {
+    let saved = interp.stack.clone();
+    interp.stack.clear();
+    interp.stack.push(acc);
+    interp.stack.push(elem);
+    let res = execute_quantized_block_stack_top(interp, qb).and_then(|_| {
+        interp
+            .stack
+            .pop()
+            .ok_or_else(|| AjisaiError::from("FOLD: expected return value from quantized block, got empty stack"))
+    });
     interp.stack = saved;
     res
 }
@@ -335,45 +379,62 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
                 let elem: Value = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(elem.clone());
-                match execute_executable_code(interp, &executable) {
-                    Ok(_) => {
-                        let condition_result: Value = match interp.stack.pop() {
-                            Some(r) => r,
-                            None => {
-                                error = Some(AjisaiError::from(
-                                    "FILTER: expected boolean value, got empty stack",
-                                ));
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => {
+                        match execute_quantized_predicate_kernel(interp, qb, elem.clone()) {
+                            Ok(is_true) => {
+                                if is_true {
+                                    results.push(elem);
+                                }
+                            }
+                            Err(e) => {
+                                error = Some(e);
                                 break;
                             }
-                        };
-
-                        let is_true: bool = if is_vector_value(&condition_result) {
-                            if condition_result.len() == 1 {
-                                is_truthy_boolean(condition_result.get_child(0).unwrap())
-                            } else {
-                                error = Some(AjisaiError::create_structure_error(
-                                    "boolean result from FILTER code",
-                                    "other format",
-                                ));
-                                break;
-                            }
-                        } else {
-                            error = Some(AjisaiError::create_structure_error(
-                                "boolean vector result from FILTER code",
-                                "other format",
-                            ));
-                            break;
-                        };
-
-                        if is_true {
-                            results.push(elem);
                         }
                     }
-                    Err(e) => {
-                        error = Some(e);
-                        break;
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(elem.clone());
+                        match execute_executable_code(interp, &executable) {
+                            Ok(_) => {
+                                let condition_result: Value = match interp.stack.pop() {
+                                    Some(r) => r,
+                                    None => {
+                                        error = Some(AjisaiError::from(
+                                            "FILTER: expected boolean value, got empty stack",
+                                        ));
+                                        break;
+                                    }
+                                };
+
+                                let is_true: bool = if is_vector_value(&condition_result) {
+                                    if condition_result.len() == 1 {
+                                        is_truthy_boolean(condition_result.get_child(0).unwrap())
+                                    } else {
+                                        error = Some(AjisaiError::create_structure_error(
+                                            "boolean result from FILTER code",
+                                            "other format",
+                                        ));
+                                        break;
+                                    }
+                                } else {
+                                    error = Some(AjisaiError::create_structure_error(
+                                        "boolean vector result from FILTER code",
+                                        "other format",
+                                    ));
+                                    break;
+                                };
+
+                                if is_true {
+                                    results.push(elem);
+                                }
+                            }
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -516,20 +577,9 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
                 let elem = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(elem);
-                match execute_executable_code(interp, &executable) {
-                    Ok(_) => {
-                        let condition_result = match interp.stack.pop() {
-                            Some(v) => v,
-                            None => {
-                                error = Some(AjisaiError::from(
-                                    "FILTER: expected boolean value, got empty stack",
-                                ));
-                                break;
-                            }
-                        };
-                        match extract_predicate_boolean(condition_result) {
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => {
+                        match execute_quantized_predicate_kernel(interp, qb, elem) {
                             Ok(is_true) => {
                                 if is_true {
                                     result = true;
@@ -542,9 +592,38 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
                             }
                         }
                     }
-                    Err(e) => {
-                        error = Some(e);
-                        break;
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
+                            Ok(_) => {
+                                let condition_result = match interp.stack.pop() {
+                                    Some(v) => v,
+                                    None => {
+                                        error = Some(AjisaiError::from(
+                                            "ANY: expected boolean value, got empty stack",
+                                        ));
+                                        break;
+                                    }
+                                };
+                                match extract_predicate_boolean(condition_result) {
+                                    Ok(is_true) => {
+                                        if is_true {
+                                            result = true;
+                                            break;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error = Some(e);
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -689,20 +768,9 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
                 let elem = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(elem);
-                match execute_executable_code(interp, &executable) {
-                    Ok(_) => {
-                        let condition_result = match interp.stack.pop() {
-                            Some(v) => v,
-                            None => {
-                                error = Some(AjisaiError::from(
-                                    "FILTER: expected boolean value, got empty stack",
-                                ));
-                                break;
-                            }
-                        };
-                        match extract_predicate_boolean(condition_result) {
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => {
+                        match execute_quantized_predicate_kernel(interp, qb, elem) {
                             Ok(is_true) => {
                                 if !is_true {
                                     result = false;
@@ -715,9 +783,38 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
                             }
                         }
                     }
-                    Err(e) => {
-                        error = Some(e);
-                        break;
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
+                            Ok(_) => {
+                                let condition_result = match interp.stack.pop() {
+                                    Some(v) => v,
+                                    None => {
+                                        error = Some(AjisaiError::from(
+                                            "ALL: expected boolean value, got empty stack",
+                                        ));
+                                        break;
+                                    }
+                                };
+                                match extract_predicate_boolean(condition_result) {
+                                    Ok(is_true) => {
+                                        if !is_true {
+                                            result = false;
+                                            break;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error = Some(e);
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -862,20 +959,9 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
                 let elem = target_val.get_child(i).unwrap().clone();
-                interp.stack.clear();
-                interp.stack.push(elem);
-                match execute_executable_code(interp, &executable) {
-                    Ok(_) => {
-                        let condition_result = match interp.stack.pop() {
-                            Some(v) => v,
-                            None => {
-                                error = Some(AjisaiError::from(
-                                    "FILTER: expected boolean value, got empty stack",
-                                ));
-                                break;
-                            }
-                        };
-                        match extract_predicate_boolean(condition_result) {
+                match &executable {
+                    ExecutableCode::QuantizedBlock(qb) => {
+                        match execute_quantized_predicate_kernel(interp, qb, elem) {
                             Ok(is_true) => {
                                 if is_true {
                                     count += 1;
@@ -887,9 +973,37 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
                             }
                         }
                     }
-                    Err(e) => {
-                        error = Some(e);
-                        break;
+                    _ => {
+                        interp.stack.clear();
+                        interp.stack.push(elem);
+                        match execute_executable_code(interp, &executable) {
+                            Ok(_) => {
+                                let condition_result = match interp.stack.pop() {
+                                    Some(v) => v,
+                                    None => {
+                                        error = Some(AjisaiError::from(
+                                            "COUNT: expected boolean value, got empty stack",
+                                        ));
+                                        break;
+                                    }
+                                };
+                                match extract_predicate_boolean(condition_result) {
+                                    Ok(is_true) => {
+                                        if is_true {
+                                            count += 1;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error = Some(e);
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error = Some(e);
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/rust/src/interpreter/perf-regression-tests.rs
+++ b/rust/src/interpreter/perf-regression-tests.rs
@@ -1,3 +1,12 @@
+/// Perf-regression smoke tests.
+///
+/// These tests verify that the quantized execution path is actually taken for
+/// the key higher-order functions, and that the cache invalidation machinery
+/// works correctly after re-definitions.
+///
+/// They also print lightweight timing/metrics summaries when run with
+/// `-- --nocapture` so you can see hit rates and quantized-usage counts
+/// without a full bench harness.
 use crate::interpreter::Interpreter;
 
 fn run_code(code: &str) -> Interpreter {
@@ -9,36 +18,160 @@ fn run_code(code: &str) -> Interpreter {
     interp
 }
 
+fn run_code_timed(code: &str) -> (Interpreter, std::time::Duration) {
+    let mut interp = Interpreter::new();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let start = std::time::Instant::now();
+    rt.block_on(async {
+        interp.execute(code).await.expect("code should execute");
+    });
+    let elapsed = start.elapsed();
+    (interp, elapsed)
+}
+
+fn print_metrics(label: &str, interp: &Interpreter, elapsed: std::time::Duration) {
+    let m = interp.runtime_metrics();
+    println!(
+        "[perf] {label}: elapsed={elapsed:?} \
+         plan_build={} hit={} miss={} \
+         quant_build={} quant_use={}",
+        m.compiled_plan_build_count,
+        m.compiled_plan_cache_hit_count,
+        m.compiled_plan_cache_miss_count,
+        m.quantized_block_build_count,
+        m.quantized_block_use_count,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CompiledPlan cache smoke tests
+// ---------------------------------------------------------------------------
+
 #[test]
 fn bench_user_word_repeated() {
     let code = "{ [ 1 ] + } 'INC' DEF [ 1 ] INC [ 1 ] INC [ 1 ] INC [ 1 ] INC";
-    let interp = run_code(code);
-    assert!(interp.runtime_metrics().compiled_plan_build_count >= 1);
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("user_word_repeated", &interp, elapsed);
+    assert!(m.compiled_plan_build_count >= 1, "plan should be compiled at least once");
+    assert!(m.compiled_plan_cache_hit_count >= 3, "3 of 4 calls should be cache hits");
 }
+
+#[test]
+fn bench_redef_invalidates_plan() {
+    let code = "{ [ 1 ] + } 'INC' DEF [ 1 ] INC { [ 2 ] + } 'INC' DEF [ 1 ] INC";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("redef_invalidation", &interp, elapsed);
+    assert!(m.compiled_plan_cache_miss_count >= 1, "cache miss expected after redef");
+}
+
+// ---------------------------------------------------------------------------
+// MAP — quantized path
+// ---------------------------------------------------------------------------
 
 #[test]
 fn bench_map_increment() {
     let code = "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 1 ] + } MAP";
-    let interp = run_code(code);
-    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("map_increment", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 10, "all 10 elements should use quantized kernel");
 }
+
+// ---------------------------------------------------------------------------
+// FILTER — quantized predicate path
+// ---------------------------------------------------------------------------
 
 #[test]
 fn bench_filter_positive() {
-    let _interp = run_code("[ -2 -1 0 1 2 3 ] { [ 0 ] < NOT } FILTER");
+    let code = "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("filter_positive", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 1, "FILTER should use quantized predicate kernel");
 }
+
+// ---------------------------------------------------------------------------
+// ANY / ALL / COUNT — quantized predicate path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bench_any_quantized() {
+    let code = "[ 1 2 3 4 5 ] { [ 3 ] = } ANY";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("any_quantized", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 1, "ANY should use quantized predicate kernel");
+}
+
+#[test]
+fn bench_all_quantized() {
+    let code = "[ 1 2 3 4 5 ] { [ 0 ] <= NOT } ALL";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("all_quantized", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 1, "ALL should use quantized predicate kernel");
+}
+
+#[test]
+fn bench_count_quantized() {
+    // { [ 5 ] <= NOT } = elem > 5
+    let code = "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] <= NOT } COUNT";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("count_quantized", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 1, "COUNT should use quantized predicate kernel");
+}
+
+// ---------------------------------------------------------------------------
+// FOLD / SCAN — quantized fold path
+// ---------------------------------------------------------------------------
 
 #[test]
 fn bench_fold_sum() {
-    let _interp = run_code("[ 1 2 3 4 5 ] [ 0 ] { + } FOLD");
+    let code = "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("fold_sum", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 1, "FOLD should use quantized fold kernel");
 }
 
 #[test]
-fn bench_redef_invalidation() {
-    let code = "{ [ 1 ] + } 'INC' DEF [ 1 ] INC { [ 2 ] + } 'INC' DEF [ 1 ] INC";
-    let interp = run_code(code);
-    assert!(interp.runtime_metrics().compiled_plan_cache_miss_count >= 1);
+fn bench_scan_prefix_sums() {
+    let code = "[ 1 2 3 4 5 ] [ 0 ] { + } SCAN";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("scan_prefix_sums", &interp, elapsed);
+    assert!(m.quantized_block_use_count >= 1, "SCAN should use quantized fold kernel");
 }
+
+// ---------------------------------------------------------------------------
+// Comprehensive hit-rate check
+// ---------------------------------------------------------------------------
+
+/// Run the same user-word many times and verify the cache hit rate is high.
+#[test]
+fn bench_high_hit_rate() {
+    // 8 calls after 1 definition → expect ≥ 7 cache hits (first call builds).
+    let code = "{ [ 1 ] + } 'INC' DEF \
+                [ 1 ] INC [ 1 ] INC [ 1 ] INC [ 1 ] INC \
+                [ 1 ] INC [ 1 ] INC [ 1 ] INC [ 1 ] INC";
+    let (interp, elapsed) = run_code_timed(code);
+    let m = interp.runtime_metrics();
+    print_metrics("high_hit_rate", &interp, elapsed);
+    let total = m.compiled_plan_cache_hit_count + m.compiled_plan_cache_miss_count;
+    assert!(total >= 8, "should have at least 8 plan lookups");
+    assert!(
+        m.compiled_plan_cache_hit_count >= 7,
+        "hit rate should be ≥ 7/8 after warm-up, got hits={}",
+        m.compiled_plan_cache_hit_count
+    );
+}
+
+// ---------------------------------------------------------------------------
+// child runtime
+// ---------------------------------------------------------------------------
 
 #[test]
 fn bench_child_runtime_restart() {

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -1,11 +1,382 @@
-use crate::interpreter::quantized_block::{is_quantizable_block, quantize_code_block};
+use crate::interpreter::quantized_block::{
+    is_quantizable_block, quantize_code_block, QuantizedArity, QuantizedPurity,
+};
 use crate::interpreter::Interpreter;
-use crate::types::Token;
+use crate::types::{Token, Value};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_interp() -> Interpreter {
+    Interpreter::new()
+}
+
+fn num(s: &str) -> Token {
+    Token::Number(s.into())
+}
+
+fn sym(s: &str) -> Token {
+    Token::Symbol(s.into())
+}
+
+fn run_code(code: &str) -> Interpreter {
+    let mut interp = Interpreter::new();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        interp.execute(code).await.expect("code should execute");
+    });
+    interp
+}
+
+fn stack_top(interp: &Interpreter) -> &Value {
+    interp.get_stack().last().expect("stack should not be empty")
+}
+
+/// Extract i64 from top of stack, handling both raw scalars and
+/// single-element vectors (which Ajisai often produces for numeric results).
+fn stack_top_i64(interp: &Interpreter) -> i64 {
+    let top = stack_top(interp);
+    if let Some(f) = top.as_scalar() {
+        return f.to_i64().expect("scalar should be representable as i64");
+    }
+    if top.len() == 1 {
+        if let Some(child) = top.get_child(0) {
+            if let Some(f) = child.as_scalar() {
+                return f.to_i64().expect("inner scalar should be representable as i64");
+            }
+        }
+    }
+    panic!(
+        "stack top should be integer scalar or single-element vector, got len={}",
+        top.len()
+    );
+}
+
+/// Extract bool from top of stack, handling both scalars and single-element vectors.
+fn stack_top_bool(interp: &Interpreter) -> bool {
+    let top = stack_top(interp);
+    if let Some(f) = top.as_scalar() {
+        return !f.is_zero();
+    }
+    if top.len() == 1 {
+        if let Some(child) = top.get_child(0) {
+            if let Some(f) = child.as_scalar() {
+                return !f.is_zero();
+            }
+        }
+    }
+    panic!("stack top should be boolean scalar or single-element vector");
+}
+
+// ---------------------------------------------------------------------------
+// is_quantizable_block
+// ---------------------------------------------------------------------------
 
 #[test]
 fn quantizes_simple_block() {
-    let mut interp = Interpreter::new();
-    let tokens = vec![Token::Number("1".into()), Token::Symbol("+".into())];
+    let mut interp = make_interp();
+    let tokens = vec![num("1"), sym("+")];
     assert!(is_quantizable_block(&tokens));
     assert!(quantize_code_block(&tokens, &mut interp).is_some());
+}
+
+#[test]
+fn empty_block_is_not_quantizable() {
+    assert!(!is_quantizable_block(&[]));
+}
+
+#[test]
+fn linebreak_makes_block_non_quantizable() {
+    let tokens = vec![num("1"), Token::LineBreak, sym("+")];
+    assert!(!is_quantizable_block(&tokens));
+}
+
+#[test]
+fn safemode_token_makes_block_non_quantizable() {
+    // Token::SafeMode is the safe-mode sentinel
+    let tokens = vec![Token::SafeMode, sym("+")];
+    assert!(!is_quantizable_block(&tokens));
+}
+
+// ---------------------------------------------------------------------------
+// Arity inference — pure-builtin blocks only
+// ---------------------------------------------------------------------------
+
+/// `{ + }` consumes 2 from external stack, produces 1.
+#[test]
+fn arity_binary_add() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Fixed(2));
+    assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+/// `{ - }` — binary: 2 in, 1 out.
+#[test]
+fn arity_binary_sub() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("-")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Fixed(2));
+    assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+/// `{ < }` — binary comparison: 2 in, 1 out.
+#[test]
+fn arity_binary_compare() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("<")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Fixed(2));
+    assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+/// `{ NOT }` — unary: 1 in, 1 out.
+#[test]
+fn arity_unary_not() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("NOT")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Fixed(1));
+    assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+/// Words not in BUILTIN_SPECS compile to FallbackToken → arity is Variable.
+/// DROP/DUP/SWAP are not Ajisai builtins, so arity inference gives Variable.
+#[test]
+fn arity_non_builtin_word_is_variable() {
+    let mut interp = make_interp();
+    // "ABS" is in BUILTIN_SPECS, "NOT" is too, but "REORDER" may not be.
+    // We use a word that is definitely not in BUILTIN_SPECS.
+    let tokens = vec![sym("DROP")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    // DROP is not in BUILTIN_SPECS → FallbackToken → Variable arity
+    assert_eq!(qb.input_arity, QuantizedArity::Variable);
+    assert_eq!(qb.output_arity, QuantizedArity::Variable);
+}
+
+/// `{ NOT < }` — two builtins: NOT is 1→1, then < is 2→1.
+/// Combined arity is determined by simulation: start depth=0,
+/// NOT needs 1 → min=-1, depth=0; then < needs 2 → depth=-2 (min=-2), depth=-1.
+/// input_arity = 2, output_arity = 1.
+#[test]
+fn arity_chain_not_then_compare() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("NOT"), sym("<")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    // NOT: 1→1, then <: 2→1.  Net: 2 from external, 1 result.
+    assert_eq!(qb.input_arity, QuantizedArity::Fixed(2));
+    assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+/// A block calling an unknown builtin (e.g. MAP) should fall back to Variable.
+#[test]
+fn arity_unknown_builtin_falls_back_to_variable() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("MAP")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Variable);
+    assert_eq!(qb.output_arity, QuantizedArity::Variable);
+}
+
+/// A block calling a user-defined word should have Variable arity.
+#[test]
+fn arity_user_word_is_variable() {
+    let mut interp = make_interp();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        interp.execute("{ + } 'ADD' DEF").await.unwrap();
+    });
+    let tokens = vec![sym("ADD")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Variable);
+    assert_eq!(qb.output_arity, QuantizedArity::Variable);
+}
+
+/// A block with literal push (Number token) contributes +1 to depth.
+/// `{ 1 + }` — push literal 1 (depth +1), then + (needs 2, gets 1 from literal and
+/// 1 from external, depth -1 after consuming + producing 1 → net 0).
+/// input_arity = 1, output_arity = 1.
+#[test]
+fn arity_literal_then_add() {
+    let mut interp = make_interp();
+    // Simulate { 1 + } by constructing tokens directly
+    let tokens = vec![num("1"), sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.input_arity, QuantizedArity::Fixed(1));
+    assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+// ---------------------------------------------------------------------------
+// Purity inference
+// ---------------------------------------------------------------------------
+
+/// Pure arithmetic block should be marked Pure.
+#[test]
+fn purity_arithmetic_is_pure() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.purity, QuantizedPurity::Pure);
+}
+
+/// `can_fuse` and `can_short_circuit` should reflect purity.
+#[test]
+fn can_fuse_reflects_purity() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert!(qb.can_fuse);
+    assert!(qb.can_short_circuit);
+}
+
+// ---------------------------------------------------------------------------
+// Dependency word collection
+// ---------------------------------------------------------------------------
+
+/// A block that calls a user-defined word records it in `dependency_words`.
+/// The resolved name may be namespace-qualified (e.g. "NS@MY_ADD"), so we check
+/// that at least one entry contains the word name.
+#[test]
+fn dependency_words_collected() {
+    let mut interp = make_interp();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        interp.execute("{ + } 'MY_ADD' DEF").await.unwrap();
+    });
+    let tokens = vec![sym("MY_ADD")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert!(
+        qb.dependency_words.iter().any(|w| w.contains("MY_ADD")),
+        "expected 'MY_ADD' (possibly namespace-qualified) in dependency_words: {:?}",
+        qb.dependency_words
+    );
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: verify quantized path is used for each HOF
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantized_path_used_for_map() {
+    // { [ 1 ] + } increments each element
+    let interp = run_code("[ 1 2 3 ] { [ 1 ] + } MAP");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 3);
+}
+
+#[test]
+fn quantized_path_used_for_filter() {
+    // { [ 0 ] <= NOT } = elem > 0
+    let interp = run_code("[ -2 -1 0 1 2 3 ] { [ 0 ] <= NOT } FILTER");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+#[test]
+fn quantized_path_used_for_any() {
+    let interp = run_code("[ 1 2 3 ] { [ 2 ] = } ANY");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+#[test]
+fn quantized_path_used_for_all() {
+    // { [ 0 ] <= NOT } = elem > 0
+    let interp = run_code("[ 1 2 3 ] { [ 0 ] <= NOT } ALL");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+#[test]
+fn quantized_path_used_for_count() {
+    // { [ 3 ] <= NOT } = elem > 3
+    let interp = run_code("[ 1 2 3 4 5 ] { [ 3 ] <= NOT } COUNT");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+#[test]
+fn quantized_path_used_for_fold() {
+    let interp = run_code("[ 1 2 3 4 5 ] [ 0 ] { + } FOLD");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+#[test]
+fn quantized_path_used_for_scan() {
+    let interp = run_code("[ 1 2 3 ] [ 0 ] { + } SCAN");
+    assert!(interp.runtime_metrics().quantized_block_use_count >= 1);
+}
+
+// ---------------------------------------------------------------------------
+// Result correctness: quantized path must produce the same semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn filter_keeps_elements_above_zero() {
+    // { [ 0 ] <= NOT } = elem > 0
+    let interp = run_code("[ -2 -1 0 1 2 3 ] { [ 0 ] <= NOT } FILTER");
+    let top = stack_top(&interp);
+    assert_eq!(top.len(), 3, "expected [1, 2, 3], got len={}", top.len());
+}
+
+#[test]
+fn any_true_when_element_matches() {
+    let interp = run_code("[ 1 2 3 ] { [ 2 ] = } ANY");
+    assert!(stack_top_bool(&interp));
+}
+
+#[test]
+fn any_false_when_no_match() {
+    let interp = run_code("[ 1 2 3 ] { [ 5 ] = } ANY");
+    assert!(!stack_top_bool(&interp));
+}
+
+#[test]
+fn all_true_when_all_above_zero() {
+    // { [ 0 ] <= NOT } = elem > 0
+    let interp = run_code("[ 1 2 3 ] { [ 0 ] <= NOT } ALL");
+    assert!(stack_top_bool(&interp));
+}
+
+#[test]
+fn all_false_when_one_fails() {
+    // -1 > 0 is false, so ALL should be false
+    let interp = run_code("[ -1 2 3 ] { [ 0 ] <= NOT } ALL");
+    assert!(!stack_top_bool(&interp));
+}
+
+#[test]
+fn count_counts_matching_elements() {
+    // { [ 3 ] <= NOT } = elem > 3, so 4 and 5 match
+    let interp = run_code("[ 1 2 3 4 5 ] { [ 3 ] <= NOT } COUNT");
+    assert_eq!(stack_top_i64(&interp), 2);
+}
+
+#[test]
+fn fold_sum_is_correct() {
+    let interp = run_code("[ 1 2 3 4 5 ] [ 0 ] { + } FOLD");
+    assert_eq!(stack_top_i64(&interp), 15);
+}
+
+#[test]
+fn scan_produces_prefix_sums() {
+    let interp = run_code("[ 1 2 3 ] [ 0 ] { + } SCAN");
+    let top = stack_top(&interp);
+    assert_eq!(top.len(), 3, "SCAN result should have 3 elements");
+    // Each child may be a scalar or a single-element vector — extract i64 from either.
+    let extract = |v: &Value| -> i64 {
+        if let Some(f) = v.as_scalar() {
+            return f.to_i64().expect("scalar should be i64");
+        }
+        if v.len() == 1 {
+            if let Some(child) = v.get_child(0) {
+                if let Some(f) = child.as_scalar() {
+                    return f.to_i64().expect("inner scalar should be i64");
+                }
+            }
+        }
+        panic!("SCAN element is not a numeric scalar or single-element vector");
+    };
+    let vals: Vec<i64> = (0..3)
+        .map(|i| extract(top.get_child(i).unwrap()))
+        .collect();
+    assert_eq!(vals, vec![1, 3, 6]);
 }

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::types::Token;
 
-use super::{compile_word_definition, CompiledPlan, EpochSnapshot, Interpreter, WordDefinition};
+use super::{compile_word_definition, compiled_plan::CompiledOp, CompiledPlan, EpochSnapshot, Interpreter, WordDefinition};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum QuantizedArity {
@@ -29,6 +29,130 @@ pub struct QuantizedBlock {
     pub dependency_words: Vec<String>,
 }
 
+/// Returns (inputs_consumed, outputs_produced) for well-known pure builtins.
+/// Returns None for unknown or variable-arity builtins.
+fn builtin_arity(name: &str) -> Option<(i32, i32)> {
+    match name {
+        // Binary arithmetic
+        "+" | "-" | "*" | "/" | "%" | "^" => Some((2, 1)),
+        // Binary comparison
+        "<" | ">" | "<=" | ">=" | "=" | "!=" => Some((2, 1)),
+        // Binary logical
+        "AND" | "OR" | "XOR" => Some((2, 1)),
+        // Unary arithmetic / math
+        "NOT" | "ABS" | "NEG" | "SQRT" | "FLOOR" | "CEIL" | "ROUND"
+        | "SIGN" | "SUCC" | "PRED" | "EXP" | "LOG" | "LOG2" | "LOG10"
+        | "SIN" | "COS" | "TAN" | "ASIN" | "ACOS" | "ATAN" => Some((1, 1)),
+        // Type cast / unary
+        "INT" | "FLOAT" | "STR" | "BOOL" | "CHAR" => Some((1, 1)),
+        // Unknown arity (vector ops, HOF, stack words not in BUILTIN_SPECS, etc.) → None
+        _ => None,
+    }
+}
+
+/// Words that have observable side effects (I/O, state mutation, concurrency).
+fn is_side_effecting_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        "PRINT" | "EMIT" | "READ" | "WRITE" | "READLINE"
+            | "SPAWN" | "AWAIT" | "SEND" | "RECV"
+            | "DEF" | "DEL" | "IMPORT"
+            | "RAND" | "SEED"
+    )
+}
+
+/// Statically analyse a compiled plan and return
+/// `(input_arity, output_arity, purity, dependency_words)`.
+///
+/// Arity analysis uses a symbolic stack-depth simulation:
+/// - Start at depth 0.
+/// - Each push op adds 1; each builtin with known arity adjusts depth.
+/// - If depth would go below the running minimum, update `min_depth`.
+/// - `input_arity  = -min_depth`  (values consumed from the external stack)
+/// - `output_arity = final_depth - min_depth` (values left on stack after execution)
+///
+/// If any op has unknown arity (user words, qualified words, fallback tokens),
+/// both arities are `Variable`.
+fn analyze_compiled_plan(plan: &CompiledPlan) -> (QuantizedArity, QuantizedArity, QuantizedPurity, Vec<String>) {
+    let mut depth: i32 = 0;
+    let mut min_depth: i32 = 0;
+    let mut all_known = true;
+    let mut is_pure = true;
+    let mut dep_words: Vec<String> = Vec::new();
+
+    'outer: for line in &plan.lines {
+        for op in &line.ops {
+            match op {
+                CompiledOp::PushLiteral(_) | CompiledOp::PushCodeBlock(_) => {
+                    depth += 1;
+                }
+                // Meta-ops with no stack effect
+                CompiledOp::SetTargetModeStackTop
+                | CompiledOp::SetTargetModeStack
+                | CompiledOp::SetConsumptionConsume
+                | CompiledOp::SetConsumptionKeep
+                | CompiledOp::BeginGuardedBlock
+                | CompiledOp::LineBreak => {}
+
+                CompiledOp::CallBuiltin(name) => {
+                    if is_side_effecting_builtin(name) {
+                        is_pure = false;
+                    }
+                    if let Some((inputs, outputs)) = builtin_arity(name) {
+                        depth -= inputs;
+                        if depth < min_depth {
+                            min_depth = depth;
+                        }
+                        depth += outputs;
+                    } else {
+                        // Unknown arity; cannot determine statically
+                        all_known = false;
+                        break 'outer;
+                    }
+                }
+
+                CompiledOp::CallUserWord(name) => {
+                    dep_words.push(name.clone());
+                    all_known = false;
+                    break 'outer;
+                }
+
+                CompiledOp::CallQualifiedWord { namespace, word } => {
+                    dep_words.push(format!("{}@{}", namespace, word));
+                    all_known = false;
+                    break 'outer;
+                }
+
+                CompiledOp::FallbackToken(_) => {
+                    all_known = false;
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    let (input_arity, output_arity) = if all_known {
+        let input = if min_depth < 0 {
+            QuantizedArity::Fixed((-min_depth) as usize)
+        } else {
+            QuantizedArity::Fixed(0)
+        };
+        // Values remaining on the mini-stack = final_depth - min_depth
+        let output = QuantizedArity::Fixed((depth - min_depth) as usize);
+        (input, output)
+    } else {
+        (QuantizedArity::Variable, QuantizedArity::Variable)
+    };
+
+    let purity = if is_pure {
+        QuantizedPurity::Pure
+    } else {
+        QuantizedPurity::SideEffecting
+    };
+
+    (input_arity, output_arity, purity, dep_words)
+}
+
 pub fn is_quantizable_block(tokens: &[Token]) -> bool {
     !tokens.is_empty() && !tokens.iter().any(|t| matches!(t, Token::LineBreak | Token::SafeMode))
 }
@@ -53,16 +177,26 @@ pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option
     let plan = Arc::new(compile_word_definition(&def, interp));
     interp.bump_execution_epoch();
     interp.runtime_metrics.quantized_block_build_count += 1;
+
+    let (input_arity, output_arity, purity, dependency_words) = analyze_compiled_plan(&plan);
+
+    let can_fuse = purity == QuantizedPurity::Pure;
+    let can_short_circuit = purity == QuantizedPurity::Pure;
+
     #[cfg(feature = "trace-quant")]
-    eprintln!("[trace-quant] quantized block generated");
+    eprintln!(
+        "[trace-quant] quantized block generated: input={:?} output={:?} purity={:?} deps={:?}",
+        input_arity, output_arity, purity, dependency_words
+    );
+
     Some(QuantizedBlock {
         compiled_plan: plan,
         captured_epoch: interp.current_epoch_snapshot(),
-        input_arity: QuantizedArity::Variable,
-        output_arity: QuantizedArity::Variable,
-        purity: QuantizedPurity::Unknown,
-        can_fuse: false,
-        can_short_circuit: false,
-        dependency_words: Vec::new(),
+        input_arity,
+        output_arity,
+        purity,
+        can_fuse,
+        can_short_circuit,
+        dependency_words,
     })
 }


### PR DESCRIPTION
## Summary

This PR adds static analysis of quantized code blocks to infer their input/output arity and purity properties at compile time, enabling better optimization and validation. It also refactors higher-order operations (MAP, FILTER, ANY, ALL, COUNT, FOLD, SCAN) to use specialized quantized kernels for improved performance.

## Key Changes

### Arity and Purity Analysis (`quantized-block.rs`)
- **New `analyze_compiled_plan()` function**: Performs symbolic stack-depth simulation on compiled plans to determine:
  - Input arity: number of values consumed from external stack
  - Output arity: number of values produced
  - Purity: whether the block has side effects
  - Dependency words: user-defined words called by the block
- **`builtin_arity()` lookup table**: Maps known pure builtins (arithmetic, comparison, logical, type casts) to their (inputs, outputs) signatures
- **`is_side_effecting_builtin()` check**: Identifies I/O, state mutation, and concurrency operations that prevent optimization
- **Updated `quantize_code_block()`**: Now populates `QuantizedBlock` fields with analyzed values instead of defaults

### Quantized Kernel Functions (`higher-order-operations.rs`)
- **`execute_quantized_predicate_kernel()`**: Executes a predicate block with a single element, handling stack isolation and boolean extraction
- **`execute_quantized_fold_kernel()`**: Executes a fold block with (accumulator, element) pair, returning the new accumulator
- **Made `extract_predicate_boolean()` public**: Allows reuse across modules

### Higher-Order Operation Refactoring
- **FILTER, ANY, ALL, COUNT**: Updated to dispatch to `execute_quantized_predicate_kernel()` for quantized blocks, falling back to generic path for non-quantized code
- **FOLD, SCAN**: Updated to dispatch to `execute_quantized_fold_kernel()` for quantized blocks
- Each operation now has a fast path for quantized blocks and a fallback path for general code

### Comprehensive Test Suite (`quantized-block-tests.rs`)
- **Helper functions**: `make_interp()`, `num()`, `sym()`, `run_code()`, `stack_top()`, `stack_top_i64()`, `stack_top_bool()`
- **Quantizability tests**: Empty blocks, linebreaks, safe-mode tokens
- **Arity inference tests**: Binary/unary operations, chained operations, literals, user-defined words, unknown builtins
- **Purity tests**: Arithmetic blocks marked as pure, `can_fuse` and `can_short_circuit` flags
- **Dependency tracking**: Verifies user-defined words are recorded
- **End-to-end correctness**: MAP, FILTER, ANY, ALL, COUNT, FOLD, SCAN produce correct results and use quantized path

### Performance Testing (`perf-regression-tests.rs`)
- **Timing infrastructure**: `run_code_timed()` and `print_metrics()` for lightweight profiling
- **Cache validation**: Tests for CompiledPlan cache hits/misses and invalidation on redefinition
- **Quantized path verification**: Confirms each HOF uses quantized kernels
- **Hit-rate validation**: Verifies cache hit rates are high for repeated operations

## Implementation Details

- **Symbolic stack simulation**: Tracks depth changes through operations; if depth would go negative, updates minimum depth to detect external stack consumption
- **Graceful fallback**: If any operation has unknown arity (user words, qualified words, fallback tokens), both input and output arity become `Variable`
- **Stack isolation**: Quantized kernels save/restore the outer stack to prevent interference
- **Metrics tracking**: Runtime metrics count quantized block builds and uses for performance monitoring

https://claude.ai/code/session_01Pj6oZtQQVh4i4GisdAoLqM