### PR TITLE
Lower code suggestion trigger threshold from 4 to 3 characters

### DIFF
--- a/js/gui/code-input-editor.ts
+++ b/js/gui/code-input-editor.ts
@@ -67,7 +67,7 @@ const lookupSelectionRange = (element: HTMLTextAreaElement): { start: number; en
 
 const MOBILE_BREAKPOINT = 768;
 const MAX_SUGGESTIONS = 10;
-const MIN_SUGGESTION_TRIGGER_LENGTH = 4;
+const MIN_SUGGESTION_TRIGGER_LENGTH = 3;
 const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
 
 const extractToken = (


### PR DESCRIPTION
## Summary
Reduced the minimum character length required to trigger code suggestions in the code input editor from 4 to 3 characters.

## Changes
- Updated `MIN_SUGGESTION_TRIGGER_LENGTH` constant from `4` to `3` in `js/gui/code-input-editor.ts`

## Details
This change allows code suggestions to appear earlier as users type, improving the suggestion experience by providing hints with fewer characters entered. This can help users discover available options and complete code more quickly.

https://claude.ai/code/session_0137WoAQRLdtsBWAe5uofi5D