### PR TITLE
Ignore dictionary background clicks in empty-filter state to prevent editor placeholder switch

### DIFF
--- a/js/gui/dictionary-element-builders.ts
+++ b/js/gui/dictionary-element-builders.ts
@@ -32,7 +32,11 @@ export const registerBackgroundClickListeners = (
     onBackgroundClick?: () => void,
     onBackgroundDoubleClick?: () => void
 ): void => {
+    const shouldIgnoreBackgroundInteraction = (): boolean =>
+        container.classList.contains('is-empty');
+
     const isBackgroundClick = (e: MouseEvent): boolean => {
+        if (shouldIgnoreBackgroundInteraction()) return false;
         const target = e.target as HTMLElement;
         return !target.closest('.word-button');
     };


### PR DESCRIPTION
### Motivation
- Users observed that when a dictionary filter was active and a sheet selector was changed, the editor's placeholder unexpectedly appeared due to a background-click side effect from the dictionary word container.
- The root cause was background click/double-click handlers on the dictionary words container firing even when the container was in an empty/filtered state, which triggered editor-side actions.

### Description
- Added a guard `shouldIgnoreBackgroundInteraction` in `registerBackgroundClickListeners` to detect `container.classList.contains('is-empty')` and skip background click/double-click handling when true.
- Updated the `isBackgroundClick` predicate to return `false` when the container is empty so background interactions do not invoke `onBackgroundClick`/`onBackgroundDoubleClick`.
- Change is implemented in `js/gui/dictionary-element-builders.ts` and prevents accidental propagation into editor actions (e.g., switching to input mode or inserting whitespace) during filtered empty views.

### Testing
- Ran the TypeScript check with `npm run check` (runs `tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19807a94c8326ba2118b2f7d9f026)