### PR TITLE
Simplify Demonstration word panel DOM nesting

### DIFF
--- a/debug-borders.css
+++ b/debug-borders.css
@@ -10,8 +10,8 @@
  *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .dictionary-toolbar 等
  *   Level 4 (緑    #34C759): div祖先 3個  — .right-mode-selector, .vocabulary-container 等
  *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
- *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, .user-dictionary-controls 等
- *   Level 7 (青緑  #00C7BE): div祖先 6個  — .dictionary-sheet-selector (user sheet内)
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, #user-dictionary-select 等
+ *   Level 7 (青緑  #00C7BE): div祖先 6個  — （現状は基本的に未使用）
  *
  * 余白について:
  *   padding: 4px !important を全 div に付与することで、親の padding が子 div を

--- a/index.html
+++ b/index.html
@@ -139,13 +139,11 @@
                     <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
                         <div class="vocabulary-container">
                             <div class="words-area">
-                                <div class="user-dictionary-controls">
-                                    <div class="dictionary-sheet-selector">
-                                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                                        <select id="user-dictionary-select">
-                                            <option value="DEMO">Demonstration word</option>
-                                        </select>
-                                    </div>
+                                <div class="dictionary-sheet-selector">
+                                    <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                                    <select id="user-dictionary-select">
+                                        <option value="DEMO">Demonstration word</option>
+                                    </select>
                                 </div>
                                 <span id="user-word-info" class="word-info-display"></span>
                                 <div id="user-words-display" class="words-display"></div>


### PR DESCRIPTION
### Motivation
- Reduce an unnecessary DOM nesting level in the Demonstration word (user dictionary) panel so the HTML hierarchy is cleaner and easier to inspect when using the debug borders.

### Description
- Removed the redundant `<div class="user-dictionary-controls">` wrapper from `index.html` and placed the `dictionary-sheet-selector` directly under the `.words-area` to remove one layer of divs.
- Updated the explanatory legend comments in `debug-borders.css` to reflect the adjusted DOM depth examples.

### Testing
- Ran `npm run -s build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf24352cc8326879ad661bcfed2da)