### PR TITLE
Restore debug-borders.css and update for new HTML structure

### DIFF
--- a/debug-borders.css
+++ b/debug-borders.css
@@ -1,0 +1,68 @@
+/*
+ * DEBUG: div階層ごとの枠線表示
+ * 構造確認用の一時ファイルです。確認後は下記を削除してください:
+ *   1. このファイル (debug-borders.css)
+ *   2. index.html の <link rel="stylesheet" href="debug-borders.css"> 行
+ *
+ * 色凡例:
+ *   Level 1 (赤    #FF3B30): div祖先 0個  — .container
+ *   Level 2 (橙    #FF9500): div祖先 1個  — #editor-panel, #state-panel 等
+ *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .dictionary-toolbar 等
+ *   Level 4 (緑    #34C759): div祖先 3個  — .right-mode-selector, .vocabulary-container 等
+ *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, .user-dictionary-controls 等
+ *   Level 7 (青緑  #00C7BE): div祖先 6個  — .dictionary-sheet-selector (user sheet内)
+ *
+ * 余白について:
+ *   padding: 4px !important を全 div に付与することで、親の padding が子 div を
+ *   4px 内側に押し込み、各階層の outline が重ならないようにしています。
+ */
+
+/* Level 1 — div祖先 0個 */
+div {
+    outline: 1px solid #FF3B30;
+    outline-offset: -1px;
+    padding: 4px !important;
+}
+
+/* Level 2 — div祖先 1個 */
+div div {
+    outline: 1px solid #FF9500;
+    outline-offset: -1px;
+    padding: 4px !important;
+}
+
+/* Level 3 — div祖先 2個 */
+div div div {
+    outline: 1px solid #FFCC00;
+    outline-offset: -1px;
+    padding: 4px !important;
+}
+
+/* Level 4 — div祖先 3個 */
+div div div div {
+    outline: 1px solid #34C759;
+    outline-offset: -1px;
+    padding: 4px !important;
+}
+
+/* Level 5 — div祖先 4個 */
+div div div div div {
+    outline: 1px solid #007AFF;
+    outline-offset: -1px;
+    padding: 4px !important;
+}
+
+/* Level 6 — div祖先 5個 */
+div div div div div div {
+    outline: 1px solid #AF52DE;
+    outline-offset: -1px;
+    padding: 4px !important;
+}
+
+/* Level 7 — div祖先 6個以上 */
+div div div div div div div {
+    outline: 1px solid #00C7BE;
+    outline-offset: -1px;
+    padding: 4px !important;
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 
     <link rel="stylesheet" href="./ajisai-base.css?v=20260408">
     <link rel="stylesheet" href="app-interface.css?v=20260408">
+    <link rel="stylesheet" href="debug-borders.css">
 </head>
 <body>
     <a href="#code-input" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
Re-adds debug-borders.css (deleted during main merge). Updated to Level 7 to cover the new .user-dictionary-controls > .dictionary-sheet-selector nesting. Also added .right-mode-selector and #right-panel-dictionary-search which are new Level 4 divs in the updated HTML.

https://claude.ai/code/session_01KzTHCuaUi1MATzuhXNiRPt