### PR TITLE
Remove legacy user-dictionary search box from Demonstration section

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,10 +138,6 @@
                                             <option value="DEMO">Demonstration word</option>
                                         </select>
                                     </div>
-                                    <div class="search-wrapper">
-                                        <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
-                                        <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
-                                    </div>
                                 </div>
                                 <span id="user-word-info" class="word-info-display"></span>
                                 <div id="user-words-display" class="words-display"></div>


### PR DESCRIPTION
### Motivation
- Remove an obsolete search input block left under the `Demonstration word` user-dictionary selector that was a leftover incorrect implementation and created duplicated DOM IDs.

### Description
- Deleted the `search-wrapper` block containing `input#dictionary-search` and `button#dictionary-search-clear-btn` from the `Demonstration word` controls in `index.html`, leaving only the intended right-side search UI (`right-panel-dictionary-search`).

### Testing
- Ran `npm run check` (`tsc --noEmit`) and the TypeScript check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1941537948326986295ce72123489)