### PR TITLE
Mobile tap flow: transition Output -> Stack -> Editor on mobile

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -205,7 +205,11 @@ export const createGUI = (): GUI => {
         {
             const TAP_MOVEMENT_LIMIT = 10;
 
-            const setupTapToReturn = (target: HTMLElement, activeMode: ViewMode): void => {
+            const setupTapToTransition = (
+                target: HTMLElement,
+                activeMode: ViewMode,
+                nextMode: ViewMode
+            ): void => {
                 let tapStartX = 0;
                 let tapStartY = 0;
 
@@ -229,13 +233,13 @@ export const createGUI = (): GUI => {
 
                     if (deltaX < TAP_MOVEMENT_LIMIT && deltaY < TAP_MOVEMENT_LIMIT) {
                         if ((e.target as HTMLElement).closest('button, a')) return;
-                        switchArea('input');
+                        switchArea(nextMode);
                     }
                 }, { passive: true });
             };
 
-            setupTapToReturn(elements.outputDisplay, 'output');
-            setupTapToReturn(elements.stackDisplay, 'stack');
+            setupTapToTransition(elements.outputDisplay, 'output', 'stack');
+            setupTapToTransition(elements.stackDisplay, 'stack', 'input');
         }
 
         elements.copyOutputBtn.addEventListener('click', (e: MouseEvent) => {


### PR DESCRIPTION
### Motivation
- Improve mobile UX by making an explicit panel-to-panel tap flow so tapping the Output area first opens the Stack panel, and tapping Stack then returns to the editor, matching the requested "Output → Stack → Editor" sequence.

### Description
- Replace the single-purpose tap handler with `setupTapToTransition(target, activeMode, nextMode)` in `js/gui/gui-application.ts` and wire `elements.outputDisplay` to transition from `output` → `stack` and `elements.stackDisplay` to transition from `stack` → `input`; swipe gestures and desktop click behavior are unchanged.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbf865f408326a899fdf1480a6bf7)