### PR TITLE
Run code on mobile triple-tap of code input

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -267,6 +267,33 @@ export const createGUI = (): GUI => {
             }
         });
 
+        {
+            const TRIPLE_TAP_INTERVAL_MS = 500;
+            let tapCount = 0;
+            let lastTapAt = 0;
+
+            elements.codeInput.addEventListener('touchend', (e: TouchEvent) => {
+                if (!mobile.isMobile()) return;
+                if (e.changedTouches.length === 0) return;
+
+                const now = Date.now();
+                if (now - lastTapAt <= TRIPLE_TAP_INTERVAL_MS) {
+                    tapCount += 1;
+                } else {
+                    tapCount = 1;
+                }
+
+                if (tapCount >= 3) {
+                    executionController.executeCode(editor.extractValue());
+                    tapCount = 0;
+                    lastTapAt = 0;
+                    return;
+                }
+
+                lastTapAt = now;
+            }, { passive: true });
+        }
+
         window.addEventListener('resize', () => {
             applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, layoutState.currentMode);
             updateEditorPlaceholder(elements, mobile);


### PR DESCRIPTION
### Motivation
- Provide a quick mobile gesture to execute the editor content by detecting a triple-tap on `elements.codeInput` so mobile users can run code without the keyboard modifiers.

### Description
- Added a `touchend` listener on `elements.codeInput` that checks `mobile.isMobile()` and tracks taps within a `TRIPLE_TAP_INTERVAL_MS` (500ms) window using `tapCount` and `lastTapAt`, and invokes `executionController.executeCode(editor.extractValue())` when three taps are detected, registered as a `{ passive: true }` listener.

### Testing
- Ran the project's automated test suite (`npm test`) and the build (`npm run build`), and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc53a29388326b0390605a79fa25e)