### PR TITLE
Use semantic HTML for panels and fix area-selector-right CSS selector

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -115,7 +115,7 @@
     gap: 0.5rem;
 }
 
-.area-selector-right .right-mode-selector {
+.area-selector-right select {
     flex: 1.618 1 0%;
 }
 

--- a/index.html
+++ b/index.html
@@ -16,19 +16,17 @@
     <a href="#code-input" class="skip-link">Skip to main content</a>
     <div class="container">
         <header role="banner">
-            <div class="app-header-top">
-                <div class="app-brand-meta">
-                    <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
-                        <span class="logo-swap" aria-hidden="true">
-                            <img src="./images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
-                            <img src="./images/ajisai-qr.png" alt="" class="logo logo-qr">
-                        </span>
-                        <h1>Ajisai</h1>
-                    </a>
-                    <span class="version">ver.loading...</span>
-                </div>
-            </div>
-            <div class="header-actions">
+            <section class="app-brand-meta">
+                <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
+                    <span class="logo-swap" aria-hidden="true">
+                        <img src="./images/ajisai-logo-thumbnail-w40.jpg" alt="" class="logo logo-default">
+                        <img src="./images/ajisai-qr.png" alt="" class="logo logo-qr">
+                    </span>
+                    <h1>Ajisai</h1>
+                </a>
+                <span class="version">ver.loading...</span>
+            </section>
+            <nav class="header-actions" aria-label="Header actions">
                 <a href="docs/index.html" class="btn-secondary" target="_blank">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                         <path d="M9 9h6v6M15 9l-6 6M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z"/>
@@ -41,7 +39,7 @@
                     </svg>
                     Test
                 </button>
-            </div>
+            </nav>
         </header>
 
         <main class="main-layout">
@@ -55,7 +53,7 @@
               Dictionary mode (right / mobile); .area-selector-left has no search
               input because the left column never shows the dictionary.
             -->
-            <div class="area-selector area-selector-mobile">
+            <section class="area-selector area-selector-mobile">
                 <label for="mobile-panel-select" class="visually-hidden">Select panel</label>
                 <select id="mobile-panel-select">
                     <option value="input">Input</option>
@@ -63,20 +61,20 @@
                     <option value="stack">Stack</option>
                     <option value="dictionary">Dictionary</option>
                 </select>
-                <div id="mobile-panel-dictionary-search" class="search-wrapper" hidden>
+                <span id="mobile-panel-dictionary-search" class="search-wrapper" hidden>
                     <input type="text" id="mobile-dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
                     <button id="mobile-dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
-                </div>
-            </div>
+                </span>
+            </section>
 
             <div id="editor-panel">
-                <div class="area-selector area-selector-left">
+                <section class="area-selector area-selector-left">
                     <label for="left-panel-select" class="visually-hidden">Select left panel</label>
                     <select id="left-panel-select">
                         <option value="input">Input</option>
                         <option value="output">Output</option>
                     </select>
-                </div>
+                </section>
                 <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0" hidden>
                     <h2 class="visually-hidden">Output</h2>
                     <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
@@ -97,19 +95,17 @@
             </div>
 
             <div id="state-panel">
-                <div class="area-selector area-selector-right">
-                    <div class="right-mode-selector">
-                        <label for="right-panel-select" class="visually-hidden">Select right panel</label>
-                        <select id="right-panel-select">
-                            <option value="stack">Stack</option>
-                            <option value="dictionary">Dictionary</option>
-                        </select>
-                    </div>
-                    <div id="right-panel-dictionary-search" class="search-wrapper" hidden>
+                <section class="area-selector area-selector-right">
+                    <label for="right-panel-select" class="visually-hidden">Select right panel</label>
+                    <select id="right-panel-select">
+                        <option value="stack">Stack</option>
+                        <option value="dictionary">Dictionary</option>
+                    </select>
+                    <span id="right-panel-dictionary-search" class="search-wrapper" hidden>
                         <input type="text" id="dictionary-search" class="vocabulary-search-input" placeholder="Search word" aria-label="Search word">
                         <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
-                    </div>
-                </div>
+                    </span>
+                </section>
                 <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
                     <h2 class="visually-hidden">Stack</h2>
                     <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
@@ -118,19 +114,19 @@
                 </section>
 
                 <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
-                    <div class="dictionary-toolbar">
+                    <header class="dictionary-toolbar">
                         <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
                         <select id="dictionary-sheet-select" class="dictionary-sheet-select">
                             <option value="core">Core word</option>
                             <option value="user">User word</option>
                         </select>
-                    </div>
-                    <div id="dictionary-sheet-core" class="dictionary-sheet words-area active">
+                    </header>
+                    <section id="dictionary-sheet-core" class="dictionary-sheet words-area active">
                         <span id="core-word-info" class="word-info-display"></span>
                         <div id="core-words-display" class="words-display"></div>
                         <div class="vocabulary-actions"></div>
-                    </div>
-                    <div id="dictionary-sheet-user" class="dictionary-sheet words-area" hidden>
+                    </section>
+                    <section id="dictionary-sheet-user" class="dictionary-sheet words-area" hidden>
                         <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
                         <select id="user-dictionary-select" class="dictionary-sheet-select">
                             <option value="DEMO">Demonstration word</option>
@@ -141,7 +137,7 @@
                             <button id="export-btn" class="btn-primary" type="button">Export</button>
                             <button id="import-btn" class="btn-primary" type="button">Import</button>
                         </div>
-                    </div>
+                    </section>
                 </section>
             </div>
         </main>


### PR DESCRIPTION
### Motivation
- Improve document semantics and accessibility by replacing generic containers with `section`, `nav`, `header`, and `span` where appropriate.
- Simplify and clarify the DOM structure for area selectors and dictionary panels to better reflect their roles.
- Ensure CSS targets the actual `select` element inside the right-area selector by updating the selector to match the revised markup.

### Description
- Replaced multiple `div` wrappers with semantic elements such as `section`, `nav`, and `header` for header, area selectors, and dictionary toolbar.
- Converted certain search wrapper containers to `span` and standardized area selector containers to `section` to reduce extra wrapper elements.
- Updated stylesheet selector `.area-selector-right .right-mode-selector` to `.area-selector-right select` to match the new markup.
- Reorganized dictionary sheets from `div` blocks to `section` blocks and moved the toolbar into a `header` element.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7eff100c83269fcd681d91663442)