### PR TITLE
Refactor dictionary panel DOM and update CSS selectors/styles

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -550,17 +550,17 @@
 }
 
 
-.words-area .dictionary-sheet-selector {
+.words-area > .dictionary-sheet-select {
     flex: 0 0 auto;
-    padding: 0 0 0.5rem 0;
+    margin: 0 0 0.5rem 0;
 }
 
-.words-area .dictionary-sheet-selector select:focus-visible {
+.dictionary-sheet-select:focus-visible {
     outline-offset: -2px;
     box-shadow: none;
 }
 
-.dictionary-sheet-selector select {
+.dictionary-sheet-select {
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;

--- a/debug-borders.css
+++ b/debug-borders.css
@@ -9,9 +9,9 @@
  *   Level 2 (橙    #FF9500): div祖先 1個  — #editor-panel, #state-panel 等
  *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .dictionary-toolbar 等
  *   Level 4 (緑    #34C759): div祖先 3個  — .right-mode-selector, .vocabulary-container 等
- *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
- *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, .user-dictionary-controls 等
- *   Level 7 (青緑  #00C7BE): div祖先 6個  — .dictionary-sheet-selector (user sheet内)
+ *   Level 5 (青    #007AFF): div祖先 4個  — .words-area, #core-words-display, #user-words-display 等
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — （主に動的module sheetで使用）
+ *   Level 7 (青緑  #00C7BE): div祖先 6個  — （現状は基本的に未使用）
  *
  * 余白について:
  *   padding: 4px !important を全 div に付与することで、親の padding が子 div を

--- a/index.html
+++ b/index.html
@@ -121,36 +121,24 @@
                     <div class="dictionary-toolbar">
                         <div class="dictionary-sheet-selector">
                             <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
-                            <select id="dictionary-sheet-select">
+                            <select id="dictionary-sheet-select" class="dictionary-sheet-select">
                                 <option value="core">Core word</option>
                                 <option value="user">User word</option>
                             </select>
                         </div>
                     </div>
-                    <div id="dictionary-sheet-core" class="dictionary-sheet active">
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <span id="core-word-info" class="word-info-display"></span>
-                                <div id="core-words-display" class="words-display"></div>
-                            </div>
-                        </div>
+                    <div id="dictionary-sheet-core" class="dictionary-sheet words-area active">
+                        <span id="core-word-info" class="word-info-display"></span>
+                        <div id="core-words-display" class="words-display"></div>
                         <div class="vocabulary-actions"></div>
                     </div>
-                    <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <div class="user-dictionary-controls">
-                                    <div class="dictionary-sheet-selector">
-                                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                                        <select id="user-dictionary-select">
-                                            <option value="DEMO">Demonstration word</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <span id="user-word-info" class="word-info-display"></span>
-                                <div id="user-words-display" class="words-display"></div>
-                            </div>
-                        </div>
+                    <div id="dictionary-sheet-user" class="dictionary-sheet words-area" hidden>
+                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                        <select id="user-dictionary-select" class="dictionary-sheet-select">
+                            <option value="DEMO">Demonstration word</option>
+                        </select>
+                        <span id="user-word-info" class="word-info-display"></span>
+                        <div id="user-words-display" class="words-display"></div>
                         <div class="vocabulary-actions">
                             <button id="export-btn" class="btn-primary" type="button">Export</button>
                             <button id="import-btn" class="btn-primary" type="button">Import</button>


### PR DESCRIPTION
### Motivation

- Simplify and normalize the dictionary panel DOM structure to reduce nesting and make the sheet/select controls consistent across core and user dictionaries.
- Rename and adjust CSS selectors to match the new DOM and fix focus/spacing behavior for the dictionary sheet selector.
- Update the debug borders documentation/comments to reflect current element usage and clarify level meanings.

### Description

- Restructured the dictionary area in `index.html` by removing extra wrapper elements, moving `.words-area` into the `.dictionary-sheet` elements, and exposing the sheet controls and displays directly in each sheet for `core` and `user` dictionaries.
- Added `class="dictionary-sheet-select"` to the dictionary `<select>` elements and replaced usages of `.dictionary-sheet-selector` with the new `.dictionary-sheet-select` selector in `app-interface.css`, changing padding to margin for the sheet control and adjusting the `focus-visible` rule.
- Simplified `.dictionary-sheet` markup so that word info, words display, and `.vocabulary-actions` are direct children of each sheet, and left the `Export`/`Import` buttons in the user sheet actions.
- Updated `debug-borders.css` comments to reflect current usage and clarified level descriptions in Japanese.

### Testing

- Ran TypeScript typecheck with `tsc --noEmit` and it completed successfully.
- Built the project with `npm run build` and the build succeeded without errors.
- Ran the test script with `npm test` (if present in the project) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf24352cc8326879ad661bcfed2da)