### PR TITLE
Move dictionary search to right panel, sync visibility, and update layout/styles

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -119,6 +119,26 @@
     display: none;
 }
 
+.area-selector-right {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.area-selector-right .right-mode-selector {
+    flex: 1.618 1 0%;
+}
+
+.area-selector-right #right-panel-dictionary-search {
+    flex: 1 1 0%;
+    min-width: 0;
+}
+
+.area-selector-right .vocabulary-search-input {
+    width: 100%;
+    max-width: none;
+}
+
 
 .visually-hidden {
     position: absolute;
@@ -566,7 +586,6 @@ body[data-active-area] #state-panel {
     padding: 0 0 0.5rem 0;
 }
 
-
 .words-area .dictionary-sheet-selector select:focus-visible {
     outline-offset: -2px;
     box-shadow: none;
@@ -582,16 +601,6 @@ body[data-active-area] #state-panel {
     color: var(--color-text);
     width: 100%;
     cursor: pointer;
-}
-
-.dictionary-toolbar .search-wrapper {
-    flex: 1 1 0%;
-    min-width: 0;
-}
-
-.dictionary-toolbar .vocabulary-search-input {
-    width: 100%;
-    max-width: none;
 }
 
 .dictionary-sheet {

--- a/index.html
+++ b/index.html
@@ -91,11 +91,17 @@
 
             <div id="state-panel" class="panel">
                 <div class="area-selector area-selector-right">
-                    <label for="right-panel-select" class="visually-hidden">Select right panel</label>
-                    <select id="right-panel-select">
-                        <option value="stack">Stack</option>
-                        <option value="dictionary">Dictionary</option>
-                    </select>
+                    <div class="right-mode-selector">
+                        <label for="right-panel-select" class="visually-hidden">Select right panel</label>
+                        <select id="right-panel-select">
+                            <option value="stack">Stack</option>
+                            <option value="dictionary">Dictionary</option>
+                        </select>
+                    </div>
+                    <div id="right-panel-dictionary-search" class="search-wrapper" hidden>
+                        <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
+                        <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
+                    </div>
                 </div>
                 <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
                     <h2 class="visually-hidden">Stack</h2>
@@ -111,10 +117,6 @@
                                 <option value="core">Core word</option>
                                 <option value="user">User word</option>
                             </select>
-                        </div>
-                        <div class="search-wrapper">
-                            <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
-                            <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
                         </div>
                     </div>
                     <div id="dictionary-sheet-core" class="dictionary-sheet active">

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -92,9 +92,15 @@ export const createGUI = (): GUI => {
         switchDictionarySheet(elements.dictionaryArea, sheetId);
     };
 
+    const syncDictionarySearchVisibility = (): void => {
+        const shouldShowSearch = !mobile.isMobile() && layoutState.currentRightMode === 'dictionary';
+        elements.rightPanelDictionarySearch.hidden = !shouldShowSearch;
+    };
+
     const switchArea = (mode: ViewMode): void => {
         layoutState.currentMode = mode;
         applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, mode);
+        syncDictionarySearchVisibility();
     };
 
     const updateAllDisplays = (): void => {
@@ -275,6 +281,7 @@ export const createGUI = (): GUI => {
 
         window.addEventListener('resize', () => {
             applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, layoutState.currentMode);
+            syncDictionarySearchVisibility();
             updateEditorPlaceholder(elements, mobile);
         });
 
@@ -297,6 +304,10 @@ export const createGUI = (): GUI => {
 
     const init = async (): Promise<void> => {
         console.log('[GUI] Initializing GUI...');
+
+        document.querySelector('#dictionary-sheet-user #dictionary-search')
+            ?.closest('.search-wrapper')
+            ?.remove();
 
         elements = cacheElements();
         layoutState = createLayoutState();

--- a/js/gui/gui-dom-cache.ts
+++ b/js/gui/gui-dom-cache.ts
@@ -27,6 +27,7 @@ export interface GUIElements {
     readonly statePanel: HTMLElement;
     readonly leftPanelSelect: HTMLSelectElement;
     readonly rightPanelSelect: HTMLSelectElement;
+    readonly rightPanelDictionarySearch: HTMLElement;
     readonly mobilePanelSelect: HTMLSelectElement;
     readonly copyOutputBtn: HTMLButtonElement;
 }
@@ -56,6 +57,7 @@ export const cacheElements = (): GUIElements => ({
     statePanel: document.getElementById('state-panel')!,
     leftPanelSelect: document.getElementById('left-panel-select') as HTMLSelectElement,
     rightPanelSelect: document.getElementById('right-panel-select') as HTMLSelectElement,
+    rightPanelDictionarySearch: document.getElementById('right-panel-dictionary-search')!,
     mobilePanelSelect: document.getElementById('mobile-panel-select') as HTMLSelectElement,
     copyOutputBtn: document.getElementById('copy-output-btn') as HTMLButtonElement
 });


### PR DESCRIPTION
### Motivation

- Improve the UI by relocating the dictionary search input to the right panel so it is only visible when the right panel is in dictionary mode on non-mobile viewports.

### Description

- Add CSS classes (`.area-selector-right`, `.right-mode-selector`, `.vocabulary-search-input` and related rules) to support the new right-panel search layout and adjust toolbar styling.
- Move the dictionary search input out of the dictionary toolbar in `index.html` into a new `#right-panel-dictionary-search` container inside the right area selector and wrap the select in a `.right-mode-selector` container.
- Add `rightPanelDictionarySearch` to the DOM cache in `gui-dom-cache.ts` and update `cacheElements` to return the new element.
- Implement `syncDictionarySearchVisibility` in `gui-application.ts` and call it from `switchArea` and the window `resize` handler to show/hide the right-panel search based on `mobile` and `layoutState`, and remove the duplicate search wrapper from the user dictionary during initialization.

### Testing

- Ran TypeScript compilation with `tsc` which completed successfully.
- Ran the linting step with `eslint` which reported no errors.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e189f1d5948326be787fac61d2b45c)