### PR TITLE
Standardize word tooltips and usage examples

### DIFF
--- a/js/gui/demo-words.ts
+++ b/js/gui/demo-words.ts
@@ -1,32 +1,32 @@
 import type { UserWord } from '../wasm-interpreter-types';
 
 
-export const DEMO_WORDS_VERSION = 8;
+export const DEMO_WORDS_VERSION = 9;
 
 export const DEMO_USER_WORDS: UserWord[] = [
     {
         name: 'SAY-HELLO',
         definition: "'Hello' ,, PRINT",
-        description: 'Map型: スタックトップを保持しつつOutputに「Hello」を出力する。入力: 任意、出力: 入力そのまま',
+        description: 'Map: Print "Hello" while passing input through. Any -> Any',
     },
     {
         name: 'SAY-WORLD',
         definition: "'World' ,, PRINT",
-        description: 'Map型: スタックトップを保持しつつOutputに「World」を出力する。入力: 任意、出力: 入力そのまま',
+        description: 'Map: Print "World" while passing input through. Any -> Any',
     },
     {
         name: 'SAY-BANG',
         definition: "'!' ,, PRINT",
-        description: 'Map型: スタックトップを保持しつつOutputに「!」を出力する。入力: 任意、出力: 入力そのまま',
+        description: 'Map: Print "!" while passing input through. Any -> Any',
     },
     {
         name: 'GREET',
         definition: "{ [ 1 ] = } { SAY-HELLO } { [ 2 ] = } { SAY-WORLD } { IDLE } { SAY-BANG } COND",
-        description: 'Form型: 入力値に応じてHello/World/!を分岐出力する（CONDパターン例）。入力: Scalar(1|2|other)、出力: 入力そのまま',
+        description: 'Form: Print Hello/World/! by value (1/2/other). Scalar -> Scalar',
     },
     {
         name: 'GREET-ALL',
         definition: '{ GREET } MAP',
-        description: 'Form型: Vectorの各要素にGREETを適用する（MAPパターン例）。入力: Vector、出力: Vector',
+        description: 'Form: Apply GREET to each element. Vector -> Vector',
     },
 ];

--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -84,12 +84,6 @@ const clearElement = (element: HTMLElement): void => {
 
 const DEFAULT_WORD_INFO_MESSAGE = 'Hover over a word button to view its usage.';
 
-const resolveDisplayDescription = (wordInfo: WordInfo): string | null => {
-    const desc = wordInfo.description;
-    if (!desc || desc === wordInfo.name) return null;
-    return desc;
-};
-
 const renderWordInfo = (element: HTMLElement, text: string, isPlaceholder = false): void => {
     element.textContent = text;
     element.classList.toggle('is-placeholder', isPlaceholder);
@@ -310,15 +304,11 @@ export const createVocabularyManager = (
                 () => onWordClick(wordInfo.dictionary === 'DEMO' ? wordInfo.name : `${wordInfo.dictionary}@${wordInfo.name}`),
                 () => {
                     const lookupName = `${wordInfo.dictionary}@${wordInfo.name}`;
-                    const definition = window.ajisaiInterpreter?.lookup_word_definition(lookupName);
-                    const desc = resolveDisplayDescription(wordInfo);
-                    const displayText = desc
-                        ? `${desc}\n\n${definition ?? ''}`.trim()
-                        : (definition ?? '');
+                    const definition = window.ajisaiInterpreter?.lookup_word_definition(lookupName) ?? '';
                     renderWordInfo(
                         elements.userWordInfo,
-                        displayText || DEFAULT_WORD_INFO_MESSAGE,
-                        !displayText
+                        definition || DEFAULT_WORD_INFO_MESSAGE,
+                        !definition
                     );
                 },
                 () => { resetWordInfoDisplay(elements.userWordInfo); },


### PR DESCRIPTION
Align Demonstration word descriptions with the core word style (concise English "Kind: Action. Type -> Type"). For user-word hover info, show only the definition code so it fits the single-line display area instead of cramming description plus definition into one truncated line.

https://claude.ai/code/session_01KhdPaAoHVp8deWzPg3JRf5