### PR TITLE
Auto-switch right panel to Stack when Output mode is selected

### DIFF
--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -60,6 +60,10 @@ const syncDesktopLayout = (elements: GUIElements, state: LayoutState): void => {
 const updateDesktopModes = (state: LayoutState, mode: ViewMode): void => {
     if (LEFT_TAB_MODES.includes(mode)) {
         state.currentLeftMode = mode;
+        if (mode === 'output') {
+            // Running code surfaces Output on the left, so pull the right column to Stack so execution results are immediately visible.
+            state.currentRightMode = 'stack';
+        }
     }
     if (RIGHT_TAB_MODES.includes(mode)) {
         state.currentRightMode = mode;


### PR DESCRIPTION
## Summary
When the Output view mode is selected on the left panel, automatically switch the right panel to Stack mode to ensure execution results are immediately visible to the user.

## Key Changes
- Added logic to `updateDesktopModes()` to detect when 'output' mode is selected on the left panel
- Automatically sets `currentRightMode` to 'stack' when output mode is activated, ensuring the Stack panel is visible alongside the Output panel for better visibility of execution results

## Implementation Details
- The change is minimal and focused, adding a conditional check within the existing LEFT_TAB_MODES handler
- This improves the user experience by automatically arranging the layout to show both output and stack information when running code

https://claude.ai/code/session_01JB9aWSuUH48TTbBC69nVA3