### PR TITLE
Replace touch tap handler with dblclick transition and change output navigation

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -203,39 +203,21 @@ export const createGUI = (): GUI => {
         });
 
         {
-            const TAP_MOVEMENT_LIMIT = 10;
-
-            const setupTapToReturn = (target: HTMLElement, activeMode: ViewMode): void => {
-                let tapStartX = 0;
-                let tapStartY = 0;
-
-                target.addEventListener('touchstart', (e: TouchEvent) => {
-                    const touch = e.changedTouches[0];
-                    if (touch) {
-                        tapStartX = touch.screenX;
-                        tapStartY = touch.screenY;
-                    }
-                }, { passive: true });
-
-                target.addEventListener('touchend', (e: TouchEvent) => {
+            const setupTapToTransition = (
+                target: HTMLElement,
+                activeMode: ViewMode,
+                nextMode: ViewMode
+            ): void => {
+                target.addEventListener('dblclick', (e: MouseEvent) => {
                     if (!mobile.isMobile()) return;
                     if (layoutState.currentMode !== activeMode) return;
-
-                    const touch = e.changedTouches[0];
-                    if (!touch) return;
-
-                    const deltaX = Math.abs(touch.screenX - tapStartX);
-                    const deltaY = Math.abs(touch.screenY - tapStartY);
-
-                    if (deltaX < TAP_MOVEMENT_LIMIT && deltaY < TAP_MOVEMENT_LIMIT) {
-                        if ((e.target as HTMLElement).closest('button, a')) return;
-                        switchArea('input');
-                    }
-                }, { passive: true });
+                    if ((e.target as HTMLElement).closest('button, a')) return;
+                    switchArea(nextMode);
+                });
             };
 
-            setupTapToReturn(elements.outputDisplay, 'output');
-            setupTapToReturn(elements.stackDisplay, 'stack');
+            setupTapToTransition(elements.outputDisplay, 'output', 'stack');
+            setupTapToTransition(elements.stackDisplay, 'stack', 'input');
         }
 
         elements.copyOutputBtn.addEventListener('click', (e: MouseEvent) => {


### PR DESCRIPTION
### Motivation
- Simplify and reduce fragile touch handling by replacing custom touchstart/touchend movement-based tap detection with a simpler event handler. 
- Make view transitions explicit and configurable by introducing a `nextMode` parameter for tap-based transitions.

### Description
- Replaced `setupTapToReturn` (touchstart/touchend + movement threshold) with `setupTapToTransition(target, activeMode, nextMode)` that listens for `dblclick` and switches to `nextMode`.
- Removed `TAP_MOVEMENT_LIMIT` and all touch coordinate tracking logic and passive listeners.
- Updated transition targets so `outputDisplay` now transitions from `'output'` to `'stack'`, and `stackDisplay` transitions from `'stack'` to `'input'`, and added guards to ignore clicks on `button, a` and when `layoutState.currentMode` does not match `activeMode`.

### Testing
- Ran TypeScript build with `npm run build` and it completed successfully.
- Ran unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbf865f408326a899fdf1480a6bf7)