### PR TITLE
Align dictionary selector nesting with input selector structure

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -115,7 +115,7 @@
     gap: 0.5rem;
 }
 
-.area-selector-right .right-mode-selector {
+.area-selector-right select {
     flex: 1.618 1 0%;
 }
 

--- a/index.html
+++ b/index.html
@@ -98,13 +98,11 @@
 
             <div id="state-panel">
                 <div class="area-selector area-selector-right">
-                    <div class="right-mode-selector">
-                        <label for="right-panel-select" class="visually-hidden">Select right panel</label>
-                        <select id="right-panel-select">
-                            <option value="stack">Stack</option>
-                            <option value="dictionary">Dictionary</option>
-                        </select>
-                    </div>
+                    <label for="right-panel-select" class="visually-hidden">Select right panel</label>
+                    <select id="right-panel-select">
+                        <option value="stack">Stack</option>
+                        <option value="dictionary">Dictionary</option>
+                    </select>
                     <div id="right-panel-dictionary-search" class="search-wrapper" hidden>
                         <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
                         <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>


### PR DESCRIPTION
### Motivation
- Ensure debug border outlines and DOM hierarchy are consistent between the left (Input) and right (Dictionary/Stack) panels by removing an extra wrapper around the right-side selector.

### Description
- Removed the `.right-mode-selector` wrapper in `index.html` and placed the `label` and `select#right-panel-select` directly under `.area-selector.area-selector-right`.
- Updated `app-interface.css` to target `.area-selector-right select` with `flex: 1.618 1 0%` instead of `.area-selector-right .right-mode-selector` so layout styling applies to the moved `<select>`.

### Testing
- Ran `npm run -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7eff100c83269fcd681d91663442)