### PR TITLE
Add hedged execution scaffolding: modes, metrics, hedging modules, and mode propagation

### DIFF
--- a/js/gui/interpreter-execution-utils.ts
+++ b/js/gui/interpreter-execution-utils.ts
@@ -20,7 +20,8 @@ export const createExecutionSnapshot = (interpreter: AjisaiInterpreter): Interpr
     createInterpreterSnapshot({
         stack: interpreter.collect_stack(),
         userWords: collectUserWords(interpreter),
-        importedModules: interpreter.collect_imported_modules()
+        importedModules: interpreter.collect_imported_modules(),
+        executionMode: interpreter.get_execution_mode()
     });
 
 export const syncInterpreterState = (

--- a/js/wasm-interpreter-types.ts
+++ b/js/wasm-interpreter-types.ts
@@ -1,4 +1,11 @@
 
+export type ExecutionMode =
+    | 'greedy'
+    | 'elastic-safe'
+    | 'elastic-force'
+    | 'hedged-safe'
+    | 'hedged-trace';
+
 
 export interface AjisaiInterpreterClass {
     new(): AjisaiInterpreter;
@@ -28,6 +35,8 @@ export interface AjisaiInterpreter {
     collect_module_sample_words_info(module_name: string): Array<[string, string | null]>;
     collect_dictionary_dependencies(): Array<[string, string[], string[]]>;
     restore_imported_modules(modules: string[]): void;
+    set_execution_mode(mode: ExecutionMode): void;
+    get_execution_mode(): ExecutionMode;
 }
 
 export interface ExecuteResult {

--- a/js/workers/execution-worker-manager.ts
+++ b/js/workers/execution-worker-manager.ts
@@ -8,6 +8,7 @@ interface WorkerTask {
     id: string;
     code: string;
     state: InterpreterSnapshot;
+    hedgedRequestId: string;
     resolve: (result: any) => void;
     reject: (error: any) => void;
 }
@@ -126,7 +127,9 @@ export class WorkerManager {
             type: 'execute',
             id: task.id,
             code: task.code,
-            state: task.state
+            state: task.state,
+            executionMode: task.state.executionMode,
+            hedgedRequestId: task.hedgedRequestId
         });
     }
 
@@ -139,6 +142,10 @@ export class WorkerManager {
         return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
     }
 
+    private createHedgedRequestId(): string {
+        return `hedged-${this.createTaskId()}`;
+    }
+
     execute(code: string, state: InterpreterSnapshot): Promise<ExecuteResult> {
         this.ensureWorkers();
         return new Promise((resolve, reject) => {
@@ -146,6 +153,7 @@ export class WorkerManager {
                 id: this.createTaskId(),
                 code,
                 state,
+                hedgedRequestId: this.createHedgedRequestId(),
                 resolve,
                 reject
             };

--- a/js/workers/interpreter-snapshot.ts
+++ b/js/workers/interpreter-snapshot.ts
@@ -1,19 +1,22 @@
-import type { AjisaiInterpreter, UserWord, Value } from '../wasm-interpreter-types';
+import type { AjisaiInterpreter, ExecutionMode, UserWord, Value } from '../wasm-interpreter-types';
 
 export interface InterpreterSnapshot {
     readonly stack: Value[];
     readonly userWords: UserWord[];
     readonly importedModules: string[];
+    readonly executionMode: ExecutionMode;
 }
 
 export const createInterpreterSnapshot = (snapshot: {
     readonly stack: Value[];
     readonly userWords: UserWord[];
     readonly importedModules?: string[];
+    readonly executionMode?: ExecutionMode;
 }): InterpreterSnapshot => ({
     stack: snapshot.stack,
     userWords: snapshot.userWords,
-    importedModules: snapshot.importedModules ?? []
+    importedModules: snapshot.importedModules ?? [],
+    executionMode: snapshot.executionMode ?? "greedy"
 });
 
 export const applyInterpreterSnapshot = (
@@ -31,5 +34,8 @@ export const applyInterpreterSnapshot = (
     }
     if (snapshot.userWords) {
         interpreter.restore_user_words(snapshot.userWords);
+    }
+    if (snapshot.executionMode) {
+        interpreter.set_execution_mode(snapshot.executionMode);
     }
 };

--- a/rust/src/elastic/cache_manager.rs
+++ b/rust/src/elastic/cache_manager.rs
@@ -1,3 +1,4 @@
+use crate::types::Value;
 /// Pure-result cache for the Elastic Engine (M4).
 ///
 /// Only values produced by words with `purity == Purity::Pure` are stored.
@@ -9,9 +10,7 @@
 /// ```
 /// where `args_repr` is the `Debug` representation of the argument list and
 /// `mode` is the execution mode string (`"elastic-safe"` etc.).
-
 use std::collections::HashMap;
-use crate::types::Value;
 
 // ── Internal entry ────────────────────────────────────────────────────────────
 
@@ -25,8 +24,8 @@ struct CacheEntry {
 
 #[derive(Debug, Default)]
 pub struct CacheManager {
-    store:      HashMap<String, CacheEntry>,
-    hit_count:  u64,
+    store: HashMap<String, CacheEntry>,
+    hit_count: u64,
     miss_count: u64,
 }
 
@@ -42,7 +41,22 @@ impl CacheManager {
     /// `args_repr` should be a stable, deterministic string representation
     /// of the word's input arguments (e.g. `format!("{:?}", args)`).
     pub fn build_key(word_name: &str, args_repr: &str, mode: &str) -> String {
-        format!("{}|{}|{}", word_name, args_repr, mode)
+        Self::build_key_with_context(word_name, args_repr, mode, None, 0, 0)
+    }
+
+    pub fn build_key_with_context(
+        word_name: &str,
+        args_repr: &str,
+        mode: &str,
+        strategy_label: Option<&str>,
+        dictionary_epoch: u64,
+        module_epoch: u64,
+    ) -> String {
+        let strategy = strategy_label.unwrap_or("none");
+        format!(
+            "{}|{}|{}|{}|dict:{}|mod:{}",
+            word_name, args_repr, mode, strategy, dictionary_epoch, module_epoch
+        )
     }
 
     // ── Read ──────────────────────────────────────────────────────────────
@@ -54,7 +68,7 @@ impl CacheManager {
     pub fn fetch(&mut self, key: &str) -> (Option<Value>, bool) {
         if let Some(entry) = self.store.get_mut(key) {
             entry.hit_count += 1;
-            self.hit_count  += 1;
+            self.hit_count += 1;
             if crate::elastic::tracer::is_enabled() {
                 eprintln!("[cache]   HIT  key={}", key);
             }
@@ -79,7 +93,13 @@ impl CacheManager {
         if !pure {
             return;
         }
-        self.store.insert(key, CacheEntry { value, hit_count: 0 });
+        self.store.insert(
+            key,
+            CacheEntry {
+                value,
+                hit_count: 0,
+            },
+        );
     }
 
     // ── Invalidation ──────────────────────────────────────────────────────
@@ -114,6 +134,10 @@ impl CacheManager {
     /// Hit rate in [0.0, 1.0].  Returns `0.0` when no accesses have occurred.
     pub fn hit_rate(&self) -> f64 {
         let total = self.hit_count + self.miss_count;
-        if total == 0 { 0.0 } else { self.hit_count as f64 / total as f64 }
+        if total == 0 {
+            0.0
+        } else {
+            self.hit_count as f64 / total as f64
+        }
     }
 }

--- a/rust/src/elastic/elastic-engine-tests.rs
+++ b/rust/src/elastic/elastic-engine-tests.rs
@@ -13,16 +13,25 @@ mod tests {
     // M1 — Purity table
     // ────────────────────────────────────────────────────────────────────────
 
-    use crate::elastic::purity_table::{purity_by_name, infer_purity, Purity, EvalCost};
+    use crate::elastic::purity_table::{infer_purity, purity_by_name, EvalCost, Purity};
 
     #[test]
     fn purity_table_arithmetic_is_pure_trivial() {
         for word in &["+", "-", "*", "/", "=", "<", "<="] {
             let info = purity_by_name(word)
                 .unwrap_or_else(|| panic!("missing purity entry for '{}'", word));
-            assert_eq!(info.purity, Purity::Pure,   "{}: expected Pure",           word);
-            assert_eq!(info.cost,   EvalCost::Trivial, "{}: expected Trivial cost", word);
-            assert!(!info.order_sensitive, "{}: should not be order_sensitive", word);
+            assert_eq!(info.purity, Purity::Pure, "{}: expected Pure", word);
+            assert_eq!(
+                info.cost,
+                EvalCost::Trivial,
+                "{}: expected Trivial cost",
+                word
+            );
+            assert!(
+                !info.order_sensitive,
+                "{}: should not be order_sensitive",
+                word
+            );
         }
     }
 
@@ -51,7 +60,7 @@ mod tests {
             let info = purity_by_name(word)
                 .unwrap_or_else(|| panic!("missing purity entry for '{}'", word));
             assert_eq!(info.purity, Purity::Pure, "{}: expected Pure", word);
-            assert_eq!(info.cost,   EvalCost::Light, "{}: expected Light cost", word);
+            assert_eq!(info.cost, EvalCost::Light, "{}: expected Light cost", word);
         }
     }
 
@@ -67,12 +76,18 @@ mod tests {
 
     #[test]
     fn infer_purity_one_unknown() {
-        assert_eq!(infer_purity(&[Purity::Pure, Purity::Unknown, Purity::Pure]), Purity::Unknown);
+        assert_eq!(
+            infer_purity(&[Purity::Pure, Purity::Unknown, Purity::Pure]),
+            Purity::Unknown
+        );
     }
 
     #[test]
     fn infer_purity_one_impure_dominates() {
-        assert_eq!(infer_purity(&[Purity::Pure, Purity::Unknown, Purity::Impure]), Purity::Impure);
+        assert_eq!(
+            infer_purity(&[Purity::Pure, Purity::Unknown, Purity::Impure]),
+            Purity::Impure
+        );
     }
 
     #[test]
@@ -138,8 +153,8 @@ mod tests {
     #[test]
     fn evaluation_unit_priority_score() {
         let mut u = EvaluationUnit::new("FOO");
-        u.estimated_cost  = 4.0;
-        u.pruning_bonus   = 1.5;
+        u.estimated_cost = 4.0;
+        u.pruning_bonus = 1.5;
         // priority_score = cost - bonus = 2.5
         let score = u.priority_score();
         assert!((score - 2.5).abs() < f64::EPSILON);
@@ -157,11 +172,13 @@ mod tests {
     // ────────────────────────────────────────────────────────────────────────
 
     use crate::elastic::cache_manager::CacheManager;
-    use crate::types::{Value, ValueData};
     use crate::types::fraction::Fraction;
+    use crate::types::{Value, ValueData};
 
     fn scalar_value(n: i64) -> Value {
-        Value { data: ValueData::Scalar(Fraction::from(n)) }
+        Value {
+            data: ValueData::Scalar(Fraction::from(n)),
+        }
     }
 
     #[test]
@@ -180,7 +197,8 @@ mod tests {
     #[test]
     fn cache_miss_on_absent_key() {
         let mut cm = CacheManager::new();
-        let (val, hit) = cm.fetch("nonexistent|[]|greedy");
+        let missing_key = CacheManager::build_key("nonexistent", "[]", "greedy");
+        let (val, hit) = cm.fetch(&missing_key);
         assert!(!hit, "expected cache miss");
         assert!(val.is_none());
         assert_eq!(cm.miss_count(), 1);
@@ -214,9 +232,21 @@ mod tests {
     #[test]
     fn cache_invalidate_prefix() {
         let mut cm = CacheManager::new();
-        cm.store(CacheManager::build_key("+", "[1,2]", "es"), scalar_value(3), true);
-        cm.store(CacheManager::build_key("-", "[5,2]", "es"), scalar_value(3), true);
-        cm.store(CacheManager::build_key("MAP", "[]", "es"),  scalar_value(0), true);
+        cm.store(
+            CacheManager::build_key("+", "[1,2]", "es"),
+            scalar_value(3),
+            true,
+        );
+        cm.store(
+            CacheManager::build_key("-", "[5,2]", "es"),
+            scalar_value(3),
+            true,
+        );
+        cm.store(
+            CacheManager::build_key("MAP", "[]", "es"),
+            scalar_value(0),
+            true,
+        );
 
         assert_eq!(cm.cached_key_count(), 3);
         cm.invalidate_prefix("+");
@@ -231,12 +261,35 @@ mod tests {
 
     #[test]
     fn elastic_mode_from_str_known() {
-        assert_eq!(ElasticMode::from_str("greedy"),        ElasticMode::Greedy);
-        assert_eq!(ElasticMode::from_str("elastic-safe"),  ElasticMode::ElasticSafe);
-        assert_eq!(ElasticMode::from_str("elastic-force"), ElasticMode::ElasticForce);
-        assert_eq!(ElasticMode::from_str("elastic_safe"),  ElasticMode::ElasticSafe);
-        assert_eq!(ElasticMode::from_str("elastic_force"), ElasticMode::ElasticForce);
-        assert_eq!(ElasticMode::from_str(" Elastic-Safe "), ElasticMode::ElasticSafe);
+        assert_eq!(ElasticMode::from_str("greedy"), ElasticMode::Greedy);
+        assert_eq!(
+            ElasticMode::from_str("elastic-safe"),
+            ElasticMode::ElasticSafe
+        );
+        assert_eq!(
+            ElasticMode::from_str("elastic-force"),
+            ElasticMode::ElasticForce
+        );
+        assert_eq!(
+            ElasticMode::from_str("hedged-safe"),
+            ElasticMode::HedgedSafe
+        );
+        assert_eq!(
+            ElasticMode::from_str("hedged-trace"),
+            ElasticMode::HedgedTrace
+        );
+        assert_eq!(
+            ElasticMode::from_str("elastic_safe"),
+            ElasticMode::ElasticSafe
+        );
+        assert_eq!(
+            ElasticMode::from_str("elastic_force"),
+            ElasticMode::ElasticForce
+        );
+        assert_eq!(
+            ElasticMode::from_str(" Elastic-Safe "),
+            ElasticMode::ElasticSafe
+        );
     }
 
     #[test]
@@ -248,12 +301,20 @@ mod tests {
     fn elastic_mode_is_elastic() {
         assert!(!ElasticMode::Greedy.is_elastic());
         assert!(ElasticMode::ElasticSafe.is_elastic());
+        assert!(ElasticMode::HedgedSafe.is_elastic());
+        assert!(ElasticMode::HedgedTrace.is_elastic());
         assert!(ElasticMode::ElasticForce.is_elastic());
     }
 
     #[test]
     fn elastic_mode_as_str_round_trip() {
-        for mode in &[ElasticMode::Greedy, ElasticMode::ElasticSafe, ElasticMode::ElasticForce] {
+        for mode in &[
+            ElasticMode::Greedy,
+            ElasticMode::ElasticSafe,
+            ElasticMode::HedgedSafe,
+            ElasticMode::HedgedTrace,
+            ElasticMode::ElasticForce,
+        ] {
             assert_eq!(ElasticMode::from_str(mode.as_str()), *mode);
         }
     }
@@ -266,9 +327,9 @@ mod tests {
 
     fn make_unit(pure: bool, order_sensitive: bool, eager: bool) -> EvaluationUnit {
         let mut u = EvaluationUnit::new("TEST");
-        u.pure            = pure;
+        u.pure = pure;
         u.order_sensitive = order_sensitive;
-        u.eager_required  = eager;
+        u.eager_required = eager;
         u
     }
 
@@ -313,7 +374,10 @@ mod tests {
         let u = make_unit(false, true, true);
         let reason = bridge.should_fallback(&u, ElasticMode::ElasticForce);
         assert_eq!(reason, None);
-        assert!(bridge.fallback_log.is_empty(), "ElasticForce must not log fallbacks");
+        assert!(
+            bridge.fallback_log.is_empty(),
+            "ElasticForce must not log fallbacks"
+        );
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -334,13 +398,16 @@ mod tests {
     async fn run_elastic(code: &str) -> Vec<String> {
         let mut interp = Interpreter::new();
         interp.set_elastic_mode(ElasticMode::ElasticSafe);
-        interp.execute(code).await.expect("elastic-safe execution failed");
+        interp
+            .execute(code)
+            .await
+            .expect("elastic-safe execution failed");
         interp.stack.iter().map(|v| format!("{:?}", v)).collect()
     }
 
     macro_rules! assert_semantics_match {
         ($code:expr) => {{
-            let greedy  = run_greedy($code).await;
+            let greedy = run_greedy($code).await;
             let elastic = run_elastic($code).await;
             assert_eq!(
                 greedy, elastic,
@@ -465,6 +532,9 @@ mod tests {
     async fn interpreter_elastic_safe_runs_without_error() {
         let mut interp = Interpreter::new();
         interp.set_elastic_mode(ElasticMode::ElasticSafe);
-        interp.execute("[10] [20] + [5] - LENGTH").await.expect("elastic-safe mode failed");
+        interp
+            .execute("[10] [20] + [5] - LENGTH")
+            .await
+            .expect("elastic-safe mode failed");
     }
 }

--- a/rust/src/elastic/evaluation_unit.rs
+++ b/rust/src/elastic/evaluation_unit.rs
@@ -3,9 +3,8 @@
 /// Each unit represents one word invocation that the engine tracks.
 /// In greedy mode every unit is created and immediately marked `Done`.
 /// In elastic-safe mode the scheduler can reorder or cache pure units.
-
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 static UNIT_COUNTER: AtomicU32 = AtomicU32::new(1);
 
@@ -34,11 +33,11 @@ pub enum UnitState {
 impl std::fmt::Display for UnitState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            UnitState::Pending  => "pending",
-            UnitState::Ready    => "ready",
-            UnitState::Running  => "running",
-            UnitState::Done     => "done",
-            UnitState::Failed   => "failed",
+            UnitState::Pending => "pending",
+            UnitState::Ready => "ready",
+            UnitState::Running => "running",
+            UnitState::Done => "done",
+            UnitState::Failed => "failed",
             UnitState::Bypassed => "bypassed",
         };
         write!(f, "{}", s)
@@ -71,6 +70,18 @@ pub struct EvaluationUnit {
     pub pruning_bonus: f64,
     /// Append-only execution log for debugging / trace output.
     pub trace_log: Vec<String>,
+    /// `true` when this unit can participate in hedged execution.
+    pub hedge_eligible: bool,
+    /// Correlation id for candidate paths that belong to the same race.
+    pub hedge_group_id: Option<u64>,
+    /// Optional strategy descriptor used in trace and cache keys.
+    pub strategy_label: Option<String>,
+    /// `true` once a winner has been validated and committed.
+    pub winner_committed: bool,
+    /// `true` when this unit got cancelled as a losing candidate.
+    pub cancelled: bool,
+    /// Epoch captured when the race was spawned.
+    pub epoch_snapshot_at_spawn: Option<u64>,
 }
 
 impl EvaluationUnit {
@@ -87,21 +98,30 @@ impl EvaluationUnit {
             cache_key: None,
             pruning_bonus: 0.0,
             trace_log: Vec::new(),
+            hedge_eligible: false,
+            hedge_group_id: None,
+            strategy_label: None,
+            winner_committed: false,
+            cancelled: false,
+            epoch_snapshot_at_spawn: None,
         }
     }
 
     /// Build a unit pre-populated from purity table data.
-    pub fn from_purity(word_name: impl Into<String>, info: &crate::elastic::purity_table::PurityInfo) -> Self {
+    pub fn from_purity(
+        word_name: impl Into<String>,
+        info: &crate::elastic::purity_table::PurityInfo,
+    ) -> Self {
         use crate::elastic::purity_table::{EvalCost, Purity};
         let mut u = Self::new(word_name);
-        u.pure             = info.purity == Purity::Pure;
-        u.order_sensitive  = info.order_sensitive;
-        u.eager_required   = info.purity == Purity::Impure;
-        u.estimated_cost   = match info.cost {
+        u.pure = info.purity == Purity::Pure;
+        u.order_sensitive = info.order_sensitive;
+        u.eager_required = info.purity == Purity::Impure;
+        u.estimated_cost = match info.cost {
             EvalCost::Trivial => 0.5,
-            EvalCost::Light   => 1.0,
-            EvalCost::Medium  => 3.0,
-            EvalCost::Heavy   => 8.0,
+            EvalCost::Light => 1.0,
+            EvalCost::Medium => 3.0,
+            EvalCost::Heavy => 8.0,
         };
         u
     }

--- a/rust/src/elastic/execution_mode.rs
+++ b/rust/src/elastic/execution_mode.rs
@@ -4,6 +4,8 @@
 /// |---------------|-----------|
 /// | `Greedy`      | Sequential evaluation identical to all prior versions. Default. |
 /// | `ElasticSafe` | Pure sub-expressions may be cached; impure words always fall back to greedy. |
+/// | `HedgedSafe`  | Safe hedged race for allowlisted pure paths. |
+/// | `HedgedTrace` | Same as `HedgedSafe` plus verbose race tracing. |
 /// | `ElasticForce`| Debug only — bypasses some safety gates. **Never use in production.** |
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -11,6 +13,8 @@ pub enum ElasticMode {
     #[default]
     Greedy,
     ElasticSafe,
+    HedgedSafe,
+    HedgedTrace,
     ElasticForce,
 }
 
@@ -21,11 +25,15 @@ impl ElasticMode {
     pub fn from_str(s: &str) -> Self {
         let normalized = s.trim().to_ascii_lowercase();
         match normalized.as_str() {
-            "elastic-safe"  => ElasticMode::ElasticSafe,
-            "elastic_safe"  => ElasticMode::ElasticSafe,
+            "elastic-safe" => ElasticMode::ElasticSafe,
+            "elastic_safe" => ElasticMode::ElasticSafe,
             "elastic-force" => ElasticMode::ElasticForce,
             "elastic_force" => ElasticMode::ElasticForce,
-            "greedy"        => ElasticMode::Greedy,
+            "hedged-safe" => ElasticMode::HedgedSafe,
+            "hedged_safe" => ElasticMode::HedgedSafe,
+            "hedged-trace" => ElasticMode::HedgedTrace,
+            "hedged_trace" => ElasticMode::HedgedTrace,
+            "greedy" => ElasticMode::Greedy,
             _ => {
                 eprintln!(
                     "[warn] Unknown execution mode '{}'. Falling back to greedy.",
@@ -38,15 +46,23 @@ impl ElasticMode {
 
     pub fn as_str(self) -> &'static str {
         match self {
-            ElasticMode::Greedy       => "greedy",
-            ElasticMode::ElasticSafe  => "elastic-safe",
+            ElasticMode::Greedy => "greedy",
+            ElasticMode::ElasticSafe => "elastic-safe",
+            ElasticMode::HedgedSafe => "hedged-safe",
+            ElasticMode::HedgedTrace => "hedged-trace",
             ElasticMode::ElasticForce => "elastic-force",
         }
     }
 
     /// `true` for any elastic variant (safe or force).
     pub fn is_elastic(self) -> bool {
-        matches!(self, ElasticMode::ElasticSafe | ElasticMode::ElasticForce)
+        matches!(
+            self,
+            ElasticMode::ElasticSafe
+                | ElasticMode::HedgedSafe
+                | ElasticMode::HedgedTrace
+                | ElasticMode::ElasticForce
+        )
     }
 }
 

--- a/rust/src/elastic/fallback_bridge.rs
+++ b/rust/src/elastic/fallback_bridge.rs
@@ -6,7 +6,6 @@
 ///
 /// Every fallback decision is logged (when tracing is enabled) and
 /// appended to `fallback_log` for post-run analysis.
-
 use crate::elastic::evaluation_unit::EvaluationUnit;
 use crate::elastic::execution_mode::ElasticMode;
 use crate::elastic::tracer;
@@ -26,16 +25,28 @@ pub enum FallbackReason {
     UnexpectedSideEffect,
     /// `ElasticForce` is not active and a safety rule would be violated.
     ElasticForceDisabled,
+    HedgeDisabled,
+    HedgePolicyRejected,
+    HedgeValidationFailed,
+    EpochChangedDuringRace,
+    LoserDiscarded,
+    WorkerUnavailable,
 }
 
 impl FallbackReason {
     pub fn as_str(self) -> &'static str {
         match self {
-            FallbackReason::UnknownPurity            => "unknown_purity",
-            FallbackReason::OrderSensitive           => "order_sensitive",
-            FallbackReason::DependencyUnresolvable   => "dependency_unresolvable",
-            FallbackReason::UnexpectedSideEffect     => "unexpected_side_effect",
-            FallbackReason::ElasticForceDisabled     => "elastic_force_disabled",
+            FallbackReason::UnknownPurity => "unknown_purity",
+            FallbackReason::OrderSensitive => "order_sensitive",
+            FallbackReason::DependencyUnresolvable => "dependency_unresolvable",
+            FallbackReason::UnexpectedSideEffect => "unexpected_side_effect",
+            FallbackReason::ElasticForceDisabled => "elastic_force_disabled",
+            FallbackReason::HedgeDisabled => "hedge_disabled",
+            FallbackReason::HedgePolicyRejected => "hedge_policy_rejected",
+            FallbackReason::HedgeValidationFailed => "hedge_validation_failed",
+            FallbackReason::EpochChangedDuringRace => "epoch_changed_during_race",
+            FallbackReason::LoserDiscarded => "loser_discarded",
+            FallbackReason::WorkerUnavailable => "worker_unavailable",
         }
     }
 }
@@ -50,9 +61,9 @@ impl std::fmt::Display for FallbackReason {
 
 #[derive(Debug, Clone)]
 pub struct FallbackLogEntry {
-    pub unit_id:   u32,
+    pub unit_id: u32,
     pub word_name: String,
-    pub reason:    FallbackReason,
+    pub reason: FallbackReason,
 }
 
 // ── Bridge ────────────────────────────────────────────────────────────────────
@@ -79,8 +90,8 @@ impl FallbackBridge {
     /// 4. `eager_required`     → `OrderSensitive` (I/O must be immediate)
     pub fn should_fallback(
         &mut self,
-        unit:  &EvaluationUnit,
-        mode:  ElasticMode,
+        unit: &EvaluationUnit,
+        mode: ElasticMode,
     ) -> Option<FallbackReason> {
         // ElasticForce skips all safety gates (debug / benchmarking only).
         if mode == ElasticMode::ElasticForce {
@@ -113,7 +124,7 @@ impl FallbackBridge {
             );
         }
         self.fallback_log.push(FallbackLogEntry {
-            unit_id:   unit.id,
+            unit_id: unit.id,
             word_name: unit.word_name.clone(),
             reason,
         });

--- a/rust/src/elastic/hedged_executor.rs
+++ b/rust/src/elastic/hedged_executor.rs
@@ -1,0 +1,18 @@
+use super::hedged_result::{HedgedCandidateResult, HedgedRejectReason, HedgedWinner};
+
+pub fn validate_winner(
+    winner: &HedgedCandidateResult,
+    current_epoch: u64,
+    expected_stack_len: usize,
+) -> Result<HedgedWinner, HedgedRejectReason> {
+    if winner.epoch_at_spawn != current_epoch {
+        return Err(HedgedRejectReason::EpochMismatch);
+    }
+    if winner.stack.len() < expected_stack_len {
+        return Err(HedgedRejectReason::StackShapeMismatch);
+    }
+    Ok(HedgedWinner {
+        path: winner.path,
+        stack: winner.stack.clone(),
+    })
+}

--- a/rust/src/elastic/hedged_policy.rs
+++ b/rust/src/elastic/hedged_policy.rs
@@ -1,0 +1,32 @@
+const DENY_WORDS: &[&str] = &[
+    "PRINT",
+    "INPUT",
+    "IMPORT",
+    "RESTORE-MODULE",
+    "RESTORE-IMPORTS",
+    "NOW",
+    "RAND",
+];
+
+const HOF_ALLOWLIST: &[&str] = &["MAP", "FILTER", "ANY", "ALL", "COUNT", "FOLD", "SCAN"];
+
+pub fn can_hedge_word(word: &str) -> bool {
+    let upper = word.trim().to_ascii_uppercase();
+    if DENY_WORDS.contains(&upper.as_str()) {
+        return false;
+    }
+    true
+}
+
+pub fn can_hedge_code_block(tokens: &[String]) -> bool {
+    !tokens.is_empty() && tokens.iter().all(|token| can_hedge_word(token))
+}
+
+pub fn can_hedge_cond_guard(tokens: &[String]) -> bool {
+    can_hedge_code_block(tokens)
+}
+
+pub fn can_hedge_hof_kernel(word: &str) -> bool {
+    let upper = word.trim().to_ascii_uppercase();
+    HOF_ALLOWLIST.contains(&upper.as_str())
+}

--- a/rust/src/elastic/hedged_result.rs
+++ b/rust/src/elastic/hedged_result.rs
@@ -1,0 +1,23 @@
+use crate::types::Value;
+
+use super::hedged_trace::HedgedPath;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HedgedRejectReason {
+    EpochMismatch,
+    StackShapeMismatch,
+    ValidationFailed,
+}
+
+#[derive(Debug, Clone)]
+pub struct HedgedCandidateResult {
+    pub path: HedgedPath,
+    pub stack: Vec<Value>,
+    pub epoch_at_spawn: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct HedgedWinner {
+    pub path: HedgedPath,
+    pub stack: Vec<Value>,
+}

--- a/rust/src/elastic/hedged_snapshot.rs
+++ b/rust/src/elastic/hedged_snapshot.rs
@@ -1,0 +1,26 @@
+use crate::interpreter::EpochSnapshot;
+use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::types::{DisplayHint, Value};
+
+#[derive(Debug, Clone)]
+pub struct HedgedSnapshot {
+    pub stack: Vec<Value>,
+    pub display_hints: Vec<DisplayHint>,
+    pub operation_target_mode: OperationTargetMode,
+    pub consumption_mode: ConsumptionMode,
+    pub safe_mode: bool,
+    pub epoch_snapshot: EpochSnapshot,
+}
+
+impl HedgedSnapshot {
+    pub fn from_interpreter(interpreter: &Interpreter) -> Self {
+        Self {
+            stack: interpreter.stack.clone(),
+            display_hints: interpreter.collect_stack_hints().to_vec(),
+            operation_target_mode: interpreter.operation_target_mode,
+            consumption_mode: interpreter.consumption_mode,
+            safe_mode: interpreter.safe_mode,
+            epoch_snapshot: interpreter.current_epoch_snapshot(),
+        }
+    }
+}

--- a/rust/src/elastic/hedged_trace.rs
+++ b/rust/src/elastic/hedged_trace.rs
@@ -1,0 +1,25 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HedgedPath {
+    Quantized,
+    Plain,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HedgedTraceEvent {
+    pub label: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HedgedTrace {
+    pub events: Vec<HedgedTraceEvent>,
+}
+
+impl HedgedTrace {
+    pub fn push(&mut self, label: impl Into<String>, detail: impl Into<String>) {
+        self.events.push(HedgedTraceEvent {
+            label: label.into(),
+            detail: detail.into(),
+        });
+    }
+}

--- a/rust/src/elastic/mod.rs
+++ b/rust/src/elastic/mod.rs
@@ -6,11 +6,15 @@
 ///
 /// All functionality is additive: the existing greedy evaluator is
 /// never rewritten — only wrapped.
-
 pub mod cache_manager;
 pub mod evaluation_unit;
 pub mod execution_mode;
 pub mod fallback_bridge;
+pub mod hedged_executor;
+pub mod hedged_policy;
+pub mod hedged_result;
+pub mod hedged_snapshot;
+pub mod hedged_trace;
 pub mod purity_table;
 pub mod tracer;
 
@@ -23,3 +27,11 @@ pub use purity_table::{infer_purity, purity_by_name, EvalCost, Purity, PurityInf
 #[cfg(test)]
 #[path = "elastic-engine-tests.rs"]
 mod elastic_engine_tests;
+
+pub use hedged_executor::validate_winner as validate_hedged_winner;
+pub use hedged_policy::{
+    can_hedge_code_block, can_hedge_cond_guard, can_hedge_hof_kernel, can_hedge_word,
+};
+pub use hedged_result::{HedgedCandidateResult, HedgedRejectReason, HedgedWinner};
+pub use hedged_snapshot::HedgedSnapshot;
+pub use hedged_trace::{HedgedPath, HedgedTrace, HedgedTraceEvent};

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -91,7 +91,6 @@ pub(crate) struct ChildRuntime {
     pub spawn_epoch: EpochSnapshot,
 }
 
-
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RuntimeMetrics {
     pub compiled_plan_build_count: u64,
@@ -99,6 +98,13 @@ pub struct RuntimeMetrics {
     pub compiled_plan_cache_miss_count: u64,
     pub quantized_block_build_count: u64,
     pub quantized_block_use_count: u64,
+    pub hedged_race_started_count: u64,
+    pub hedged_race_winner_quantized_count: u64,
+    pub hedged_race_winner_plain_count: u64,
+    pub hedged_race_fallback_count: u64,
+    pub hedged_race_cancel_count: u64,
+    pub hedged_race_validation_reject_count: u64,
+    pub cond_guard_prefetch_count: u64,
 }
 
 pub struct Interpreter {
@@ -149,7 +155,7 @@ pub struct Interpreter {
     pub(crate) runtime_metrics: RuntimeMetrics,
 
     // ── Elastic Engine (MVP) ──────────────────────────────────────────────
-    pub(crate) elastic_mode:  crate::elastic::ElasticMode,
+    pub(crate) elastic_mode: crate::elastic::ElasticMode,
     pub(crate) elastic_cache: crate::elastic::CacheManager,
 }
 
@@ -197,7 +203,7 @@ impl Interpreter {
             runtime_metrics: RuntimeMetrics::default(),
 
             // Elastic Engine
-            elastic_mode:  crate::elastic::ElasticMode::Greedy,
+            elastic_mode: crate::elastic::ElasticMode::Greedy,
             elastic_cache: crate::elastic::CacheManager::new(),
         };
         crate::elastic::tracer::init_from_env();
@@ -231,8 +237,6 @@ impl Interpreter {
         )
     }
 
-
-
     pub(crate) fn next_epoch(&mut self) -> u64 {
         self.global_epoch += 1;
         self.global_epoch
@@ -251,19 +255,28 @@ impl Interpreter {
     pub(crate) fn bump_dictionary_epoch(&mut self) {
         self.dictionary_epoch = self.next_epoch();
         #[cfg(feature = "trace-epoch")]
-        eprintln!("[trace-epoch] dictionary_epoch={} global_epoch={}", self.dictionary_epoch, self.global_epoch);
+        eprintln!(
+            "[trace-epoch] dictionary_epoch={} global_epoch={}",
+            self.dictionary_epoch, self.global_epoch
+        );
     }
 
     pub(crate) fn bump_module_epoch(&mut self) {
         self.module_epoch = self.next_epoch();
         #[cfg(feature = "trace-epoch")]
-        eprintln!("[trace-epoch] module_epoch={} global_epoch={}", self.module_epoch, self.global_epoch);
+        eprintln!(
+            "[trace-epoch] module_epoch={} global_epoch={}",
+            self.module_epoch, self.global_epoch
+        );
     }
 
     pub(crate) fn bump_execution_epoch(&mut self) {
         self.execution_epoch = self.next_epoch();
         #[cfg(feature = "trace-epoch")]
-        eprintln!("[trace-epoch] execution_epoch={} global_epoch={}", self.execution_epoch, self.global_epoch);
+        eprintln!(
+            "[trace-epoch] execution_epoch={} global_epoch={}",
+            self.execution_epoch, self.global_epoch
+        );
     }
 
     pub fn runtime_metrics(&self) -> RuntimeMetrics {
@@ -310,7 +323,6 @@ impl Interpreter {
         Ok(new_flow)
     }
 
-
     pub fn verify_all_flows(&self) -> Result<()> {
         for flow in &self.active_flows {
             let consumed_for_flow: Vec<Fraction> = self
@@ -323,7 +335,6 @@ impl Interpreter {
         }
         Ok(())
     }
-
 
     pub fn assert_all_flows_complete(&self) -> Result<()> {
         for flow in &self.active_flows {
@@ -344,7 +355,6 @@ impl Interpreter {
         }
         Ok(children)
     }
-
 
     pub(crate) fn update_operation_target_mode(&mut self, mode: OperationTargetMode) {
         self.operation_target_mode = mode;
@@ -379,7 +389,6 @@ impl Interpreter {
         self.next_registration_order += 1;
         order
     }
-
 
     pub fn execute_reset(&mut self) -> Result<()> {
         self.stack.clear();


### PR DESCRIPTION
### Motivation

- Introduce a hedged evaluation mode (safe + trace) as a controlled, allowlist-driven optimization path while preserving existing greedy semantics. 
- Provide runtime scaffolding (metrics, trace, snapshot, policy, result validation) required to implement hedged races for pure operations without enabling speculative commits. 
- Propagate execution mode through JS snapshots and worker requests to allow worker-side hedged execution and future winner/loser cancellation handling. 

### Description

- Add `HedgedSafe` and `HedgedTrace` to `ElasticMode` parsing/serialization and extend `is_elastic` handling in `rust/src/elastic/execution_mode.rs`. 
- Add hedged-related runtime counters to `RuntimeMetrics` in `rust/src/interpreter/interpreter-core.rs` (started/winner/fallback/cancel/validation reject and `cond_guard_prefetch_count`). 
- Add hedged engine scaffolding under `rust/src/elastic/`: `hedged_policy.rs`, `hedged_result.rs`, `hedged_snapshot.rs`, `hedged_executor.rs`, and `hedged_trace.rs`, and wire them into `rust/src/elastic/mod.rs` as public APIs. 
- Extend `EvaluationUnit` with hedged lifecycle fields (`hedge_eligible`, `hedge_group_id`, `strategy_label`, `winner_committed`, `cancelled`, `epoch_snapshot_at_spawn`) in `rust/src/elastic/evaluation_unit.rs`. 
- Extend `FallbackReason` in `rust/src/elastic/fallback_bridge.rs` with hedging-specific reasons (`HedgeDisabled`, `HedgePolicyRejected`, `HedgeValidationFailed`, `EpochChangedDuringRace`, `LoserDiscarded`, `WorkerUnavailable`). 
- Expand cache key support in `rust/src/elastic/cache_manager.rs` with `build_key_with_context(...)` to include `strategy_label`, `dictionary_epoch`, and `module_epoch`, and make `build_key` a backward-compatible wrapper. 
- Add hedged snapshot creation helper `HedgedSnapshot::from_interpreter` in `rust/src/elastic/hedged_snapshot.rs` to capture isolated state for candidate execution. 
- Propagate execution mode into JS types and snapshots by adding `ExecutionMode` and `executionMode` to `js/wasm-interpreter-types.ts` and `js/workers/interpreter-snapshot.ts`, include `executionMode` in `createExecutionSnapshot` in `js/gui/interpreter-execution-utils.ts`, and send `executionMode` plus a `hedgedRequestId` in worker messages from `js/workers/execution-worker-manager.ts`. 
- Add lightweight `validate_winner` in `rust/src/elastic/hedged_executor.rs` and simple hedging policy helpers in `rust/src/elastic/hedged_policy.rs` as allowlist/deny scaffolding. 
- Update `rust/src/elastic/elastic-engine-tests.rs` to cover new mode parsing/round-trip checks and adapt cache-key usage. 

### Testing

- Ran the elastic engine unit tests with `cargo test --manifest-path rust/Cargo.toml elastic_engine_tests -- --nocapture` and all targeted tests passed (`46 passed; 0 failed`).
- Ran `cargo fmt` (via `cargo fmt --manifest-path rust/Cargo.toml`) and test run included build-time warnings only, with no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd68efab988326905a239284e439a0)