### PR TITLE
Refine header/footer gradient: expand red-purple and use OKLCH interp…

### DIFF
--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -84,7 +84,7 @@ select:focus-visible {
 
 
 header {
-    background: linear-gradient(to right, var(--gradient-header) 75%, var(--gradient-header-right) 100%);
+    background: linear-gradient(in oklch to right, var(--gradient-header) 70%, var(--gradient-header-right) 100%);
     padding: 1rem 2rem;
     display: flex;
     flex-direction: column;
@@ -175,7 +175,7 @@ header h1 a {
 
 
 footer {
-    background: linear-gradient(to right, var(--gradient-header) 75%, var(--gradient-header-right) 100%);
+    background: linear-gradient(in oklch to right, var(--gradient-header) 70%, var(--gradient-header-right) 100%);
     padding: 0.75rem 2rem;
     display: flex;
     align-items: center;


### PR DESCRIPTION
…olation

- Shift color stop from 75% to 70% (red-purple portion: 25% → 30%)
- Change interpolation from default sRGB to `in oklch` (perceptually uniform HCL-equivalent color space) to prevent muddiness at the blend point

https://claude.ai/code/session_01JMHLR7tcQuGSuQnQ5j4XA4