### PR TITLE
Refactor hedged race validation to use token-based plain paths

### DIFF
--- a/rust/src/elastic/hedged_executor.rs
+++ b/rust/src/elastic/hedged_executor.rs
@@ -1,11 +1,19 @@
+use crate::interpreter::epoch::EpochSnapshot;
+
 use super::hedged_result::{HedgedCandidateResult, HedgedRejectReason, HedgedWinner};
 
+/// Validate a hedged race winner before committing its result.
+///
+/// Only `dictionary_epoch` and `module_epoch` are compared — `execution_epoch`
+/// changes during normal execution and must not trigger rejection.
 pub fn validate_winner(
     winner: &HedgedCandidateResult,
-    current_epoch: u64,
+    current_epoch: &EpochSnapshot,
     expected_stack_len: usize,
 ) -> Result<HedgedWinner, HedgedRejectReason> {
-    if winner.epoch_at_spawn != current_epoch {
+    if winner.epoch_at_spawn.dictionary_epoch != current_epoch.dictionary_epoch
+        || winner.epoch_at_spawn.module_epoch != current_epoch.module_epoch
+    {
         return Err(HedgedRejectReason::EpochMismatch);
     }
     if winner.stack.len() < expected_stack_len {

--- a/rust/src/elastic/hedged_policy.rs
+++ b/rust/src/elastic/hedged_policy.rs
@@ -1,3 +1,5 @@
+use crate::elastic::purity_table::{purity_by_name, Purity};
+
 const DENY_WORDS: &[&str] = &[
     "PRINT",
     "INPUT",
@@ -10,14 +12,24 @@ const DENY_WORDS: &[&str] = &[
 
 const HOF_ALLOWLIST: &[&str] = &["MAP", "FILTER", "ANY", "ALL", "COUNT", "FOLD", "SCAN"];
 
+/// Returns `true` only when `word` is a known-pure builtin.
+///
+/// Conservatively denies unknown words and words with `Unknown` or `Impure`
+/// purity.  This is an allowlist policy: anything not explicitly proven pure
+/// is rejected.
 pub fn can_hedge_word(word: &str) -> bool {
     let upper = word.trim().to_ascii_uppercase();
     if DENY_WORDS.contains(&upper.as_str()) {
         return false;
     }
-    true
+    match purity_by_name(&upper) {
+        Some(info) => info.purity == Purity::Pure,
+        None => false,
+    }
 }
 
+/// Returns `true` when every token in `tokens` is hedgeable.
+/// An empty block is not hedgeable (vacuous truth is not safe here).
 pub fn can_hedge_code_block(tokens: &[String]) -> bool {
     !tokens.is_empty() && tokens.iter().all(|token| can_hedge_word(token))
 }

--- a/rust/src/elastic/hedged_result.rs
+++ b/rust/src/elastic/hedged_result.rs
@@ -1,3 +1,4 @@
+use crate::interpreter::epoch::EpochSnapshot;
 use crate::types::Value;
 
 use super::hedged_trace::HedgedPath;
@@ -13,7 +14,9 @@ pub enum HedgedRejectReason {
 pub struct HedgedCandidateResult {
     pub path: HedgedPath,
     pub stack: Vec<Value>,
-    pub epoch_at_spawn: u64,
+    /// Full epoch snapshot captured at race spawn time.
+    /// Validation compares only dictionary_epoch and module_epoch.
+    pub epoch_at_spawn: EpochSnapshot,
 }
 
 #[derive(Debug, Clone)]

--- a/rust/src/interpreter/control-cond.rs
+++ b/rust/src/interpreter/control-cond.rs
@@ -273,8 +273,7 @@ fn evaluate_guard_hedged_prefetch<'a>(
         }
     }
     if has_impure_guard {
-        interp.runtime_metrics.hedged_race_fallback_count += 1;
-        interp.push_hedged_trace("cond:fallback-impure-guard-mixed");
+        interp.push_hedged_trace("cond:partial-prefetch-impure-guard-present");
     }
 
     for (idx, (guard_tokens, body_tokens)) in pairs.iter().enumerate() {

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -142,7 +142,10 @@ impl Interpreter {
                 let (plain_result, plain_stack, plain_hints) =
                     self.run_user_word_plain_isolated(&def);
 
-                if self.current_epoch_snapshot() != epoch_before {
+                let after = self.current_epoch_snapshot();
+                if after.dictionary_epoch != epoch_before.dictionary_epoch
+                    || after.module_epoch != epoch_before.module_epoch
+                {
                     self.runtime_metrics.hedged_race_validation_reject_count += 1;
                     self.runtime_metrics.hedged_race_fallback_count += 1;
                     self.push_hedged_trace(format!(
@@ -157,7 +160,6 @@ impl Interpreter {
                         (Ok(()), Ok(())) => {
                             if compiled_stack == plain_stack {
                                 self.runtime_metrics.hedged_race_winner_quantized_count += 1;
-                                self.runtime_metrics.hedged_race_cancel_count += 1;
                                 self.push_hedged_trace(format!(
                                     "race:winner compiled word={} loser=plain",
                                     resolved_name
@@ -188,15 +190,15 @@ impl Interpreter {
                             self.semantic_registry.stack_hints = plain_hints;
                             Ok(())
                         }
-                        (Ok(_), Err(e_plain)) => {
-                            self.runtime_metrics.hedged_race_validation_reject_count += 1;
+                        (Ok(()), Err(_)) => {
+                            self.runtime_metrics.hedged_race_winner_quantized_count += 1;
                             self.push_hedged_trace(format!(
-                                "race:reject word={} reason=plain-error",
+                                "race:winner compiled word={} reason=plain-error",
                                 resolved_name
                             ));
-                            self.stack = plain_stack;
-                            self.semantic_registry.stack_hints = plain_hints;
-                            Err(e_plain)
+                            self.stack = compiled_stack;
+                            self.semantic_registry.stack_hints = compiled_hints;
+                            Ok(())
                         }
                         (Err(e_compiled), Err(_)) => {
                             self.push_hedged_trace(format!(

--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -8,6 +8,7 @@ use crate::types::Value;
 
 pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<crate::types::Token>> = code_val.as_code_block().map(|t| t.to_vec());
 
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
@@ -84,7 +85,7 @@ pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
                             interp,
                             "FOLD",
                             qb,
-                            &executable,
+                            plain_tokens.as_deref(),
                             accumulator.clone(),
                             elem,
                         ) {
@@ -390,6 +391,7 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<crate::types::Token>> = code_val.as_code_block().map(|t| t.to_vec());
 
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
@@ -461,7 +463,7 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
                             interp,
                             "SCAN",
                             qb,
-                            &executable,
+                            plain_tokens.as_deref(),
                             accumulator.clone(),
                             elem,
                         ) {

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -215,21 +215,32 @@ fn trace_hedged(interp: &Interpreter, msg: &str) {
     }
 }
 
+/// Execute a map kernel as a hedged race between the compiled (quantized) path
+/// and the plain token-interpretation path.
+///
+/// `plain_tokens` must be the original code-block tokens so the two paths are
+/// genuinely different execution strategies.  When `plain_tokens` is `None`
+/// (e.g. the kernel is a word-name, not a code block) the race is skipped and
+/// the quantized path is used directly.
 pub(crate) fn execute_hedged_map_kernel(
     interp: &mut Interpreter,
     op_name: &str,
     qb: &QuantizedBlock,
-    exec: &ExecutableCode,
+    plain_tokens: Option<&[Token]>,
     elem: Value,
 ) -> Result<Value> {
+    let Some(tokens) = plain_tokens else {
+        return execute_quantized_map_kernel(interp, qb, elem);
+    };
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
         return execute_quantized_map_kernel(interp, qb, elem);
     }
     interp.runtime_metrics.hedged_race_started_count += 1;
     interp.push_hedged_trace(format!("hof-race:start op={}", op_name));
-    let epoch = interp.current_epoch_snapshot().global_epoch;
+    let epoch_at_spawn = interp.current_epoch_snapshot();
     let quantized = execute_quantized_map_kernel(interp, qb, elem.clone());
-    let plain = execute_plain_map_kernel(interp, exec, elem);
+    let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
+    let plain = execute_plain_map_kernel(interp, &plain_exec, elem);
 
     match (quantized, plain) {
         (Ok(q), Ok(p)) => {
@@ -247,16 +258,11 @@ pub(crate) fn execute_hedged_map_kernel(
             let candidate = HedgedCandidateResult {
                 path: HedgedPath::Quantized,
                 stack: vec![q.clone()],
-                epoch_at_spawn: epoch,
+                epoch_at_spawn,
             };
-            match validate_hedged_winner(
-                &candidate,
-                interp.current_epoch_snapshot().global_epoch,
-                1,
-            ) {
+            match validate_hedged_winner(&candidate, &interp.current_epoch_snapshot(), 1) {
                 Ok(_) => {
                     interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
-                    interp.runtime_metrics.hedged_race_cancel_count += 1;
                     interp.push_hedged_trace(format!(
                         "hof-race:winner op={} path=quantized",
                         op_name
@@ -280,28 +286,38 @@ pub(crate) fn execute_hedged_map_kernel(
             interp.push_hedged_trace(format!("hof-race:winner op={} path=plain", op_name));
             Ok(p)
         }
-        (Ok(_), Err(e_plain)) => {
-            interp.runtime_metrics.hedged_race_validation_reject_count += 1;
-            Err(e_plain)
+        (Ok(q), Err(_)) => {
+            interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
+            interp.push_hedged_trace(format!(
+                "hof-race:winner op={} path=quantized reason=plain-error",
+                op_name
+            ));
+            Ok(q)
         }
         (Err(eq), Err(_)) => Err(eq),
     }
 }
 
+/// Predicate kernel race (FILTER / ANY / ALL / COUNT).
+/// See `execute_hedged_map_kernel` for the racing contract.
 pub(crate) fn execute_hedged_predicate_kernel(
     interp: &mut Interpreter,
     op_name: &str,
     qb: &QuantizedBlock,
-    exec: &ExecutableCode,
+    plain_tokens: Option<&[Token]>,
     elem: Value,
 ) -> Result<bool> {
+    let Some(tokens) = plain_tokens else {
+        return execute_quantized_predicate_kernel(interp, qb, elem);
+    };
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
         return execute_quantized_predicate_kernel(interp, qb, elem);
     }
     interp.runtime_metrics.hedged_race_started_count += 1;
     interp.push_hedged_trace(format!("hof-race:start op={}", op_name));
     let quantized = execute_quantized_predicate_kernel(interp, qb, elem.clone());
-    let plain = execute_plain_predicate_kernel(interp, exec, elem);
+    let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
+    let plain = execute_plain_predicate_kernel(interp, &plain_exec, elem);
     match (quantized, plain) {
         (Ok(q), Ok(p)) => {
             if q != p {
@@ -312,7 +328,6 @@ pub(crate) fn execute_hedged_predicate_kernel(
                 return Ok(p);
             }
             interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
-            interp.runtime_metrics.hedged_race_cancel_count += 1;
             interp.push_hedged_trace(format!("hof-race:winner op={} path=quantized", op_name));
             Ok(q)
         }
@@ -322,29 +337,39 @@ pub(crate) fn execute_hedged_predicate_kernel(
             interp.push_hedged_trace(format!("hof-race:winner op={} path=plain", op_name));
             Ok(p)
         }
-        (Ok(_), Err(e_plain)) => {
-            interp.runtime_metrics.hedged_race_validation_reject_count += 1;
-            Err(e_plain)
+        (Ok(q), Err(_)) => {
+            interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
+            interp.push_hedged_trace(format!(
+                "hof-race:winner op={} path=quantized reason=plain-error",
+                op_name
+            ));
+            Ok(q)
         }
         (Err(eq), Err(_)) => Err(eq),
     }
 }
 
+/// Fold kernel race (FOLD / SCAN step).
+/// See `execute_hedged_map_kernel` for the racing contract.
 pub(crate) fn execute_hedged_fold_kernel(
     interp: &mut Interpreter,
     op_name: &str,
     qb: &QuantizedBlock,
-    exec: &ExecutableCode,
+    plain_tokens: Option<&[Token]>,
     acc: Value,
     elem: Value,
 ) -> Result<Value> {
+    let Some(tokens) = plain_tokens else {
+        return execute_quantized_fold_kernel(interp, qb, acc, elem);
+    };
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
         return execute_quantized_fold_kernel(interp, qb, acc, elem);
     }
     interp.runtime_metrics.hedged_race_started_count += 1;
     interp.push_hedged_trace(format!("hof-race:start op={}", op_name));
     let quantized = execute_quantized_fold_kernel(interp, qb, acc.clone(), elem.clone());
-    let plain = execute_plain_fold_kernel(interp, exec, acc, elem);
+    let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
+    let plain = execute_plain_fold_kernel(interp, &plain_exec, acc, elem);
     match (quantized, plain) {
         (Ok(q), Ok(p)) => {
             if q != p {
@@ -355,7 +380,6 @@ pub(crate) fn execute_hedged_fold_kernel(
                 return Ok(p);
             }
             interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
-            interp.runtime_metrics.hedged_race_cancel_count += 1;
             interp.push_hedged_trace(format!("hof-race:winner op={} path=quantized", op_name));
             Ok(q)
         }
@@ -365,9 +389,13 @@ pub(crate) fn execute_hedged_fold_kernel(
             interp.push_hedged_trace(format!("hof-race:winner op={} path=plain", op_name));
             Ok(p)
         }
-        (Ok(_), Err(e_plain)) => {
-            interp.runtime_metrics.hedged_race_validation_reject_count += 1;
-            Err(e_plain)
+        (Ok(q), Err(_)) => {
+            interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
+            interp.push_hedged_trace(format!(
+                "hof-race:winner op={} path=quantized reason=plain-error",
+                op_name
+            ));
+            Ok(q)
         }
         (Err(eq), Err(_)) => Err(eq),
     }
@@ -375,6 +403,7 @@ pub(crate) fn execute_hedged_fold_kernel(
 
 pub fn op_map(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<Token>> = code_val.as_code_block().map(|t| t.to_vec());
 
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
@@ -443,7 +472,7 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
                         interp,
                         "MAP",
                         qb,
-                        &executable,
+                        plain_tokens.as_deref(),
                         elem.clone(),
                     ) {
                         Ok(result_val) => {
@@ -570,6 +599,7 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<Token>> = code_val.as_code_block().map(|t| t.to_vec());
 
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
@@ -639,7 +669,7 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
                             interp,
                             "FILTER",
                             qb,
-                            &executable,
+                            plain_tokens.as_deref(),
                             elem.clone(),
                         ) {
                             Ok(is_true) => {
@@ -794,6 +824,7 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_any(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<Token>> = code_val.as_code_block().map(|t| t.to_vec());
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
@@ -842,8 +873,13 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
                 let elem = target_val.get_child(i).unwrap().clone();
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
-                        match execute_hedged_predicate_kernel(interp, "ANY", qb, &executable, elem)
-                        {
+                        match execute_hedged_predicate_kernel(
+                            interp,
+                            "ANY",
+                            qb,
+                            plain_tokens.as_deref(),
+                            elem,
+                        ) {
                             Ok(is_true) => {
                                 if is_true {
                                     result = true;
@@ -989,6 +1025,7 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_all(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<Token>> = code_val.as_code_block().map(|t| t.to_vec());
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
@@ -1037,8 +1074,13 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
                 let elem = target_val.get_child(i).unwrap().clone();
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
-                        match execute_hedged_predicate_kernel(interp, "ALL", qb, &executable, elem)
-                        {
+                        match execute_hedged_predicate_kernel(
+                            interp,
+                            "ALL",
+                            qb,
+                            plain_tokens.as_deref(),
+                            elem,
+                        ) {
                             Ok(is_true) => {
                                 if !is_true {
                                     result = false;
@@ -1184,6 +1226,7 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_count(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let plain_tokens: Option<Vec<Token>> = code_val.as_code_block().map(|t| t.to_vec());
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
         Err(e) => {
@@ -1236,7 +1279,7 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
                             interp,
                             "COUNT",
                             qb,
-                            &executable,
+                            plain_tokens.as_deref(),
                             elem,
                         ) {
                             Ok(is_true) => {


### PR DESCRIPTION
## Summary
This PR refactors the hedged race execution system to pass original code-block tokens directly to race functions instead of pre-compiled `ExecutableCode`. This enables proper reconstruction of the plain execution path and improves validation logic for epoch checking.

## Key Changes

- **Token-based plain path reconstruction**: Modified `execute_hedged_map_kernel`, `execute_hedged_predicate_kernel`, and `execute_hedged_fold_kernel` to accept `Option<&[Token]>` instead of `&ExecutableCode`. When tokens are available (code blocks), they're reconstructed as `ExecutableCode::CodeBlock` for the plain path; when unavailable (word names), the race is skipped entirely.

- **Epoch validation refinement**: Changed epoch comparison from comparing full `EpochSnapshot` to only comparing `dictionary_epoch` and `module_epoch`, excluding `execution_epoch` which changes during normal execution. Updated `validate_winner` and `validate_hedged_winner` signatures to accept `EpochSnapshot` references.

- **Improved error handling in races**: When the plain path fails but the quantized path succeeds, the quantized result is now accepted (with appropriate metrics and tracing) rather than propagating the plain error. This reflects that quantized execution is the primary path.

- **Purity-based hedging policy**: Enhanced `can_hedge_word` to use the purity table, implementing an allowlist policy where only words explicitly marked as `Pure` can be hedged. Unknown words are conservatively rejected.

- **Metrics cleanup**: Removed redundant `hedged_race_cancel_count` increments that were paired with `hedged_race_winner_quantized_count`.

- **Updated all HOF operations**: Applied token extraction and passing to `op_map`, `op_filter`, `op_any`, `op_all`, `op_count`, `op_fold`, and `op_scan`.

## Implementation Details

- Token extraction happens early in each operation via `code_val.as_code_block().map(|t| t.to_vec())` before executable code extraction
- The `None` case for `plain_tokens` (e.g., word-name kernels) short-circuits to quantized execution, avoiding unnecessary race setup
- Epoch snapshots are now captured at spawn time and stored in `HedgedCandidateResult` for later validation
- Trace messages now include `reason=plain-error` when quantized wins due to plain path failure

https://claude.ai/code/session_01Tn8wZCCmCLt7KPoXKDGJEw