### PR TITLE
Align UNFOLD/Stack-mode GUI tests with specification

### DIFF
--- a/js/gui/gui-interpreter-test-cases.ts
+++ b/js/gui/gui-interpreter-test-cases.ts
@@ -424,7 +424,7 @@ export const TEST_CASES: TestCase[] = [
     {
         name: "UNFOLD - basic",
         code: "[ 1 ] { { [ 1 ] = } { [ 1 2 ] } { [ 2 ] = } { [ 2 3 ] } { [ 3 ] = } { [ 3 NIL ] } { IDLE } { NIL } COND } UNFOLD",
-        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3'), createNumber('4')])],
+        expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3')])],
         category: "Higher-Order Functions"
     },
     {
@@ -512,7 +512,7 @@ export const TEST_CASES: TestCase[] = [
 
     {
         name: "Stack mode - LENGTH",
-        code: "[ 1 ] [ 2 ] [ 3 ] .. LENGTH",
+        code: "[ 1 ] [ 2 ] [ 3 ] ..,, LENGTH",
         expectedStack: [
             createVector([createNumber('1')]),
             createVector([createNumber('2')]),
@@ -523,7 +523,7 @@ export const TEST_CASES: TestCase[] = [
     },
     {
         name: "Stack mode - GET",
-        code: "[ 'a' ] [ 'b' ] [ 'c' ] [ 1 ] .. GET",
+        code: "[ 'a' ] [ 'b' ] [ 'c' ] [ 1 ] ..,, GET",
         expectedStack: [
             createVector([createString('a')]),
             createVector([createString('b')]),

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -127,6 +127,13 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             continue;
         }
 
+        if let Some(expanded) = split_compound_modifier(&token_str) {
+            for symbol in expanded {
+                tokens.push(Token::Symbol(symbol.into()));
+            }
+            continue;
+        }
+
 
         if let Some(token) = parse_number_from_string(&token_str) {
             tokens.push(token);
@@ -409,7 +416,37 @@ fn parse_keyword_from_string(s: &str) -> Option<Token> {
     match s {
         "." => Some(Token::Symbol(".".into())),
         ".." => Some(Token::Symbol("..".into())),
+        "," => Some(Token::Symbol(",".into())),
+        ",," => Some(Token::Symbol(",,".into())),
         _ => None,
+    }
+}
+
+fn split_compound_modifier(s: &str) -> Option<Vec<String>> {
+    let mut remaining = s;
+    let mut parts: Vec<String> = Vec::new();
+    while !remaining.is_empty() {
+        let matched = if let Some(rest) = remaining.strip_prefix("..") {
+            parts.push("..".to_string());
+            rest
+        } else if let Some(rest) = remaining.strip_prefix(",,") {
+            parts.push(",,".to_string());
+            rest
+        } else if let Some(rest) = remaining.strip_prefix('.') {
+            parts.push(".".to_string());
+            rest
+        } else if let Some(rest) = remaining.strip_prefix(',') {
+            parts.push(",".to_string());
+            rest
+        } else {
+            return None;
+        };
+        remaining = matched;
+    }
+    if parts.len() >= 2 {
+        Some(parts)
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
Three previously-failing GUI tests had expected values that conflicted with `SPECIFICATION.md` and the Rust-level tests. Realign them to the canonical semantics and add compound-modifier tokenization so the spec's sample combined forms (e.g. `..,,`) actually parse.

- `UNFOLD - basic`: expected length was 4, but the canonical example in `detail-lookup-control-higher-order.rs` and the Rust test `test_unfold_basic_generation` both document 3 (`[ 1 2 3 ]`), which also matches standard unfold semantics (`[x, NIL]` = "emit x, then terminate"). Update the expected stack to three elements.
- `Stack mode - LENGTH` / `Stack mode - GET`: expected keep-behavior (stack retained under the result), but used `..` alone. Per `SPECIFICATION.md` §6.2, `,` (Consume) is the default, so keep behavior requires the explicit `,,` modifier. Rewrite both codes from `..` to `..,,`.
- `tokenizer::split_compound_modifier`: the spec (§6.4) promises combined forms like `..,,` are valid, but the tokenizer was emitting them as a single unknown symbol. Parse compound-modifier runs of `.`/`..`/`,`/`,,` into their constituent symbol tokens.

https://claude.ai/code/session_01TupqiGmzFXtorWkvMP6BRq