### PR TITLE
Preserve DisplayHint for nested Vectors: preserve Value.hint through Arena & WASM paths

### DIFF
--- a/docs/dev/arena-nodeid-soa-migration-instructions.md
+++ b/docs/dev/arena-nodeid-soa-migration-instructions.md
@@ -124,6 +124,10 @@ pub struct ValueArena {
    - 明示文字列のみ string hint として表示される。
 3. **深いネスト**
    - 既存次元制限撤廃前提で 10+ 深度でも hint が崩れない。
+4. **2要素数値ベクター回帰**
+   - `[65 66]` のような codepoint 範囲内整数列でも、明示 string hint が無い限り string 判定しない。
+5. **WASM 境界 hint 回帰**
+   - `arena_node_to_js` で子再帰時に `None` を渡しても、NodeId ごとの hint が維持される。
 
 ### 5.2 互換性テスト
 
@@ -176,3 +180,18 @@ pub struct ValueArena {
 - [ ] 再現ケースの回帰テストが追加・成功
 - [ ] 既存主要テストが成功
 - [ ] ドキュメント（本書）と実装が同期
+
+---
+
+## 9. 無制限ネスト対応メモ（DisplayHint 伝播）
+
+- 旧 10 次元制限は撤廃済みであり、現在はメモリ許容範囲でネスト可能。
+- `collect_vector_with_depth` は再帰結果の `nested_hint` を破棄せず、内側 Value に保持すること。
+- `value_to_arena` は `is_string_like` 推論で hint を再決定せず、`Value.hint` をそのまま SoA (`hints[NodeId]`) へ転写すること。
+- `is_string_like` は `DisplayHint::Auto` 表示時の fallback 専用とし、変換経路（Value -> Arena / JSON / WASM）の判定には使わない。
+
+### 9.1 GUI 手動確認手順（回帰確認）
+
+1. GUI を起動し、`examples/nested-vector-brackets-sample-test.ajisai` を読み込む。
+2. テキストエディタでネストした数値ベクター（例: `[[[[[65 66]]]]]`）を評価する。
+3. Stack 表示で `'...'` 形式へ変換されず、数値ベクター表示 (`[ 65 66 ]` など) が維持されることを確認する。

--- a/rust/src/elastic/elastic-engine-tests.rs
+++ b/rust/src/elastic/elastic-engine-tests.rs
@@ -173,11 +173,12 @@ mod tests {
 
     use crate::elastic::cache_manager::CacheManager;
     use crate::types::fraction::Fraction;
-    use crate::types::{Value, ValueData};
+    use crate::types::{DisplayHint, Value, ValueData};
 
     fn scalar_value(n: i64) -> Value {
         Value {
             data: ValueData::Scalar(Fraction::from(n)),
+            hint: DisplayHint::Number,
         }
     }
 

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -51,14 +51,19 @@ impl Interpreter {
         while i < tokens.len() {
             match &tokens[i] {
                 Token::VectorStart => {
-                    let (nested_values, consumed, _nested_hint) =
+                    // Hint 伝播フロー:
+                    // collect_vector_with_depth(inner) -> nested_hint
+                    //   -> Value::from_vector_with_hint(nested_values, nested_hint)
+                    //   -> value_to_arena が Value.hint をそのまま Node hint として採用
+                    // これにより、ネスト深度に依存せず明示 hint を維持する。
+                    let (nested_values, consumed, nested_hint) =
                         self.collect_vector_with_depth(tokens, i, depth + 1)?;
                     if nested_values.is_empty() {
                         return Err(AjisaiError::from(
                             "Empty vector is not allowed. Use NIL for empty values.",
                         ));
                     }
-                    values.push(Value::from_vector(nested_values));
+                    values.push(Value::from_vector_with_hint(nested_values, nested_hint));
                     has_other = true;
                     i += consumed;
                 }

--- a/rust/src/interpreter/json.rs
+++ b/rust/src/interpreter/json.rs
@@ -3,7 +3,7 @@ use crate::interpreter::{ConsumptionMode, Interpreter};
 use crate::types::arena::{
     arena_node_to_json, arena_to_value, json_to_arena_node, value_to_arena, ValueArena,
 };
-use crate::types::{Value, ValueData};
+use crate::types::{DisplayHint, Value, ValueData};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -168,6 +168,7 @@ pub fn op_json_keys(interp: &mut Interpreter) -> Result<()> {
     } else {
         interp.stack.push(Value {
             data: ValueData::Vector(Rc::new(keys)),
+            hint: DisplayHint::Auto,
         });
     }
 
@@ -226,6 +227,7 @@ pub fn op_json_set(interp: &mut Interpreter) -> Result<()> {
                                 kv[0].clone(),
                                 new_value.clone(),
                             ])),
+                            hint: DisplayHint::Auto,
                         });
                         continue;
                     }
@@ -238,6 +240,7 @@ pub fn op_json_set(interp: &mut Interpreter) -> Result<()> {
             new_index.insert(key_str.clone(), new_pairs.len());
             new_pairs.push(Value {
                 data: ValueData::Vector(Rc::new(vec![Value::from_string(&key_str), new_value])),
+                hint: DisplayHint::Auto,
             });
         }
 
@@ -258,15 +261,18 @@ pub fn op_json_set(interp: &mut Interpreter) -> Result<()> {
                 pairs: Rc::new(new_pairs),
                 index: new_index,
             },
+            hint: DisplayHint::Auto,
         });
     } else {
         let mut index = HashMap::new();
         index.insert(key_str.clone(), 0);
         let pairs = Rc::new(vec![Value {
             data: ValueData::Vector(Rc::new(vec![Value::from_string(&key_str), new_value])),
+            hint: DisplayHint::Auto,
         }]);
         interp.stack.push(Value {
             data: ValueData::Record { pairs, index },
+            hint: DisplayHint::Auto,
         });
     }
 

--- a/rust/src/interpreter/optimization-hooks.rs
+++ b/rust/src/interpreter/optimization-hooks.rs
@@ -29,7 +29,7 @@ pub(crate) fn check_in_place_candidate(value: &Value, flow: Option<&FlowToken>) 
 mod tests {
     use super::*;
     use crate::types::fraction::Fraction;
-    use crate::types::ValueData;
+    use crate::types::{DisplayHint, ValueData};
     use std::rc::Rc;
 
     fn scalar(n: i64) -> Value {
@@ -141,9 +141,11 @@ mod tests {
         let children = Rc::new(vec![scalar(1), scalar(2)]);
         let v1 = Value {
             data: ValueData::Vector(Rc::clone(&children)),
+            hint: DisplayHint::Auto,
         };
         let _v2 = Value {
             data: ValueData::Vector(Rc::clone(&children)),
+            hint: DisplayHint::Auto,
         };
 
         let flow = fresh_flow(&v1);
@@ -158,6 +160,7 @@ mod tests {
         let children = Rc::new(vec![scalar(1), scalar(2)]);
         let v1 = Value {
             data: ValueData::Vector(Rc::clone(&children)),
+            hint: DisplayHint::Auto,
         };
 
         drop(children);

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -1,6 +1,6 @@
 use crate::error::{AjisaiError, Result};
 use crate::types::fraction::Fraction;
-use crate::types::{Value, ValueData};
+use crate::types::{DisplayHint, Value, ValueData};
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
@@ -150,6 +150,7 @@ pub(crate) fn build_nested_value(data: &[Fraction], shape: &[usize]) -> Value {
         if data.len() == 1 {
             return Value {
                 data: ValueData::Scalar(data[0].clone()),
+                hint: DisplayHint::Number,
             };
         }
         let children: Vec<Value> = data
@@ -166,6 +167,7 @@ pub(crate) fn build_nested_value(data: &[Fraction], shape: &[usize]) -> Value {
             .collect();
         return Value {
             data: ValueData::Vector(Rc::new(children)),
+            hint: DisplayHint::Auto,
         };
     }
 
@@ -183,6 +185,7 @@ pub(crate) fn build_nested_value(data: &[Fraction], shape: &[usize]) -> Value {
 
     Value {
         data: ValueData::Vector(Rc::new(children)),
+        hint: DisplayHint::Auto,
     }
 }
 

--- a/rust/src/types/arena.rs
+++ b/rust/src/types/arena.rs
@@ -1,4 +1,3 @@
-use super::display::is_string_like;
 use super::fraction::Fraction;
 use super::{DisplayHint, Token, Value, ValueData};
 use num_traits::ToPrimitive;
@@ -99,35 +98,30 @@ impl ValueArena {
 pub fn value_to_arena(root: &Value) -> (ValueArena, NodeId) {
     fn alloc_recursive(value: &Value, arena: &mut ValueArena) -> NodeId {
         match &value.data {
-            ValueData::Nil => arena.alloc_nil(DisplayHint::Auto),
-            ValueData::Scalar(f) => arena.alloc_scalar(f.clone(), DisplayHint::Auto),
+            ValueData::Nil => arena.alloc_nil(value.hint),
+            ValueData::Scalar(f) => arena.alloc_scalar(f.clone(), value.hint),
             ValueData::Vector(children) => {
                 let child_ids = children
                     .iter()
                     .map(|child| alloc_recursive(child, arena))
                     .collect();
-                let hint = if children.len() > 1 && is_string_like(children) {
-                    DisplayHint::String
-                } else {
-                    DisplayHint::Auto
-                };
-                arena.alloc_vector(child_ids, hint)
+                arena.alloc_vector(child_ids, value.hint)
             }
             ValueData::Record { pairs, index } => {
                 let pair_ids = pairs
                     .iter()
                     .map(|pair| alloc_recursive(pair, arena))
                     .collect();
-                arena.alloc_record(pair_ids, index.clone(), DisplayHint::Auto)
+                arena.alloc_record(pair_ids, index.clone(), value.hint)
             }
             ValueData::CodeBlock(tokens) => {
-                arena.alloc_node(NodeKind::CodeBlock(tokens.clone()), DisplayHint::Auto)
+                arena.alloc_node(NodeKind::CodeBlock(tokens.clone()), value.hint)
             }
             ValueData::ProcessHandle(id) => {
-                arena.alloc_node(NodeKind::ProcessHandle(*id), DisplayHint::Auto)
+                arena.alloc_node(NodeKind::ProcessHandle(*id), value.hint)
             }
             ValueData::SupervisorHandle(id) => {
-                arena.alloc_node(NodeKind::SupervisorHandle(*id), DisplayHint::Auto)
+                arena.alloc_node(NodeKind::SupervisorHandle(*id), value.hint)
             }
         }
     }
@@ -140,14 +134,26 @@ pub fn value_to_arena(root: &Value) -> (ValueArena, NodeId) {
 pub fn arena_to_value(arena: &ValueArena, root: NodeId) -> Value {
     fn rebuild_recursive(arena: &ValueArena, id: NodeId) -> Value {
         match arena.kind(id) {
-            NodeKind::Nil => Value::nil(),
-            NodeKind::Scalar(f) => Value::from_fraction(f.clone()),
+            NodeKind::Nil => Value {
+                data: ValueData::Nil,
+                hint: arena.hint(id),
+            },
+            NodeKind::Scalar(f) => Value {
+                data: ValueData::Scalar(f.clone()),
+                hint: match arena.hint(id) {
+                    DisplayHint::DateTime => DisplayHint::DateTime,
+                    _ => DisplayHint::Number,
+                },
+            },
             NodeKind::Vector { children } => {
                 let values = children
                     .iter()
                     .map(|child_id| rebuild_recursive(arena, *child_id))
                     .collect();
-                Value::from_children(values)
+                Value {
+                    data: ValueData::Vector(Rc::new(values)),
+                    hint: arena.hint(id),
+                }
             }
             NodeKind::Record { pairs, index } => {
                 let values = pairs
@@ -159,11 +165,21 @@ pub fn arena_to_value(arena: &ValueArena, root: NodeId) -> Value {
                         pairs: Rc::new(values),
                         index: index.clone(),
                     },
+                    hint: arena.hint(id),
                 }
             }
-            NodeKind::CodeBlock(tokens) => Value::from_code_block(tokens.clone()),
-            NodeKind::ProcessHandle(id) => Value::from_process_handle(*id),
-            NodeKind::SupervisorHandle(id) => Value::from_supervisor_handle(*id),
+            NodeKind::CodeBlock(tokens) => Value {
+                data: ValueData::CodeBlock(tokens.clone()),
+                hint: arena.hint(id),
+            },
+            NodeKind::ProcessHandle(handle_id) => Value {
+                data: ValueData::ProcessHandle(*handle_id),
+                hint: arena.hint(id),
+            },
+            NodeKind::SupervisorHandle(handle_id) => Value {
+                data: ValueData::SupervisorHandle(*handle_id),
+                hint: arena.hint(id),
+            },
         }
     }
 
@@ -347,5 +363,69 @@ mod tests {
         assert!(json.is_array(), "root should be array, got {json}");
         let first = json.as_array().expect("root array")[0].clone();
         assert!(first.is_array(), "nested numeric vector must stay array");
+    }
+
+    #[test]
+    fn two_element_numeric_vector_stays_number_hint() {
+        let value = Value::from_children(vec![Value::from_int(65), Value::from_int(66)]);
+        let (arena, root) = value_to_arena(&value);
+        assert_ne!(arena.hint(root), DisplayHint::String);
+    }
+
+    #[test]
+    fn deeply_nested_numeric_vector_preserves_number_hint() {
+        let mut inner = Value::from_children(vec![Value::from_int(65), Value::from_int(66)]);
+        for _ in 0..14 {
+            inner = Value::from_children(vec![inner]);
+        }
+
+        let (arena, root) = value_to_arena(&inner);
+        let mut current = root;
+        for depth in 0..15 {
+            let children = arena.children(current);
+            if depth < 14 {
+                assert_eq!(children.len(), 1, "depth {depth}: expected one child");
+                assert_ne!(arena.hint(current), DisplayHint::String);
+                current = children[0];
+            } else {
+                assert_ne!(arena.hint(current), DisplayHint::String);
+            }
+        }
+    }
+
+    #[test]
+    fn nested_mixed_numeric_vectors_stay_numeric() {
+        let value = Value::from_children(vec![
+            Value::from_children(vec![
+                Value::from_children(vec![Value::from_int(88)]),
+                Value::from_children(vec![Value::from_int(99)]),
+                Value::from_children(vec![Value::from_int(100)]),
+            ]),
+            Value::from_children(vec![
+                Value::from_children(vec![Value::from_int(50)]),
+                Value::from_children(vec![Value::from_int(32)]),
+                Value::from_children(vec![Value::from_int(44)]),
+                Value::from_int(22),
+            ]),
+        ]);
+
+        let (arena, _root) = value_to_arena(&value);
+        for id in 0..arena.nodes.len() as u32 {
+            if let NodeKind::Vector { children } = arena.kind(id) {
+                let all_plain_ints = children.iter().all(|c| {
+                    matches!(arena.kind(*c), NodeKind::Scalar(f) if f.is_integer())
+                });
+                if all_plain_ints && !children.is_empty() {
+                    assert_ne!(arena.hint(id), DisplayHint::String, "node {id} incorrectly string");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_string_literal_retains_string_hint() {
+        let mut arena = ValueArena::new();
+        let root = arena.alloc_string("AB");
+        assert_eq!(arena.hint(root), DisplayHint::String);
     }
 }

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", format_value_auto(&self.data))
+        write!(f, "{}", format_with_hint(self, self.hint))
     }
 }
 
@@ -18,7 +18,7 @@ pub fn format_with_hint(value: &Value, hint: DisplayHint) -> String {
                 format_value_recursive(&value.data, 0)
             }
         }
-        DisplayHint::Auto => format_value_auto(&value.data),
+        DisplayHint::Auto => format_value_auto(value),
         DisplayHint::Number => format_value_recursive(&value.data, 0),
         DisplayHint::String => format_as_string(&value.data),
         DisplayHint::Boolean => format_as_boolean(&value.data),
@@ -26,15 +26,16 @@ pub fn format_with_hint(value: &Value, hint: DisplayHint) -> String {
     }
 }
 
-fn format_value_auto(data: &ValueData) -> String {
-    match data {
+fn format_value_auto(value: &Value) -> String {
+    match &value.data {
         ValueData::Nil => "NIL".to_string(),
         ValueData::Scalar(f) => format_fraction(f),
         ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
+            // NOTE: string-like 推論は Auto hint の表示 fallback でのみ使用すること。
             if !v.is_empty() && is_string_like(v) {
-                return format_as_string(data);
+                return format_as_string(&value.data);
             }
-            format_value_recursive(data, 0)
+            format_value_recursive(&value.data, 0)
         }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
         ValueData::ProcessHandle(id) => format!("<process:{}>", id),
@@ -42,6 +43,8 @@ fn format_value_auto(data: &ValueData) -> String {
     }
 }
 
+/// Returns whether every element can be interpreted as a printable Unicode code point.
+/// This heuristic must be used only for DisplayHint::Auto fallback formatting.
 pub fn is_string_like(values: &[Value]) -> bool {
     values.iter().all(|v| {
         if let ValueData::Scalar(f) = &v.data {

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -56,6 +56,7 @@ pub enum ValueData {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Value {
     pub data: ValueData,
+    pub hint: DisplayHint,
 }
 
 pub struct SemanticRegistry {

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -7,6 +7,7 @@ impl Value {
     pub fn nil() -> Self {
         Self {
             data: ValueData::Nil,
+            hint: DisplayHint::Nil,
         }
     }
 
@@ -14,6 +15,7 @@ impl Value {
     pub fn from_fraction(f: Fraction) -> Self {
         Self {
             data: ValueData::Scalar(f),
+            hint: DisplayHint::Number,
         }
     }
 
@@ -21,6 +23,7 @@ impl Value {
     pub fn from_int(n: i64) -> Self {
         Self {
             data: ValueData::Scalar(Fraction::from(n)),
+            hint: DisplayHint::Number,
         }
     }
 
@@ -28,6 +31,7 @@ impl Value {
     pub fn from_bool(b: bool) -> Self {
         Self {
             data: ValueData::Scalar(Fraction::from(if b { 1 } else { 0 })),
+            hint: DisplayHint::Number,
         }
     }
 
@@ -41,6 +45,7 @@ impl Value {
         }
         Self {
             data: ValueData::Vector(Rc::new(children)),
+            hint: DisplayHint::String,
         }
     }
 
@@ -52,6 +57,15 @@ impl Value {
     pub fn from_children(children: Vec<Value>) -> Self {
         Self {
             data: ValueData::Vector(Rc::new(children)),
+            hint: DisplayHint::Auto,
+        }
+    }
+
+    #[inline]
+    pub fn from_children_with_hint(children: Vec<Value>, hint: DisplayHint) -> Self {
+        Self {
+            data: ValueData::Vector(Rc::new(children)),
+            hint,
         }
     }
 
@@ -61,6 +75,17 @@ impl Value {
         }
         Self {
             data: ValueData::Vector(Rc::new(values)),
+            hint: DisplayHint::Auto,
+        }
+    }
+
+    pub fn from_vector_with_hint(values: Vec<Value>, hint: DisplayHint) -> Self {
+        if values.is_empty() {
+            return Self::nil();
+        }
+        Self {
+            data: ValueData::Vector(Rc::new(values)),
+            hint,
         }
     }
 
@@ -71,7 +96,10 @@ impl Value {
 
     #[inline]
     pub fn from_datetime(f: Fraction) -> Self {
-        Self::from_fraction(f)
+        Self {
+            data: ValueData::Scalar(f),
+            hint: DisplayHint::DateTime,
+        }
     }
 
     #[inline]
@@ -327,12 +355,14 @@ impl Value {
     pub fn from_code_block(tokens: Vec<Token>) -> Self {
         Self {
             data: ValueData::CodeBlock(tokens),
+            hint: DisplayHint::Auto,
         }
     }
 
     pub fn from_process_handle(id: u64) -> Self {
         Self {
             data: ValueData::ProcessHandle(id),
+            hint: DisplayHint::Auto,
         }
     }
 
@@ -346,6 +376,7 @@ impl Value {
     pub fn from_supervisor_handle(id: u64) -> Self {
         Self {
             data: ValueData::SupervisorHandle(id),
+            hint: DisplayHint::Auto,
         }
     }
 

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -158,7 +158,9 @@ pub(crate) fn arena_node_to_js(
     external_hint_opt: Option<DisplayHint>,
 ) -> JsValue {
     let obj = js_sys::Object::new();
-    let effective_hint = external_hint_opt.unwrap_or_else(|| arena.hint(root_id));
+    // external_hint_opt が無い場合は必ず Arena 側の hint を参照する。
+    // 子ノード再帰では None を渡し、各 NodeId の明示 hint を尊重する。
+    let effective_hint = resolve_effective_hint(arena, root_id, external_hint_opt);
 
     let hint_str: &str = match effective_hint {
         DisplayHint::Auto => "auto",
@@ -260,6 +262,14 @@ pub(crate) fn arena_node_to_js(
     obj.into()
 }
 
+fn resolve_effective_hint(
+    arena: &ValueArena,
+    root_id: NodeId,
+    external_hint_opt: Option<DisplayHint>,
+) -> DisplayHint {
+    external_hint_opt.unwrap_or_else(|| arena.hint(root_id))
+}
+
 pub(crate) fn extract_display_hint_from_js(js_val: &JsValue) -> DisplayHint {
     let obj = js_sys::Object::from(js_val.clone());
     let hint_js = js_sys::Reflect::get(&obj, &"displayHint".into()).unwrap_or(JsValue::UNDEFINED);
@@ -275,7 +285,9 @@ pub(crate) fn extract_display_hint_from_js(js_val: &JsValue) -> DisplayHint {
 
 #[cfg(test)]
 mod test_input_helper {
-    use super::build_bracket_structure_from_shape;
+    use super::{build_bracket_structure_from_shape, resolve_effective_hint};
+    use crate::types::arena::ValueArena;
+    use crate::types::DisplayHint;
 
     #[test]
     fn test_build_bracket_structure_from_shape() {
@@ -314,6 +326,20 @@ mod test_input_helper {
         assert_eq!(
             build_bracket_structure_from_shape(&[1, 1, 1, 1]),
             "[ [ [ [ ] ] ] ]"
+        );
+    }
+
+    #[test]
+    fn effective_hint_prefers_external_otherwise_uses_arena() {
+        let mut arena = ValueArena::new();
+        let id = arena.alloc_string("AB");
+        assert_eq!(
+            resolve_effective_hint(&arena, id, None),
+            DisplayHint::String
+        );
+        assert_eq!(
+            resolve_effective_hint(&arena, id, Some(DisplayHint::Number)),
+            DisplayHint::Number
         );
     }
 }

--- a/rust/tests/fractional-dataflow-behavior-tests.rs
+++ b/rust/tests/fractional-dataflow-behavior-tests.rs
@@ -587,11 +587,14 @@ async fn test_can_update_in_place_after_partial_consumption() {
 #[tokio::test]
 async fn test_can_update_in_place_with_aliased_vector() {
     use std::rc::Rc;
-    use ajisai_core::types::ValueData;
+    use ajisai_core::types::{DisplayHint, ValueData};
 
     let children = Rc::new(vec![Value::from_int(1), Value::from_int(2)]);
     let _alias = children.clone();
-    let val = Value { data: ValueData::Vector(children) };
+    let val = Value {
+        data: ValueData::Vector(children),
+        hint: DisplayHint::Auto,
+    };
     let token = FlowToken::from_value(&val);
 
 


### PR DESCRIPTION
### Motivation

- Fix a long-standing failure where numeric vectors (e.g. `[65 66]`) were heuristically misclassified as `String` when moved into the Arena, causing GUI/WASM/JSON display corruption for nested vectors. 
- Ensure DisplayHint is preserved across arbitrary nesting depth (no 10-level limitation) so user-entered numeric data is always displayed as numbers unless explicitly marked as string.
- Move from heuristic-driven inference in conversion paths to explicit hint propagation so display semantics are deterministic and stable.

### Description

- Added an explicit `hint: DisplayHint` field to `Value` and updated constructors so literals/constructors record the intended hint (e.g. string literals use `DisplayHint::String`, numbers default to `Number` or `Auto` as appropriate). (`rust/src/types/mod.rs`, `rust/src/types/value-operations.rs`).
- Stopped using `is_string_like` during `value_to_arena`; `value_to_arena` now copies `Value.hint` to the Arena SoA `hints` array for all node kinds so Arena node hints reflect the source `Value` (no heuristic re-decision). (`rust/src/types/arena.rs`).
- Propagated nested vector hints from the parser: `collect_vector_with_depth` returns an element hint which is used to construct nested `Value` via `from_vector_with_hint`, preserving inner hints instead of discarding them. (`rust/src/interpreter/execution-loop.rs`).
- Restricted `is_string_like` to a display-time fallback used only by `format_value_auto`, and documented this policy in code comments; display now prefers explicit hints. (`rust/src/types/display.rs`).
- Ensured WASM conversion respects per-Node Arena hints when `external_hint_opt` is `None` by centralizing effective-hint resolution (`resolve_effective_hint`) and keeping child recursion passing `None` so each NodeId’s hint is used. (`rust/src/wasm-value-conversion.rs`).
- Added regression tests that assert correct hint propagation across cases: two-element numeric vectors, deeply nested (15-level) numeric vectors, mixed nested numeric vectors, explicit string literal allocation, and effective-hint behavior at the WASM boundary. Also updated migration docs with additional test/checklist and a GUI manual verification procedure. (`rust/src/types/arena.rs`, `rust/src/wasm-value-conversion.rs`, `docs/dev/arena-nodeid-soa-migration-instructions.md`).

### Testing

- Ran `cd rust && cargo test --lib` and the full library test suite; all library tests passed (all tests green).
- Ran `cd rust && cargo test --tests` and the test binary suite; all tests passed (all tests green).
- Executed focused regression checks for new tests such as `types::arena::tests::two_element_numeric_vector_stays_number_hint` and the WASM effective-hint test; they succeeded.
- Ran `npm run check` at repository root to validate TypeScript checks; the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e432217e48832688a862ab596d3ac8)