### PR TITLE
Add mobile double-tap gesture to run editor code

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -267,6 +267,40 @@ export const createGUI = (): GUI => {
             }
         });
 
+        {
+            const DOUBLE_TAP_INTERVAL_MS = 300;
+            const TAP_MOVEMENT_LIMIT = 10;
+            let lastTapAt = 0;
+            let tapStartX = 0;
+            let tapStartY = 0;
+
+            elements.codeInput.addEventListener('touchstart', (e: TouchEvent) => {
+                const touch = e.changedTouches[0];
+                if (!touch) return;
+                tapStartX = touch.screenX;
+                tapStartY = touch.screenY;
+            }, { passive: true });
+
+            elements.codeInput.addEventListener('touchend', (e: TouchEvent) => {
+                if (!mobile.isMobile()) return;
+
+                const touch = e.changedTouches[0];
+                if (!touch) return;
+
+                const deltaX = Math.abs(touch.screenX - tapStartX);
+                const deltaY = Math.abs(touch.screenY - tapStartY);
+                if (deltaX >= TAP_MOVEMENT_LIMIT || deltaY >= TAP_MOVEMENT_LIMIT) return;
+
+                const now = Date.now();
+                if (now - lastTapAt <= DOUBLE_TAP_INTERVAL_MS) {
+                    executionController.executeCode(editor.extractValue());
+                    lastTapAt = 0;
+                    return;
+                }
+                lastTapAt = now;
+            }, { passive: true });
+        }
+
         window.addEventListener('resize', () => {
             applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, layoutState.currentMode);
             updateEditorPlaceholder(elements, mobile);


### PR DESCRIPTION
### Motivation
- Mobile users currently can only run code via the `Run` button, which is inconvenient compared to desktop keyboard shortcuts. 
- Provide a quick, discoverable gesture to execute the editor content on touch devices without changing desktop behavior. 
- Avoid accidental runs while scrolling or selecting by filtering out taps with significant movement.

### Description
- Added `touchstart` and `touchend` handlers on the editor textarea (`codeInput`) in `js/gui/gui-application.ts` to detect a double-tap gesture and call `executionController.executeCode(editor.extractValue())` when detected. 
- Gesture detection uses a `DOUBLE_TAP_INTERVAL_MS = 300`ms window and a `TAP_MOVEMENT_LIMIT = 10`px threshold to ignore drags or scrolls. 
- The behavior is guarded by `mobile.isMobile()` so it only runs on mobile views and does not affect desktop shortcuts or inputs. 

### Testing
- Ran TypeScript checks with `npm run check` (`tsc --noEmit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc53a29388326b0390605a79fa25e)