### PR TITLE
Simplify user dictionary markup and update debug-borders legend

### DIFF
--- a/debug-borders.css
+++ b/debug-borders.css
@@ -10,8 +10,8 @@
  *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .dictionary-toolbar 等
  *   Level 4 (緑    #34C759): div祖先 3個  — .right-mode-selector, .vocabulary-container 等
  *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
- *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, .user-dictionary-controls 等
- *   Level 7 (青緑  #00C7BE): div祖先 6個  — .dictionary-sheet-selector (user sheet内)
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, #user-words-display 等
+ *   Level 7 (青緑  #00C7BE): div祖先 6個  — （現状は基本的に未使用）
  *
  * 余白について:
  *   padding: 4px !important を全 div に付与することで、親の padding が子 div を

--- a/index.html
+++ b/index.html
@@ -137,19 +137,15 @@
                         <div class="vocabulary-actions"></div>
                     </div>
                     <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <div class="user-dictionary-controls">
-                                    <div class="dictionary-sheet-selector">
-                                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                                        <select id="user-dictionary-select">
-                                            <option value="DEMO">Demonstration word</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <span id="user-word-info" class="word-info-display"></span>
-                                <div id="user-words-display" class="words-display"></div>
+                        <div class="words-area">
+                            <div class="dictionary-sheet-selector">
+                                <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                                <select id="user-dictionary-select">
+                                    <option value="DEMO">Demonstration word</option>
+                                </select>
                             </div>
+                            <span id="user-word-info" class="word-info-display"></span>
+                            <div id="user-words-display" class="words-display"></div>
                         </div>
                         <div class="vocabulary-actions">
                             <button id="export-btn" class="btn-primary" type="button">Export</button>


### PR DESCRIPTION
### Motivation
- Simplify the nested DOM for the user dictionary sheet to make styling and scripting easier and reduce unnecessary wrappers.
- Keep the `debug-borders.css` legend accurate so the visual debug overlay reflects the actual element usage.

### Description
- Remove the `.vocabulary-container` and `.user-dictionary-controls` wrappers inside `#dictionary-sheet-user` and move the `dictionary-sheet-selector` into the `.words-area` for a flatter structure.
- Reposition `#user-word-info` and `#user-words-display` under the `.words-area` to match the simplified layout.
- Update `debug-borders.css` legend entries for Level 6 to reference `#user-words-display` and mark Level 7 as currently unused.

### Testing
- No automated tests were added or changed for this update.
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf24352cc8326879ad661bcfed2da)