### PR TITLE
fix(gui): eliminate mobile startup FOUC by pre-seeding initial panel …

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="app-interface.css?v=20260408">
     <link rel="stylesheet" href="debug-borders.css">
 </head>
-<body>
+<body data-active-area="input">
     <a href="#code-input" class="skip-link">Skip to main content</a>
     <div class="container">
         <header role="banner">
@@ -77,7 +77,7 @@
                         <option value="output">Output</option>
                     </select>
                 </div>
-                <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0">
+                <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0" hidden>
                     <h2 class="visually-hidden">Output</h2>
                     <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
                     <div class="vocabulary-actions">


### PR DESCRIPTION
…state

Before JS ran, the mobile viewport briefly rendered both editor-panel and state-panel because the CSS hiding rule keys on body[data-active-area] and that attribute was only set when switchArea() fired late in init. Within editor-panel, the output-area was also visible for the same window.

Pre-seed the HTML with data-active-area="input" on <body> and mark #output-panel hidden, matching the initial LayoutState. Mobile CSS now hides #state-panel from the first paint, and desktop is unaffected (its @media block treats data-active-area as a presence flag and stack-area remains visible as intended).