### PR TITLE
Desktop: focus editor when returning from Output to Input

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -199,6 +199,7 @@ export const createGUI = (): GUI => {
             if ((e.target as HTMLElement).closest('button, a')) return;
             if (!mobile.isMobile() && layoutState.currentLeftMode === 'output') {
                 switchArea('input');
+                editor.focus();
             }
         });
 


### PR DESCRIPTION
### Motivation
- When clicking the Output area to return to the Input pane on desktop, the editor should receive keyboard focus and caret placement immediately so users can continue typing without an extra click.

### Description
- Call `editor.focus()` after `switchArea('input')` in the `outputArea` click handler in `js/gui/gui-application.ts` so the textarea gets focus when returning to Input.

### Testing
- Ran TypeScript type-check with `npm run check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e023c5c52883269de6e46050034b3d)