### PR TITLE
Refactor dictionary sheet markup and CSS selectors; update debug-borders legend

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -545,22 +545,21 @@
 }
 
 
-.dictionary-sheet-selector {
+.dictionary-toolbar > .dictionary-sheet-select {
     flex: 1.618 1 0%;
 }
 
-
-.words-area .dictionary-sheet-selector {
+.words-area > .dictionary-sheet-select {
     flex: 0 0 auto;
-    padding: 0 0 0.5rem 0;
+    margin: 0 0 0.5rem 0;
 }
 
-.words-area .dictionary-sheet-selector select:focus-visible {
+.dictionary-sheet-select:focus-visible {
     outline-offset: -2px;
     box-shadow: none;
 }
 
-.dictionary-sheet-selector select {
+.dictionary-sheet-select {
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;

--- a/debug-borders.css
+++ b/debug-borders.css
@@ -9,9 +9,9 @@
  *   Level 2 (橙    #FF9500): div祖先 1個  — #editor-panel, #state-panel 等
  *   Level 3 (黄    #FFCC00): div祖先 2個  — #output-display, .dictionary-toolbar 等
  *   Level 4 (緑    #34C759): div祖先 3個  — .right-mode-selector, .vocabulary-container 等
- *   Level 5 (青    #007AFF): div祖先 4個  — .words-area
- *   Level 6 (紫    #AF52DE): div祖先 5個  — #core-words-display, .user-dictionary-controls 等
- *   Level 7 (青緑  #00C7BE): div祖先 6個  — .dictionary-sheet-selector (user sheet内)
+ *   Level 5 (青    #007AFF): div祖先 4個  — .words-area, #core-words-display, #user-words-display 等
+ *   Level 6 (紫    #AF52DE): div祖先 5個  — （主に動的module sheetで使用）
+ *   Level 7 (青緑  #00C7BE): div祖先 6個  — （現状は基本的に未使用）
  *
  * 余白について:
  *   padding: 4px !important を全 div に付与することで、親の padding が子 div を

--- a/index.html
+++ b/index.html
@@ -119,38 +119,24 @@
 
                 <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
                     <div class="dictionary-toolbar">
-                        <div class="dictionary-sheet-selector">
-                            <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
-                            <select id="dictionary-sheet-select">
-                                <option value="core">Core word</option>
-                                <option value="user">User word</option>
-                            </select>
-                        </div>
+                        <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
+                        <select id="dictionary-sheet-select" class="dictionary-sheet-select">
+                            <option value="core">Core word</option>
+                            <option value="user">User word</option>
+                        </select>
                     </div>
-                    <div id="dictionary-sheet-core" class="dictionary-sheet active">
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <span id="core-word-info" class="word-info-display"></span>
-                                <div id="core-words-display" class="words-display"></div>
-                            </div>
-                        </div>
+                    <div id="dictionary-sheet-core" class="dictionary-sheet words-area active">
+                        <span id="core-word-info" class="word-info-display"></span>
+                        <div id="core-words-display" class="words-display"></div>
                         <div class="vocabulary-actions"></div>
                     </div>
-                    <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
-                        <div class="vocabulary-container">
-                            <div class="words-area">
-                                <div class="user-dictionary-controls">
-                                    <div class="dictionary-sheet-selector">
-                                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                                        <select id="user-dictionary-select">
-                                            <option value="DEMO">Demonstration word</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <span id="user-word-info" class="word-info-display"></span>
-                                <div id="user-words-display" class="words-display"></div>
-                            </div>
-                        </div>
+                    <div id="dictionary-sheet-user" class="dictionary-sheet words-area" hidden>
+                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                        <select id="user-dictionary-select" class="dictionary-sheet-select">
+                            <option value="DEMO">Demonstration word</option>
+                        </select>
+                        <span id="user-word-info" class="word-info-display"></span>
+                        <div id="user-words-display" class="words-display"></div>
                         <div class="vocabulary-actions">
                             <button id="export-btn" class="btn-primary" type="button">Export</button>
                             <button id="import-btn" class="btn-primary" type="button">Import</button>


### PR DESCRIPTION
### Motivation
- Simplify and standardize the dictionary sheet markup to reduce nested wrapper elements and make select controls consistent across sheets.
- Align CSS selectors with the new DOM structure to avoid overly-specific nested selectors and fix spacing on the sheet selectors.
- Clarify the debug borders legend to better reflect current DOM usage and dynamic module sheets.

### Description
- Moved the dictionary `select` elements out of extra wrapper `div`s and added a shared `dictionary-sheet-select` class to each `select` control in `index.html` to simplify structure.
- Updated dictionary sheet containers to include `words-area` and moved `vocabulary-actions` to be sibling elements for a flatter layout in `index.html`.
- Adjusted CSS in `app-interface.css` to use `.dictionary-toolbar > .dictionary-sheet-select` and `.words-area > .dictionary-sheet-select`, changed padding to margin for `.words-area` selectors, and updated focus/appearance rules for `.dictionary-sheet-select`.
- Revised `debug-borders.css` comment legend entries to reflect current element examples and usage of dynamic module sheets.

### Testing
- Ran the project linting via `npm run lint` and fixed no new lint issues related to these edits, which succeeded.
- Performed a development build with `npm run build` to ensure CSS and HTML changes did not break the build, which completed successfully.
- Executed the test suite with `npm test` and observed all automated tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf24352cc8326879ad661bcfed2da)