### PR TITLE
Fix elastic mode parsing robustness and add WASM execution mode APIs

### DIFF
--- a/rust/src/elastic/elastic-engine-tests.rs
+++ b/rust/src/elastic/elastic-engine-tests.rs
@@ -234,6 +234,9 @@ mod tests {
         assert_eq!(ElasticMode::from_str("greedy"),        ElasticMode::Greedy);
         assert_eq!(ElasticMode::from_str("elastic-safe"),  ElasticMode::ElasticSafe);
         assert_eq!(ElasticMode::from_str("elastic-force"), ElasticMode::ElasticForce);
+        assert_eq!(ElasticMode::from_str("elastic_safe"),  ElasticMode::ElasticSafe);
+        assert_eq!(ElasticMode::from_str("elastic_force"), ElasticMode::ElasticForce);
+        assert_eq!(ElasticMode::from_str(" Elastic-Safe "), ElasticMode::ElasticSafe);
     }
 
     #[test]

--- a/rust/src/elastic/execution_mode.rs
+++ b/rust/src/elastic/execution_mode.rs
@@ -19,14 +19,17 @@ impl ElasticMode {
     ///
     /// Unknown strings produce a stderr warning and fall back to `Greedy`.
     pub fn from_str(s: &str) -> Self {
-        match s {
+        let normalized = s.trim().to_ascii_lowercase();
+        match normalized.as_str() {
             "elastic-safe"  => ElasticMode::ElasticSafe,
+            "elastic_safe"  => ElasticMode::ElasticSafe,
             "elastic-force" => ElasticMode::ElasticForce,
+            "elastic_force" => ElasticMode::ElasticForce,
             "greedy"        => ElasticMode::Greedy,
-            other => {
+            _ => {
                 eprintln!(
                     "[warn] Unknown execution mode '{}'. Falling back to greedy.",
-                    other
+                    s
                 );
                 ElasticMode::Greedy
             }

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -5,6 +5,7 @@ use super::{set_js_prop, AjisaiInterpreter};
 use crate::builtins;
 use crate::interpreter;
 use crate::tokenizer;
+use crate::elastic::ElasticMode;
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 
@@ -241,6 +242,17 @@ impl AjisaiInterpreter {
     #[wasm_bindgen]
     pub fn clear_io_output_buffer(&mut self) {
         self.interpreter.io_output_buffer.clear();
+    }
+
+    #[wasm_bindgen]
+    pub fn set_execution_mode(&mut self, mode: &str) {
+        self.interpreter
+            .set_elastic_mode(ElasticMode::from_str(mode));
+    }
+
+    #[wasm_bindgen]
+    pub fn get_execution_mode(&self) -> String {
+        self.interpreter.elastic_mode().as_str().to_string()
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
### Motivation
- Mode selection for the new Elastic Evaluation Engine was brittle and silently fell back to `Greedy` for minor input differences (case, whitespace, underscore). 
- JS/WASM integration lacked any API to change or read the interpreter execution mode, making it hard to use the elastic modes from the UI or embedding contexts. 

### Description
- Normalize incoming strings in `ElasticMode::from_str` with `trim().to_ascii_lowercase()` before matching. 
- Accept both hyphen and underscore aliases (`elastic-safe` / `elastic_safe`, `elastic-force` / `elastic_force`) in the parser. 
- Add WASM bindings on `AjisaiInterpreter`: `set_execution_mode(mode: &str)` and `get_execution_mode() -> String` in `rust/src/wasm-interpreter-state.rs`. 
- Extend the elastic mode unit test in `rust/src/elastic/elastic-engine-tests.rs` to cover underscore aliases and whitespace/case normalization. 

### Testing
- Ran `cargo test elastic_mode_from_str_known` which passed. 
- Ran `cargo test interpreter_elastic_safe_runs_without_error` which passed. 
- Ran full Rust test suite with `cd rust && cargo test` and `npm run check` in the repo root via `cd /workspace/Ajisai && npm run check`, and the automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6008b8648326a6be4af9e6ae08a7)