### PR TITLE
Add is-empty class to vocabulary container when no results found

### DIFF
--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -238,6 +238,7 @@ export const createVocabularyManager = (
         coreWords: unknown[][]
     ): void => {
         clearElement(container);
+        container.classList.remove('is-empty');
 
 
         const filtered = coreWords.filter(
@@ -276,6 +277,7 @@ export const createVocabularyManager = (
         });
 
         if (searchFilter && matched.length === 0) {
+            container.classList.add('is-empty');
             container.appendChild(createNoResultsElement());
         }
     };


### PR DESCRIPTION
## Summary
Updated the vocabulary state controller to properly manage the `is-empty` CSS class on the container element based on search results.

## Key Changes
- Remove `is-empty` class when rendering vocabulary (clearing previous empty state)
- Add `is-empty` class to the container when a search filter returns no results

## Implementation Details
The changes ensure that the container's visual state accurately reflects whether search results are empty. The class is removed at the start of rendering to clear any previous empty state, and conditionally added only when a search filter is active and produces no matches. This allows CSS styling to properly reflect the empty state UI.

https://claude.ai/code/session_01Xq4BFAPPokd4o2cJdS67Zf