### PR TITLE
Fix mobile dictionary search visibility

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -782,6 +782,19 @@ body[data-active-area] #state-panel {
         display: none;
     }
 
+    body[data-active-area="dictionary"] .area-selector-right {
+        display: flex;
+        padding: 0.75rem 0.75rem 0;
+    }
+
+    body[data-active-area="dictionary"] .area-selector-right .right-mode-selector {
+        display: none;
+    }
+
+    body[data-active-area="dictionary"] .area-selector-right #right-panel-dictionary-search {
+        width: 100%;
+    }
+
     .area-selector-mobile {
         display: block;
         padding: 0.75rem 0.75rem 0;

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -93,7 +93,9 @@ export const createGUI = (): GUI => {
     };
 
     const syncDictionarySearchVisibility = (): void => {
-        const shouldShowSearch = !mobile.isMobile() && layoutState.currentRightMode === 'dictionary';
+        const shouldShowSearch = mobile.isMobile()
+            ? layoutState.currentMode === 'dictionary'
+            : layoutState.currentRightMode === 'dictionary';
         elements.rightPanelDictionarySearch.hidden = !shouldShowSearch;
     };
 


### PR DESCRIPTION
### Motivation
- モバイルで辞書（Dictionary）表示中に検索入力欄が表示されない不具合を解消するための修正です。原因は表示制御ロジックとモバイル用CSSの両方にありました。 

### Description
- `js/gui/gui-application.ts` の `syncDictionarySearchVisibility` を修正し、モバイル時は `layoutState.currentMode === 'dictionary'` のときに検索欄を表示するようにしました（デスクトップは従来どおり `layoutState.currentRightMode === 'dictionary'` を参照）。
- モバイル用のCSS（`app-interface.css` の `@media (max-width: 768px)` 内）に、`body[data-active-area="dictionary"] .area-selector-right` を表示するオーバーライドを追加し、右側モードセレクタを隠して検索欄を全幅表示するスタイルを追加しました。
- これにより、モバイルで辞書画面を表示した際に上部の検索欄が正しく露出するようになります。

### Testing
- 自動チェックとして `npm run check`（`tsc --noEmit`）を実行し、型チェックは正常に通りました (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b6684c588326b857e0ca80484591)