### PR TITLE
Refactor dictionary sheet selector markup and CSS; simplify words-area structure

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -550,17 +550,17 @@
 }
 
 
-.words-area .dictionary-sheet-selector {
+.words-area > .dictionary-sheet-select {
     flex: 0 0 auto;
-    padding: 0 0 0.5rem 0;
+    margin: 0 0 0.5rem 0;
 }
 
-.words-area .dictionary-sheet-selector select:focus-visible {
+.dictionary-sheet-select:focus-visible {
     outline-offset: -2px;
     box-shadow: none;
 }
 
-.dictionary-sheet-selector select {
+.dictionary-sheet-select {
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;

--- a/debug-borders.css
+++ b/debug-borders.css
@@ -10,8 +10,8 @@
  *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .dictionary-toolbar 等
  *   Level 4 (緑    #34C759): div祖先 3個  — .right-mode-selector, .vocabulary-container 等
  *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
- *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, .user-dictionary-controls 等
- *   Level 7 (青緑  #00C7BE): div祖先 6個  — .dictionary-sheet-selector (user sheet内)
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, #user-words-display 等
+ *   Level 7 (青緑  #00C7BE): div祖先 6個  — （現状は基本的に未使用）
  *
  * 余白について:
  *   padding: 4px !important を全 div に付与することで、親の padding が子 div を

--- a/index.html
+++ b/index.html
@@ -121,35 +121,27 @@
                     <div class="dictionary-toolbar">
                         <div class="dictionary-sheet-selector">
                             <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
-                            <select id="dictionary-sheet-select">
+                            <select id="dictionary-sheet-select" class="dictionary-sheet-select">
                                 <option value="core">Core word</option>
                                 <option value="user">User word</option>
                             </select>
                         </div>
                     </div>
                     <div id="dictionary-sheet-core" class="dictionary-sheet active">
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <span id="core-word-info" class="word-info-display"></span>
-                                <div id="core-words-display" class="words-display"></div>
-                            </div>
+                        <div class="words-area">
+                            <span id="core-word-info" class="word-info-display"></span>
+                            <div id="core-words-display" class="words-display"></div>
                         </div>
                         <div class="vocabulary-actions"></div>
                     </div>
                     <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <div class="user-dictionary-controls">
-                                    <div class="dictionary-sheet-selector">
-                                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                                        <select id="user-dictionary-select">
-                                            <option value="DEMO">Demonstration word</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <span id="user-word-info" class="word-info-display"></span>
-                                <div id="user-words-display" class="words-display"></div>
-                            </div>
+                        <div class="words-area">
+                            <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                            <select id="user-dictionary-select" class="dictionary-sheet-select">
+                                <option value="DEMO">Demonstration word</option>
+                            </select>
+                            <span id="user-word-info" class="word-info-display"></span>
+                            <div id="user-words-display" class="words-display"></div>
                         </div>
                         <div class="vocabulary-actions">
                             <button id="export-btn" class="btn-primary" type="button">Export</button>


### PR DESCRIPTION
### Motivation
- Simplify the DOM around the dictionary UI and unify the selector styling to make layout and focus behavior more predictable.
- Reduce nesting by removing extra wrapper elements in the `words-area` to improve maintainability and CSS targeting.
- Update debug documentation to reflect current element usage and clarify which levels are in use.

### Description
- Replace and standardize the selector class from `dictionary-sheet-selector` to `dictionary-sheet-select` in markup and styles, and update the focus rule to `:focus-visible` on the new class (`.dictionary-sheet-select`).
- Change the selector rule for sheet selects to target immediate children with `.words-area > .dictionary-sheet-select` and switch the spacing from `padding` to `margin` for that element.
- Simplify the HTML structure by removing intermediate `.vocabulary-container` and `.user-dictionary-controls` wrappers and moving the `select` elements directly into the `.words-area`, adding `class="dictionary-sheet-select"` to the select elements (`#dictionary-sheet-select` and `#user-dictionary-select`).
- Update `debug-borders.css` comments to reflect current component placement and note that one of the deeper levels is presently unused.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf24352cc8326879ad661bcfed2da)