### PR TITLE
Add FastGuarded elastic mode and fast HOF kernel paths with tests and benchmark

### DIFF
--- a/rust/benches/interpreter-performance-benchmarks.rs
+++ b/rust/benches/interpreter-performance-benchmarks.rs
@@ -4,6 +4,7 @@ use num_bigint::BigInt;
 use num_traits::One;
 
 use ajisai_core::types::fraction::Fraction;
+use ajisai_core::elastic::ElasticMode;
 use ajisai_core::interpreter::Interpreter;
 
 
@@ -370,6 +371,53 @@ fn bench_interpreter_reuse(c: &mut Criterion) {
     });
 }
 
+fn bench_interpreter_hof_mode_matrix(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let scenarios: [(&str, &str, ElasticMode); 13] = [
+        ("map_arith_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP", ElasticMode::Greedy),
+        ("map_arith_hedged", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP", ElasticMode::HedgedSafe),
+        ("map_arith_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP", ElasticMode::FastGuarded),
+        ("map_predicate_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] < } MAP", ElasticMode::Greedy),
+        ("map_predicate_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] < } MAP", ElasticMode::FastGuarded),
+        ("filter_greedy", "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER", ElasticMode::Greedy),
+        ("filter_fast_guarded", "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER", ElasticMode::FastGuarded),
+        ("fold_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD", ElasticMode::Greedy),
+        ("fold_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD", ElasticMode::FastGuarded),
+        ("scan_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } SCAN", ElasticMode::Greedy),
+        ("scan_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } SCAN", ElasticMode::FastGuarded),
+        ("epoch_change_hedged", "{ [2] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP { [3] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP", ElasticMode::HedgedSafe),
+        ("epoch_change_fast_guarded", "{ [2] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP { [3] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP", ElasticMode::FastGuarded),
+    ];
+
+    c.bench_function("interp_hof_mode_matrix", |b| {
+        b.iter_custom(|iters| {
+            let start = std::time::Instant::now();
+            let mut last_metrics = None;
+            for _ in 0..iters {
+                for (_name, code, mode) in &scenarios {
+                    let mut interp = Interpreter::new();
+                    interp.set_elastic_mode(*mode);
+                    rt.block_on(interp.execute(code)).unwrap();
+                    black_box(interp.get_stack().clone());
+                    last_metrics = Some(interp.runtime_metrics());
+                }
+            }
+            if let Some(m) = last_metrics {
+                eprintln!(
+                    "[bench metrics] quant_use={} hedged_started={} winner_q={} winner_plain={} fallback={} reject={}",
+                    m.quantized_block_use_count,
+                    m.hedged_race_started_count,
+                    m.hedged_race_winner_quantized_count,
+                    m.hedged_race_winner_plain_count,
+                    m.hedged_race_fallback_count,
+                    m.hedged_race_validation_reject_count
+                );
+            }
+            start.elapsed()
+        })
+    });
+}
+
 
 const TRIE_ALPHABET_SIZE: usize = 40;
 
@@ -526,6 +574,7 @@ criterion_group!(
     bench_interpreter_custom_word,
     bench_interpreter_vector_construction,
     bench_interpreter_fraction_heavy,
+    bench_interpreter_hof_mode_matrix,
 );
 
 criterion_main!(dictionary_benches, fraction_benches, interpreter_benches);

--- a/rust/src/elastic/elastic-engine-tests.rs
+++ b/rust/src/elastic/elastic-engine-tests.rs
@@ -279,6 +279,10 @@ mod tests {
             ElasticMode::HedgedTrace
         );
         assert_eq!(
+            ElasticMode::from_str("fast-guarded"),
+            ElasticMode::FastGuarded
+        );
+        assert_eq!(
             ElasticMode::from_str("elastic_safe"),
             ElasticMode::ElasticSafe
         );
@@ -303,6 +307,7 @@ mod tests {
         assert!(ElasticMode::ElasticSafe.is_elastic());
         assert!(ElasticMode::HedgedSafe.is_elastic());
         assert!(ElasticMode::HedgedTrace.is_elastic());
+        assert!(ElasticMode::FastGuarded.is_elastic());
         assert!(ElasticMode::ElasticForce.is_elastic());
     }
 
@@ -313,6 +318,7 @@ mod tests {
             ElasticMode::ElasticSafe,
             ElasticMode::HedgedSafe,
             ElasticMode::HedgedTrace,
+            ElasticMode::FastGuarded,
             ElasticMode::ElasticForce,
         ] {
             assert_eq!(ElasticMode::from_str(mode.as_str()), *mode);
@@ -415,6 +421,16 @@ mod tests {
         interp.stack.iter().map(|v| format!("{:?}", v)).collect()
     }
 
+    async fn run_fast_guarded(code: &str) -> Vec<String> {
+        let mut interp = Interpreter::new();
+        interp.set_elastic_mode(ElasticMode::FastGuarded);
+        interp
+            .execute(code)
+            .await
+            .expect("fast-guarded execution failed");
+        interp.stack.iter().map(|v| format!("{:?}", v)).collect()
+    }
+
     macro_rules! assert_semantics_match {
         ($code:expr) => {{
             let greedy = run_greedy($code).await;
@@ -475,6 +491,34 @@ mod tests {
         assert_greedy_hedged_match!("[1 2 3 4 5 6] { [2] MOD [0] = } FILTER");
         assert_greedy_hedged_match!("[1 2 3 4] [0] { + } FOLD");
         assert_greedy_hedged_match!("[1 2 3 4] [0] { + } SCAN");
+    }
+
+    #[tokio::test]
+    async fn semantics_fast_guarded_hof_kernels() {
+        let code = "[1 2 3 4] { [1] + } MAP [1 2 3 4] { [2] MOD [0] = } FILTER [1 2 3 4] [0] { + } FOLD";
+        let greedy = run_greedy(code).await;
+        let fast_guarded = run_fast_guarded(code).await;
+        assert_eq!(
+            greedy, fast_guarded,
+            "Semantic divergence for fast-guarded mode:\n  greedy = {:?}\n  fast_guarded = {:?}",
+            greedy, fast_guarded
+        );
+    }
+
+    #[tokio::test]
+    async fn fast_guarded_avoids_hedged_race_start() {
+        let mut interp = Interpreter::new();
+        interp.set_elastic_mode(ElasticMode::FastGuarded);
+        interp
+            .execute("[1 2 3 4] { [1] + } MAP [1 2 3 4] [0] { + } FOLD")
+            .await
+            .expect("fast-guarded execution failed");
+        let m = interp.runtime_metrics();
+        assert_eq!(m.hedged_race_started_count, 0);
+        assert!(
+            m.quantized_block_use_count >= 1,
+            "fast-guarded should still use quantized kernels when guards pass"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/elastic/execution_mode.rs
+++ b/rust/src/elastic/execution_mode.rs
@@ -6,6 +6,7 @@
 /// | `ElasticSafe` | Pure sub-expressions may be cached; impure words always fall back to greedy. |
 /// | `HedgedSafe`  | Safe hedged race for allowlisted pure paths. |
 /// | `HedgedTrace` | Same as `HedgedSafe` plus verbose race tracing. |
+/// | `FastGuarded` | Guarded fast path (no plain race); guard miss falls back safely. |
 /// | `ElasticForce`| Debug only — bypasses some safety gates. **Never use in production.** |
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -15,6 +16,7 @@ pub enum ElasticMode {
     ElasticSafe,
     HedgedSafe,
     HedgedTrace,
+    FastGuarded,
     ElasticForce,
 }
 
@@ -33,6 +35,8 @@ impl ElasticMode {
             "hedged_safe" => ElasticMode::HedgedSafe,
             "hedged-trace" => ElasticMode::HedgedTrace,
             "hedged_trace" => ElasticMode::HedgedTrace,
+            "fast-guarded" => ElasticMode::FastGuarded,
+            "fast_guarded" => ElasticMode::FastGuarded,
             "greedy" => ElasticMode::Greedy,
             _ => {
                 eprintln!(
@@ -50,6 +54,7 @@ impl ElasticMode {
             ElasticMode::ElasticSafe => "elastic-safe",
             ElasticMode::HedgedSafe => "hedged-safe",
             ElasticMode::HedgedTrace => "hedged-trace",
+            ElasticMode::FastGuarded => "fast-guarded",
             ElasticMode::ElasticForce => "elastic-force",
         }
     }
@@ -61,6 +66,7 @@ impl ElasticMode {
             ElasticMode::ElasticSafe
                 | ElasticMode::HedgedSafe
                 | ElasticMode::HedgedTrace
+                | ElasticMode::FastGuarded
                 | ElasticMode::ElasticForce
         )
     }

--- a/rust/src/interpreter/fast-guarded-tests.rs
+++ b/rust/src/interpreter/fast-guarded-tests.rs
@@ -1,0 +1,166 @@
+use crate::elastic::ElasticMode;
+use crate::interpreter::higher_order::{
+    execute_hedged_fold_kernel, execute_hedged_map_kernel, execute_hedged_predicate_kernel,
+};
+use crate::interpreter::quantized_block::quantize_code_block;
+use crate::interpreter::Interpreter;
+use crate::types::fraction::Fraction;
+use crate::types::{Token, Value};
+
+fn t_num(n: &str) -> Token {
+    Token::Number(n.into())
+}
+
+fn t_sym(s: &str) -> Token {
+    Token::Symbol(s.into())
+}
+
+fn map_mul2_tokens() -> Vec<Token> {
+    vec![Token::VectorStart, t_num("2"), Token::VectorEnd, t_sym("*")]
+}
+
+fn predicate_lt2_tokens() -> Vec<Token> {
+    vec![Token::VectorStart, t_num("2"), Token::VectorEnd, t_sym("<")]
+}
+
+fn fold_add_tokens() -> Vec<Token> {
+    vec![t_sym("+")]
+}
+
+fn bump_dictionary_epoch(interp: &mut Interpreter) {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        interp
+            .execute("{ [ 1 ] + } 'INC_GUARD' DEF")
+            .await
+            .expect("define helper word");
+    });
+}
+
+fn value_to_i64(v: &Value) -> i64 {
+    if let Some(f) = v.as_scalar() {
+        return f.to_i64().expect("scalar i64");
+    }
+    if v.len() == 1 {
+        if let Some(child) = v.get_child(0) {
+            if let Some(f) = child.as_scalar() {
+                return f.to_i64().expect("inner scalar i64");
+            }
+        }
+    }
+    panic!("expected scalar or single-element vector");
+}
+
+#[test]
+fn fast_guarded_guard_hit_uses_quantized_without_race() {
+    let mut interp = Interpreter::new();
+    interp.set_elastic_mode(ElasticMode::FastGuarded);
+
+    let tokens = map_mul2_tokens();
+    let qb = quantize_code_block(&tokens, &mut interp).expect("quantize block");
+
+    let out = execute_hedged_map_kernel(
+        &mut interp,
+        "MAP",
+        &qb,
+        Some(tokens.as_slice()),
+        Value::from_number(Fraction::from(3_i64)),
+    )
+    .expect("fast-guarded map should succeed");
+
+    assert_eq!(value_to_i64(&out), 6);
+
+    let m = interp.runtime_metrics();
+    assert_eq!(m.hedged_race_started_count, 0);
+    assert_eq!(m.hedged_race_fallback_count, 0);
+    assert!(
+        m.quantized_block_use_count >= 1,
+        "guard hit should execute quantized path"
+    );
+}
+
+#[test]
+fn fast_guarded_guard_miss_falls_back_to_plain_without_race() {
+    let mut interp = Interpreter::new();
+    interp.set_elastic_mode(ElasticMode::FastGuarded);
+
+    let tokens = map_mul2_tokens();
+    let qb = quantize_code_block(&tokens, &mut interp).expect("quantize block");
+
+    // Mutate dictionary epoch after quantization so the guard signature mismatches.
+    bump_dictionary_epoch(&mut interp);
+
+    let out = execute_hedged_map_kernel(
+        &mut interp,
+        "MAP",
+        &qb,
+        Some(tokens.as_slice()),
+        Value::from_number(Fraction::from(3_i64)),
+    )
+    .expect("guard-miss fallback should succeed");
+
+    assert_eq!(value_to_i64(&out), 6);
+
+    let m = interp.runtime_metrics();
+    assert_eq!(m.hedged_race_started_count, 0);
+    assert!(
+        m.hedged_race_fallback_count >= 1,
+        "guard miss should record fallback"
+    );
+    assert!(
+        interp
+            .drain_hedged_trace()
+            .iter()
+            .any(|msg| msg.contains("fast-guarded:fallback")),
+        "guard miss should emit fast-guarded fallback trace"
+    );
+}
+
+#[test]
+fn fast_guarded_predicate_guard_miss_falls_back_to_plain_without_race() {
+    let mut interp = Interpreter::new();
+    interp.set_elastic_mode(ElasticMode::FastGuarded);
+
+    let tokens = predicate_lt2_tokens();
+    let qb = quantize_code_block(&tokens, &mut interp).expect("quantize block");
+    bump_dictionary_epoch(&mut interp);
+
+    let out = execute_hedged_predicate_kernel(
+        &mut interp,
+        "FILTER",
+        &qb,
+        Some(tokens.as_slice()),
+        Value::from_number(Fraction::from(1_i64)),
+    )
+    .expect("guard-miss predicate fallback should succeed");
+
+    assert!(out, "1 < 2 should be true");
+    let m = interp.runtime_metrics();
+    assert_eq!(m.hedged_race_started_count, 0);
+    assert!(m.hedged_race_fallback_count >= 1);
+}
+
+#[test]
+fn fast_guarded_fold_guard_miss_falls_back_to_plain_without_race() {
+    let mut interp = Interpreter::new();
+    interp.set_elastic_mode(ElasticMode::FastGuarded);
+
+    let tokens = fold_add_tokens();
+    let qb = quantize_code_block(&tokens, &mut interp).expect("quantize block");
+    bump_dictionary_epoch(&mut interp);
+
+    let out = execute_hedged_fold_kernel(
+        &mut interp,
+        "FOLD",
+        &qb,
+        Some(tokens.as_slice()),
+        Value::from_number(Fraction::from(10_i64)),
+        Value::from_number(Fraction::from(5_i64)),
+    )
+    .expect("guard-miss fold fallback should succeed");
+
+    assert_eq!(value_to_i64(&out), 15);
+    let m = interp.runtime_metrics();
+    assert_eq!(m.hedged_race_started_count, 0);
+    assert!(m.hedged_race_fallback_count >= 1);
+}

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -7,6 +7,7 @@ use crate::interpreter::value_extraction_helpers::{
     extract_integer_from_value, extract_word_name_from_value, is_vector_value,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, Token, Value, ValueData};
 
 pub(crate) enum ExecutableCode {
@@ -85,11 +86,224 @@ fn execute_quantized_block_stack_top(interp: &mut Interpreter, qb: &QuantizedBlo
     crate::interpreter::compiled_plan::execute_compiled_plan(interp, &qb.compiled_plan)
 }
 
+#[derive(Clone)]
+enum FastUnaryMapKernel {
+    AddConst(Fraction),
+    SubConst(Fraction),
+    MulConst(Fraction),
+    DivConst(Fraction),
+    ModConst(Fraction),
+    EqConst(Fraction),
+    LtConst(Fraction),
+    Abs,
+    Neg,
+    Not,
+}
+
+#[derive(Clone)]
+enum FastUnaryPredicateKernel {
+    EqConst(Fraction),
+    LtConst(Fraction),
+    Not,
+}
+
+#[derive(Clone, Copy)]
+enum FastBinaryFoldKernel {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+}
+
+fn parse_const_number_token(token: &Token) -> Option<Fraction> {
+    if let Token::Number(n) = token {
+        return Fraction::from_str(n).ok();
+    }
+    None
+}
+
+fn detect_fast_unary_map_kernel(tokens: &[Token]) -> Option<FastUnaryMapKernel> {
+    if tokens.len() == 1 {
+        if let Token::Symbol(sym) = &tokens[0] {
+            return match Interpreter::normalize_symbol(sym).as_ref() {
+                "ABS" => Some(FastUnaryMapKernel::Abs),
+                "NEG" => Some(FastUnaryMapKernel::Neg),
+                "NOT" => Some(FastUnaryMapKernel::Not),
+                _ => None,
+            };
+        }
+    }
+
+    if tokens.len() != 4 {
+        return None;
+    }
+
+    match (&tokens[0], &tokens[1], &tokens[2], &tokens[3]) {
+        (Token::VectorStart, constant, Token::VectorEnd, Token::Symbol(op)) => {
+            let c = parse_const_number_token(constant)?;
+            match Interpreter::normalize_symbol(op).as_ref() {
+                "+" => Some(FastUnaryMapKernel::AddConst(c)),
+                "-" => Some(FastUnaryMapKernel::SubConst(c)),
+                "*" => Some(FastUnaryMapKernel::MulConst(c)),
+                "/" => Some(FastUnaryMapKernel::DivConst(c)),
+                "MOD" => Some(FastUnaryMapKernel::ModConst(c)),
+                "=" => Some(FastUnaryMapKernel::EqConst(c)),
+                "<" => Some(FastUnaryMapKernel::LtConst(c)),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn execute_fast_unary_map_kernel(kernel: &FastUnaryMapKernel, elem: Value) -> Option<Result<Value>> {
+    let x = elem.as_scalar()?.clone();
+    Some(match kernel {
+        FastUnaryMapKernel::AddConst(c) => Ok(Value::from_number(x.add(c))),
+        FastUnaryMapKernel::SubConst(c) => Ok(Value::from_number(x.sub(c))),
+        FastUnaryMapKernel::MulConst(c) => Ok(Value::from_number(x.mul(c))),
+        FastUnaryMapKernel::DivConst(c) => {
+            if c.is_zero() {
+                return Some(Err(AjisaiError::from("MAP fast kernel: division by zero")));
+            }
+            Ok(Value::from_number(x.div(c)))
+        }
+        FastUnaryMapKernel::ModConst(c) => {
+            if c.is_zero() {
+                return Some(Err(AjisaiError::from("MAP fast kernel: modulo by zero")));
+            }
+            Ok(Value::from_number(x.modulo(c)))
+        }
+        FastUnaryMapKernel::EqConst(c) => Ok(Value::from_bool(x == *c)),
+        FastUnaryMapKernel::LtConst(c) => Ok(Value::from_bool(x.lt(c))),
+        FastUnaryMapKernel::Abs => Ok(Value::from_number(x.abs())),
+        FastUnaryMapKernel::Neg => Ok(Value::from_number(x.mul(&Fraction::from(-1_i64)))),
+        FastUnaryMapKernel::Not => Ok(Value::from_bool(x.is_zero())),
+    })
+}
+
+fn try_execute_fast_quantized_map_kernel(interp: &mut Interpreter, qb: &QuantizedBlock, elem: Value) -> Option<Result<Value>> {
+    let line = qb.compiled_plan.lines.first()?;
+    let kernel = detect_fast_unary_map_kernel(&line.source_tokens)?;
+    interp.runtime_metrics.quantized_block_use_count += 1;
+    execute_fast_unary_map_kernel(&kernel, elem)
+}
+
+fn detect_fast_unary_predicate_kernel(tokens: &[Token]) -> Option<FastUnaryPredicateKernel> {
+    if tokens.len() == 1 {
+        if let Token::Symbol(sym) = &tokens[0] {
+            if Interpreter::normalize_symbol(sym).as_ref() == "NOT" {
+                return Some(FastUnaryPredicateKernel::Not);
+            }
+        }
+        return None;
+    }
+
+    if tokens.len() != 4 {
+        return None;
+    }
+
+    match (&tokens[0], &tokens[1], &tokens[2], &tokens[3]) {
+        (Token::VectorStart, constant, Token::VectorEnd, Token::Symbol(op)) => {
+            let c = parse_const_number_token(constant)?;
+            match Interpreter::normalize_symbol(op).as_ref() {
+                "=" => Some(FastUnaryPredicateKernel::EqConst(c)),
+                "<" => Some(FastUnaryPredicateKernel::LtConst(c)),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn execute_fast_unary_predicate_kernel(
+    kernel: &FastUnaryPredicateKernel,
+    elem: Value,
+) -> Option<Result<bool>> {
+    let x = elem.as_scalar()?.clone();
+    Some(match kernel {
+        FastUnaryPredicateKernel::EqConst(c) => Ok(x == *c),
+        FastUnaryPredicateKernel::LtConst(c) => Ok(x.lt(c)),
+        FastUnaryPredicateKernel::Not => Ok(x.is_zero()),
+    })
+}
+
+fn try_execute_fast_quantized_predicate_kernel(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    elem: Value,
+) -> Option<Result<bool>> {
+    let line = qb.compiled_plan.lines.first()?;
+    let kernel = detect_fast_unary_predicate_kernel(&line.source_tokens)?;
+    interp.runtime_metrics.quantized_block_use_count += 1;
+    execute_fast_unary_predicate_kernel(&kernel, elem)
+}
+
+fn detect_fast_binary_fold_kernel(tokens: &[Token]) -> Option<FastBinaryFoldKernel> {
+    if tokens.len() != 1 {
+        return None;
+    }
+    let Token::Symbol(sym) = &tokens[0] else {
+        return None;
+    };
+    match Interpreter::normalize_symbol(sym).as_ref() {
+        "+" => Some(FastBinaryFoldKernel::Add),
+        "-" => Some(FastBinaryFoldKernel::Sub),
+        "*" => Some(FastBinaryFoldKernel::Mul),
+        "/" => Some(FastBinaryFoldKernel::Div),
+        "MOD" => Some(FastBinaryFoldKernel::Mod),
+        _ => None,
+    }
+}
+
+fn execute_fast_binary_fold_kernel(
+    kernel: FastBinaryFoldKernel,
+    acc: Value,
+    elem: Value,
+) -> Option<Result<Value>> {
+    let a = acc.as_scalar()?.clone();
+    let b = elem.as_scalar()?.clone();
+    Some(match kernel {
+        FastBinaryFoldKernel::Add => Ok(Value::from_number(a.add(&b))),
+        FastBinaryFoldKernel::Sub => Ok(Value::from_number(a.sub(&b))),
+        FastBinaryFoldKernel::Mul => Ok(Value::from_number(a.mul(&b))),
+        FastBinaryFoldKernel::Div => {
+            if b.is_zero() {
+                return Some(Err(AjisaiError::from("FOLD fast kernel: division by zero")));
+            }
+            Ok(Value::from_number(a.div(&b)))
+        }
+        FastBinaryFoldKernel::Mod => {
+            if b.is_zero() {
+                return Some(Err(AjisaiError::from("FOLD fast kernel: modulo by zero")));
+            }
+            Ok(Value::from_number(a.modulo(&b)))
+        }
+    })
+}
+
+fn try_execute_fast_quantized_fold_kernel(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    acc: Value,
+    elem: Value,
+) -> Option<Result<Value>> {
+    let line = qb.compiled_plan.lines.first()?;
+    let kernel = detect_fast_binary_fold_kernel(&line.source_tokens)?;
+    interp.runtime_metrics.quantized_block_use_count += 1;
+    execute_fast_binary_fold_kernel(kernel, acc, elem)
+}
+
 pub(crate) fn execute_quantized_map_kernel(
     interp: &mut Interpreter,
     qb: &QuantizedBlock,
     elem: Value,
 ) -> Result<Value> {
+    if let Some(fast) = try_execute_fast_quantized_map_kernel(interp, qb, elem.clone()) {
+        return fast;
+    }
+
     let saved = interp.stack.clone();
     interp.stack.clear();
     interp.stack.push(elem);
@@ -127,6 +341,10 @@ pub(crate) fn execute_quantized_predicate_kernel(
     qb: &QuantizedBlock,
     elem: Value,
 ) -> Result<bool> {
+    if let Some(fast) = try_execute_fast_quantized_predicate_kernel(interp, qb, elem.clone()) {
+        return fast;
+    }
+
     let saved = interp.stack.clone();
     interp.stack.clear();
     interp.stack.push(elem);
@@ -172,6 +390,11 @@ pub(crate) fn execute_quantized_fold_kernel(
     acc: Value,
     elem: Value,
 ) -> Result<Value> {
+    if let Some(fast) = try_execute_fast_quantized_fold_kernel(interp, qb, acc.clone(), elem.clone())
+    {
+        return fast;
+    }
+
     let saved = interp.stack.clone();
     interp.stack.clear();
     interp.stack.push(acc);
@@ -209,6 +432,17 @@ fn hedged_mode(mode: ElasticMode) -> bool {
     matches!(mode, ElasticMode::HedgedSafe | ElasticMode::HedgedTrace)
 }
 
+fn fast_guarded_mode(mode: ElasticMode) -> bool {
+    matches!(mode, ElasticMode::FastGuarded)
+}
+
+fn is_quantized_block_guard_valid(interp: &Interpreter, qb: &QuantizedBlock) -> bool {
+    qb.guard_signature.dictionary_epoch == interp.dictionary_epoch
+        && qb.guard_signature.module_epoch == interp.module_epoch
+        && qb.guard_signature.kernel_kind == qb.kernel_kind
+        && qb.guard_signature.purity == qb.purity
+}
+
 fn trace_hedged(interp: &Interpreter, msg: &str) {
     if interp.elastic_mode() == ElasticMode::HedgedTrace {
         eprintln!("[hedged] {}", msg);
@@ -232,6 +466,18 @@ pub(crate) fn execute_hedged_map_kernel(
     let Some(tokens) = plain_tokens else {
         return execute_quantized_map_kernel(interp, qb, elem);
     };
+    if fast_guarded_mode(interp.elastic_mode()) {
+        if is_quantized_block_guard_valid(interp, qb) {
+            return execute_quantized_map_kernel(interp, qb, elem);
+        }
+        interp.runtime_metrics.hedged_race_fallback_count += 1;
+        interp.push_hedged_trace(format!(
+            "fast-guarded:fallback op={} reason=guard-miss",
+            op_name
+        ));
+        let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
+        return execute_plain_map_kernel(interp, &plain_exec, elem);
+    }
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
         return execute_quantized_map_kernel(interp, qb, elem);
     }
@@ -310,6 +556,18 @@ pub(crate) fn execute_hedged_predicate_kernel(
     let Some(tokens) = plain_tokens else {
         return execute_quantized_predicate_kernel(interp, qb, elem);
     };
+    if fast_guarded_mode(interp.elastic_mode()) {
+        if is_quantized_block_guard_valid(interp, qb) {
+            return execute_quantized_predicate_kernel(interp, qb, elem);
+        }
+        interp.runtime_metrics.hedged_race_fallback_count += 1;
+        interp.push_hedged_trace(format!(
+            "fast-guarded:fallback op={} reason=guard-miss",
+            op_name
+        ));
+        let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
+        return execute_plain_predicate_kernel(interp, &plain_exec, elem);
+    }
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
         return execute_quantized_predicate_kernel(interp, qb, elem);
     }
@@ -362,6 +620,18 @@ pub(crate) fn execute_hedged_fold_kernel(
     let Some(tokens) = plain_tokens else {
         return execute_quantized_fold_kernel(interp, qb, acc, elem);
     };
+    if fast_guarded_mode(interp.elastic_mode()) {
+        if is_quantized_block_guard_valid(interp, qb) {
+            return execute_quantized_fold_kernel(interp, qb, acc, elem);
+        }
+        interp.runtime_metrics.hedged_race_fallback_count += 1;
+        interp.push_hedged_trace(format!(
+            "fast-guarded:fallback op={} reason=guard-miss",
+            op_name
+        ));
+        let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
+        return execute_plain_fold_kernel(interp, &plain_exec, acc, elem);
+    }
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
         return execute_quantized_fold_kernel(interp, qb, acc, elem);
     }

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -449,6 +449,17 @@ fn trace_hedged(interp: &Interpreter, msg: &str) {
     }
 }
 
+fn normalize_map_kernel_result(value: Value) -> Value {
+    if value.len() == 1 {
+        if let Some(child) = value.get_child(0) {
+            if child.as_scalar().is_some() {
+                return child.clone();
+            }
+        }
+    }
+    value
+}
+
 /// Execute a map kernel as a hedged race between the compiled (quantized) path
 /// and the plain token-interpretation path.
 ///
@@ -490,6 +501,8 @@ pub(crate) fn execute_hedged_map_kernel(
 
     match (quantized, plain) {
         (Ok(q), Ok(p)) => {
+            let q = normalize_map_kernel_result(q);
+            let p = normalize_map_kernel_result(p);
             if q != p {
                 interp.runtime_metrics.hedged_race_validation_reject_count += 1;
                 interp.runtime_metrics.hedged_race_fallback_count += 1;
@@ -527,12 +540,14 @@ pub(crate) fn execute_hedged_map_kernel(
             }
         }
         (Err(_), Ok(p)) => {
+            let p = normalize_map_kernel_result(p);
             interp.runtime_metrics.hedged_race_winner_plain_count += 1;
             interp.runtime_metrics.hedged_race_fallback_count += 1;
             interp.push_hedged_trace(format!("hof-race:winner op={} path=plain", op_name));
             Ok(p)
         }
         (Ok(q), Err(_)) => {
+            let q = normalize_map_kernel_result(q);
             interp.runtime_metrics.hedged_race_winner_quantized_count += 1;
             interp.push_hedged_trace(format!(
                 "hof-race:winner op={} path=quantized reason=plain-error",

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -115,3 +115,6 @@ mod quantized_block_tests;
 #[cfg(test)]
 #[path = "perf-regression-tests.rs"]
 mod perf_regression_tests;
+#[cfg(test)]
+#[path = "fast-guarded-tests.rs"]
+mod fast_guarded_tests;

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -1,5 +1,5 @@
 use crate::interpreter::quantized_block::{
-    is_quantizable_block, quantize_code_block, QuantizedArity, QuantizedPurity,
+    is_quantizable_block, quantize_code_block, KernelKind, QuantizedArity, QuantizedPurity,
 };
 use crate::interpreter::Interpreter;
 use crate::types::{Token, Value};
@@ -242,6 +242,46 @@ fn can_fuse_reflects_purity() {
     assert!(qb.can_short_circuit);
 }
 
+#[test]
+fn impure_builtin_is_not_classified_as_fast_kernel() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("PRINT")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.purity, QuantizedPurity::SideEffecting);
+    assert_eq!(qb.kernel_kind, KernelKind::GenericCompiled);
+    assert!(qb.fast_path_id.is_none());
+}
+
+#[test]
+fn kernel_kind_detects_map_unary_const_plus() {
+    let mut interp = make_interp();
+    let tokens = vec![Token::VectorStart, num("2"), Token::VectorEnd, sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::MapUnaryPure);
+    assert!(qb.fast_path_id.is_some());
+    assert!(qb.eligible_for_cache);
+    assert!(qb.eligible_for_fusion);
+}
+
+#[test]
+fn kernel_kind_detects_predicate_not() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("NOT")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::PredicateUnaryPure);
+    assert!(qb.fast_path_id.is_some());
+}
+
+#[test]
+fn kernel_kind_defaults_to_generic_for_unknown_pattern() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("MAP")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::GenericCompiled);
+    assert!(qb.fast_path_id.is_none());
+    assert!(!qb.lowered_kernel_ir.is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Dependency word collection
 // ---------------------------------------------------------------------------
@@ -328,7 +368,20 @@ fn filter_keeps_elements_above_zero() {
 }
 
 #[test]
+fn filter_with_simple_fast_predicate_pattern() {
+    let interp = run_code("[ -2 -1 0 1 2 3 ] { [ 2 ] < } FILTER");
+    let top = stack_top(&interp);
+    assert_eq!(top.len(), 4, "expected [-2, -1, 0, 1], got len={}", top.len());
+}
+
+#[test]
 fn any_true_when_element_matches() {
+    let interp = run_code("[ 1 2 3 ] { [ 2 ] = } ANY");
+    assert!(stack_top_bool(&interp));
+}
+
+#[test]
+fn any_with_simple_fast_predicate_pattern() {
     let interp = run_code("[ 1 2 3 ] { [ 2 ] = } ANY");
     assert!(stack_top_bool(&interp));
 }
@@ -364,6 +417,12 @@ fn count_counts_matching_elements() {
 fn fold_sum_is_correct() {
     let interp = run_code("[ 1 2 3 4 5 ] [ 0 ] { + } FOLD");
     assert_eq!(stack_top_i64(&interp), 15);
+}
+
+#[test]
+fn fold_product_is_correct() {
+    let interp = run_code("[ 1 2 3 4 ] [ 1 ] { * } FOLD");
+    assert_eq!(stack_top_i64(&interp), 24);
 }
 
 #[test]

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -17,6 +17,24 @@ pub enum QuantizedPurity {
     Unknown,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KernelKind {
+    MapUnaryPure,
+    PredicateUnaryPure,
+    FoldBinaryPure,
+    ScanBinaryPure,
+    GenericCompiled,
+    NonQuantizable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuardSignature {
+    pub dictionary_epoch: u64,
+    pub module_epoch: u64,
+    pub kernel_kind: KernelKind,
+    pub purity: QuantizedPurity,
+}
+
 #[derive(Debug, Clone)]
 pub struct QuantizedBlock {
     pub compiled_plan: Arc<CompiledPlan>,
@@ -24,6 +42,12 @@ pub struct QuantizedBlock {
     pub input_arity: QuantizedArity,
     pub output_arity: QuantizedArity,
     pub purity: QuantizedPurity,
+    pub kernel_kind: KernelKind,
+    pub fast_path_id: Option<String>,
+    pub guard_signature: GuardSignature,
+    pub lowered_kernel_ir: Vec<CompiledOp>,
+    pub eligible_for_cache: bool,
+    pub eligible_for_fusion: bool,
     pub can_fuse: bool,
     pub can_short_circuit: bool,
     pub dependency_words: Vec<String>,
@@ -162,6 +186,53 @@ pub fn is_quantizable_block(tokens: &[Token]) -> bool {
     !tokens.is_empty() && !tokens.iter().any(|t| matches!(t, Token::LineBreak | Token::SafeMode))
 }
 
+fn is_const_vector_token(token: &Token) -> bool {
+    matches!(token, Token::Number(_) | Token::String(_))
+        || matches!(token, Token::Symbol(sym) if sym.as_ref() == "TRUE" || sym.as_ref() == "FALSE")
+}
+
+fn is_const_vector_pattern(tokens: &[Token], op: &str) -> bool {
+    if tokens.len() != 4 {
+        return false;
+    }
+    matches!(
+        (&tokens[0], &tokens[1], &tokens[2], &tokens[3]),
+        (Token::VectorStart, constant, Token::VectorEnd, Token::Symbol(sym))
+            if is_const_vector_token(constant) && sym.as_ref() == op
+    )
+}
+
+fn detect_kernel_kind(tokens: &[Token], purity: QuantizedPurity, _input_arity: QuantizedArity) -> KernelKind {
+    if purity != QuantizedPurity::Pure {
+        return KernelKind::GenericCompiled;
+    }
+
+    // Initial pattern recognition (Phase B-2)
+    if is_const_vector_pattern(tokens, "+")
+        || is_const_vector_pattern(tokens, "-")
+        || is_const_vector_pattern(tokens, "*")
+        || is_const_vector_pattern(tokens, "/")
+        || is_const_vector_pattern(tokens, "MOD")
+        || is_const_vector_pattern(tokens, "=")
+        || is_const_vector_pattern(tokens, "<")
+    {
+        return KernelKind::MapUnaryPure;
+    }
+
+    if tokens.len() == 1 {
+        if let Token::Symbol(sym) = &tokens[0] {
+            return match sym.as_ref() {
+                "NOT" => KernelKind::PredicateUnaryPure,
+                "ABS" | "NEG" => KernelKind::MapUnaryPure,
+                "+" | "-" | "*" | "/" | "MOD" => KernelKind::FoldBinaryPure,
+                _ => KernelKind::GenericCompiled,
+            };
+        }
+    }
+
+    KernelKind::GenericCompiled
+}
+
 pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option<QuantizedBlock> {
     if !is_quantizable_block(tokens) {
         return None;
@@ -184,9 +255,30 @@ pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option
     interp.runtime_metrics.quantized_block_build_count += 1;
 
     let (input_arity, output_arity, purity, dependency_words) = analyze_compiled_plan(&plan);
+    let kernel_kind = detect_kernel_kind(tokens, purity, input_arity);
 
     let can_fuse = purity == QuantizedPurity::Pure;
     let can_short_circuit = purity == QuantizedPurity::Pure;
+    let captured_epoch = interp.current_epoch_snapshot();
+    let fast_path_id = match kernel_kind {
+        KernelKind::GenericCompiled | KernelKind::NonQuantizable => None,
+        _ => Some(format!(
+            "kernel::{kernel_kind:?}::in={input_arity:?}::out={output_arity:?}"
+        )),
+    };
+    let guard_signature = GuardSignature {
+        dictionary_epoch: captured_epoch.dictionary_epoch,
+        module_epoch: captured_epoch.module_epoch,
+        kernel_kind,
+        purity,
+    };
+    let lowered_kernel_ir = plan
+        .lines
+        .iter()
+        .flat_map(|line| line.ops.iter().cloned())
+        .collect::<Vec<_>>();
+    let eligible_for_cache = purity == QuantizedPurity::Pure;
+    let eligible_for_fusion = matches!(kernel_kind, KernelKind::MapUnaryPure | KernelKind::PredicateUnaryPure);
 
     #[cfg(feature = "trace-quant")]
     eprintln!(
@@ -196,10 +288,16 @@ pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option
 
     Some(QuantizedBlock {
         compiled_plan: plan,
-        captured_epoch: interp.current_epoch_snapshot(),
+        captured_epoch,
         input_arity,
         output_arity,
         purity,
+        kernel_kind,
+        fast_path_id,
+        guard_signature,
+        lowered_kernel_ir,
+        eligible_for_cache,
+        eligible_for_fusion,
         can_fuse,
         can_short_circuit,
         dependency_words,


### PR DESCRIPTION
### Motivation
- Introduce a guarded fast-path execution mode that avoids launching hedged races while still using quantized kernels when guards pass. 
- Improve performance for common higher-order function (HOF) kernels (map/predicate/fold) by recognizing simple patterns and executing them directly from quantized metadata. 
- Expose guard signatures so quantized blocks can be validated cheaply against interpreter epoch and kernel kind.

### Description
- Add `ElasticMode::FastGuarded` with parsing (`from_str`), `as_str`, and `is_elastic` support in `execution_mode.rs`.
- Extend `QuantizedBlock` with `KernelKind`, `GuardSignature`, `fast_path_id`, `lowered_kernel_ir`, and eligibility flags, and add `detect_kernel_kind` logic in `quantized-block.rs` to classify common patterns (map unary const, predicate unary, fold binary).
- Implement fast-path detection and execution in `higher-order-operations.rs` via `try_execute_fast_quantized_*` helpers and pattern-specific fast kernels for map/predicate/fold, and short-circuit hedged races when running in `FastGuarded` by validating the block guard signature and falling back to plain execution on guard-miss (without starting a hedged race).
- Add tests and test integrations: new `fast-guarded-tests.rs`, additions to `elastic-engine-tests.rs` and `quantized-block-tests.rs` to validate mode parsing, semantics, metrics, and kernel-kind detection; expose the new test module in `interpreter/mod.rs` and add benchmarks in `interpreter-performance-benchmarks.rs` to exercise HOF mode matrix scenarios.

### Testing
- Ran the Rust unit test suite with `cargo test`, which executed the updated and new tests including `fast_guarded_*` and `quantized-block` assertions, and all tests passed.
- Executed the interpreter benchmarks via `cargo bench` to exercise the added `interp_hof_mode_matrix` benchmark scenario and confirm it runs (bench completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee07d17588326854d2c54037291d4)