### PR TITLE
Introduce dictionary tiers, stability & capabilities; move time/crypto/algo words to Standard modules with deprecation aliases

### DIFF
--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -289,15 +289,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         Some(BuiltinExecutorKey::Collect)
     ),
     builtin_spec!(
-        "SORT",
-        "vector",
-        "Form: Sort elements ascending. Vector -> Vector",
-        "[ 3 1 2 ] SORT → [ 1 2 3 ]",
-        "form",
-        BuiltinDetailGroup::VectorOps,
-        Some(BuiltinExecutorKey::Sort)
-    ),
-    builtin_spec!(
         "TRUE",
         "constant",
         "Push TRUE to stack",
@@ -377,33 +368,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         "map",
         BuiltinDetailGroup::StringCast,
         Some(BuiltinExecutorKey::Chr)
-    ),
-    builtin_spec!(
-        "NOW",
-        "datetime",
-        "Get current UNIX timestamp. -> Scalar",
-        "NOW → [ 1732531200 ]",
-        "none",
-        BuiltinDetailGroup::IoModule,
-        Some(BuiltinExecutorKey::Now)
-    ),
-    builtin_spec!(
-        "DATETIME",
-        "datetime",
-        "Convert timestamp to datetime string. Scalar -> String",
-        "[ 1732531200 ] 'LOCAL' DATETIME → [ 2024 11 25 23 0 0 ]",
-        "none",
-        BuiltinDetailGroup::IoModule,
-        Some(BuiltinExecutorKey::Datetime)
-    ),
-    builtin_spec!(
-        "TIMESTAMP",
-        "datetime",
-        "Convert datetime string to timestamp. String -> Scalar",
-        "[ 2024 11 25 23 0 0 ] 'LOCAL' TIMESTAMP → [ 1732531200 ]",
-        "none",
-        BuiltinDetailGroup::IoModule,
-        Some(BuiltinExecutorKey::Timestamp)
     ),
     builtin_spec!(
         "+",
@@ -791,24 +755,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         "map",
         BuiltinDetailGroup::ArithmeticLogic,
         Some(BuiltinExecutorKey::Round)
-    ),
-    builtin_spec!(
-        "CSPRNG",
-        "random",
-        "Generate cryptographic pseudorandom number. -> Scalar",
-        "[ 6 ] [ 1 ] CSPRNG → [ 0 ] to [ 5/6 ], [ 5 ] CSPRNG → 5 randoms",
-        "none",
-        BuiltinDetailGroup::IoModule,
-        Some(BuiltinExecutorKey::Csprng)
-    ),
-    builtin_spec!(
-        "HASH",
-        "hash",
-        "Compute hash value. Any -> Numeric",
-        "'hello' HASH → [ 0.xxx ], [ 128 ] 'hello' HASH → 128-bit",
-        "none",
-        BuiltinDetailGroup::IoModule,
-        Some(BuiltinExecutorKey::Hash)
     ),
     builtin_spec!(
         "EXEC",

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -22,7 +22,7 @@ pub use builtin_word_definitions::{
 };
 pub use builtin_word_details::lookup_builtin_detail;
 
-use crate::types::WordDefinition;
+use crate::types::{Capabilities, Stability, Tier, WordDefinition};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -30,11 +30,15 @@ pub fn register_builtins(dictionary: &mut HashMap<String, Arc<WordDefinition>>) 
     for spec in builtin_specs() {
         let name = spec.name;
         let description = spec.short_description;
+        let capabilities = core_builtin_capabilities(spec.executor_key, name);
         dictionary.insert(
             name.to_string(),
             Arc::new(WordDefinition {
                 lines: std::sync::Arc::from([]),
                 is_builtin: true,
+                tier: Tier::Core,
+                stability: Stability::Stable,
+                capabilities,
                 description: Some(description.to_string()),
                 dependencies: HashSet::new(),
                 original_source: None,
@@ -43,5 +47,28 @@ pub fn register_builtins(dictionary: &mut HashMap<String, Arc<WordDefinition>>) 
                 execution_plans: None,
             }),
         );
+    }
+}
+
+fn core_builtin_capabilities(
+    key: Option<BuiltinExecutorKey>,
+    name: &str,
+) -> Capabilities {
+    match (key, name) {
+        (Some(BuiltinExecutorKey::Def), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::Del), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::Import), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::ImportOnly), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::Eval), _) => Capabilities::EVAL,
+        (Some(BuiltinExecutorKey::Spawn), _) => Capabilities::SPAWN,
+        (Some(BuiltinExecutorKey::Await), _) => Capabilities::SPAWN,
+        (Some(BuiltinExecutorKey::Status), _) => Capabilities::SPAWN,
+        (Some(BuiltinExecutorKey::Kill), _) => Capabilities::SPAWN,
+        (Some(BuiltinExecutorKey::Monitor), _) => Capabilities::SPAWN,
+        (Some(BuiltinExecutorKey::Supervise), _) => Capabilities::SPAWN,
+        (Some(BuiltinExecutorKey::Print), _) => Capabilities::IO,
+        (None, "'") => Capabilities::IO,
+        (None, "!") => Capabilities::MUTATES_DICT,
+        _ => Capabilities::PURE,
     }
 }

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -140,9 +140,33 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
 /// Returns `None` for user-defined or unknown words; use `infer_purity`
 /// to handle those.
 pub fn purity_by_name(name: &str) -> Option<PurityInfo> {
-    crate::builtins::lookup_builtin_spec(name)
+    if let Some(info) = crate::builtins::lookup_builtin_spec(name)
         .and_then(|spec| spec.executor_key)
         .map(builtin_purity)
+    {
+        return Some(info);
+    }
+
+    match name.to_uppercase().as_str() {
+        "NOW" | "DATETIME" | "TIMESTAMP" | "TIME@NOW" | "TIME@DATETIME" | "TIME@TIMESTAMP" => {
+            Some(PurityInfo {
+                purity: Purity::Impure,
+                cost: EvalCost::Light,
+                order_sensitive: true,
+            })
+        }
+        "CSPRNG" | "CRYPTO@CSPRNG" => Some(PurityInfo {
+            purity: Purity::Impure,
+            cost: EvalCost::Light,
+            order_sensitive: true,
+        }),
+        "HASH" | "CRYPTO@HASH" | "SORT" | "ALGO@SORT" => Some(PurityInfo {
+            purity: Purity::Pure,
+            cost: EvalCost::Light,
+            order_sensitive: false,
+        }),
+        _ => None,
+    }
 }
 
 // ── Inference for user-defined words ─────────────────────────────────────────

--- a/rust/src/interpreter/compiled-plan-tests.rs
+++ b/rust/src/interpreter/compiled-plan-tests.rs
@@ -1,5 +1,5 @@
 use crate::interpreter::{compile_word_definition, is_plan_valid, CompiledOp, Interpreter};
-use crate::types::{ExecutionLine, Token, WordDefinition};
+use crate::types::{Capabilities, ExecutionLine, Stability, Tier, Token, WordDefinition};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -9,6 +9,9 @@ fn test_word(tokens: Vec<Token>) -> WordDefinition {
             body_tokens: Arc::from(tokens),
         }]),
         is_builtin: false,
+        tier: Tier::Contrib,
+        stability: Stability::Stable,
+        capabilities: Capabilities::PURE,
         description: None,
         dependencies: HashSet::new(),
         original_source: None,

--- a/rust/src/interpreter/deprecated-core-aliases.rs
+++ b/rust/src/interpreter/deprecated-core-aliases.rs
@@ -1,0 +1,43 @@
+pub(crate) struct DeprecatedCoreAlias {
+    pub old_name: &'static str,
+    pub replacement_qualified: &'static str,
+    pub import_hint: &'static str,
+}
+
+pub(crate) const DEPRECATED_CORE_ALIASES: &[DeprecatedCoreAlias] = &[
+    DeprecatedCoreAlias {
+        old_name: "NOW",
+        replacement_qualified: "TIME@NOW",
+        import_hint: "'time' IMPORT and TIME@NOW",
+    },
+    DeprecatedCoreAlias {
+        old_name: "DATETIME",
+        replacement_qualified: "TIME@DATETIME",
+        import_hint: "'time' IMPORT and TIME@DATETIME",
+    },
+    DeprecatedCoreAlias {
+        old_name: "TIMESTAMP",
+        replacement_qualified: "TIME@TIMESTAMP",
+        import_hint: "'time' IMPORT and TIME@TIMESTAMP",
+    },
+    DeprecatedCoreAlias {
+        old_name: "CSPRNG",
+        replacement_qualified: "CRYPTO@CSPRNG",
+        import_hint: "'crypto' IMPORT and CRYPTO@CSPRNG",
+    },
+    DeprecatedCoreAlias {
+        old_name: "HASH",
+        replacement_qualified: "CRYPTO@HASH",
+        import_hint: "'crypto' IMPORT and CRYPTO@HASH",
+    },
+    DeprecatedCoreAlias {
+        old_name: "SORT",
+        replacement_qualified: "ALGO@SORT",
+        import_hint: "'algo' IMPORT and ALGO@SORT",
+    },
+];
+
+pub(crate) fn lookup_deprecated_core_alias(name: &str) -> Option<&'static DeprecatedCoreAlias> {
+    let upper = name.to_uppercase();
+    DEPRECATED_CORE_ALIASES.iter().find(|alias| alias.old_name == upper)
+}

--- a/rust/src/interpreter/dictionary-tier-tests.rs
+++ b/rust/src/interpreter/dictionary-tier-tests.rs
@@ -1,0 +1,102 @@
+#[cfg(test)]
+mod tests {
+    use crate::builtins::builtin_specs;
+    use crate::interpreter::Interpreter;
+    use crate::types::{Capabilities, Stability, Tier};
+
+    #[tokio::test]
+    async fn core_words_have_expected_attributes() {
+        let interp = Interpreter::new();
+        let add = interp.core_vocabulary.get("+").unwrap();
+        assert_eq!(add.tier, Tier::Core);
+        assert_eq!(add.stability, Stability::Stable);
+        assert_eq!(add.capabilities, Capabilities::PURE);
+
+        let map = interp.core_vocabulary.get("MAP").unwrap();
+        assert_eq!(map.tier, Tier::Core);
+        assert_eq!(map.stability, Stability::Stable);
+        assert_eq!(map.capabilities, Capabilities::PURE);
+
+        let def = interp.core_vocabulary.get("DEF").unwrap();
+        assert_eq!(def.tier, Tier::Core);
+        assert_eq!(def.stability, Stability::Stable);
+        assert_eq!(def.capabilities, Capabilities::MUTATES_DICT);
+    }
+
+    #[tokio::test]
+    async fn standard_module_words_have_expected_attributes() {
+        let mut interp = Interpreter::new();
+        interp.execute("'time' IMPORT").await.unwrap();
+        interp.execute("'crypto' IMPORT").await.unwrap();
+
+        let time_now = interp
+            .module_vocabulary
+            .get("TIME")
+            .and_then(|m| m.words.get("TIME@NOW"))
+            .unwrap();
+        assert_eq!(time_now.tier, Tier::Standard);
+        assert_eq!(time_now.capabilities, Capabilities::TIME);
+
+        let csprng = interp
+            .module_vocabulary
+            .get("CRYPTO")
+            .and_then(|m| m.words.get("CRYPTO@CSPRNG"))
+            .unwrap();
+        assert_eq!(csprng.tier, Tier::Standard);
+        assert_eq!(
+            csprng.capabilities,
+            Capabilities::RANDOM | Capabilities::CRYPTO
+        );
+    }
+
+    #[tokio::test]
+    async fn user_defined_word_is_contrib_tier() {
+        let mut interp = Interpreter::new();
+        interp.execute("{ 1 } 'X' DEF").await.unwrap();
+        let def = interp
+            .user_dictionaries
+            .get("DEMO")
+            .and_then(|d| d.words.get("X"))
+            .unwrap();
+        assert_eq!(def.tier, Tier::Contrib);
+        assert_eq!(def.stability, Stability::Stable);
+    }
+
+    #[tokio::test]
+    async fn deprecated_sort_alias_warns_and_matches_algo_sort() {
+        let mut interp = Interpreter::new();
+        interp.execute("[ 3 1 2 ] SORT").await.unwrap();
+        let warning = interp.collect_output();
+        assert!(warning.contains("Warning: 'SORT' is deprecated."));
+
+        let sort_from_alias = interp.stack.pop().unwrap();
+        interp.execute("'algo' IMPORT").await.unwrap();
+        interp.execute("[ 3 1 2 ] ALGO@SORT").await.unwrap();
+        let sort_qualified = interp.stack.pop().unwrap();
+        assert_eq!(sort_from_alias, sort_qualified);
+    }
+
+    #[test]
+    fn now_is_not_in_builtin_specs() {
+        assert!(builtin_specs().iter().all(|s| s.name != "NOW"));
+    }
+
+    #[tokio::test]
+    async fn imported_sort_and_qualified_sort_do_not_warn() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'algo' IMPORT [ 3 1 2 ] SORT [ 3 1 2 ] ALGO@SORT")
+            .await
+            .unwrap();
+        let out = interp.collect_output();
+        assert!(!out.contains("deprecated"));
+    }
+
+    #[test]
+    fn capabilities_bit_operations_work() {
+        assert_eq!(Capabilities::PURE & Capabilities::IO, Capabilities::empty());
+        let joined = Capabilities::IO | Capabilities::TIME;
+        assert!(joined.contains(Capabilities::IO));
+        assert!(joined.contains(Capabilities::TIME));
+    }
+}

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -66,6 +66,25 @@ impl Interpreter {
     ///
     /// Never call directly — use `execute_word_core` so tracing applies.
     fn execute_word_core_inner(&mut self, name: &str) -> Result<()> {
+        if self.resolve_word_entry(name).is_none() {
+            if let Some(alias) = super::deprecated_core_aliases::lookup_deprecated_core_alias(name) {
+                self.execution_step_count += 1;
+                if self.execution_step_count > self.max_execution_steps {
+                    return Err(AjisaiError::ExecutionLimitExceeded {
+                        limit: self.max_execution_steps,
+                    });
+                }
+                self.call_stack.push(alias.replacement_qualified.to_string());
+                self.output_buffer.push_str(&format!(
+                    "Warning: '{}' is deprecated. Use {} instead.\n",
+                    alias.old_name, alias.import_hint
+                ));
+                let alias_result = self.execute_builtin(alias.replacement_qualified);
+                self.call_stack.pop();
+                return alias_result;
+            }
+        }
+
         let (resolved_name, def) = self.resolve_word_entry(name).ok_or_else(|| {
             let ambiguous = self.check_ambiguity(name);
             if !ambiguous.is_empty() {

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -2,7 +2,7 @@ use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::extract_word_name_from_value;
 use crate::interpreter::vector_exec::format_vector_to_source;
 use crate::interpreter::{Interpreter, OperationTargetMode, WordDefinition};
-use crate::types::{ExecutionLine, Token, Value, ValueData};
+use crate::types::{Capabilities, ExecutionLine, Stability, Tier, Token, Value, ValueData};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -238,6 +238,9 @@ pub(crate) fn op_def_inner(
     let new_def = WordDefinition {
         lines: lines.into(),
         is_builtin: false,
+        tier: Tier::Contrib,
+        stability: Stability::Stable,
+        capabilities: Capabilities::PURE,
         description,
         dependencies: new_dependencies,
         original_source: None,

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -68,6 +68,8 @@ mod execution_loop;
 
 #[path = "execute-builtin.rs"]
 mod execute_builtin;
+#[path = "deprecated-core-aliases.rs"]
+mod deprecated_core_aliases;
 
 #[cfg(test)]
 #[path = "child-runtime-tests.rs"]
@@ -87,6 +89,9 @@ mod dictionary_operation_tests;
 #[cfg(test)]
 #[path = "dictionary-resolution-tests.rs"]
 mod dictionary_resolution_tests;
+#[cfg(test)]
+#[path = "dictionary-tier-tests.rs"]
+mod dictionary_tier_tests;
 #[cfg(test)]
 #[path = "hash-tests.rs"]
 mod hash_tests;

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,211 +1,71 @@
-use crate::interpreter::{audio, json};
+use crate::interpreter::{audio, datetime, hash, json, random, sort};
+use crate::types::{Capabilities, Stability};
 
 use super::module_word_types::{ModuleSpec, ModuleWord, SampleWord};
 
 const MUSIC_WORDS: &[ModuleWord] = &[
-    ModuleWord {
-        short_name: "SEQ",
-        description: "Set sequential playback mode",
-        executor: audio::op_seq,
-        preserves_modes: true,
-    },
-    ModuleWord {
-        short_name: "SIM",
-        description: "Set simultaneous playback mode",
-        executor: audio::op_sim,
-        preserves_modes: true,
-    },
-    ModuleWord {
-        short_name: "SLOT",
-        description: "Set slot duration in seconds",
-        executor: audio::op_slot,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "GAIN",
-        description: "Set volume level (0.0-1.0)",
-        executor: audio::op_gain,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "GAIN-RESET",
-        description: "Reset volume to default (1.0)",
-        executor: audio::op_gain_reset,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "PAN",
-        description: "Set stereo position (-1.0 left to 1.0 right)",
-        executor: audio::op_pan,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "PAN-RESET",
-        description: "Reset pan to center (0.0)",
-        executor: audio::op_pan_reset,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "FX-RESET",
-        description: "Reset all audio effects to defaults",
-        executor: audio::op_fx_reset,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "PLAY",
-        description: "Play audio",
-        executor: audio::op_play,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "CHORD",
-        description: "Mark vector as chord (simultaneous)",
-        executor: audio::op_chord,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "ADSR",
-        description: "Set ADSR envelope",
-        executor: audio::op_adsr,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "SINE",
-        description: "Set sine waveform",
-        executor: audio::op_sine,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "SQUARE",
-        description: "Set square waveform",
-        executor: audio::op_square,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "SAW",
-        description: "Set sawtooth waveform",
-        executor: audio::op_saw,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "TRI",
-        description: "Set triangle waveform",
-        executor: audio::op_tri,
-        preserves_modes: false,
-    },
+    ModuleWord { short_name: "SEQ", description: "Set sequential playback mode", executor: audio::op_seq, preserves_modes: true, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "SIM", description: "Set simultaneous playback mode", executor: audio::op_sim, preserves_modes: true, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "SLOT", description: "Set slot duration in seconds", executor: audio::op_slot, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "GAIN", description: "Set volume level (0.0-1.0)", executor: audio::op_gain, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "GAIN-RESET", description: "Reset volume to default (1.0)", executor: audio::op_gain_reset, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "PAN", description: "Set stereo position (-1.0 left to 1.0 right)", executor: audio::op_pan, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "PAN-RESET", description: "Reset pan to center (0.0)", executor: audio::op_pan_reset, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "FX-RESET", description: "Reset all audio effects to defaults", executor: audio::op_fx_reset, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "PLAY", description: "Play audio", executor: audio::op_play, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "CHORD", description: "Mark vector as chord (simultaneous)", executor: audio::op_chord, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "ADSR", description: "Set ADSR envelope", executor: audio::op_adsr, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "SINE", description: "Set sine waveform", executor: audio::op_sine, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "SQUARE", description: "Set square waveform", executor: audio::op_square, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "SAW", description: "Set sawtooth waveform", executor: audio::op_saw, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "TRI", description: "Set triangle waveform", executor: audio::op_tri, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
 ];
 
 const JSON_WORDS: &[ModuleWord] = &[
-    ModuleWord {
-        short_name: "PARSE",
-        description: "Parse JSON string to Ajisai value",
-        executor: json::op_parse,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "STRINGIFY",
-        description: "Convert Ajisai value to JSON string",
-        executor: json::op_stringify,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "GET",
-        description: "Get value by key from JSON object",
-        executor: json::op_json_get,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "KEYS",
-        description: "Get all keys from JSON object",
-        executor: json::op_json_keys,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "SET",
-        description: "Set key-value in JSON object",
-        executor: json::op_json_set,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "EXPORT",
-        description: "Export stack top as JSON file download",
-        executor: json::op_json_export,
-        preserves_modes: false,
-    },
+    ModuleWord { short_name: "PARSE", description: "Parse JSON string to Ajisai value", executor: json::op_parse, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
+    ModuleWord { short_name: "STRINGIFY", description: "Convert Ajisai value to JSON string", executor: json::op_stringify, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
+    ModuleWord { short_name: "GET", description: "Get value by key from JSON object", executor: json::op_json_get, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
+    ModuleWord { short_name: "KEYS", description: "Get all keys from JSON object", executor: json::op_json_keys, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
+    ModuleWord { short_name: "SET", description: "Set key-value in JSON object", executor: json::op_json_set, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
+    ModuleWord { short_name: "EXPORT", description: "Export stack top as JSON file download", executor: json::op_json_export, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
 ];
 
 const IO_WORDS: &[ModuleWord] = &[
-    ModuleWord {
-        short_name: "INPUT",
-        description: "Read text from input buffer",
-        executor: json::op_input,
-        preserves_modes: false,
-    },
-    ModuleWord {
-        short_name: "OUTPUT",
-        description: "Write value to output buffer",
-        executor: json::op_output,
-        preserves_modes: false,
-    },
+    ModuleWord { short_name: "INPUT", description: "Read text from input buffer", executor: json::op_input, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    ModuleWord { short_name: "OUTPUT", description: "Write value to output buffer", executor: json::op_output, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+];
+
+const TIME_WORDS: &[ModuleWord] = &[
+    ModuleWord { short_name: "NOW", description: "Get current Unix timestamp", executor: datetime::op_now, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::TIME },
+    ModuleWord { short_name: "DATETIME", description: "Convert timestamp to datetime vector", executor: datetime::op_datetime, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::TIME },
+    ModuleWord { short_name: "TIMESTAMP", description: "Convert datetime vector to timestamp", executor: datetime::op_timestamp, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::TIME },
+];
+
+const CRYPTO_WORDS: &[ModuleWord] = &[
+    ModuleWord { short_name: "CSPRNG", description: "Generate cryptographically secure random numbers", executor: random::op_csprng, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::RANDOM.union(Capabilities::CRYPTO) },
+    ModuleWord { short_name: "HASH", description: "Compute hash value", executor: hash::op_hash, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE.union(Capabilities::CRYPTO) },
+];
+
+const ALGO_WORDS: &[ModuleWord] = &[
+    ModuleWord { short_name: "SORT", description: "Sort vector elements in ascending order", executor: sort::op_sort, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
 ];
 
 const MUSIC_SAMPLES: &[SampleWord] = &[
-    SampleWord {
-        name: "C4",
-        definition: "264",
-        description: "純正律 C4 / ド (264Hz)",
-    },
-    SampleWord {
-        name: "D4",
-        definition: "C4 9 * 8 /",
-        description: "純正律 D4 / レ (297Hz)",
-    },
-    SampleWord {
-        name: "E4",
-        definition: "C4 5 * 4 /",
-        description: "純正律 E4 / ミ (330Hz)",
-    },
-    SampleWord {
-        name: "F4",
-        definition: "C4 4 * 3 /",
-        description: "純正律 F4 / ファ (352Hz)",
-    },
-    SampleWord {
-        name: "G4",
-        definition: "C4 3 * 2 /",
-        description: "純正律 G4 / ソ (396Hz)",
-    },
-    SampleWord {
-        name: "A4",
-        definition: "C4 5 * 3 /",
-        description: "純正律 A4 / ラ (440Hz)",
-    },
-    SampleWord {
-        name: "B4",
-        definition: "C4 15 * 8 /",
-        description: "純正律 B4 / シ (495Hz)",
-    },
-    SampleWord {
-        name: "C5",
-        definition: "C4 2 *",
-        description: "純正律 C5 / 高いド (528Hz)",
-    },
+    SampleWord { name: "C4", definition: "264", description: "純正律 C4 / ド (264Hz)" },
+    SampleWord { name: "D4", definition: "C4 9 * 8 /", description: "純正律 D4 / レ (297Hz)" },
+    SampleWord { name: "E4", definition: "C4 5 * 4 /", description: "純正律 E4 / ミ (330Hz)" },
+    SampleWord { name: "F4", definition: "C4 4 * 3 /", description: "純正律 F4 / ファ (352Hz)" },
+    SampleWord { name: "G4", definition: "C4 3 * 2 /", description: "純正律 G4 / ソ (396Hz)" },
+    SampleWord { name: "A4", definition: "C4 5 * 3 /", description: "純正律 A4 / ラ (440Hz)" },
+    SampleWord { name: "B4", definition: "C4 15 * 8 /", description: "純正律 B4 / シ (495Hz)" },
+    SampleWord { name: "C5", definition: "C4 2 *", description: "純正律 C5 / 高いド (528Hz)" },
 ];
 
 pub(super) const MODULE_SPECS: &[ModuleSpec] = &[
-    ModuleSpec {
-        name: "MUSIC",
-        words: MUSIC_WORDS,
-        sample_words: MUSIC_SAMPLES,
-    },
-    ModuleSpec {
-        name: "JSON",
-        words: JSON_WORDS,
-        sample_words: &[],
-    },
-    ModuleSpec {
-        name: "IO",
-        words: IO_WORDS,
-        sample_words: &[],
-    },
+    ModuleSpec { name: "MUSIC", words: MUSIC_WORDS, sample_words: MUSIC_SAMPLES },
+    ModuleSpec { name: "JSON", words: JSON_WORDS, sample_words: &[] },
+    ModuleSpec { name: "IO", words: IO_WORDS, sample_words: &[] },
+    ModuleSpec { name: "TIME", words: TIME_WORDS, sample_words: &[] },
+    ModuleSpec { name: "CRYPTO", words: CRYPTO_WORDS, sample_words: &[] },
+    ModuleSpec { name: "ALGO", words: ALGO_WORDS, sample_words: &[] },
 ];

--- a/rust/src/interpreter/modules/module_registry.rs
+++ b/rust/src/interpreter/modules/module_registry.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::{is_string_value, value_as_string};
 use crate::interpreter::{Interpreter, ModuleDictionary};
-use crate::types::{Value, ValueData, WordDefinition};
+use crate::types::{Tier, Value, ValueData, WordDefinition};
 
 use super::module_builtins::MODULE_SPECS;
 use super::module_samples::build_sample_words;
@@ -26,6 +26,9 @@ pub(super) fn ensure_module_dictionary(interp: &mut Interpreter, module_name: &s
             Arc::new(WordDefinition {
                 lines: Arc::from([]),
                 is_builtin: true,
+                tier: Tier::Standard,
+                stability: word.stability,
+                capabilities: word.capabilities,
                 description: Some(word.description.to_string()),
                 dependencies: HashSet::new(),
                 original_source: None,

--- a/rust/src/interpreter/modules/module_samples.rs
+++ b/rust/src/interpreter/modules/module_samples.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::error::{AjisaiError, Result};
-use crate::types::{ExecutionLine, Token, WordDefinition};
+use crate::types::{Capabilities, ExecutionLine, Stability, Tier, Token, WordDefinition};
 
 use super::module_word_types::SampleWord;
 
@@ -24,6 +24,9 @@ pub(super) fn build_sample_words(
             Arc::new(WordDefinition {
                 lines: lines.into(),
                 is_builtin: false,
+                tier: Tier::Standard,
+                stability: Stability::Stable,
+                capabilities: Capabilities::PURE,
                 description: Some(sample.description.to_string()),
                 dependencies: HashSet::new(),
                 original_source: None,

--- a/rust/src/interpreter/modules/module_word_types.rs
+++ b/rust/src/interpreter/modules/module_word_types.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use crate::interpreter::Interpreter;
+use crate::types::{Capabilities, Stability};
 
 pub(super) type ModuleExecutor = fn(&mut Interpreter) -> Result<()>;
 
@@ -9,6 +10,8 @@ pub(super) struct ModuleWord {
     pub description: &'static str,
     pub executor: ModuleExecutor,
     pub preserves_modes: bool,
+    pub stability: Stability,
+    pub capabilities: Capabilities,
 }
 
 #[derive(Clone)]

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::elastic::purity_table::{purity_by_name, Purity};
-use crate::types::Token;
+use crate::types::{Capabilities, Stability, Tier, Token};
 
 use super::{
     compile_word_definition, compiled_plan::CompiledOp, CompiledPlan, EpochSnapshot, Interpreter,
@@ -181,7 +181,13 @@ fn analyze_compiled_plan_with_context(
                     all_known = false;
                 }
 
-                CompiledOp::FallbackToken(_) => {
+                CompiledOp::FallbackToken(token) => {
+                    if let Token::Symbol(sym) = token {
+                        let normalized = Interpreter::normalize_symbol(sym);
+                        if is_side_effecting_builtin(normalized.as_ref()) {
+                            is_pure = false;
+                        }
+                    }
                     if min_depth_at_first_unknown.is_none() {
                         min_depth_at_first_unknown = Some(min_depth);
                     }
@@ -325,6 +331,9 @@ pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option
     let def = WordDefinition {
         lines: lines.into(),
         is_builtin: false,
+        tier: Tier::Contrib,
+        stability: Stability::Stable,
+        capabilities: Capabilities::PURE,
         description: None,
         dependencies: Default::default(),
         original_source: None,

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -164,10 +164,83 @@ pub struct ExecutionLine {
     pub body_tokens: Arc<[Token]>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Tier {
+    Core,
+    Standard,
+    #[default]
+    Contrib,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Stability {
+    #[default]
+    Stable,
+    Experimental,
+    Deprecated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Capabilities {
+    bits: u32,
+}
+
+impl Capabilities {
+    pub const PURE: Self = Self { bits: 0b0000_0001 };
+    pub const IO: Self = Self { bits: 0b0000_0010 };
+    pub const TIME: Self = Self { bits: 0b0000_0100 };
+    pub const RANDOM: Self = Self { bits: 0b0000_1000 };
+    pub const CRYPTO: Self = Self { bits: 0b0001_0000 };
+    pub const SPAWN: Self = Self { bits: 0b0010_0000 };
+    pub const EVAL: Self = Self { bits: 0b0100_0000 };
+    pub const MUTATES_DICT: Self = Self { bits: 0b1000_0000 };
+
+    pub const fn empty() -> Self {
+        Self { bits: 0 }
+    }
+
+    pub const fn contains(self, other: Self) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self {
+            bits: self.bits | other.bits,
+        }
+    }
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self::PURE
+    }
+}
+
+impl std::ops::BitOr for Capabilities {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            bits: self.bits | rhs.bits,
+        }
+    }
+}
+
+impl std::ops::BitAnd for Capabilities {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self {
+            bits: self.bits & rhs.bits,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct WordDefinition {
     pub lines: Arc<[ExecutionLine]>,
     pub is_builtin: bool,
+    pub tier: Tier,
+    pub stability: Stability,
+    pub capabilities: Capabilities,
     pub description: Option<String>,
     pub dependencies: HashSet<String>,
     pub original_source: Option<String>,


### PR DESCRIPTION
### Motivation
- Reduce language core surface by separating environment-dependent and domain words from Core into Standard modules. 
- Provide static metadata so tools can reason about word safety/purity (tier + stability + capability). 
- Preserve backward compatibility by keeping old short names resolvable with runtime deprecation warnings while enabling qualified module usage.

### Description
- Added `Tier`, `Stability`, and `Capabilities` to `WordDefinition` and implemented a small `Capabilities` bitset type to avoid external crate usage. 
- Marked Core builtins with `tier=Core` and appropriate `capabilities`, made module/sample words `Tier::Standard`, and user `DEF` words `Tier::Contrib`. 
- Created three new standard modules and registered words: `TIME` (`TIME@NOW|DATETIME|TIMESTAMP`), `CRYPTO` (`CRYPTO@CSPRNG|HASH`), and `ALGO` (`ALGO@SORT`), and removed those names from `BUILTIN_SPECS`. 
- Added a `deprecated_core_aliases` table and fallback in execution so legacy short names emit deprecation warnings and delegate to the qualified module words; updated purity lookup and quantized-block fallback detection to account for moved names. 
- Updated module word metadata types, sample-word construction, quantized/compiled-plan helpers, and multiple registration sites to initialize the new fields. 
- Added tests `rust/src/interpreter/dictionary-tier-tests.rs` which cover tier/stability/capabilities, deprecated-alias behavior, and capability bit operations.

### Testing
- Ran the Rust test suite with `cargo test -q` and all tests passed (`618 passed; 0 failed`).
- Ran targeted tests `cargo test -q dictionary_tier_tests` and `cargo test -q module_registry_tests` and they passed.
- Built the library with `cargo build --release` which completed successfully.
- Frontend checks and build succeeded with `npm run check` and `npm run build:web`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaa5072a0832696b9c3728094243c)