### PR TITLE
Automate build version label and dated branch naming workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ npm run check
 
 ---
 
+## Version / Branch Automation
+
+- ヘッダーの `ver.` 表示はビルド時に自動生成されます（`YYYYMMDDHHmm (YYYYMMDD(変更内容))`）。
+- ブランチ作成は以下で自動化できます。
+
+```sh
+npm run branch:new -- "変更内容"
+```
+
+このコマンドは `YYYYMMDD(変更内容)` 形式のブランチを作成し、そのまま `git switch` します。
+
+---
+
 ## License
 
 MIT (`LICENSE`)

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                         </span>
                         <h1>Ajisai</h1>
                     </a>
-                    <span class="version">ver.202604160935</span>
+                    <span class="version">ver.loading...</span>
                 </div>
                 <span id="offline-indicator" class="offline-indicator" style="display: none;">Offline</span>
             </div>

--- a/js/web-app-entrypoint.ts
+++ b/js/web-app-entrypoint.ts
@@ -5,11 +5,20 @@ import { initWasm } from './wasm-module-loader';
 import './indexeddb-user-word-store';
 import type { WasmModule, AjisaiInterpreter } from './wasm-interpreter-types';
 
+declare const __AJISAI_BUILD_VERSION__: string;
+
 declare global {
     interface Window {
         AjisaiWasm: WasmModule;
         ajisaiInterpreter: AjisaiInterpreter;
     }
+}
+
+function setBuildVersionLabel(): void {
+    const versionElement = document.querySelector<HTMLElement>('.version');
+    if (!versionElement) return;
+
+    versionElement.textContent = `ver.${__AJISAI_BUILD_VERSION__}`;
 }
 
 async function main(): Promise<void> {
@@ -143,6 +152,7 @@ function setupLogoTouchQR(): void {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    setBuildVersionLabel();
     setupLogoTouchQR();
     main();
 });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clean": "rm -rf dist node_modules",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "branch:new": "bash ./scripts/create-dated-branch.sh"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/scripts/create-dated-branch.sh
+++ b/scripts/create-dated-branch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: npm run branch:new -- \"変更内容\""
+  exit 1
+fi
+
+date_prefix="$(date +%Y%m%d)"
+description="$*"
+
+normalized_description="$(printf '%s' "$description" | tr '[:space:]' '-' | tr -s '-')"
+branch_name="${date_prefix}(${normalized_description})"
+
+if ! git check-ref-format --branch "$branch_name" >/dev/null 2>&1; then
+  echo "Invalid branch name: $branch_name"
+  exit 1
+fi
+
+git switch -c "$branch_name"
+echo "Created and switched to branch: $branch_name"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,62 @@
-
-
+import { execSync } from 'node:child_process';
 import { defineConfig } from 'vite';
 
-
 const isTauri = !!process.env.TAURI_ENV_TARGET_TRIPLE;
+
+function runGitCommand(command: string): string {
+  try {
+    return execSync(command, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  } catch {
+    return '';
+  }
+}
+
+function formatDatePart(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+function formatBuildStamp(date: Date): string {
+  const datePart = formatDatePart(date);
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+  return `${datePart}${hours}${minutes}`;
+}
+
+function normalizeBranchName(rawBranchName: string, datePart: string): string {
+  if (/^\d{8}\(.+\)$/.test(rawBranchName)) {
+    return rawBranchName;
+  }
+
+  const cleaned = rawBranchName
+    .replace(/^\/*/, '')
+    .replace(/\/+$/, '')
+    .replace(/\//g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/\(+/g, '-')
+    .replace(/\)+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const detail = cleaned.length > 0 ? cleaned : 'update';
+  return `${datePart}(${detail})`;
+}
+
+const now = new Date();
+const datePart = formatDatePart(now);
+const buildStamp = formatBuildStamp(now);
+const gitBranchName = runGitCommand('git rev-parse --abbrev-ref HEAD') || 'detached-head';
+const branchLabel = normalizeBranchName(gitBranchName, datePart);
+const buildVersion = `${buildStamp} (${branchLabel})`;
 
 export default defineConfig({
   root: '.',
   base: './',
+  define: {
+    __AJISAI_BUILD_VERSION__: JSON.stringify(buildVersion)
+  },
   server: {
     port: 3000,
     open: !isTauri,


### PR DESCRIPTION
### Motivation

- Remove hard-coded header version and generate a build-time version label that reflects build timestamp and branch name.
- Make branch creation consistent and easy by providing a simple script to create date-prefixed branches in `YYYYMMDD(変更内容)` format.

### Description

- Inject `__AJISAI_BUILD_VERSION__` from `vite.config.ts` using the current build timestamp (`YYYYMMDDHHmm`) and a normalized branch label (`YYYYMMDD(変更内容)`) so builds embed a concise version string.
- Update `js/web-app-entrypoint.ts` to set the header `.version` element at startup using `__AJISAI_BUILD_VERSION__` and add the `setBuildVersionLabel` helper function.
- Change `index.html` to show a placeholder `ver.loading...` until the script updates it at startup.
- Add `scripts/create-dated-branch.sh` and an npm shortcut `npm run branch:new -- "変更内容"` to create and switch to `YYYYMMDD(変更内容)` branches, and document the workflow in `README.md`.

### Testing

- Ran `npm run check` (`tsc --noEmit`) and it completed successfully.
- Ran `npm run build:web` (`vite build`) and the production build completed successfully, with only existing unrelated warnings from CSS query-string and sourcemap name collisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03bec09d88326a6c8cce72b7def00)