### PR TITLE
Fix display hints and result flattening in fold/scan operations

### DIFF
--- a/rust/src/interpreter/cast-conversions.rs
+++ b/rust/src/interpreter/cast-conversions.rs
@@ -1,6 +1,6 @@
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::cast::cast_value_helpers::{
-    apply_unary_cast, format_fraction_to_string, format_value_to_string_repr,
+    apply_unary_cast, format_fraction_to_string, format_value_to_string_repr_with_hint,
     is_boolean_value, is_number_value, is_string_value_with_hint,
 };
 use crate::interpreter::value_extraction_helpers::{create_number_value, value_as_string};
@@ -24,7 +24,7 @@ fn convert_value_to_string(val: &Value, hint: DisplayHint) -> Result<Value> {
         }
     }
 
-    let string_repr = format_value_to_string_repr(val);
+    let string_repr = format_value_to_string_repr_with_hint(val, hint);
     Ok(Value::from_string(&string_repr))
 }
 

--- a/rust/src/interpreter/cast-value-helpers.rs
+++ b/rust/src/interpreter/cast-value-helpers.rs
@@ -154,6 +154,13 @@ pub(crate) fn try_char_from_value(val: &Value) -> Option<char> {
 }
 
 pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
+    format_value_to_string_repr_with_hint(value, DisplayHint::Auto)
+}
+
+pub(crate) fn format_value_to_string_repr_with_hint(
+    value: &Value,
+    hint: DisplayHint,
+) -> String {
     if value.is_nil() {
         return "NIL".to_string();
     }
@@ -168,7 +175,7 @@ pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
         }
     }
 
-    if is_string_value(value) {
+    if is_string_value_with_hint(value, hint) {
         return crate::interpreter::value_extraction_helpers::value_as_string(value)
             .unwrap_or_default();
     }

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -6,9 +6,9 @@ use super::value_extraction_helpers::create_number_value;
 use super::{modules, ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::SemanticRegistry;
 
-fn apply_word_hint_override(registry: &mut SemanticRegistry, word: &str) {
+fn apply_word_hint_override(interp: &mut Interpreter, word: &str) {
     let hint: Option<DisplayHint> = match word {
-        "STR" | "CHR" | "CHARS" | "JOIN" => Some(DisplayHint::String),
+        "STR" | "CHR" | "JOIN" => Some(DisplayHint::String),
         "NUM" | "+" | "-" | "*" | "/" | "MOD" | "FLOOR" | "CEIL" | "ROUND" | "FOLD" => {
             Some(DisplayHint::Number)
         }
@@ -16,9 +16,13 @@ fn apply_word_hint_override(registry: &mut SemanticRegistry, word: &str) {
         "LOWER" | "UPPER" | "WIDTH" => Some(DisplayHint::Number),
         "BOOL" | "<" | "<=" | "=" | "AND" | "OR" | "NOT" => Some(DisplayHint::Boolean),
         "NOW" | "DATETIME" | "TIMESTAMP" => Some(DisplayHint::DateTime),
+        "CHARS" | "MAP" | "FILTER" | "SCAN" | "UNFOLD" | "REVERSE" | "CONCAT" | "SORT"
+        | "TAKE" | "REORDER" | "SPLIT" | "COLLECT" | "RESHAPE" | "TRANSPOSE" | "FILL"
+        | "FRAME" => Some(DisplayHint::Auto),
         _ => None,
     };
     if let Some(h) = hint {
+        let registry: &mut SemanticRegistry = &mut interp.semantic_registry;
         let len: usize = registry.len();
         if len > 0 {
             registry.update_hint_at(len - 1, h);
@@ -248,10 +252,7 @@ impl Interpreter {
                                 Ok(()) => {
                                     self.semantic_registry
                                         .normalize_to_stack_len(self.stack.len());
-                                    apply_word_hint_override(
-                                        &mut self.semantic_registry,
-                                        upper.as_ref(),
-                                    );
+                                    apply_word_hint_override(self, upper.as_ref());
                                 }
                                 Err(_) => {
                                     self.stack = stack_snapshot;
@@ -264,7 +265,7 @@ impl Interpreter {
                             self.execute_word_core(upper.as_ref())?;
                             self.semantic_registry
                                 .normalize_to_stack_len(self.stack.len());
-                            apply_word_hint_override(&mut self.semantic_registry, upper.as_ref());
+                            apply_word_hint_override(self, upper.as_ref());
                         }
                         if !modules::is_mode_preserving_word(upper.as_ref()) {
                             self.reset_execution_modes();

--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -535,7 +535,17 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
             if results.is_empty() {
                 interp.stack.push(Value::nil());
             } else {
-                interp.stack.push(Value::from_vector(results));
+                let flattened: Vec<Value> = results
+                    .into_iter()
+                    .map(|v| {
+                        if is_vector_value(&v) && v.len() == 1 {
+                            v.get_child(0).unwrap().clone()
+                        } else {
+                            v
+                        }
+                    })
+                    .collect();
+                interp.stack.push(Value::from_vector(flattened));
             }
             Ok(())
         }
@@ -607,7 +617,17 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
             if results.is_empty() {
                 interp.stack.push(Value::nil());
             } else {
-                interp.stack.push(Value::from_vector(results));
+                let flattened: Vec<Value> = results
+                    .into_iter()
+                    .map(|v| {
+                        if is_vector_value(&v) && v.len() == 1 {
+                            v.get_child(0).unwrap().clone()
+                        } else {
+                            v
+                        }
+                    })
+                    .collect();
+                interp.stack.push(Value::from_vector(flattened));
             }
             Ok(())
         }

--- a/rust/src/interpreter/higher-order-operations.rs
+++ b/rust/src/interpreter/higher-order-operations.rs
@@ -1505,6 +1505,8 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
 
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);
+            let saved_hints: Vec<DisplayHint> =
+                std::mem::take(&mut interp.semantic_registry.stack_hints);
             let saved_target = interp.operation_target_mode;
             let saved_no_change_check = interp.disable_no_change_check;
             interp.operation_target_mode = OperationTargetMode::StackTop;
@@ -1572,6 +1574,7 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
             interp.operation_target_mode = saved_target;
             interp.disable_no_change_check = saved_no_change_check;
             interp.stack = saved_stack;
+            interp.semantic_registry.stack_hints = saved_hints;
 
             if let Some(e) = error {
                 interp.stack.push(target_val);
@@ -1579,7 +1582,8 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
                 return Err(e);
             }
 
-            interp.stack.push(Value::from_int(count));
+            interp.stack
+                .push(Value::from_vector(vec![Value::from_int(count)]));
             Ok(())
         }
         OperationTargetMode::Stack => {
@@ -1635,7 +1639,8 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
             interp.operation_target_mode = saved_target;
             interp.disable_no_change_check = saved_no_change_check;
             interp.stack = saved_stack;
-            interp.stack.push(Value::from_int(matched_count));
+            interp.stack
+                .push(Value::from_vector(vec![Value::from_int(matched_count)]));
             Ok(())
         }
     }

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -230,9 +230,13 @@ pub(crate) fn arena_node_to_js(
                 js_sys::Reflect::set(&obj, &"type".into(), &"string".into()).unwrap();
                 js_sys::Reflect::set(&obj, &"value".into(), &text.into()).unwrap();
             } else {
+                let child_external: Option<DisplayHint> = match effective_hint {
+                    DisplayHint::Boolean => Some(DisplayHint::Boolean),
+                    _ => None,
+                };
                 let js_array = js_sys::Array::new();
                 for child in children {
-                    js_array.push(&arena_node_to_js(arena, *child, None));
+                    js_array.push(&arena_node_to_js(arena, *child, child_external));
                 }
                 js_sys::Reflect::set(&obj, &"type".into(), &"vector".into()).unwrap();
                 js_sys::Reflect::set(&obj, &"value".into(), &js_array).unwrap();


### PR DESCRIPTION
## Summary
This PR fixes display hint handling and result formatting in higher-order operations, particularly for `scan` and `count` operations. It also improves semantic registry management and display hint propagation throughout the interpreter.

## Key Changes

- **Scan operation result flattening**: Modified `op_scan` in `higher-order-fold-operations.rs` to flatten single-element vectors in results, preventing unnecessary nesting of intermediate values.

- **Display hint improvements**: 
  - Updated `apply_word_hint_override` to accept the full `Interpreter` instead of just the registry, enabling better context-aware hint application
  - Added `DisplayHint::Auto` for collection operations (`CHARS`, `MAP`, `FILTER`, `SCAN`, `UNFOLD`, `REVERSE`, `CONCAT`, `SORT`, `TAKE`, `REORDER`, `SPLIT`, `COLLECT`, `RESHAPE`, `TRANSPOSE`, `FILL`, `FRAME`)
  - Removed `CHARS` from the `String` hint category to use `Auto` instead

- **String formatting with hints**: Introduced `format_value_to_string_repr_with_hint` function that respects display hints when determining string representation, replacing direct calls to the hint-agnostic version.

- **Count operation fixes**:
  - Properly save and restore semantic registry stack hints during execution
  - Changed return value from bare integer to wrapped vector for consistency with other operations

- **WASM value conversion**: Enhanced boolean hint propagation to child elements in vector serialization, ensuring proper type information in JavaScript representation.

## Implementation Details

The changes ensure that:
1. Display hints are properly maintained through operation execution
2. Result values are consistently formatted according to their semantic hints
3. Intermediate computation state (including hints) is properly preserved during nested operations
4. Collection operations return results with appropriate hint information for downstream processing

https://claude.ai/code/session_01TupqiGmzFXtorWkvMP6BRq