### PR TITLE
refactor(gui): deps-ify applyAreaState, drop dead CSS resets

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -76,16 +76,6 @@
 }
 
 
-.main-layout .display-area,
-.main-layout .state-display,
-.main-layout .words-display,
-.main-layout .area-content-flow {
-    align-content: flex-start;
-    align-items: flex-start;
-    justify-content: flex-start;
-}
-
-
 .main-layout {
     display: flex;
     flex: 1;
@@ -154,15 +144,6 @@
 
 [hidden] {
     display: none !important;
-}
-
-
-.main-layout section {
-    margin-bottom: 0;
-    border: none;
-    border-radius: 0;
-    background: transparent;
-    padding: 0;
 }
 
 

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -19,7 +19,8 @@ import {
     applyAreaState,
     updateHighlights,
     updateEditorPlaceholder,
-    LayoutState
+    LayoutState,
+    ApplyAreaStateDeps
 } from './gui-layout-state';
 import { switchDictionarySheet } from './gui-dictionary-sheet';
 
@@ -103,9 +104,17 @@ export const createGUI = (): GUI => {
         elements.mobilePanelDictionarySearch.hidden = !isMobileDictionary;
     };
 
+    const buildApplyAreaStateDeps = (): ApplyAreaStateDeps => ({
+        elements,
+        state: layoutState,
+        mobile,
+        moduleTabManager,
+        switchDictionarySheet: doSwitchDictionarySheet,
+    });
+
     const switchArea = (mode: ViewMode): void => {
         layoutState.currentMode = mode;
-        applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, mode);
+        applyAreaState(buildApplyAreaStateDeps(), mode);
         syncDictionarySearchVisibility();
     };
 
@@ -189,7 +198,7 @@ export const createGUI = (): GUI => {
         setupTapToTransition(elements.stackDisplay, 'stack', 'input');
 
         window.addEventListener('resize', () => {
-            applyAreaState(elements, layoutState, mobile, moduleTabManager, doSwitchDictionarySheet, layoutState.currentMode);
+            applyAreaState(buildApplyAreaStateDeps(), layoutState.currentMode);
             syncDictionarySearchVisibility();
             updateEditorPlaceholder(elements, mobile);
         });

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -70,32 +70,40 @@ const updateDesktopModes = (state: LayoutState, mode: ViewMode): void => {
     }
 };
 
-export const applyAreaState = (
-    elements: GUIElements,
-    state: LayoutState,
-    mobile: MobileHandler,
-    moduleTabManager: ModuleTabManager,
-    switchDictionarySheet: (sheetId: string) => void,
-    mode: ViewMode
-): void => {
-    if (mobile.isMobile()) {
-        mobile.updateView(mode);
-        document.body.dataset.activeArea = mode;
-        syncMobileSelectorState(elements, mode);
-        return;
+export interface ApplyAreaStateDeps {
+    readonly elements: GUIElements;
+    readonly state: LayoutState;
+    readonly mobile: MobileHandler;
+    readonly moduleTabManager: ModuleTabManager;
+    readonly switchDictionarySheet: (sheetId: string) => void;
+}
+
+const applyMobileAreaState = (deps: ApplyAreaStateDeps, mode: ViewMode): void => {
+    deps.mobile.updateView(mode);
+    document.body.dataset.activeArea = mode;
+    syncMobileSelectorState(deps.elements, mode);
+};
+
+const applyDesktopAreaState = (deps: ApplyAreaStateDeps, mode: ViewMode): void => {
+    updateDesktopModes(deps.state, mode);
+
+    const currentSheet = deps.elements.dictionarySheetSelect?.value;
+    if (currentSheet?.startsWith('module-') && !deps.moduleTabManager.lookupModuleArea(currentSheet)) {
+        deps.elements.dictionarySheetSelect.value = 'core';
+        deps.switchDictionarySheet('core');
     }
 
-    updateDesktopModes(state, mode);
+    syncDesktopLayout(deps.elements, deps.state);
+    document.body.dataset.activeArea = deps.state.currentRightMode;
+    syncSelectorState(deps.elements, deps.state.currentLeftMode, deps.state.currentRightMode);
+};
 
-    const currentSheet = elements.dictionarySheetSelect?.value;
-    if (currentSheet?.startsWith('module-') && !moduleTabManager.lookupModuleArea(currentSheet)) {
-        elements.dictionarySheetSelect.value = 'core';
-        switchDictionarySheet('core');
+export const applyAreaState = (deps: ApplyAreaStateDeps, mode: ViewMode): void => {
+    if (deps.mobile.isMobile()) {
+        applyMobileAreaState(deps, mode);
+    } else {
+        applyDesktopAreaState(deps, mode);
     }
-
-    syncDesktopLayout(elements, state);
-    document.body.dataset.activeArea = state.currentRightMode;
-    syncSelectorState(elements, state.currentLeftMode, state.currentRightMode);
 };
 
 export const updateHighlights = (elements: GUIElements, content: string): void => {


### PR DESCRIPTION
- A-1/A-6: split applyAreaState into mobile/desktop dispatchers using an ApplyAreaStateDeps object, so callers pass explicit collaborators instead of relying on module-scoped closures.
- E-1: remove .main-layout section reset block (dead; universal reset in ajisai-base.css already covers these properties).
- E-5 Block 2: remove align-content/items/justify-content reset for .display-area/.state-display/.words-display/.area-content-flow (dead; targets aren't flex containers at this scope).

https://claude.ai/code/session_01MHmKtPx12tq5nugKwRefqy