### PR TITLE
Add MC/DC test suites for core arithmetic, tokenizer, and WASM

### DIFF
--- a/.github/ISSUE_TEMPLATE/quality_issue.yml
+++ b/.github/ISSUE_TEMPLATE/quality_issue.yml
@@ -1,5 +1,5 @@
 name: Quality issue
-about: Track verification gaps, process deviations, or quality defects.
+description: Track verification gaps, process deviations, or quality defects.
 title: "[QUALITY] "
 labels: [quality]
 body:

--- a/docs/quality/TRACEABILITY_MATRIX.md
+++ b/docs/quality/TRACEABILITY_MATRIX.md
@@ -2,8 +2,19 @@
 
 | Requirement ID | Objective | Implementation Reference | Verification Reference |
 |---|---|---|---|
-| AQ-REQ-001 | Core arithmetic remains exact and deterministic. | `rust/src/types/fraction.rs`, `rust/src/types/fraction-arithmetic.rs` | `cargo test --all-targets --verbose` |
+| AQ-REQ-001 | Core arithmetic remains exact and deterministic. | `rust/src/types/fraction.rs`, `rust/src/types/fraction-arithmetic.rs` | `cargo test --all-targets --verbose`; AQ-VER-001-A through AQ-VER-001-F |
 | AQ-REQ-002 | Parsing/tokenization behavior is stable across regressions. | `rust/src/tokenizer.rs` | `rust/src/tokenizer-regression-tests.rs`, `rust/src/tokenizer-regression-tests-2.rs` |
 | AQ-REQ-003 | WASM target build integrity is preserved. | `rust/src/wasm-interpreter-bindings.rs` | CI rust wasm check in `.github/workflows/test.yml` |
 | AQ-REQ-004 | TypeScript runtime typing remains sound. | `js/` runtime modules | `npm run check` |
 | AQ-REQ-005 | Quality gates block merges on formatting/lint/test failures. | `.github/workflows/test.yml` | CI quality gate job |
+
+## Verification Index
+
+| Verification ID | Requirement | Decision Under Test | Test Location |
+|---|---|---|---|
+| AQ-VER-001-A | AQ-REQ-001 | `Fraction::eq` NIL guard (`is_nil() \|\| is_nil()` and `is_nil() && is_nil()`) | `rust/src/types/fraction-mcdc-tests.rs::nil_equality_guard` |
+| AQ-VER-001-B | AQ-REQ-001 | `Fraction::cmp` Small fast-path same-denominator branch | `rust/src/types/fraction-mcdc-tests.rs::cmp_small_fast_path` |
+| AQ-VER-001-C | AQ-REQ-001 | `Fraction::as_usize` Small arm (`d == 1 && n >= 0`) | `rust/src/types/fraction-mcdc-tests.rs::as_usize_small` |
+| AQ-VER-001-D | AQ-REQ-001 | `Fraction::add` Small fast paths (`b == 1 && d == 1`, `b == d`) | `rust/src/types/fraction-mcdc-tests.rs::add_small_fast_paths` |
+| AQ-VER-001-E | AQ-REQ-001 | `Fraction::floor` (`n < 0 && r != 0`) | `rust/src/types/fraction-mcdc-tests.rs::floor_negative_remainder` |
+| AQ-VER-001-F | AQ-REQ-001 | `Fraction::ceil` (`n > 0 && r != 0`) | `rust/src/types/fraction-mcdc-tests.rs::ceil_positive_remainder` |

--- a/docs/quality/TRACEABILITY_MATRIX.md
+++ b/docs/quality/TRACEABILITY_MATRIX.md
@@ -3,8 +3,8 @@
 | Requirement ID | Objective | Implementation Reference | Verification Reference |
 |---|---|---|---|
 | AQ-REQ-001 | Core arithmetic remains exact and deterministic. | `rust/src/types/fraction.rs`, `rust/src/types/fraction-arithmetic.rs` | `cargo test --all-targets --verbose`; AQ-VER-001-A through AQ-VER-001-F |
-| AQ-REQ-002 | Parsing/tokenization behavior is stable across regressions. | `rust/src/tokenizer.rs` | `rust/src/tokenizer-regression-tests.rs`, `rust/src/tokenizer-regression-tests-2.rs` |
-| AQ-REQ-003 | WASM target build integrity is preserved. | `rust/src/wasm-interpreter-bindings.rs` | CI rust wasm check in `.github/workflows/test.yml` |
+| AQ-REQ-002 | Parsing/tokenization behavior is stable across regressions. | `rust/src/tokenizer.rs` | `rust/src/tokenizer-regression-tests.rs`, `rust/src/tokenizer-regression-tests-2.rs`; AQ-VER-002-A through AQ-VER-002-F |
+| AQ-REQ-003 | WASM target build integrity is preserved. | `rust/src/wasm-interpreter-bindings.rs`, `rust/src/wasm-value-conversion.rs` | CI rust wasm check in `.github/workflows/test.yml`; AQ-VER-003-A, AQ-VER-003-B (native pure-helper coverage) |
 | AQ-REQ-004 | TypeScript runtime typing remains sound. | `js/` runtime modules | `npm run check` |
 | AQ-REQ-005 | Quality gates block merges on formatting/lint/test failures. | `.github/workflows/test.yml` | CI quality gate job |
 
@@ -18,3 +18,22 @@
 | AQ-VER-001-D | AQ-REQ-001 | `Fraction::add` Small fast paths (`b == 1 && d == 1`, `b == d`) | `rust/src/types/fraction-mcdc-tests.rs::add_small_fast_paths` |
 | AQ-VER-001-E | AQ-REQ-001 | `Fraction::floor` (`n < 0 && r != 0`) | `rust/src/types/fraction-mcdc-tests.rs::floor_negative_remainder` |
 | AQ-VER-001-F | AQ-REQ-001 | `Fraction::ceil` (`n > 0 && r != 0`) | `rust/src/types/fraction-mcdc-tests.rs::ceil_positive_remainder` |
+| AQ-VER-002-A | AQ-REQ-002 | `tokenize` `\n` linebreak deduplication (`tokens.last() != Some(LineBreak)`) | `rust/src/tokenizer-mcdc-tests.rs::linebreak_dedup` |
+| AQ-VER-002-B | AQ-REQ-002 | `tokenize` comment `had_token_before` (`!is_empty() && last != LineBreak`) | `rust/src/tokenizer-mcdc-tests.rs::comment_had_token_before` |
+| AQ-VER-002-C | AQ-REQ-002 | `tokenize` comment newline absorption (`!had_token_before && i < len && c == '\n'`) | `rust/src/tokenizer-mcdc-tests.rs::comment_newline_absorption` |
+| AQ-VER-002-D | AQ-REQ-002 | `tokenize` `=` two-char lookahead (`i+1 < len && chars[i+1] == X`) | `rust/src/tokenizer-mcdc-tests.rs::equals_lookahead` |
+| AQ-VER-002-E | AQ-REQ-002 | `is_string_close_delimiter` (`is_whitespace \|\| (is_special && != '\'')`) | `rust/src/tokenizer-mcdc-tests.rs::string_close_delimiter` |
+| AQ-VER-002-F | AQ-REQ-002 | `parse_number_from_string` sign preamble (length-1 and non-digit guards) | `rust/src/tokenizer-mcdc-tests.rs::number_sign_guards` |
+| AQ-VER-003-A | AQ-REQ-003 | `resolve_effective_hint` external/arena precedence | `rust/src/wasm-value-conversion.rs::mcdc_tests::aq_ver_003_a_resolve_effective_hint` |
+| AQ-VER-003-B | AQ-REQ-003 | `build_bracket_structure_from_shape` empty/single/multi-dim | `rust/src/wasm-value-conversion.rs::mcdc_tests::aq_ver_003_b_bracket_structure` |
+
+## Coverage Notes
+
+- AQ-REQ-003: the JsValue-bridging entry points (`js_value_to_value`,
+  `arena_node_to_js`, `extract_display_hint_from_js`) are not directly
+  unit-testable on the native target because they exercise
+  `wasm_bindgen` runtime glue. They are verified by the
+  `cargo check --target wasm32-unknown-unknown` step in
+  `.github/workflows/test.yml` and by downstream WASM smoke runs.
+  Native MC/DC coverage targets the pure helpers reachable on both
+  targets.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,6 +18,10 @@ mod tokenizer_regression_tests;
 mod tokenizer_regression_tests_2;
 
 #[cfg(test)]
+#[path = "tokenizer-mcdc-tests.rs"]
+mod tokenizer_mcdc_tests;
+
+#[cfg(test)]
 #[path = "arithmetic-operation-tests.rs"]
 mod arithmetic_operation_tests;
 

--- a/rust/src/tokenizer-mcdc-tests.rs
+++ b/rust/src/tokenizer-mcdc-tests.rs
@@ -1,0 +1,383 @@
+// AQ-VER-002: tokenizer MC/DC tests for QL-B boolean decisions.
+//
+// Scope: `crate::tokenizer::tokenize` — boolean decisions whose
+// independent atomic conditions can each cause an incorrect token
+// stream (token-count drift, wrong token kind, mis-classified
+// linebreak/comment behavior, etc.).
+//
+// Tests are black-box through `tokenize()` because the helpers
+// (`is_string_close_delimiter`, `parse_number_from_string`, ...) are
+// crate-private. For each decision we document the DUT, atomic
+// conditions, and the rows of the MC/DC truth table that demonstrate
+// each condition independently flipping the outcome.
+//
+// Trace: docs/quality/TRACEABILITY_MATRIX.md, requirement AQ-REQ-002.
+
+#![cfg(test)]
+
+use crate::tokenizer::tokenize;
+use crate::types::Token;
+
+fn sym(s: &str) -> Token {
+    Token::Symbol(s.into())
+}
+
+fn num(s: &str) -> Token {
+    Token::Number(s.into())
+}
+
+fn string_tok(s: &str) -> Token {
+    Token::String(s.into())
+}
+
+// AQ-VER-002-A
+// DUT: rust/src/tokenizer.rs:13 inside the '\n' whitespace branch
+//
+//     if tokens.last() != Some(&Token::LineBreak) { tokens.push(LineBreak); }
+//
+// One atomic condition C = (tokens.last() != Some(&LineBreak)).
+//   row 1: C = T -> emit LineBreak
+//   row 2: C = F -> suppress LineBreak (dedup)
+//
+// To observe row 2 we must place two consecutive newlines so the second
+// `\n` sees a LineBreak as the most recent token. The trailing-LineBreak
+// pop at the end of `tokenize` does not affect inter-token positions, so
+// observing the *count* of LineBreak tokens between two Symbols proves
+// dedup behavior.
+mod linebreak_dedup {
+    use super::*;
+
+    #[test]
+    fn aq_ver_002_a_row1_single_newline_emits_linebreak() {
+        let tokens = tokenize("a\nb").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::LineBreak, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_a_row2_consecutive_newlines_dedupe() {
+        // Three '\n' between a and b must collapse to a single LineBreak
+        // token thanks to the C = F path.
+        let tokens = tokenize("a\n\n\nb").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::LineBreak, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_a_trailing_linebreak_is_popped() {
+        // Documents the post-loop cleanup that complements the dedup rule.
+        let tokens = tokenize("a\n").unwrap();
+        assert_eq!(tokens, vec![sym("a")]);
+    }
+}
+
+// AQ-VER-002-B
+// DUT: rust/src/tokenizer.rs:23 inside the '#' comment branch
+//
+//     let had_token_before =
+//         !tokens.is_empty() && tokens.last() != Some(&Token::LineBreak);
+//
+// Conditions:
+//   A = !tokens.is_empty()
+//   B = tokens.last() != Some(&LineBreak)
+//
+// Reachable rows (note: A=F implies last()==None, which is != Some(LB),
+// so B is forced T whenever A is F):
+//   row 1: (A=T, B=T) -> had_token = true  (real preceding token)
+//   row 2: (A=T, B=F) -> had_token = false (only a LineBreak preceding)
+//   row 3: (A=F, B=T) -> had_token = false (empty stream)
+//
+// MC/DC pairs:
+//   (1,2) holds A=T and flips B -> proves B's independent effect.
+//   (1,3) holds B=T and flips A -> proves A's independent effect.
+//
+// `had_token_before` is observable indirectly via the AQ-VER-002-C
+// decision (newline absorption). Here we verify the three reachable
+// rows by checking the resulting token stream shape.
+mod comment_had_token_before {
+    use super::*;
+
+    #[test]
+    fn aq_ver_002_b_row1_preceding_real_token_keeps_linebreak() {
+        // (A=T, B=T): "a # c\nb" — preceding 'a' is a non-LineBreak token,
+        // so had_token=true and the comment's trailing newline is NOT
+        // absorbed; a LineBreak appears between 'a' and 'b'.
+        let tokens = tokenize("a # c\nb").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::LineBreak, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_b_row2_preceding_linebreak_absorbs_newline() {
+        // (A=T, B=F): "a\n# c\nb" — last token before the comment is the
+        // LineBreak emitted by the first '\n', so had_token=false. The
+        // comment line absorbs its trailing newline, leaving a single
+        // LineBreak between 'a' and 'b'.
+        let tokens = tokenize("a\n# c\nb").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::LineBreak, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_b_row3_empty_stream_absorbs_newline() {
+        // (A=F, B=T trivially): "# c\nb" — empty before the comment. The
+        // comment swallows its newline, so the result starts directly
+        // with 'b' (no leading LineBreak).
+        let tokens = tokenize("# c\nb").unwrap();
+        assert_eq!(tokens, vec![sym("b")]);
+    }
+}
+
+// AQ-VER-002-C
+// DUT: rust/src/tokenizer.rs:29 inside the '#' comment branch
+//
+//     if !had_token_before && i < chars.len() && chars[i] == '\n' {
+//         i += 1;
+//     }
+//
+// Conditions:
+//   C = !had_token_before
+//   D = i < chars.len()
+//   E = chars[i] == '\n'
+//
+// Reachability constraint: the inner `while i < chars.len() && chars[i]
+// != '\n'` exits only when D = F (EOF) or chars[i] == '\n' (E = T given
+// D = T). Hence E cannot be F when D is T — the (C, D=T, E=F) rows are
+// structurally unreachable. This is documented but not asserted.
+//
+// Reachable rows:
+//   row 1: (C=T, D=T, E=T) -> consume newline (no LineBreak inserted)
+//   row 2: (C=F, D=T, E=T) -> leave newline (LineBreak will be emitted)
+//   row 3: (C=T, D=F, _ )  -> nothing to consume (EOF)
+//   row 4: (C=F, D=F, _ )  -> nothing to consume (EOF)
+//
+// MC/DC pairs:
+//   (1,2) holds D=T,E=T and flips C -> proves C's independent effect.
+//   (1,3) holds C=T,E=*  and flips D -> proves D's independent effect.
+//   E is short-circuit-masked by D and cannot be exercised independently.
+mod comment_newline_absorption {
+    use super::*;
+
+    #[test]
+    fn aq_ver_002_c_row1_lone_comment_absorbs_trailing_newline() {
+        // (C=T, D=T, E=T): see AQ-VER-002-B row 3 for the full chain.
+        let tokens = tokenize("# c\nb").unwrap();
+        assert_eq!(tokens, vec![sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_c_row2_inline_comment_keeps_trailing_newline() {
+        // (C=F, D=T, E=T): preceding token forces had_token=true so the
+        // newline is not absorbed and surfaces as a LineBreak token.
+        let tokens = tokenize("a # c\nb").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::LineBreak, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_c_row3_lone_comment_at_eof_no_absorption() {
+        // (C=T, D=F): comment runs to EOF, nothing to absorb.
+        let tokens = tokenize("# c").unwrap();
+        assert_eq!(tokens, Vec::<Token>::new());
+    }
+
+    #[test]
+    fn aq_ver_002_c_row4_inline_comment_at_eof_no_absorption() {
+        // (C=F, D=F): same EOF condition, but with preceding token.
+        let tokens = tokenize("a # c").unwrap();
+        assert_eq!(tokens, vec![sym("a")]);
+    }
+}
+
+// AQ-VER-002-D
+// DUT: rust/src/tokenizer.rs:50, 56 inside the '=' branch
+//
+//     if i + 1 < chars.len() && chars[i + 1] == '=' { Pipeline; }
+//     if i + 1 < chars.len() && chars[i + 1] == '>' { NilCoalesce; }
+//
+// Per multi-char operator we have two short-circuit conditions:
+//   A = (i + 1 < chars.len())
+//   B = (chars[i + 1] == X)  for X in {'=','>'}
+//
+// MC/DC for `A && B` per operator:
+//   (T,T) -> match
+//   (T,F) -> no match (B's independent effect, A held T)
+//   (F,_) -> no match (A's independent effect, B masked)
+//
+// We cover both `==` -> Pipeline and `=>` -> NilCoalesce, plus the
+// fall-through to bare `=` Symbol when neither lookahead succeeds.
+mod equals_lookahead {
+    use super::*;
+
+    #[test]
+    fn aq_ver_002_d_pipeline_match_when_both_conditions_true() {
+        // (A=T, B=T) for the '==' branch.
+        let tokens = tokenize("a == b").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::Pipeline, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_d_nilcoalesce_match_when_both_conditions_true() {
+        // (A=T, B=T) for the '=>' branch.
+        let tokens = tokenize("a => b").unwrap();
+        assert_eq!(tokens, vec![sym("a"), Token::NilCoalesce, sym("b")]);
+    }
+
+    #[test]
+    fn aq_ver_002_d_falls_through_when_lookahead_char_mismatches() {
+        // (A=T, B=F) for both lookaheads: '=' followed by space. The two
+        // checks both see B=F (chars[i+1] is not '=' nor '>'), so we fall
+        // through to the bare '=' Symbol.
+        let tokens = tokenize("= a").unwrap();
+        assert_eq!(tokens, vec![sym("="), sym("a")]);
+    }
+
+    #[test]
+    fn aq_ver_002_d_falls_through_when_at_eof() {
+        // (A=F): bare '=' at end of input. Both lookahead conditions fail
+        // on A's short-circuit, so we emit the bare Symbol.
+        let tokens = tokenize("=").unwrap();
+        assert_eq!(tokens, vec![sym("=")]);
+    }
+}
+
+// AQ-VER-002-E
+// DUT: rust/src/tokenizer.rs:410 in `is_string_close_delimiter`
+//
+//     fn is_string_close_delimiter(c: char) -> bool {
+//         c.is_whitespace() || (is_special_char(c) && c != '\'')
+//     }
+//
+// Conditions:
+//   A = c.is_whitespace()
+//   B = is_special_char(c)
+//   C = c != '\''
+//
+// MC/DC pairs (see analysis below):
+//   row 1 (T, F, T): whitespace -> close. Together with row 4 proves A.
+//   row 2 (F, T, T): special non-quote -> close. Together with row 3
+//                     proves C, together with row 4 proves B.
+//   row 3 (F, T, F): a literal quote in lookahead position -> not close
+//                     (treated as escaped quote, pushed as literal).
+//   row 4 (F, F, T): regular alpha char -> not close, parser keeps
+//                     scanning until it hits an actual close or EOF.
+//
+// Observed via `tokenize()` of `'foo'<X>` strings.
+mod string_close_delimiter {
+    use super::*;
+
+    #[test]
+    fn aq_ver_002_e_row1_whitespace_after_quote_closes_string() {
+        // (A=T, B=F, C=T)
+        let tokens = tokenize("'foo' BAR").unwrap();
+        assert_eq!(tokens, vec![string_tok("foo"), sym("BAR")]);
+    }
+
+    #[test]
+    fn aq_ver_002_e_row2_special_nonquote_after_quote_closes_string() {
+        // (A=F, B=T, C=T): `[` is a special char and not a quote.
+        let tokens = tokenize("'foo'[1]").unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                string_tok("foo"),
+                Token::VectorStart,
+                num("1"),
+                Token::VectorEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn aq_ver_002_e_row3_quote_after_quote_is_literal() {
+        // (A=F, B=T, C=F): when a `'` is followed by another `'`, the
+        // close-delimiter check returns false (special, but C=F), so the
+        // current quote is pushed as a literal and the scan continues.
+        // The next `'` likewise sees a non-close delimiter ahead ('b')
+        // and is pushed too, so the resulting string contains BOTH
+        // literal quotes — there is no escape collapsing.
+        let tokens = tokenize("'foo''bar' END").unwrap();
+        assert_eq!(tokens, vec![string_tok("foo''bar"), sym("END")]);
+    }
+
+    #[test]
+    fn aq_ver_002_e_row4_regular_alpha_after_quote_does_not_close() {
+        // (A=F, B=F, C=T): alphabetic char is neither whitespace nor
+        // special. The parser treats the quote as a literal and keeps
+        // scanning for a real close; with no close available it surfaces
+        // as an Unclosed-literal error.
+        let err = tokenize("'foo'bar").unwrap_err();
+        assert!(
+            err.contains("Unclosed literal"),
+            "expected Unclosed literal error, got: {err}",
+        );
+    }
+}
+
+// AQ-VER-002-F
+// DUT: rust/src/tokenizer.rs:464-474 in `parse_number_from_string`
+//
+//     if chars[i] == '-' || chars[i] == '+' {
+//         if chars.len() == 1 { return None; }
+//         if !chars[i + 1].is_ascii_digit() { return None; }
+//         i += 1;
+//     }
+//
+// We treat the sign-handling preamble as three sequential decisions:
+//   D-F1: SIGN  = (chars[i] == '-' || chars[i] == '+')
+//   D-F2: SOLE  = (chars.len() == 1)               -- only when SIGN=T
+//   D-F3: NDIG  = !chars[i + 1].is_ascii_digit()   -- only when SOLE=F
+//
+// Reachable rows for the combined decision:
+//   row 1: SIGN=F                  -> proceed to digit scan (e.g. "5")
+//   row 2: SIGN=T, SOLE=T          -> not a number (e.g. "-")
+//   row 3: SIGN=T, SOLE=F, NDIG=T  -> not a number (e.g. "-x")
+//   row 4: SIGN=T, SOLE=F, NDIG=F  -> proceed to digit scan (e.g. "-5")
+//
+// Each row is observable via the kind of `Token` produced by
+// `tokenize()`: Number for rows 1/4, Symbol for rows 2/3.
+//
+// MC/DC pairs:
+//   (1,4) holds the digit scan path constant and flips SIGN's effect on
+//         entry into the sign branch.
+//   (2,3) holds SIGN=T and flips SOLE while keeping the path leading to
+//         a None outcome (still Symbol, but exercises a different
+//         internal exit).
+//   (3,4) holds SIGN=T,SOLE=F and flips NDIG -> proves NDIG.
+mod number_sign_guards {
+    use super::*;
+
+    #[test]
+    fn aq_ver_002_f_row1_unsigned_digit_is_number() {
+        let tokens = tokenize("5").unwrap();
+        assert_eq!(tokens, vec![num("5")]);
+    }
+
+    #[test]
+    fn aq_ver_002_f_row2_lone_minus_is_symbol() {
+        let tokens = tokenize("-").unwrap();
+        assert_eq!(tokens, vec![sym("-")]);
+    }
+
+    #[test]
+    fn aq_ver_002_f_row2_lone_plus_is_symbol() {
+        let tokens = tokenize("+").unwrap();
+        assert_eq!(tokens, vec![sym("+")]);
+    }
+
+    #[test]
+    fn aq_ver_002_f_row3_sign_then_nondigit_is_symbol() {
+        // "-x" forms a single token because '-' and 'x' are neither
+        // whitespace nor special. parse_number rejects it, leaving the
+        // raw symbol "-x".
+        let tokens = tokenize("-x").unwrap();
+        assert_eq!(tokens, vec![sym("-x")]);
+    }
+
+    #[test]
+    fn aq_ver_002_f_row4_sign_then_digit_is_negative_number() {
+        let tokens = tokenize("-5").unwrap();
+        assert_eq!(tokens, vec![num("-5")]);
+    }
+
+    #[test]
+    fn aq_ver_002_f_row4_sign_then_digit_is_positive_number() {
+        let tokens = tokenize("+5").unwrap();
+        assert_eq!(tokens, vec![num("+5")]);
+    }
+}

--- a/rust/src/types/fraction-mcdc-tests.rs
+++ b/rust/src/types/fraction-mcdc-tests.rs
@@ -1,0 +1,376 @@
+// AQ-VER-001: Fraction MC/DC tests for QL-A boolean decisions.
+//
+// Scope: numeric core (`Fraction`) — boolean decisions whose
+// independent atomic conditions can each cause an incorrect
+// arithmetic or comparison result if mis-evaluated.
+//
+// Each submodule below documents:
+//   * DUT (decision under test) — file:line and the boolean expression
+//   * Conditions — atomic predicates A, B, ...
+//   * MC/DC table — pairs of rows that demonstrate each condition
+//     independently flipping the outcome
+//
+// Trace: docs/quality/TRACEABILITY_MATRIX.md, requirement AQ-REQ-001.
+
+#![cfg(test)]
+
+use crate::types::fraction::Fraction;
+use num_bigint::BigInt;
+use std::str::FromStr;
+
+fn small(n: i64, d: i64) -> Fraction {
+    Fraction::new(BigInt::from(n), BigInt::from(d))
+}
+
+fn big_int(n: i64) -> Fraction {
+    let big = BigInt::from(i64::MAX) * BigInt::from(2i64) + BigInt::from(n);
+    Fraction::new(big, BigInt::from(1))
+}
+
+// AQ-VER-001-A
+// DUT: rust/src/types/fraction.rs:58-60 in `impl PartialEq for Fraction`
+//
+//     if self.is_nil() || other.is_nil() {
+//         return self.is_nil() && other.is_nil();
+//     }
+//
+// Conditions:
+//   A = self.is_nil()
+//   B = other.is_nil()
+//
+// MC/DC for A||B (entry guard):
+//   row 1: (A=T, B=F) -> guard taken
+//   row 2: (A=F, B=T) -> guard taken
+//   row 3: (A=F, B=F) -> guard skipped
+//   Pair (1,3) shows A independently flips outcome (B held F).
+//   Pair (2,3) shows B independently flips outcome (A held F).
+//
+// MC/DC for A&&B (returned value when guard taken):
+//   row 4: (A=T, B=T) -> true
+//   row 5: (A=T, B=F) -> false
+//   row 6: (A=F, B=T) -> false
+//   Pair (4,5) shows B independently flips outcome (A held T).
+//   Pair (4,6) shows A independently flips outcome (B held T).
+mod nil_equality_guard {
+    use super::*;
+
+    #[test]
+    fn aq_ver_001_a_row1_self_nil_other_nonnil_guard_taken_returns_false() {
+        // (A=T, B=F): guard taken, inner A&&B = false -> not equal.
+        let lhs = Fraction::nil();
+        let rhs = small(1, 1);
+        assert_ne!(lhs, rhs, "nil and non-nil must not be equal");
+    }
+
+    #[test]
+    fn aq_ver_001_a_row2_other_nil_self_nonnil_guard_taken_returns_false() {
+        // (A=F, B=T): guard taken, inner A&&B = false -> not equal.
+        let lhs = small(1, 1);
+        let rhs = Fraction::nil();
+        assert_ne!(lhs, rhs, "non-nil and nil must not be equal");
+    }
+
+    #[test]
+    fn aq_ver_001_a_row3_neither_nil_guard_skipped_compares_repr() {
+        // (A=F, B=F): guard skipped, falls through to repr comparison.
+        let lhs = small(2, 4); // reduces to 1/2
+        let rhs = small(1, 2);
+        assert_eq!(lhs, rhs, "1/2 and 2/4 must compare equal after reduction");
+
+        let unequal = small(1, 3);
+        assert_ne!(lhs, unequal);
+    }
+
+    #[test]
+    fn aq_ver_001_a_row4_both_nil_returns_true() {
+        // (A=T, B=T): inner A&&B = true -> nil equals nil.
+        let lhs = Fraction::nil();
+        let rhs = Fraction::nil();
+        assert_eq!(lhs, rhs, "nil must equal nil");
+    }
+
+    // Rows (T,F) and (F,T) coincide with rows 1 and 2 above for the inner
+    // A&&B decision: in both cases the inner expression yields false, which
+    // is the outcome being verified. No additional cases required.
+}
+
+// AQ-VER-001-B
+// DUT: rust/src/types/fraction.rs:369-376 in `impl Ord for Fraction::cmp`
+//
+//     if let (Some((a, b)), Some((c, d))) = (self.extract_i64_pair(),
+//                                            other.extract_i64_pair()) {
+//         if b == d { return a.cmp(&c); }
+//         ...
+//     }
+//
+// Conditions for the same-denominator branch:
+//   A = self.extract_i64_pair().is_some()
+//   B = other.extract_i64_pair().is_some()
+//   C = b == d
+//
+// We test the three boundary combinations that exercise the if-let pattern
+// (small/small, small/big, big/big) and, within the small/small arm, both
+// values of C.
+mod cmp_small_fast_path {
+    use super::*;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn aq_ver_001_b_small_small_same_denominator_compares_numerators() {
+        // A=T, B=T, C=T: enters fast path, compares a vs c directly.
+        let a = small(3, 7);
+        let b = small(5, 7);
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&a), Ordering::Greater);
+        assert_eq!(a.cmp(&a.clone()), Ordering::Equal);
+    }
+
+    #[test]
+    fn aq_ver_001_b_small_small_different_denominator_cross_multiplies() {
+        // A=T, B=T, C=F: skips a.cmp(&c), takes the i128 cross-multiply path.
+        // 1/3 vs 1/4 -> 4 vs 3 -> Greater.
+        let a = small(1, 3);
+        let b = small(1, 4);
+        assert_eq!(a.cmp(&b), Ordering::Greater);
+    }
+
+    #[test]
+    fn aq_ver_001_b_big_path_when_extraction_fails() {
+        // A=F or B=F: at least one side is BigInt, falls through to BigInt
+        // arithmetic. The same-denominator BigInt branch must also work.
+        let a = big_int(0); // 2*i64::MAX, denominator 1
+        let b = big_int(1); // 2*i64::MAX + 1, denominator 1
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&a), Ordering::Greater);
+
+        // Different-denominator BigInt path.
+        let c = Fraction::new(BigInt::from(1), BigInt::from(i64::MAX) * BigInt::from(2));
+        let d = Fraction::new(BigInt::from(1), BigInt::from(i64::MAX) * BigInt::from(3));
+        assert_eq!(c.cmp(&d), Ordering::Greater);
+    }
+}
+
+// AQ-VER-001-C
+// DUT: rust/src/types/fraction.rs:232 in `Fraction::as_usize` (Small arm)
+//
+//     if *d == 1 && *n >= 0 { Some(*n as usize) } else { None }
+//
+// Conditions:
+//   A = (d == 1)
+//   B = (n >= 0)
+//
+// MC/DC table:
+//   row 1: (T, T) -> Some
+//   row 2: (T, F) -> None  (proves B flips outcome with A held T)
+//   row 3: (F, T) -> None  (proves A flips outcome with B held T)
+//   row 4: (F, F) -> None  (boundary; not required for MC/DC but documented)
+//
+// Note on reachability: a normalized Small fraction with d != 1 always has
+// gcd(n, d) = 1, so non-integer values (rows 3, 4) are constructible via
+// Fraction::new and remain in Small form when both numerator and denominator
+// fit in i64.
+mod as_usize_small {
+    use super::*;
+
+    #[test]
+    fn aq_ver_001_c_row1_integer_nonneg_returns_some() {
+        let f = small(42, 1);
+        assert_eq!(f.as_usize(), Some(42));
+    }
+
+    #[test]
+    fn aq_ver_001_c_row2_integer_negative_returns_none() {
+        let f = small(-1, 1);
+        assert_eq!(f.as_usize(), None, "negative integer must not coerce to usize");
+    }
+
+    #[test]
+    fn aq_ver_001_c_row3_nonintegral_positive_returns_none() {
+        let f = small(3, 4);
+        assert_eq!(f.as_usize(), None, "non-integer fraction must not coerce");
+    }
+
+    #[test]
+    fn aq_ver_001_c_row4_nonintegral_negative_returns_none() {
+        let f = small(-3, 4);
+        assert_eq!(f.as_usize(), None);
+    }
+}
+
+// AQ-VER-001-D
+// DUT: rust/src/types/fraction-arithmetic.rs:54-58 in `Fraction::add`
+//
+//     if b == 1 && d == 1 {
+//         return Self::create_from_i128((a as i128) + (c as i128), 1);
+//     }
+//     if b == d {
+//         return Self::create_from_i128((a as i128) + (c as i128), b as i128);
+//     }
+//
+// Decision 1 conditions (integer fast path):
+//   A = (b == 1)
+//   B = (d == 1)
+//
+// MC/DC table for A&&B:
+//   row 1: (T, T) -> integer fast path
+//   row 2: (T, F) -> falls through (B flips outcome with A held T)
+//   row 3: (F, T) -> falls through (A flips outcome with B held T)
+//
+// Decision 2 conditions (same-denominator fast path):
+//   C = (b == d)  reached when not (A && B)
+//   row 4: C = T  -> common-denominator fast path
+//   row 5: C = F  -> generic cross-multiply path
+mod add_small_fast_paths {
+    use super::*;
+
+    #[test]
+    fn aq_ver_001_d_decision1_row1_both_integer() {
+        // (A=T, B=T): integer + integer fast path.
+        let a = small(7, 1);
+        let b = small(11, 1);
+        let sum = a.add(&b);
+        assert_eq!(sum, small(18, 1));
+    }
+
+    #[test]
+    fn aq_ver_001_d_decision1_row2_self_integer_other_fraction() {
+        // (A=T, B=F): self denominator 1, other not -> falls through to
+        // Decision 2; b=1, d=3 -> b != d -> generic path. 7 + 1/3 = 22/3.
+        let a = small(7, 1);
+        let b = small(1, 3);
+        let sum = a.add(&b);
+        assert_eq!(sum, small(22, 3));
+    }
+
+    #[test]
+    fn aq_ver_001_d_decision1_row3_self_fraction_other_integer() {
+        // (A=F, B=T): symmetric to row 2. 1/3 + 7 = 22/3.
+        let a = small(1, 3);
+        let b = small(7, 1);
+        let sum = a.add(&b);
+        assert_eq!(sum, small(22, 3));
+    }
+
+    #[test]
+    fn aq_ver_001_d_decision2_row4_same_denominator_nonunit() {
+        // (A=F, B=F, C=T): both have denominator 5 -> common-den fast path.
+        let a = small(2, 5);
+        let b = small(1, 5);
+        let sum = a.add(&b);
+        assert_eq!(sum, small(3, 5));
+    }
+
+    #[test]
+    fn aq_ver_001_d_decision2_row5_different_denominator() {
+        // (A=F, B=F, C=F): generic cross-multiply path.
+        // 1/3 + 1/4 = 7/12.
+        let a = small(1, 3);
+        let b = small(1, 4);
+        let sum = a.add(&b);
+        assert_eq!(sum, small(7, 12));
+    }
+
+    #[test]
+    fn aq_ver_001_d_nil_short_circuit_takes_precedence() {
+        // Documented invariant: nil propagates regardless of which side.
+        // Outside the decisions above but covers the entry guard.
+        let nil = Fraction::nil();
+        let one = small(1, 1);
+        assert!(nil.add(&one).is_nil());
+        assert!(one.add(&nil).is_nil());
+    }
+}
+
+// AQ-VER-001-E
+// DUT: rust/src/types/fraction-arithmetic.rs:268 in `Fraction::floor` (Small)
+//
+//     let floored = if *n < 0 && r != 0 { q - 1 } else { q };
+//
+// Conditions:
+//   A = (n < 0)
+//   B = (r != 0)
+//
+// Reachability note: this code runs only after `is_integer()` returns false,
+// so when `repr` is `Small` we have d > 1. Because `Fraction::new` reduces by
+// gcd, any Small with d > 1 satisfies gcd(n, d) = 1, hence n % d != 0. So in
+// normal use B = T always, and rows (T,F)/(F,F) are unreachable. We still
+// exercise both A values to demonstrate independent effect of A, and we
+// exercise the early-return path for integers as a separate row.
+mod floor_negative_remainder {
+    use super::*;
+
+    #[test]
+    fn aq_ver_001_e_row1_negative_with_remainder_rounds_toward_neg_inf() {
+        // (A=T, B=T): -7/3 -> q=-2, r=-1, floored = -3.
+        let f = small(-7, 3);
+        assert_eq!(f.floor(), small(-3, 1));
+    }
+
+    #[test]
+    fn aq_ver_001_e_row2_positive_with_remainder_truncates() {
+        // (A=F, B=T): 7/3 -> q=2, r=1, floored = 2 (else branch).
+        // Pair (row1, row2) holds B=T and flips A, demonstrating A's
+        // independent effect on the outcome.
+        let f = small(7, 3);
+        assert_eq!(f.floor(), small(2, 1));
+    }
+
+    #[test]
+    fn aq_ver_001_e_integer_short_circuits_before_decision() {
+        // is_integer() short-circuit returns self before the decision is
+        // evaluated. Documents the only realistic way to reach B = F.
+        let f = small(-6, 1);
+        assert_eq!(f.floor(), small(-6, 1));
+    }
+
+    #[test]
+    fn aq_ver_001_e_big_path_negative_with_remainder() {
+        // BigInt twin of row 1 to cover the parallel decision in the Big arm.
+        // -18446744073709551616 (= -(2*i64::MAX + 2)) does not fit i64 so the
+        // value stays in the Big representation. Divided by 3 it has trunc
+        // quotient -6148914691236517205 with remainder -1, so floor = q - 1.
+        let big_neg = BigInt::from_str("-18446744073709551616").unwrap();
+        let f = Fraction::new(big_neg, BigInt::from(3));
+        let expected = Fraction::new(
+            BigInt::from_str("-6148914691236517206").unwrap(),
+            BigInt::from(1),
+        );
+        assert_eq!(f.floor(), expected);
+    }
+}
+
+// AQ-VER-001-F
+// DUT: rust/src/types/fraction-arithmetic.rs:293 in `Fraction::ceil` (Small)
+//
+//     let ceiled = if *n > 0 && r != 0 { q + 1 } else { q };
+//
+// Conditions:
+//   A = (n > 0)
+//   B = (r != 0)
+//
+// Same reachability caveat as AQ-VER-001-E.
+mod ceil_positive_remainder {
+    use super::*;
+
+    #[test]
+    fn aq_ver_001_f_row1_positive_with_remainder_rounds_toward_pos_inf() {
+        // (A=T, B=T): 7/3 -> q=2, r=1, ceiled = 3.
+        let f = small(7, 3);
+        assert_eq!(f.ceil(), small(3, 1));
+    }
+
+    #[test]
+    fn aq_ver_001_f_row2_negative_with_remainder_truncates() {
+        // (A=F, B=T): -7/3 -> q=-2, r=-1, ceiled = -2 (else branch).
+        // Pair (row1, row2) flips A with B held T -> independent effect of A.
+        let f = small(-7, 3);
+        assert_eq!(f.ceil(), small(-2, 1));
+    }
+
+    #[test]
+    fn aq_ver_001_f_zero_short_circuits_via_is_integer() {
+        // Zero is is_integer() == true (d == 1 after reduction), short-circuits.
+        let f = small(0, 5);
+        assert_eq!(f.ceil(), small(0, 1));
+    }
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -5,6 +5,9 @@ pub mod flow_token;
 pub mod fraction;
 #[path = "fraction-arithmetic.rs"]
 mod fraction_arithmetic;
+#[cfg(test)]
+#[path = "fraction-mcdc-tests.rs"]
+mod fraction_mcdc_tests;
 pub mod interval;
 #[path = "value-operations.rs"]
 mod value_operations;

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -349,3 +349,118 @@ mod test_input_helper {
         );
     }
 }
+
+// AQ-VER-003: WASM boundary MC/DC tests for QL-B pure helpers.
+//
+// Scope: the JS-bridge conversion layer is reachable natively only for
+// its pure helpers (`resolve_effective_hint`,
+// `build_bracket_structure_from_shape`). JsValue-based entry points
+// (`js_value_to_value`, `arena_node_to_js`, `extract_display_hint_from_js`)
+// exercise `wasm_bindgen` runtime glue and are verified by the
+// `cargo check --target wasm32-unknown-unknown` step in
+// `.github/workflows/test.yml` (AQ-REQ-003). They are intentionally not
+// asserted here.
+//
+// Trace: docs/quality/TRACEABILITY_MATRIX.md, requirement AQ-REQ-003.
+#[cfg(test)]
+mod mcdc_tests {
+    use super::{build_bracket_structure_from_shape, resolve_effective_hint};
+    use crate::types::arena::ValueArena;
+    use crate::types::DisplayHint;
+
+    // AQ-VER-003-A
+    // DUT: `resolve_effective_hint`
+    //     external_hint_opt.unwrap_or_else(|| arena.hint(root_id))
+    //
+    // One atomic condition C = external_hint_opt.is_some().
+    //   row 1: C=T -> return external value verbatim
+    //   row 2: C=F -> fall back to arena hint
+    //
+    // Additional row 3 pins that C=T ignores the arena hint even when
+    // the external value disagrees — this matters because a caller
+    // passing an explicit hint must win over arena state.
+    mod aq_ver_003_a_resolve_effective_hint {
+        use super::*;
+
+        #[test]
+        fn row1_some_external_is_returned_verbatim() {
+            let mut arena = ValueArena::new();
+            let id = arena.alloc_nil(DisplayHint::Number);
+            assert_eq!(
+                resolve_effective_hint(&arena, id, Some(DisplayHint::Boolean)),
+                DisplayHint::Boolean,
+            );
+        }
+
+        #[test]
+        fn row2_none_falls_back_to_arena_hint() {
+            let mut arena = ValueArena::new();
+            let id = arena.alloc_nil(DisplayHint::DateTime);
+            assert_eq!(
+                resolve_effective_hint(&arena, id, None),
+                DisplayHint::DateTime,
+            );
+        }
+
+        #[test]
+        fn external_hint_wins_even_when_arena_disagrees() {
+            // Guards against a regression where the fallback arm is
+            // evaluated eagerly and overwrites the external value.
+            let mut arena = ValueArena::new();
+            let id = arena.alloc_nil(DisplayHint::Number);
+            assert_eq!(
+                resolve_effective_hint(&arena, id, Some(DisplayHint::String)),
+                DisplayHint::String,
+            );
+        }
+    }
+
+    // AQ-VER-003-B
+    // DUT: `build_bracket_structure_from_shape`
+    //
+    // Outer decision: `if shape.is_empty()` — one atomic condition.
+    //   row 1: empty shape -> literal "[ ]"
+    //   row 2: non-empty shape -> recurse
+    //
+    // Inner decision (in `build_level`): `if shape.len() == 1`.
+    //   row 3: tail dimension -> emit `[ ]` repeated `shape[0]` times
+    //   row 4: non-tail dimension -> wrap the inner level
+    //
+    // The existing `test_build_bracket_structure_from_shape` covers
+    // several combinations in row 3/4 already. This module adds the
+    // outer-empty boundary (row 1), which was previously untested, and
+    // asserts the leaf-count invariant to make the MC/DC intent explicit.
+    mod aq_ver_003_b_bracket_structure {
+        use super::*;
+
+        #[test]
+        fn row1_empty_shape_returns_single_pair() {
+            assert_eq!(build_bracket_structure_from_shape(&[]), "[ ]");
+        }
+
+        #[test]
+        fn row2_single_dim_emits_n_leaves() {
+            // Complements row 1 by flipping `shape.is_empty()`.
+            let out = build_bracket_structure_from_shape(&[4]);
+            assert_eq!(out, "[ ] [ ] [ ] [ ]");
+            assert_eq!(
+                out.matches("[ ]").count(),
+                4,
+                "leaf count must equal shape[0] on the tail dimension"
+            );
+        }
+
+        #[test]
+        fn row3_row4_multi_dim_wraps_inner_levels() {
+            // Non-tail dimension wraps tail output in brackets.
+            // Shape [2, 3]: 2 outer frames, each containing 3 leaves.
+            let out = build_bracket_structure_from_shape(&[2, 3]);
+            assert_eq!(out, "[ [ ] [ ] [ ] ] [ [ ] [ ] [ ] ]");
+            assert_eq!(
+                out.matches("[ ]").count(),
+                6,
+                "leaf count must equal the product of non-head dims"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive Modified Condition/Decision Coverage (MC/DC) test suites for three critical subsystems:

1. **Fraction arithmetic** (`AQ-VER-001`): Tests for `Fraction::eq`, `Fraction::cmp`, `Fraction::as_usize`, `Fraction::add`, `Fraction::floor`, and `Fraction::ceil` covering all independent atomic conditions in boolean decisions.

2. **Tokenizer** (`AQ-VER-002`): Tests for linebreak deduplication, comment handling, equals-operator lookahead, string delimiter detection, and number sign parsing—exercising each condition's independent effect on token stream correctness.

3. **WASM value conversion** (`AQ-VER-003`): Tests for pure helper functions `resolve_effective_hint` and `build_bracket_structure_from_shape` covering the native-testable portions of the JS-bridge layer.

Each test module documents the Decision Under Test (DUT), atomic conditions, MC/DC truth table rows, and the specific pairs that demonstrate independent condition flipping. The traceability matrix is updated to link requirements to verification evidence.

## Quality Classification

- Highest impacted level: **QL-A** (core arithmetic) and **QL-B** (tokenizer, WASM helpers)

## Traceability

- Requirements: AQ-REQ-001, AQ-REQ-002, AQ-REQ-003
- Verification evidence:
  - `rust/src/types/fraction-mcdc-tests.rs` — 6 decision modules, 20+ test cases
  - `rust/src/tokenizer-mcdc-tests.rs` — 6 decision modules, 18+ test cases
  - `rust/src/wasm-value-conversion.rs::mcdc_tests` — 2 decision modules, 6 test cases
  - Updated `docs/quality/TRACEABILITY_MATRIX.md` with verification index

## Quality Checklist

- [x] Relevant requirements/objectives are identified (AQ-REQ-001, AQ-REQ-002, AQ-REQ-003).
- [x] Traceability links added to matrix and test module headers.
- [x] `cargo fmt --check` applied to all new test files.
- [x] `cargo clippy --all-targets -- -D warnings` passes.
- [x] `cargo test --all-targets --verbose` passes (all new tests included).
- [x] MC/DC checklist reviewed: each decision's atomic conditions are independently exercised via paired test rows.
- [x] Minor fix: `quality_issue.yml` template field `about` → `description` for GitHub Actions compatibility.

## Notes

- All new tests are black-box through public APIs (`tokenize()`, `Fraction` methods, pure helpers) because internal helpers are crate-private.
- Reachability constraints (e.g., short-circuit masking in tokenizer lookahead) are documented in test comments.
- The WASM JsValue-based entry points remain verified by CI's `cargo check --target wasm32-unknown-unknown` step, as noted in the traceability matrix.

https://claude.ai/code/session_0127n3gKkmsq9yqfmuqtBfAt