### PR TITLE
Move Dictionary search box next to user dictionary selector

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -566,6 +566,22 @@ body[data-active-area] #state-panel {
     padding: 0 0 0.5rem 0;
 }
 
+.user-dictionary-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.user-dictionary-controls .dictionary-sheet-selector {
+    flex: 0 0 45%;
+}
+
+.user-dictionary-controls .search-wrapper {
+    flex: 1 1 0%;
+    min-width: 0;
+    padding: 0 0 0.5rem 0;
+}
+
 
 .words-area .dictionary-sheet-selector select:focus-visible {
     outline-offset: -2px;
@@ -584,12 +600,7 @@ body[data-active-area] #state-panel {
     cursor: pointer;
 }
 
-.dictionary-toolbar .search-wrapper {
-    flex: 1 1 0%;
-    min-width: 0;
-}
-
-.dictionary-toolbar .vocabulary-search-input {
+.user-dictionary-controls .vocabulary-search-input {
     width: 100%;
     max-width: none;
 }

--- a/index.html
+++ b/index.html
@@ -112,10 +112,6 @@
                                 <option value="user">User word</option>
                             </select>
                         </div>
-                        <div class="search-wrapper">
-                            <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
-                            <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
-                        </div>
                     </div>
                     <div id="dictionary-sheet-core" class="dictionary-sheet active">
                         <div class="vocabulary-container">
@@ -129,11 +125,17 @@
                     <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
                         <div class="vocabulary-container">
                             <div class="words-area">
-                                <div class="dictionary-sheet-selector">
-                                    <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                                    <select id="user-dictionary-select">
-                                        <option value="DEMO">Demonstration word</option>
-                                    </select>
+                                <div class="user-dictionary-controls">
+                                    <div class="dictionary-sheet-selector">
+                                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                                        <select id="user-dictionary-select">
+                                            <option value="DEMO">Demonstration word</option>
+                                        </select>
+                                    </div>
+                                    <div class="search-wrapper">
+                                        <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
+                                        <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
+                                    </div>
                                 </div>
                                 <span id="user-word-info" class="word-info-display"></span>
                                 <div id="user-words-display" class="words-display"></div>


### PR DESCRIPTION
### Motivation
- The dictionary search targets user dictionaries, so it should be visually colocated with the user dictionary selector instead of the top toolbar. 
- Placing the search inside the `User word` sheet keeps it hidden when the `Stack` area is shown because it stays under the `#dictionary-panel`. 
- Improve UI semantics by grouping dictionary selection and search controls together.

### Description
- Moved the `#dictionary-search` input and `#dictionary-search-clear-btn` from the top `.dictionary-toolbar` into the `User word` sheet next to `#user-dictionary-select` inside a new `.user-dictionary-controls` container in `index.html`.
- Added layout CSS for `.user-dictionary-controls` and adjusted the search input rule to `.user-dictionary-controls .vocabulary-search-input` in `app-interface.css` to align the selector and search field in one row and allow flexible sizing.
- Removed the previous toolbar search wrapper placement so the search only appears in the user sheet and remains hidden when the dictionary panel is hidden.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e189f1d5948326be787fac61d2b45c)