### PR TITLE
Add dictionary search to mobile area selector

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -783,8 +783,24 @@ body[data-active-area] #state-panel {
     }
 
     .area-selector-mobile {
-        display: block;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
         padding: 0.75rem 0.75rem 0;
+    }
+
+    .area-selector-mobile select {
+        flex: 1.618 1 0%;
+    }
+
+    .area-selector-mobile #mobile-panel-dictionary-search {
+        flex: 1 1 0%;
+        min-width: 0;
+    }
+
+    .area-selector-mobile .vocabulary-search-input {
+        width: 100%;
+        max-width: none;
     }
 
     .main-layout {

--- a/index.html
+++ b/index.html
@@ -61,6 +61,10 @@
                     <option value="stack">Stack</option>
                     <option value="dictionary">Dictionary</option>
                 </select>
+                <div id="mobile-panel-dictionary-search" class="search-wrapper" hidden>
+                    <input type="text" id="mobile-dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
+                    <button id="mobile-dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
+                </div>
             </div>
 
             <div id="editor-panel" class="panel">

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -93,8 +93,10 @@ export const createGUI = (): GUI => {
     };
 
     const syncDictionarySearchVisibility = (): void => {
-        const shouldShowSearch = !mobile.isMobile() && layoutState.currentRightMode === 'dictionary';
-        elements.rightPanelDictionarySearch.hidden = !shouldShowSearch;
+        const isDesktopDictionary = !mobile.isMobile() && layoutState.currentRightMode === 'dictionary';
+        const isMobileDictionary = mobile.isMobile() && layoutState.currentMode === 'dictionary';
+        elements.rightPanelDictionarySearch.hidden = !isDesktopDictionary;
+        elements.mobilePanelDictionarySearch.hidden = !isMobileDictionary;
     };
 
     const switchArea = (mode: ViewMode): void => {
@@ -157,6 +159,7 @@ export const createGUI = (): GUI => {
 
         const applySearchFilter = (filter: string): void => {
             elements.dictionarySearch.value = filter;
+            elements.mobileDictionarySearch.value = filter;
             vocabulary.updateSearchFilter(filter);
             moduleTabManager.updateSearchFilter(filter);
         };
@@ -165,9 +168,18 @@ export const createGUI = (): GUI => {
             applySearchFilter(elements.dictionarySearch.value);
         }, 150);
 
+        const applyMobileSearchInput = debounce(() => {
+            applySearchFilter(elements.mobileDictionarySearch.value);
+        }, 150);
+
         elements.dictionarySearch.addEventListener('input', applySearchInput);
+        elements.mobileDictionarySearch.addEventListener('input', applyMobileSearchInput);
 
         elements.dictionarySearchClearBtn.addEventListener('click', () => {
+            applySearchFilter('');
+        });
+
+        elements.mobileDictionarySearchClearBtn.addEventListener('click', () => {
             applySearchFilter('');
         });
 

--- a/js/gui/gui-dom-cache.ts
+++ b/js/gui/gui-dom-cache.ts
@@ -29,6 +29,9 @@ export interface GUIElements {
     readonly rightPanelSelect: HTMLSelectElement;
     readonly rightPanelDictionarySearch: HTMLElement;
     readonly mobilePanelSelect: HTMLSelectElement;
+    readonly mobilePanelDictionarySearch: HTMLElement;
+    readonly mobileDictionarySearch: HTMLInputElement;
+    readonly mobileDictionarySearchClearBtn: HTMLButtonElement;
     readonly copyOutputBtn: HTMLButtonElement;
 }
 
@@ -59,6 +62,9 @@ export const cacheElements = (): GUIElements => ({
     rightPanelSelect: document.getElementById('right-panel-select') as HTMLSelectElement,
     rightPanelDictionarySearch: document.getElementById('right-panel-dictionary-search')!,
     mobilePanelSelect: document.getElementById('mobile-panel-select') as HTMLSelectElement,
+    mobilePanelDictionarySearch: document.getElementById('mobile-panel-dictionary-search')!,
+    mobileDictionarySearch: document.getElementById('mobile-dictionary-search') as HTMLInputElement,
+    mobileDictionarySearchClearBtn: document.getElementById('mobile-dictionary-search-clear-btn') as HTMLButtonElement,
     copyOutputBtn: document.getElementById('copy-output-btn') as HTMLButtonElement
 });
 


### PR DESCRIPTION
## Summary
This PR adds dictionary search functionality to the mobile interface by integrating a search input field directly into the mobile area selector panel, alongside the existing mode dropdown.

## Key Changes
- **HTML Structure**: Added a new search wrapper div with input and clear button to the mobile panel selector in `index.html`
- **CSS Layout**: Updated `.area-selector-mobile` from `display: block` to `display: flex` with proper spacing and alignment, and added flex sizing rules for the select dropdown and search input to ensure they share space proportionally
- **DOM Caching**: Extended `GUIElements` interface and `cacheElements()` function to include references to the new mobile dictionary search elements
- **Search Logic**: 
  - Modified `syncDictionarySearchVisibility()` to show/hide the mobile search input when in dictionary mode on mobile devices
  - Added event listeners for the mobile search input and clear button that apply the same debounced filtering logic as the desktop version
  - Ensured search filter synchronization between desktop and mobile inputs via `applySearchFilter()`

## Implementation Details
- The mobile search input uses the same `vocabulary-search-input` class and styling as the desktop version for consistency
- Search filtering is debounced at 150ms to match the desktop behavior
- The mobile search panel is hidden by default and only shown when the user selects "Dictionary" mode on a mobile device
- The layout uses flexbox with a golden ratio (1.618) flex basis for the select dropdown to give it slightly more space than the search input

https://claude.ai/code/session_01B9yCqsARSQbqojewJJpPb4