### PR TITLE
Add sound rational Interval type, interval arithmetic, and SQRT interval support

### DIFF
--- a/rust/src/arithmetic-operation-tests.rs
+++ b/rust/src/arithmetic-operation-tests.rs
@@ -231,3 +231,121 @@ mod num_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod interval_tests {
+    use crate::interpreter::interval_ops::value_to_interval;
+    use crate::interpreter::Interpreter;
+    use crate::types::fraction::Fraction;
+
+    #[tokio::test]
+    async fn test_interval_creation_success_and_failure() {
+        let mut interp = Interpreter::new();
+        interp.execute("1 2 INTERVAL").await.unwrap();
+        let stack = interp.get_stack();
+        assert_eq!(format!("{}", stack[0]), "[1, 2]");
+
+        let mut interp_fail = Interpreter::new();
+        let result = interp_fail.execute("2 1 INTERVAL").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_interval_basic_arithmetic() {
+        let mut interp = Interpreter::new();
+        interp.execute("1 2 INTERVAL 3 4 INTERVAL +").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[4, 6]");
+
+        let mut interp = Interpreter::new();
+        interp.execute("1 2 INTERVAL 3 4 INTERVAL -").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[-3, -1]");
+
+        let mut interp = Interpreter::new();
+        interp.execute("1 2 INTERVAL 3 4 INTERVAL *").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[3, 8]");
+
+        let mut interp = Interpreter::new();
+        interp
+            .execute("-1 2 INTERVAL 3 4 INTERVAL *")
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[-4, 8]");
+
+        let mut interp = Interpreter::new();
+        interp.execute("2 4 INTERVAL 1 2 INTERVAL /").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[1, 4]");
+    }
+
+    #[tokio::test]
+    async fn test_interval_division_by_zero_interval_fails() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("1 2 INTERVAL -1 1 INTERVAL /").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_sqrt_exact_cases() {
+        let mut interp = Interpreter::new();
+        interp.execute("4 SQRT").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "2");
+
+        let mut interp = Interpreter::new();
+        interp.execute("9/16 SQRT").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "3/4");
+    }
+
+    #[tokio::test]
+    async fn test_sqrt_interval_soundness_and_eps() {
+        let mut interp = Interpreter::new();
+        interp.execute("2 SQRT").await.unwrap();
+        let iv = value_to_interval(&interp.get_stack()[0]).expect("sqrt(2) must be interval");
+        let two = Fraction::from(2);
+        assert!(iv.lo.mul(&iv.lo).le(&two));
+        assert!(iv.hi.mul(&iv.hi).ge(&two));
+        assert!(iv.lo.le(&iv.hi));
+
+        let mut interp_eps = Interpreter::new();
+        interp_eps.execute("2 1/100 SQRT_EPS").await.unwrap();
+        let iv_eps =
+            value_to_interval(&interp_eps.get_stack()[0]).expect("sqrt_eps(2) must be interval");
+        assert!(iv_eps.width().le(&Fraction::new(1.into(), 100.into())));
+    }
+
+    #[tokio::test]
+    async fn test_sqrt_interval_monotonicity() {
+        let mut interp = Interpreter::new();
+        interp.execute("1 4 INTERVAL SQRT").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[1, 2]");
+    }
+
+    #[tokio::test]
+    async fn test_interval_comparison_policy() {
+        let mut interp = Interpreter::new();
+        interp.execute("1 2 INTERVAL 3 4 INTERVAL <").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[ 1 ]");
+
+        let mut interp_undetermined = Interpreter::new();
+        let result = interp_undetermined
+            .execute("2 3 INTERVAL 3 4 INTERVAL <")
+            .await;
+        assert!(result.is_err());
+
+        let mut interp_eq = Interpreter::new();
+        interp_eq
+            .execute("1 5 INTERVAL 2 4 INTERVAL =")
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp_eq.get_stack()[0]), "[ 0 ]");
+    }
+
+    #[tokio::test]
+    async fn test_mixed_arithmetic() {
+        let mut interp = Interpreter::new();
+        interp.execute("1 2 3 INTERVAL +").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[3, 4]");
+
+        let mut interp = Interpreter::new();
+        interp.execute("2 3 5 INTERVAL *").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "[6, 10]");
+    }
+}

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -1,5 +1,3 @@
-
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BuiltinDetailGroup {
     Modifier,
@@ -66,6 +64,13 @@ pub enum BuiltinExecutorKey {
     Floor,
     Ceil,
     Round,
+    Sqrt,
+    SqrtEps,
+    Interval,
+    Lower,
+    Upper,
+    Width,
+    IsExact,
     Mod,
     Str,
     Num,
@@ -689,6 +694,69 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         Some(BuiltinExecutorKey::Fill)
     ),
     builtin_spec!(
+        "SQRT",
+        "arithmetic",
+        "Map: Square root. Exact rational roots stay exact; otherwise returns sound interval.",
+        "[ 2 ] SQRT → [lo, hi]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Sqrt)
+    ),
+    builtin_spec!(
+        "SQRT_EPS",
+        "arithmetic",
+        "Form: Square root with explicit interval width bound eps.",
+        "[ 2 ] [ 1/100 ] SQRT_EPS → interval width <= 1/100",
+        "form",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::SqrtEps)
+    ),
+    builtin_spec!(
+        "INTERVAL",
+        "arithmetic",
+        "Form: Create interval [lo, hi].",
+        "[ 1 ] [ 2 ] INTERVAL → [1, 2]",
+        "form",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Interval)
+    ),
+    builtin_spec!(
+        "LOWER",
+        "arithmetic",
+        "Map: Lower endpoint of number/interval.",
+        "[1, 2] LOWER → [ 1 ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Lower)
+    ),
+    builtin_spec!(
+        "UPPER",
+        "arithmetic",
+        "Map: Upper endpoint of number/interval.",
+        "[1, 2] UPPER → [ 2 ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Upper)
+    ),
+    builtin_spec!(
+        "WIDTH",
+        "arithmetic",
+        "Map: Interval width hi-lo.",
+        "[1, 2] WIDTH → [ 1 ]",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::Width)
+    ),
+    builtin_spec!(
+        "IS_EXACT",
+        "arithmetic",
+        "Map: True for exact number or degenerate interval.",
+        "[1, 1] IS_EXACT → TRUE",
+        "map",
+        BuiltinDetailGroup::ArithmeticLogic,
+        Some(BuiltinExecutorKey::IsExact)
+    ),
+    builtin_spec!(
         "MOD",
         "arithmetic",
         "Fold: Modulo (broadcast). Alias: % (postfix sugar). Numeric, Numeric -> Numeric",
@@ -841,7 +909,6 @@ pub fn builtin_specs() -> &'static [BuiltinSpec] {
 pub fn lookup_builtin_spec(name: &str) -> Option<&'static BuiltinSpec> {
     BUILTIN_SPECS.iter().find(|spec| spec.name == name)
 }
-
 
 pub fn collect_builtin_definitions() -> Vec<(&'static str, &'static str, &'static str, &'static str)>
 {

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -8,7 +8,6 @@
 ///
 /// For user-defined words, use `infer_purity` to propagate conservatively from
 /// component words.
-
 use crate::builtins::BuiltinExecutorKey;
 
 // ── Public types ─────────────────────────────────────────────────────────────
@@ -49,17 +48,46 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
     use EvalCost::*;
     use Purity::*;
 
-    let pure_trivial = PurityInfo { purity: Pure, cost: Trivial, order_sensitive: false };
-    let pure_light   = PurityInfo { purity: Pure, cost: Light,   order_sensitive: false };
-    let unk_medium   = PurityInfo { purity: Unknown, cost: Medium, order_sensitive: false };
-    let unk_med_ord  = PurityInfo { purity: Unknown, cost: Medium, order_sensitive: true };
-    let unk_heavy    = PurityInfo { purity: Unknown, cost: Heavy,  order_sensitive: true };
-    let imp_light    = PurityInfo { purity: Impure,  cost: Light,  order_sensitive: true };
-    let imp_heavy    = PurityInfo { purity: Impure,  cost: Heavy,  order_sensitive: true };
+    let pure_trivial = PurityInfo {
+        purity: Pure,
+        cost: Trivial,
+        order_sensitive: false,
+    };
+    let pure_light = PurityInfo {
+        purity: Pure,
+        cost: Light,
+        order_sensitive: false,
+    };
+    let unk_medium = PurityInfo {
+        purity: Unknown,
+        cost: Medium,
+        order_sensitive: false,
+    };
+    let unk_med_ord = PurityInfo {
+        purity: Unknown,
+        cost: Medium,
+        order_sensitive: true,
+    };
+    let unk_heavy = PurityInfo {
+        purity: Unknown,
+        cost: Heavy,
+        order_sensitive: true,
+    };
+    let imp_light = PurityInfo {
+        purity: Impure,
+        cost: Light,
+        order_sensitive: true,
+    };
+    let imp_heavy = PurityInfo {
+        purity: Impure,
+        cost: Heavy,
+        order_sensitive: true,
+    };
 
     match key {
         // ── Pure arithmetic ───────────────────────────────────────────────
-        Add | Sub | Mul | Div | Mod | Floor | Ceil | Round => pure_trivial,
+        Add | Sub | Mul | Div | Mod | Floor | Ceil | Round | Sqrt | SqrtEps => pure_trivial,
+        Interval | Lower | Upper | Width | IsExact => pure_light,
 
         // ── Pure comparison ───────────────────────────────────────────────
         Eq | Lt | Le => pure_trivial,
@@ -75,7 +103,7 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
 
         // ── Pure vector ops ───────────────────────────────────────────────
         Get | Length | Concat | Reverse | Range | Reorder | Sort => pure_light,
-        Take | Split | Insert | Replace | Remove | Collect      => pure_light,
+        Take | Split | Insert | Replace | Remove | Collect => pure_light,
 
         // ── Pure tensor ops ───────────────────────────────────────────────
         Shape | Rank | Reshape | Transpose | Fill => pure_light,

--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -1,11 +1,14 @@
-use crate::interpreter::{Interpreter, OperationTargetMode, ConsumptionMode};
 use crate::error::{AjisaiError, Result};
-use crate::interpreter::value_extraction_helpers::{extract_integer_from_value, extract_operands_with_flow, push_result, push_flow_result};
+use crate::interpreter::interval_ops::{interval_to_value, value_to_interval};
 use crate::interpreter::optimization_hooks;
 use crate::interpreter::simd_ops;
 use crate::interpreter::tensor_ops::apply_binary_broadcast;
-use crate::types::{FlowToken, Value, ValueData};
+use crate::interpreter::value_extraction_helpers::{
+    extract_integer_from_value, extract_operands_with_flow, push_flow_result, push_result,
+};
+use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
+use crate::types::{FlowToken, Value, ValueData};
 
 fn extract_scalar_from_value(val: &Value) -> Option<&Fraction> {
     match &val.data {
@@ -16,7 +19,9 @@ fn extract_scalar_from_value(val: &Value) -> Option<&Fraction> {
         ValueData::Vector(_) => None,
         ValueData::Nil => None,
         ValueData::Record { .. } => None,
-        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            None
+        }
     }
 }
 
@@ -32,15 +37,17 @@ where
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let (operands, flow_tokens): (Vec<Value>, Option<Vec<FlowToken>>) = extract_operands_with_flow(interp, 2)?;
+            let (operands, flow_tokens): (Vec<Value>, Option<Vec<FlowToken>>) =
+                extract_operands_with_flow(interp, 2)?;
             let a_val = &operands[0];
             let b_val = &operands[1];
 
-
-            let _in_place_candidates = flow_tokens.as_ref().map(|tokens| [
-                optimization_hooks::check_in_place_candidate(a_val, tokens.get(0)),
-                optimization_hooks::check_in_place_candidate(b_val, tokens.get(1)),
-            ]);
+            let _in_place_candidates = flow_tokens.as_ref().map(|tokens| {
+                [
+                    optimization_hooks::check_in_place_candidate(a_val, tokens.get(0)),
+                    optimization_hooks::check_in_place_candidate(b_val, tokens.get(1)),
+                ]
+            });
 
             let result = match apply_binary_broadcast(a_val, b_val, op) {
                 Ok(r) => r,
@@ -60,7 +67,7 @@ where
             } else {
                 push_result(interp, result);
             }
-        },
+        }
 
         OperationTargetMode::Stack => {
             let count_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
@@ -78,9 +85,15 @@ where
 
             let items: Vec<Value> = if is_keep_mode {
                 let stack_len = interp.stack.len();
-                interp.stack[stack_len - count..].iter().cloned().collect::<Vec<Value>>()
+                interp.stack[stack_len - count..]
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<Value>>()
             } else {
-                interp.stack.drain(interp.stack.len() - count..).collect::<Vec<Value>>()
+                interp
+                    .stack
+                    .drain(interp.stack.len() - count..)
+                    .collect::<Vec<Value>>()
             };
 
             if items.iter().any(|v| !is_scalar_value(v)) {
@@ -91,8 +104,8 @@ where
                 return Err(AjisaiError::from("+: expected scalar values in Stack mode"));
             }
 
-
-            let _in_place_candidates = items.iter()
+            let _in_place_candidates = items
+                .iter()
                 .map(|item| optimization_hooks::check_in_place_candidate(item, None))
                 .collect::<Vec<_>>();
 
@@ -114,12 +127,23 @@ where
 pub fn op_add(interp: &mut Interpreter) -> Result<()> {
     if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
         let stack_len = interp.stack.len();
+        let a = interp.stack[stack_len - 2].clone();
+        let b = interp.stack[stack_len - 1].clone();
+        if let (Some(ai), Some(bi)) = (value_to_interval(&a), value_to_interval(&b)) {
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            interp.stack.push(interval_to_value(ai.add(&bi)));
+            return Ok(());
+        }
+    }
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let stack_len = interp.stack.len();
         let a = &interp.stack[stack_len - 2];
         let b = &interp.stack[stack_len - 1];
 
         if let Some(result) = simd_ops::apply_simd_add(a, b) {
-
-
             let _in_place_candidates = [
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
@@ -132,10 +156,9 @@ pub fn op_add(interp: &mut Interpreter) -> Result<()> {
             return Ok(());
         }
 
-        if let Some(result) = simd_ops::apply_simd_scalar_add(a, b)
-            .or_else(|| simd_ops::apply_simd_scalar_add(b, a))
+        if let Some(result) =
+            simd_ops::apply_simd_scalar_add(a, b).or_else(|| simd_ops::apply_simd_scalar_add(b, a))
         {
-
             let _in_place_candidates = [
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
@@ -154,12 +177,23 @@ pub fn op_add(interp: &mut Interpreter) -> Result<()> {
 pub fn op_sub(interp: &mut Interpreter) -> Result<()> {
     if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
         let stack_len = interp.stack.len();
+        let a = interp.stack[stack_len - 2].clone();
+        let b = interp.stack[stack_len - 1].clone();
+        if let (Some(ai), Some(bi)) = (value_to_interval(&a), value_to_interval(&b)) {
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            interp.stack.push(interval_to_value(ai.sub(&bi)));
+            return Ok(());
+        }
+    }
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let stack_len = interp.stack.len();
         let a = &interp.stack[stack_len - 2];
         let b = &interp.stack[stack_len - 1];
 
         if let Some(result) = simd_ops::apply_simd_sub(a, b) {
-
-
             let _in_place_candidates = [
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
@@ -178,12 +212,23 @@ pub fn op_sub(interp: &mut Interpreter) -> Result<()> {
 pub fn op_mul(interp: &mut Interpreter) -> Result<()> {
     if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
         let stack_len = interp.stack.len();
+        let a = interp.stack[stack_len - 2].clone();
+        let b = interp.stack[stack_len - 1].clone();
+        if let (Some(ai), Some(bi)) = (value_to_interval(&a), value_to_interval(&b)) {
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            interp.stack.push(interval_to_value(ai.mul(&bi)));
+            return Ok(());
+        }
+    }
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let stack_len = interp.stack.len();
         let a = &interp.stack[stack_len - 2];
         let b = &interp.stack[stack_len - 1];
 
         if let Some(result) = simd_ops::apply_simd_mul(a, b) {
-
-
             let _in_place_candidates = [
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
@@ -196,10 +241,9 @@ pub fn op_mul(interp: &mut Interpreter) -> Result<()> {
             return Ok(());
         }
 
-        if let Some(result) = simd_ops::apply_simd_scalar_mul(a, b)
-            .or_else(|| simd_ops::apply_simd_scalar_mul(b, a))
+        if let Some(result) =
+            simd_ops::apply_simd_scalar_mul(a, b).or_else(|| simd_ops::apply_simd_scalar_mul(b, a))
         {
-
             let _in_place_candidates = [
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
@@ -216,6 +260,20 @@ pub fn op_mul(interp: &mut Interpreter) -> Result<()> {
 }
 
 pub fn op_div(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let stack_len = interp.stack.len();
+        let a = interp.stack[stack_len - 2].clone();
+        let b = interp.stack[stack_len - 1].clone();
+        if let (Some(ai), Some(bi)) = (value_to_interval(&a), value_to_interval(&b)) {
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            let result = ai.div(&bi)?;
+            interp.stack.push(interval_to_value(result));
+            return Ok(());
+        }
+    }
     apply_binary_arithmetic(interp, |a, b| {
         if b.is_zero() {
             Err(AjisaiError::DivisionByZero)

--- a/rust/src/interpreter/cast-value-helpers.rs
+++ b/rust/src/interpreter/cast-value-helpers.rs
@@ -9,7 +9,11 @@ pub(crate) fn is_string_value(val: &Value) -> bool {
 
 pub(crate) fn is_string_value_with_hint(val: &Value, hint: DisplayHint) -> bool {
     match hint {
-        DisplayHint::Number | DisplayHint::Boolean | DisplayHint::DateTime | DisplayHint::Nil => {
+        DisplayHint::Number
+        | DisplayHint::Interval
+        | DisplayHint::Boolean
+        | DisplayHint::DateTime
+        | DisplayHint::Nil => {
             return false;
         }
         DisplayHint::String | DisplayHint::Auto => {}
@@ -20,7 +24,9 @@ pub(crate) fn is_string_value_with_hint(val: &Value, hint: DisplayHint) -> bool 
         ValueData::Scalar(_) => return false,
         ValueData::Nil => return false,
         ValueData::Record { .. } => return false,
-        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return false,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            return false
+        }
     };
     children.iter().all(|child| check_char_scalar(child))
 }
@@ -31,7 +37,9 @@ fn check_char_scalar(child: &Value) -> bool {
         ValueData::Vector(_) => return false,
         ValueData::Nil => return false,
         ValueData::Record { .. } => return false,
-        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return false,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            return false
+        }
     };
     let n: i64 = match f.to_i64() {
         Some(n) if n >= 0 && n <= 0x10FFFF => n,
@@ -56,7 +64,10 @@ pub(crate) fn is_datetime_value(_val: &Value) -> bool {
     false
 }
 
-pub(crate) fn apply_unary_cast(interp: &mut Interpreter, convert: fn(&Value, DisplayHint) -> Result<Value>) -> Result<()> {
+pub(crate) fn apply_unary_cast(
+    interp: &mut Interpreter,
+    convert: fn(&Value, DisplayHint) -> Result<Value>,
+) -> Result<()> {
     let is_keep_mode: bool = interp.consumption_mode == ConsumptionMode::Keep;
 
     match interp.operation_target_mode {
@@ -136,10 +147,11 @@ pub(crate) fn format_fraction_to_string(f: &Fraction) -> String {
 pub(crate) fn try_char_from_value(val: &Value) -> Option<char> {
     let f: &Fraction = val.as_scalar()?;
     let code: i64 = f.to_i64()?;
-    if code < 0 || code > 0x10FFFF { return None; }
+    if code < 0 || code > 0x10FFFF {
+        return None;
+    }
     char::from_u32(code as u32)
 }
-
 
 pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
     if value.is_nil() {
@@ -173,7 +185,6 @@ pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
         }
     }
 
-
     fn collect_fractions(val: &Value) -> Vec<String> {
         match &val.data {
             ValueData::Nil => vec!["NIL".to_string()],
@@ -182,7 +193,9 @@ pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_fractions(c)).collect(),
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec!["<code>".to_string()],
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => vec!["<code>".to_string()],
         }
     }
 

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -1,15 +1,20 @@
 use crate::error::{AjisaiError, Result};
-use crate::interpreter::value_extraction_helpers::extract_integer_from_value;
+use crate::interpreter::interval_ops::value_to_interval;
 use crate::interpreter::tensor_ops::FlatTensor;
+use crate::interpreter::value_extraction_helpers::extract_integer_from_value;
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, Value, ValueData};
 
 fn push_boolean_result(interp: &mut Interpreter, result: bool) {
-    interp.stack.push(Value::from_vector(vec![Value::from_bool(result)]));
+    interp
+        .stack
+        .push(Value::from_vector(vec![Value::from_bool(result)]));
     let stack_len = interp.stack.len();
     interp.semantic_registry.normalize_to_stack_len(stack_len);
-    interp.semantic_registry.update_hint_at(stack_len - 1, DisplayHint::Boolean);
+    interp
+        .semantic_registry
+        .update_hint_at(stack_len - 1, DisplayHint::Boolean);
 }
 
 fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
@@ -29,10 +34,12 @@ fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
             "scalar value",
             "non-scalar value",
         )),
-        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::create_structure_error(
-            "scalar value",
-            "non-scalar value",
-        )),
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            Err(AjisaiError::create_structure_error(
+                "scalar value",
+                "non-scalar value",
+            ))
+        }
     }
 }
 
@@ -142,10 +149,68 @@ where
 }
 
 pub fn op_lt(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let len = interp.stack.len();
+        let a = interp.stack[len - 2].clone();
+        let b = interp.stack[len - 1].clone();
+        if let (Some(ai), Some(bi)) = (value_to_interval(&a), value_to_interval(&b)) {
+            let result = if ai.hi.lt(&bi.lo) {
+                Some(true)
+            } else if ai.lo.ge(&bi.hi) {
+                Some(false)
+            } else {
+                None
+            };
+            match result {
+                Some(v) => {
+                    if interp.consumption_mode != ConsumptionMode::Keep {
+                        interp.stack.pop();
+                        interp.stack.pop();
+                    }
+                    push_boolean_result(interp, v);
+                    return Ok(());
+                }
+                None => {
+                    return Err(AjisaiError::from(
+                        "interval comparison is undecidable with current precision",
+                    ));
+                }
+            }
+        }
+    }
     apply_binary_comparison(interp, |a, b| a.lt(b), "<")
 }
 
 pub fn op_le(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let len = interp.stack.len();
+        let a = interp.stack[len - 2].clone();
+        let b = interp.stack[len - 1].clone();
+        if let (Some(ai), Some(bi)) = (value_to_interval(&a), value_to_interval(&b)) {
+            let result = if ai.hi.le(&bi.lo) {
+                Some(true)
+            } else if ai.lo.gt(&bi.hi) {
+                Some(false)
+            } else {
+                None
+            };
+            match result {
+                Some(v) => {
+                    if interp.consumption_mode != ConsumptionMode::Keep {
+                        interp.stack.pop();
+                        interp.stack.pop();
+                    }
+                    push_boolean_result(interp, v);
+                    return Ok(());
+                }
+                None => {
+                    return Err(AjisaiError::from(
+                        "interval comparison is undecidable with current precision",
+                    ));
+                }
+            }
+        }
+    }
     apply_binary_comparison(interp, |a, b| a.le(b), "<=")
 }
 
@@ -172,19 +237,27 @@ pub fn op_eq(interp: &mut Interpreter) -> Result<()> {
             let result: bool = if a_val.data == b_val.data {
                 true
             } else {
-
-                match (&a_val.data, &b_val.data) {
-                    (ValueData::Scalar(_), ValueData::Vector(children))
-                        if children.len() == 1 =>
-                    {
-                        a_val.data == children[0].data
+                if let (Some(ai), Some(bi)) = (value_to_interval(&a_val), value_to_interval(&b_val))
+                {
+                    if ai.is_exact() && bi.is_exact() {
+                        ai.lo == bi.lo
+                    } else {
+                        false
                     }
-                    (ValueData::Vector(children), ValueData::Scalar(_))
-                        if children.len() == 1 =>
-                    {
-                        children[0].data == b_val.data
+                } else {
+                    match (&a_val.data, &b_val.data) {
+                        (ValueData::Scalar(_), ValueData::Vector(children))
+                            if children.len() == 1 =>
+                        {
+                            a_val.data == children[0].data
+                        }
+                        (ValueData::Vector(children), ValueData::Scalar(_))
+                            if children.len() == 1 =>
+                        {
+                            children[0].data == b_val.data
+                        }
+                        _ => false,
                     }
-                    _ => false,
                 }
             };
             push_boolean_result(interp, result);

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -10,8 +10,8 @@ use super::compiled_plan::{
 
 use super::{
     arithmetic, cast, comparison, control, control_cond, datetime, execute_def, execute_del,
-    execute_lookup, hash, higher_order, higher_order_fold, io, logic, modules, random, sort,
-    tensor_cmds, vector_ops, Interpreter,
+    execute_lookup, hash, higher_order, higher_order_fold, interval_ops, io, logic, modules,
+    random, sort, tensor_cmds, vector_ops, Interpreter,
 };
 
 #[cfg(feature = "trace-compile")]
@@ -257,6 +257,13 @@ impl Interpreter {
             BuiltinExecutorKey::Floor => tensor_cmds::op_floor(self),
             BuiltinExecutorKey::Ceil => tensor_cmds::op_ceil(self),
             BuiltinExecutorKey::Round => tensor_cmds::op_round(self),
+            BuiltinExecutorKey::Sqrt => interval_ops::op_sqrt(self),
+            BuiltinExecutorKey::SqrtEps => interval_ops::op_sqrt_eps(self),
+            BuiltinExecutorKey::Interval => interval_ops::op_interval(self),
+            BuiltinExecutorKey::Lower => interval_ops::op_lower(self),
+            BuiltinExecutorKey::Upper => interval_ops::op_upper(self),
+            BuiltinExecutorKey::Width => interval_ops::op_width(self),
+            BuiltinExecutorKey::IsExact => interval_ops::op_is_exact(self),
             BuiltinExecutorKey::Mod => tensor_cmds::op_mod(self),
             BuiltinExecutorKey::Str => cast::op_str(self),
             BuiltinExecutorKey::Num => cast::op_num(self),

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -9,10 +9,12 @@ use crate::types::SemanticRegistry;
 fn apply_word_hint_override(registry: &mut SemanticRegistry, word: &str) {
     let hint: Option<DisplayHint> = match word {
         "STR" | "CHR" | "CHARS" | "JOIN" => Some(DisplayHint::String),
-        "NUM" | "+" | "-" | "*" | "/" | "MOD" | "FLOOR" | "CEIL" | "ROUND" | "FOLD"
-            => Some(DisplayHint::Number),
-        "BOOL" | "<" | "<=" | "=" | "AND" | "OR" | "NOT"
-            => Some(DisplayHint::Boolean),
+        "NUM" | "+" | "-" | "*" | "/" | "MOD" | "FLOOR" | "CEIL" | "ROUND" | "FOLD" => {
+            Some(DisplayHint::Number)
+        }
+        "SQRT" | "SQRT_EPS" | "INTERVAL" => Some(DisplayHint::Interval),
+        "LOWER" | "UPPER" | "WIDTH" => Some(DisplayHint::Number),
+        "BOOL" | "<" | "<=" | "=" | "AND" | "OR" | "NOT" => Some(DisplayHint::Boolean),
         "NOW" | "DATETIME" | "TIMESTAMP" => Some(DisplayHint::DateTime),
         _ => None,
     };
@@ -181,7 +183,8 @@ impl Interpreter {
                     self.semantic_registry.push_hint(DisplayHint::String);
                 }
                 Token::VectorStart => {
-                    let (values, consumed, element_hint) = self.collect_vector(execute_tokens, i)?;
+                    let (values, consumed, element_hint) =
+                        self.collect_vector(execute_tokens, i)?;
                     if values.is_empty() {
                         return Err(AjisaiError::from(
                             "Empty vector is not allowed. Use NIL for empty values.",
@@ -223,53 +226,55 @@ impl Interpreter {
                     i = j;
                     continue;
                 }
-                Token::Symbol(s) => {
-                    match s.as_ref() {
-                        ".." => {
-                            self.update_operation_target_mode(OperationTargetMode::Stack);
-                        }
-                        "." => {
-                            self.update_operation_target_mode(OperationTargetMode::StackTop);
-                        }
-                        ",," => {
-                            self.update_consumption_mode(ConsumptionMode::Keep);
-                        }
-                        "," => {
-                            self.update_consumption_mode(ConsumptionMode::Consume);
-                        }
-                        _ => {
-                            let upper = Self::normalize_symbol(s);
-                            if self.safe_mode {
-                                let stack_snapshot = self.stack.clone();
-                                self.safe_mode = false;
-                                match self.execute_word_core(upper.as_ref()) {
-                                    Ok(()) => {
-                                        self.semantic_registry.normalize_to_stack_len(self.stack.len());
-                                        apply_word_hint_override(&mut self.semantic_registry, upper.as_ref());
-                                    }
-                                    Err(_) => {
-                                        self.stack = stack_snapshot;
-                                        self.stack.push(Value::nil());
-                                        self.semantic_registry.normalize_to_stack_len(self.stack.len());
-                                    }
+                Token::Symbol(s) => match s.as_ref() {
+                    ".." => {
+                        self.update_operation_target_mode(OperationTargetMode::Stack);
+                    }
+                    "." => {
+                        self.update_operation_target_mode(OperationTargetMode::StackTop);
+                    }
+                    ",," => {
+                        self.update_consumption_mode(ConsumptionMode::Keep);
+                    }
+                    "," => {
+                        self.update_consumption_mode(ConsumptionMode::Consume);
+                    }
+                    _ => {
+                        let upper = Self::normalize_symbol(s);
+                        if self.safe_mode {
+                            let stack_snapshot = self.stack.clone();
+                            self.safe_mode = false;
+                            match self.execute_word_core(upper.as_ref()) {
+                                Ok(()) => {
+                                    self.semantic_registry
+                                        .normalize_to_stack_len(self.stack.len());
+                                    apply_word_hint_override(
+                                        &mut self.semantic_registry,
+                                        upper.as_ref(),
+                                    );
                                 }
-                            } else {
-                                self.execute_word_core(upper.as_ref())?;
-                                self.semantic_registry.normalize_to_stack_len(self.stack.len());
-                                apply_word_hint_override(&mut self.semantic_registry, upper.as_ref());
+                                Err(_) => {
+                                    self.stack = stack_snapshot;
+                                    self.stack.push(Value::nil());
+                                    self.semantic_registry
+                                        .normalize_to_stack_len(self.stack.len());
+                                }
                             }
-                            if !modules::is_mode_preserving_word(upper.as_ref()) {
-                                self.reset_execution_modes();
-                            }
+                        } else {
+                            self.execute_word_core(upper.as_ref())?;
+                            self.semantic_registry
+                                .normalize_to_stack_len(self.stack.len());
+                            apply_word_hint_override(&mut self.semantic_registry, upper.as_ref());
+                        }
+                        if !modules::is_mode_preserving_word(upper.as_ref()) {
+                            self.reset_execution_modes();
                         }
                     }
-                }
+                },
                 Token::BlockEnd => {
                     return Err(AjisaiError::from("Unexpected code block end"));
                 }
-                Token::Pipeline => {
-
-                }
+                Token::Pipeline => {}
                 Token::NilCoalesce => {
                     let value = self.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
                     let hint = self.semantic_registry.pop_hint();
@@ -334,10 +339,7 @@ impl Interpreter {
         Ok(start_index + i)
     }
 
-    pub(crate) fn execute_guard_structure(
-        &mut self,
-        lines: &[ExecutionLine],
-    ) -> Result<()> {
+    pub(crate) fn execute_guard_structure(&mut self, lines: &[ExecutionLine]) -> Result<()> {
         for line in lines {
             self.execute_section_core(&line.body_tokens, 0)?;
         }

--- a/rust/src/interpreter/interval_ops.rs
+++ b/rust/src/interpreter/interval_ops.rs
@@ -1,0 +1,186 @@
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::types::fraction::Fraction;
+use crate::types::interval::{
+    default_sqrt_eps, exact_rational_sqrt, sqrt_rational_interval, Interval,
+};
+use crate::types::{DisplayHint, Value, ValueData};
+
+pub(crate) fn value_to_interval(value: &Value) -> Option<Interval> {
+    match (&value.data, value.hint) {
+        (ValueData::Scalar(f), _) => Some(Interval::from_scalar(f.clone())),
+        (ValueData::Vector(v), DisplayHint::Interval) if v.len() == 2 => {
+            let lo = v[0].as_scalar()?.clone();
+            let hi = v[1].as_scalar()?.clone();
+            Interval::new(lo, hi).ok()
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn interval_to_value(interval: Interval) -> Value {
+    if interval.is_exact() {
+        Value::from_fraction(interval.lo)
+    } else {
+        Value::from_interval(interval)
+    }
+}
+
+fn pop_with_keep(interp: &mut Interpreter) -> Result<(Value, Value)> {
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+    if interp.consumption_mode == ConsumptionMode::Keep {
+        let len = interp.stack.len();
+        Ok((interp.stack[len - 2].clone(), interp.stack[len - 1].clone()))
+    } else {
+        let b = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        let a = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+        Ok((a, b))
+    }
+}
+
+pub(crate) fn op_interval(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from("INTERVAL: Stack mode is not supported"));
+    }
+    let (lo_v, hi_v) = pop_with_keep(interp)?;
+    let lo = lo_v
+        .as_scalar()
+        .ok_or_else(|| AjisaiError::from("INTERVAL: lower bound must be scalar"))?
+        .clone();
+    let hi = hi_v
+        .as_scalar()
+        .ok_or_else(|| AjisaiError::from("INTERVAL: upper bound must be scalar"))?
+        .clone();
+    let interval = Interval::new(lo, hi)?;
+    interp.stack.push(Value::from_interval(interval));
+    interp.semantic_registry.push_hint(DisplayHint::Interval);
+    Ok(())
+}
+
+pub(crate) fn op_lower(interp: &mut Interpreter) -> Result<()> {
+    unary_interval_accessor(interp, |i| i.lo)
+}
+
+pub(crate) fn op_upper(interp: &mut Interpreter) -> Result<()> {
+    unary_interval_accessor(interp, |i| i.hi)
+}
+
+pub(crate) fn op_width(interp: &mut Interpreter) -> Result<()> {
+    unary_interval_accessor(interp, |i| i.width())
+}
+
+pub(crate) fn op_is_exact(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from("IS_EXACT: Stack mode is not supported"));
+    }
+    let value = if interp.consumption_mode == ConsumptionMode::Keep {
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
+    } else {
+        interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
+    };
+    let interval = value_to_interval(&value)
+        .ok_or_else(|| AjisaiError::from("IS_EXACT: expected Number or Interval"))?;
+    interp.stack.push(Value::from_bool(interval.is_exact()));
+    interp.semantic_registry.push_hint(DisplayHint::Boolean);
+    Ok(())
+}
+
+fn unary_interval_accessor<F>(interp: &mut Interpreter, f: F) -> Result<()>
+where
+    F: Fn(Interval) -> Fraction,
+{
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from(
+            "interval accessor: Stack mode is not supported",
+        ));
+    }
+    let value = if interp.consumption_mode == ConsumptionMode::Keep {
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
+    } else {
+        interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
+    };
+    let interval = value_to_interval(&value)
+        .ok_or_else(|| AjisaiError::from("interval accessor: expected Number or Interval"))?;
+    interp.stack.push(Value::from_fraction(f(interval)));
+    interp.semantic_registry.push_hint(DisplayHint::Number);
+    Ok(())
+}
+
+pub(crate) fn op_sqrt(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from("SQRT: Stack mode is not supported"));
+    }
+    let value = if interp.consumption_mode == ConsumptionMode::Keep {
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
+    } else {
+        interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
+    };
+    let interval = value_to_interval(&value)
+        .ok_or_else(|| AjisaiError::from("SQRT: expected Number or Interval"))?;
+
+    let result = sqrt_interval_with_eps(interval, default_sqrt_eps())?;
+    let out_hint = if result.is_exact() {
+        DisplayHint::Number
+    } else {
+        DisplayHint::Interval
+    };
+    interp.stack.push(interval_to_value(result));
+    interp.semantic_registry.push_hint(out_hint);
+    Ok(())
+}
+
+pub(crate) fn op_sqrt_eps(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from("SQRT_EPS: Stack mode is not supported"));
+    }
+    let (value, eps_value) = pop_with_keep(interp)?;
+    let interval = value_to_interval(&value)
+        .ok_or_else(|| AjisaiError::from("SQRT_EPS: expected Number or Interval as first arg"))?;
+    let eps = eps_value
+        .as_scalar()
+        .ok_or_else(|| AjisaiError::from("SQRT_EPS: eps must be scalar rational"))?
+        .clone();
+    let result = sqrt_interval_with_eps(interval, eps)?;
+    let out_hint = if result.is_exact() {
+        DisplayHint::Number
+    } else {
+        DisplayHint::Interval
+    };
+    interp.stack.push(interval_to_value(result));
+    interp.semantic_registry.push_hint(out_hint);
+    Ok(())
+}
+
+fn sqrt_interval_with_eps(interval: Interval, eps: Fraction) -> Result<Interval> {
+    if interval.hi.lt(&Fraction::from(0)) {
+        return Err(AjisaiError::from("sqrt of negative value"));
+    } else if interval.lo.lt(&Fraction::from(0)) {
+        let hi = sqrt_value_to_interval(&interval.hi, &eps)?;
+        Ok(Interval::new(Fraction::from(0), hi.hi)?)
+    } else {
+        let lo = sqrt_value_to_interval(&interval.lo, &eps)?;
+        let hi = sqrt_value_to_interval(&interval.hi, &eps)?;
+        Ok(Interval::new(lo.lo, hi.hi)?)
+    }
+}
+
+fn sqrt_value_to_interval(v: &Fraction, eps: &Fraction) -> Result<Interval> {
+    if let Some(exact) = exact_rational_sqrt(v) {
+        return Ok(Interval::from_scalar(exact));
+    }
+    sqrt_rational_interval(v, eps)
+}

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -24,6 +24,7 @@ pub mod hash;
 pub mod higher_order;
 #[path = "higher-order-fold-operations.rs"]
 pub mod higher_order_fold;
+pub mod interval_ops;
 pub mod io;
 pub mod json;
 pub mod logic;
@@ -34,11 +35,11 @@ pub(crate) mod naming_convention_checker;
 pub(crate) mod optimization_hooks;
 #[path = "quantized-block.rs"]
 pub mod quantized_block;
+pub mod random;
 #[path = "redundancy-budget.rs"]
 pub mod redundancy_budget;
 #[path = "redundancy-layer.rs"]
 pub mod redundancy_layer;
-pub mod random;
 #[path = "resolve-cache.rs"]
 mod resolve_cache;
 #[path = "shadow-validation.rs"]

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -8,7 +8,6 @@ impl fmt::Display for Value {
     }
 }
 
-
 pub fn format_with_hint(value: &Value, hint: DisplayHint) -> String {
     match hint {
         DisplayHint::Nil => {
@@ -20,9 +19,27 @@ pub fn format_with_hint(value: &Value, hint: DisplayHint) -> String {
         }
         DisplayHint::Auto => format_value_auto(value),
         DisplayHint::Number => format_value_recursive(&value.data, 0),
+        DisplayHint::Interval => format_as_interval(value),
         DisplayHint::String => format_as_string(&value.data),
         DisplayHint::Boolean => format_as_boolean(&value.data),
         DisplayHint::DateTime => format_as_datetime(&value.data),
+    }
+}
+
+fn format_as_interval(value: &Value) -> String {
+    match &value.data {
+        ValueData::Vector(v) if v.len() == 2 => {
+            let lo = match &v[0].data {
+                ValueData::Scalar(f) => format_fraction(f),
+                _ => format_value_recursive(&v[0].data, 0),
+            };
+            let hi = match &v[1].data {
+                ValueData::Scalar(f) => format_fraction(f),
+                _ => format_value_recursive(&v[1].data, 0),
+            };
+            format!("[{}, {}]", lo, hi)
+        }
+        _ => format_value_recursive(&value.data, 0),
     }
 }
 
@@ -228,7 +245,6 @@ fn format_as_datetime(data: &ValueData) -> String {
     match data {
         ValueData::Nil => format_value_recursive(data, 0),
         ValueData::Scalar(f) => {
-
             if f.is_integer() {
                 format!("@{}", f.numerator())
             } else {

--- a/rust/src/types/interval.rs
+++ b/rust/src/types/interval.rs
@@ -1,0 +1,161 @@
+use crate::error::{AjisaiError, Result};
+use crate::types::fraction::Fraction;
+use num_bigint::BigInt;
+use num_traits::{Signed, Zero};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interval {
+    pub lo: Fraction,
+    pub hi: Fraction,
+}
+
+impl Interval {
+    pub fn new(lo: Fraction, hi: Fraction) -> Result<Self> {
+        if lo.gt(&hi) {
+            return Err(AjisaiError::from("invalid interval: lo must be <= hi"));
+        }
+        Ok(Self { lo, hi })
+    }
+
+    pub fn from_scalar(v: Fraction) -> Self {
+        Self {
+            lo: v.clone(),
+            hi: v,
+        }
+    }
+
+    pub fn is_exact(&self) -> bool {
+        self.lo == self.hi
+    }
+
+    pub fn width(&self) -> Fraction {
+        self.hi.sub(&self.lo)
+    }
+
+    pub fn add(&self, other: &Self) -> Self {
+        Self {
+            lo: self.lo.add(&other.lo),
+            hi: self.hi.add(&other.hi),
+        }
+    }
+
+    pub fn sub(&self, other: &Self) -> Self {
+        Self {
+            lo: self.lo.sub(&other.hi),
+            hi: self.hi.sub(&other.lo),
+        }
+    }
+
+    pub fn neg(&self) -> Self {
+        Self {
+            lo: self.hi.mul(&Fraction::from(-1)),
+            hi: self.lo.mul(&Fraction::from(-1)),
+        }
+    }
+
+    pub fn mul(&self, other: &Self) -> Self {
+        let ac = self.lo.mul(&other.lo);
+        let ad = self.lo.mul(&other.hi);
+        let bc = self.hi.mul(&other.lo);
+        let bd = self.hi.mul(&other.hi);
+        let mut lo = ac.clone();
+        let mut hi = ac;
+        for v in [&ad, &bc, &bd] {
+            if v.lt(&lo) {
+                lo = v.clone();
+            }
+            if v.gt(&hi) {
+                hi = v.clone();
+            }
+        }
+        Self { lo, hi }
+    }
+
+    pub fn contains_zero(&self) -> bool {
+        self.lo.le(&Fraction::from(0)) && self.hi.ge(&Fraction::from(0))
+    }
+
+    pub fn reciprocal(&self) -> Result<Self> {
+        if self.contains_zero() {
+            return Err(AjisaiError::from("division by interval containing zero"));
+        }
+        let one = Fraction::from(1);
+        let a = one.div(&self.lo);
+        let b = one.div(&self.hi);
+        if a.le(&b) {
+            Ok(Self { lo: a, hi: b })
+        } else {
+            Ok(Self { lo: b, hi: a })
+        }
+    }
+
+    pub fn div(&self, other: &Self) -> Result<Self> {
+        let recip = other.reciprocal()?;
+        Ok(self.mul(&recip))
+    }
+}
+
+fn bigint_sqrt_floor(n: &BigInt) -> BigInt {
+    if n.is_zero() {
+        return BigInt::zero();
+    }
+    let mut x0 = n.clone();
+    let two = BigInt::from(2u8);
+    let mut x1 = (&x0 + (n / &x0)) / &two;
+    while x1 < x0 {
+        x0 = x1.clone();
+        x1 = (&x0 + (n / &x0)) / &two;
+    }
+    x0
+}
+
+pub fn exact_rational_sqrt(q: &Fraction) -> Option<Fraction> {
+    if q.lt(&Fraction::from(0)) {
+        return None;
+    }
+    let n = q.numerator();
+    let d = q.denominator();
+    if n.is_negative() {
+        return None;
+    }
+    let sn = bigint_sqrt_floor(&n);
+    let sd = bigint_sqrt_floor(&d);
+    if &sn * &sn == n && &sd * &sd == d {
+        return Some(Fraction::new(sn, sd));
+    }
+    None
+}
+
+pub fn sqrt_rational_interval(q: &Fraction, eps: &Fraction) -> Result<Interval> {
+    if q.lt(&Fraction::from(0)) {
+        return Err(AjisaiError::from("sqrt of negative value"));
+    }
+    if eps.le(&Fraction::from(0)) {
+        return Err(AjisaiError::from("sqrt precision must be positive"));
+    }
+    if q.is_zero() {
+        return Ok(Interval::from_scalar(Fraction::from(0)));
+    }
+    if let Some(exact) = exact_rational_sqrt(q) {
+        return Ok(Interval::from_scalar(exact));
+    }
+
+    let zero = Fraction::from(0);
+    let one = Fraction::from(1);
+    let mut lo = zero.clone();
+    let mut hi = if q.ge(&one) { q.clone() } else { one };
+    while hi.sub(&lo).gt(eps) {
+        let mid = lo.add(&hi).div(&Fraction::from(2));
+        let mid_sq = mid.mul(&mid);
+        if mid_sq.le(q) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Interval::new(lo, hi)
+}
+
+pub fn default_sqrt_eps() -> Fraction {
+    Fraction::new(BigInt::from(1), BigInt::from(1_000_000))
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -5,6 +5,7 @@ pub mod flow_token;
 pub mod fraction;
 #[path = "fraction-arithmetic.rs"]
 mod fraction_arithmetic;
+pub mod interval;
 #[path = "value-operations.rs"]
 mod value_operations;
 
@@ -33,6 +34,7 @@ pub enum DisplayHint {
     #[default]
     Auto,
     Number,
+    Interval,
     String,
     Boolean,
     DateTime,

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -1,4 +1,5 @@
 use super::fraction::Fraction;
+use super::interval::Interval;
 use super::{DisplayHint, Token, Value, ValueData};
 use std::rc::Rc;
 
@@ -95,6 +96,17 @@ impl Value {
     }
 
     #[inline]
+    pub fn from_interval(interval: Interval) -> Self {
+        Self {
+            data: ValueData::Vector(Rc::new(vec![
+                Value::from_fraction(interval.lo),
+                Value::from_fraction(interval.hi),
+            ])),
+            hint: DisplayHint::Interval,
+        }
+    }
+
+    #[inline]
     pub fn from_datetime(f: Fraction) -> Self {
         Self {
             data: ValueData::Scalar(f),
@@ -123,7 +135,9 @@ impl Value {
             ValueData::Scalar(_) | ValueData::Nil => true,
             ValueData::Vector(rc) => Rc::strong_count(rc) == 1,
             ValueData::Record { pairs, .. } => Rc::strong_count(pairs) == 1,
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => false,
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => false,
         }
     }
 
@@ -135,7 +149,9 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 !v.is_empty() && !v.iter().all(|c| !c.is_truthy())
             }
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => true,
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => true,
         }
     }
 
@@ -159,7 +175,11 @@ impl Value {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.get(index),
             ValueData::Scalar(_) if index == 0 => Some(self),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -168,7 +188,11 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 Rc::make_mut(v).get_mut(index)
             }
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -183,7 +207,9 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.last(),
             ValueData::Scalar(_) => Some(self),
             ValueData::Nil => None,
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -199,21 +225,31 @@ impl Value {
                 let old = Value::from_fraction(f.clone());
                 self.data = ValueData::Vector(Rc::new(vec![old, child]));
             }
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {}
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => {}
         }
     }
 
     pub fn pop_child(&mut self) -> Option<Value> {
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v).pop(),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
     pub fn insert_child(&mut self, index: usize, child: Value) {
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => return,
         };
         if index <= v.len() {
             v.insert(index, child);
@@ -223,7 +259,11 @@ impl Value {
     pub fn remove_child(&mut self, index: usize) -> Option<Value> {
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => return None,
         };
         if index < v.len() {
             Some(v.remove(index))
@@ -235,7 +275,11 @@ impl Value {
     pub fn replace_child(&mut self, index: usize, child: Value) -> Option<Value> {
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => return None,
         };
         if index < v.len() {
             Some(std::mem::replace(&mut v[index], child))
@@ -248,7 +292,12 @@ impl Value {
     pub fn as_scalar(&self) -> Option<&Fraction> {
         match &self.data {
             ValueData::Scalar(f) => Some(f),
-            ValueData::Vector(_) | ValueData::Record { .. } | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Vector(_)
+            | ValueData::Record { .. }
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -256,7 +305,12 @@ impl Value {
     pub fn as_scalar_mut(&mut self) -> Option<&mut Fraction> {
         match &mut self.data {
             ValueData::Scalar(f) => Some(f),
-            ValueData::Vector(_) | ValueData::Record { .. } | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Vector(_)
+            | ValueData::Record { .. }
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -274,7 +328,11 @@ impl Value {
     pub fn as_vector(&self) -> Option<&Vec<Value>> {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Some(v),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -282,7 +340,11 @@ impl Value {
     pub fn as_vector_mut(&mut self) -> Option<&mut Vec<Value>> {
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Some(Rc::make_mut(v)),
-            ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
         }
     }
 
@@ -301,7 +363,9 @@ impl Value {
                     child.collect_fractions_flat_into(buf);
                 }
             }
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {}
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => {}
         }
     }
 
@@ -312,7 +376,9 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 v.iter().map(|c| c.count_fractions()).sum()
             }
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => 0,
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => 0,
         }
     }
 
@@ -335,7 +401,9 @@ impl Value {
                     }
                 }
             }
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec![],
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => vec![],
         }
     }
 
@@ -385,7 +453,9 @@ impl Value {
             ValueData::Nil => DisplayHint::Nil,
             ValueData::Scalar(_) => DisplayHint::Number,
             ValueData::Vector(_) | ValueData::Record { .. } => DisplayHint::Auto,
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => DisplayHint::Auto,
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => DisplayHint::Auto,
         }
     }
 }

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -165,6 +165,7 @@ pub(crate) fn arena_node_to_js(
     let hint_str: &str = match effective_hint {
         DisplayHint::Auto => "auto",
         DisplayHint::Number => "number",
+        DisplayHint::Interval => "interval",
         DisplayHint::String => "string",
         DisplayHint::Boolean => "boolean",
         DisplayHint::DateTime => "datetime",
@@ -275,6 +276,7 @@ pub(crate) fn extract_display_hint_from_js(js_val: &JsValue) -> DisplayHint {
     let hint_js = js_sys::Reflect::get(&obj, &"displayHint".into()).unwrap_or(JsValue::UNDEFINED);
     match hint_js.as_string().as_deref() {
         Some("number") => DisplayHint::Number,
+        Some("interval") => DisplayHint::Interval,
         Some("string") => DisplayHint::String,
         Some("boolean") => DisplayHint::Boolean,
         Some("datetime") => DisplayHint::DateTime,


### PR DESCRIPTION
### Motivation
- Introduce a sound representation for irrational or non-rational results so Ajisai can keep “exactness-first” semantics while supporting non-rational values via rational intervals.
- Preserve existing rational handling as exact and lift only non-exact results to intervals so existing numeric semantics remain unchanged.
- Provide a user-controllable precision model for square roots and ensure all interval operations are sound (the true value is always contained).

### Description
- Add a new internal `Interval` type with rational endpoints and validation (`lo <= hi`), arithmetic (`add`, `sub`, `mul`, `div` with divisor-zero checks), `is_exact`, and `width` in `rust/src/types/interval.rs` and wire a `Value::from_interval` helper so degenerate intervals can collapse back to rationals.
- Implement sound rational `sqrt` support: exact-root detection (`exact_rational_sqrt`) and a bisection-based interval bounding routine `sqrt_rational_interval` with a default epsilon `default_sqrt_eps`, and expose `SQRT` (default eps) and `SQRT_EPS` (user-provided `eps`) builtins.
- Add an interpreter `interval_ops` module providing builtins `INTERVAL`, `LOWER`, `UPPER`, `WIDTH`, `IS_EXACT`, `SQRT`, and `SQRT_EPS`, plus conversions `value_to_interval` / `interval_to_value` to integrate intervals with existing `Value`/hint system.
- Extend arithmetic and comparison dispatch to handle mixed `Rational`/`Interval` cases: arithmetic operations operate on intervals when either operand is interval, division errors on intervals containing zero, `<`/`<=` produce decidable `true/false` only when bounds allow and return an explicit error when undecidable, and `=` only returns `true` for exact-equal degenerate intervals.
- Add `DisplayHint::Interval` and formatting (`[lo, hi]`) and propagate the hint to JS/wasm conversion; register new executor keys and update the purity table so new builtins are integrated with the runtime.
- Add tests that exercise interval creation, arithmetic, division-by-zero detection for interval divisors, exact and interval `sqrt` behavior (including `eps` control), monotonicity, comparison policy, and mixed scalar/interval arithmetic.

### Testing
- Ran `cargo test -q interval_tests` and the interval-focused test group passed (all interval-related assertions succeeded).
- Ran the full test suite with `cargo test -q` and observed all tests passing in the CI environment used for this change.
- New tests added cover: `INTERVAL` creation and validation, `[a,b] +/ -/ * /` behavior, division error for divisors containing `0`, `sqrt` exact cases and interval approximations including `eps` width guarantees, monotonicity of `sqrt([a,b])`, mixed scalar/interval arithmetic, and comparison policy (decidable/undecidable behavior and equality rules).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fcf4e03c8326857dcdc7dd47a19c)