### PR TITLE
Remove Run button and add input-assist words bar under editor

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -492,6 +492,15 @@
     justify-content: center;
 }
 
+.input-assist-words-display {
+    min-height: 2.5rem;
+    align-content: flex-start;
+}
+
+.input-assist-word {
+    min-width: 2rem;
+}
+
 .empty-words-message {
     width: 100%;
     padding: 0.75rem;
@@ -820,6 +829,16 @@
 
     .words-area .words-display {
         cursor: default;
+    }
+
+    .input-assist-word {
+        min-width: 2.25rem;
+        min-height: 2.25rem;
+    }
+
+    .input-assist-words-display {
+        max-height: 7rem;
+        overflow-y: auto;
     }
 
     .stack-area {

--- a/index.html
+++ b/index.html
@@ -90,9 +90,11 @@
                         <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
                         <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
                     </div>
-                    <div class="vocabulary-actions">
-                        <button id="run-btn" class="btn-primary" type="button">Run</button>
-                    </div>
+                    <div
+                        id="input-assist-words-display"
+                        class="words-display input-assist-words-display"
+                        aria-label="Input assist words"
+                    ></div>
                 </section>
             </div>
 

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -23,6 +23,7 @@ import {
     ApplyAreaStateDeps
 } from './gui-layout-state';
 import { switchDictionarySheet } from './gui-dictionary-sheet';
+import { createInputAssistWords, InputAssistWords } from './input-assist-words';
 
 declare global {
     interface Window {
@@ -31,6 +32,12 @@ declare global {
 }
 
 export type { GUIElements };
+
+const HIDDEN_AUTOCOMPLETE_ALIASES: ReadonlySet<string> = new Set([
+    '+', '-', '*', '/', '=', '<', '>', '<=', '>=',
+    '[', ']', '{', '}', '(', ')',
+    '.', ',', "'", '"',
+]);
 
 export interface GUI {
     readonly init: () => Promise<void>;
@@ -48,7 +55,9 @@ const collectAutocompleteWords = (): string[] => {
     if (!window.ajisaiInterpreter) return [];
 
     const coreWordsInfo = window.ajisaiInterpreter.collect_core_words_info();
-    const coreWords: string[] = coreWordsInfo.map(word => word[0]).filter((w): w is string => w !== undefined);
+    const coreWords: string[] = coreWordsInfo
+        .map(word => word[0])
+        .filter((w): w is string => w !== undefined && !HIDDEN_AUTOCOMPLETE_ALIASES.has(w));
 
     const userWordsInfo = window.ajisaiInterpreter.collect_user_words_info();
     const userWords: string[] = userWordsInfo.flatMap(word => [
@@ -87,6 +96,7 @@ export const createGUI = (): GUI => {
     let persistence: Persistence;
     let executionController: ExecutionController;
     let moduleTabManager: ModuleTabManager;
+    let inputAssistWords: InputAssistWords;
     let layoutState: LayoutState;
 
     const doSwitchDictionarySheet = (sheetId: string): void => {
@@ -205,10 +215,6 @@ export const createGUI = (): GUI => {
     };
 
     const setupInteractionEventListeners = (): void => {
-        elements.runBtn.addEventListener('click', () => {
-            executionController.executeCode(editor.extractValue());
-        });
-
         const applySearchFilter = (filter: string): void => {
             elements.dictionarySearch.value = filter;
             elements.mobileDictionarySearch.value = filter;
@@ -394,6 +400,19 @@ export const createGUI = (): GUI => {
             onSwitchToInputMode: () => switchArea('input'),
             onRequestSuggestions: () => collectAutocompleteWords()
         });
+
+        inputAssistWords = createInputAssistWords(elements.inputAssistWordsDisplay, {
+            onAssistWordClick: (word: string) => {
+                editor.insertText(word);
+            },
+            onBackgroundClick: () => {
+                editor.insertWord(' ');
+            },
+            onBackgroundDoubleClick: () => {
+                editor.removeLastWord();
+            },
+        });
+        inputAssistWords.render();
 
         vocabulary = createVocabularyManager(extractVocabularyElements(elements), {
             onWordClick: (word) => {

--- a/js/gui/gui-dom-cache.ts
+++ b/js/gui/gui-dom-cache.ts
@@ -4,13 +4,13 @@ import type { MobileElements } from './mobile-view-switcher';
 
 export interface GUIElements {
     readonly codeInput: HTMLTextAreaElement;
-    readonly runBtn: HTMLButtonElement;
     readonly clearBtn: HTMLButtonElement;
     readonly testBtn: HTMLButtonElement;
     readonly exportBtn: HTMLButtonElement;
     readonly importBtn: HTMLButtonElement;
     readonly outputDisplay: HTMLElement;
     readonly stackDisplay: HTMLElement;
+    readonly inputAssistWordsDisplay: HTMLElement;
     readonly builtInWordsDisplay: HTMLElement;
     readonly userWordsDisplay: HTMLElement;
     readonly builtInWordInfo: HTMLElement;
@@ -37,13 +37,13 @@ export interface GUIElements {
 
 export const cacheElements = (): GUIElements => ({
     codeInput: document.getElementById('code-input') as HTMLTextAreaElement,
-    runBtn: document.getElementById('run-btn') as HTMLButtonElement,
     clearBtn: document.getElementById('clear-btn') as HTMLButtonElement,
     testBtn: document.getElementById('test-btn') as HTMLButtonElement,
     exportBtn: document.getElementById('export-btn') as HTMLButtonElement,
     importBtn: document.getElementById('import-btn') as HTMLButtonElement,
     outputDisplay: document.getElementById('output-display')!,
     stackDisplay: document.getElementById('stack-display')!,
+    inputAssistWordsDisplay: document.getElementById('input-assist-words-display')!,
     builtInWordsDisplay: document.getElementById('core-words-display')!,
     userWordsDisplay: document.getElementById('user-words-display')!,
     builtInWordInfo: document.getElementById('core-word-info')!,

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -22,7 +22,8 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
 const MOBILE_EDITOR_PLACEHOLDER = [
     'Enter code here',
     '',
-    'Run → Tap the Run button',
+    'Run → Triple-tap the editor',
+    'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');
 

--- a/js/gui/input-assist-words.ts
+++ b/js/gui/input-assist-words.ts
@@ -1,0 +1,48 @@
+import {
+    createWordButtonElement,
+    registerBackgroundClickListeners,
+} from './dictionary-element-builders';
+
+export interface InputAssistWordsCallbacks {
+    readonly onAssistWordClick: (word: string) => void;
+    readonly onBackgroundClick: () => void;
+    readonly onBackgroundDoubleClick: () => void;
+}
+
+export interface InputAssistWords {
+    readonly render: () => void;
+}
+
+const INPUT_ASSIST_WORDS: readonly string[] = Object.freeze([
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+    '[', ']', '{', '}', '(', ')',
+    "'", '"', '~', '$', '%', '@', '=', '<', '>', '.', ',',
+]);
+
+export const createInputAssistWords = (
+    container: HTMLElement,
+    callbacks: InputAssistWordsCallbacks
+): InputAssistWords => {
+    const render = (): void => {
+        container.innerHTML = '';
+
+        for (const word of INPUT_ASSIST_WORDS) {
+            const button = createWordButtonElement(
+                word,
+                `Insert ${word}`,
+                'word-button input-assist-word',
+                () => callbacks.onAssistWordClick(word)
+            );
+
+            container.appendChild(button);
+        }
+    };
+
+    registerBackgroundClickListeners(
+        container,
+        callbacks.onBackgroundClick,
+        callbacks.onBackgroundDoubleClick
+    );
+
+    return { render };
+};

--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -39,6 +39,13 @@ export interface VocabularyManager {
     readonly updateSearchFilter: (filter: string) => void;
 }
 
+const HIDDEN_CORE_WORD_ALIASES: ReadonlySet<string> = new Set([
+    ';', '"',
+    '+', '-', '*', '/', '=', '<', '>', '<=', '>=',
+    '[', ']', '{', '}', '(', ')',
+    '.', ',',
+]);
+
 const DICTIONARY_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.freeze({
     'DEMO': 'Demonstration',
 });
@@ -237,7 +244,9 @@ export const createVocabularyManager = (
 
         const filtered = coreWords.filter(
             (wd): wd is unknown[] =>
-                Array.isArray(wd) && wd[0] !== ';' && wd[0] !== '"'
+                Array.isArray(wd)
+                && typeof wd[0] === 'string'
+                && !HIDDEN_CORE_WORD_ALIASES.has(wd[0])
         );
 
 


### PR DESCRIPTION
### Motivation
- Remove the in-editor Run button because keyboard and touch gestures already provide execution flows and replace that UI slot with a mobile-friendly input-assist area for hard-to-type symbols and digits.
- Provide a stable, independent input-assist widget (not generated from Core word data) so symbol input remains usable while Core word lists move toward word-based naming.
- Reduce visual clutter in Core word listings and autocomplete by hiding symbol-only aliases in the GUI while preserving runtime compatibility.

### Description
- Replaced the Run button in the input panel with a new `#input-assist-words-display` element and added `inputAssistWordsDisplay` to the GUI DOM cache to avoid stale DOM references (`index.html`, `js/gui/gui-dom-cache.ts`).
- Added `js/gui/input-assist-words.ts` which renders a fixed `INPUT_ASSIST_WORDS` set using existing `createWordButtonElement` and `registerBackgroundClickListeners`, wiring clicks to `editor.insertText(...)`, background single-click to `editor.insertWord(' ')`, and background double-click to `editor.removeLastWord()`.
- Wired the assist bar into GUI initialization (`js/gui/gui-application.ts`): imported `createInputAssistWords`, created and rendered the assist widget after editor creation, and removed the Run button click listener while keeping keyboard shortcuts (Shift+Enter, Ctrl+Enter, Escape, Ctrl+Alt+Enter) unchanged.
- Updated mobile editor placeholder copy to remove Run-button guidance and add triple-tap + input-assist hints (`js/gui/gui-layout-state.ts`).
- Added minimal CSS for the assist area and buttons with mobile-friendly sizing and scrolling (`app-interface.css`).
- Added GUI-side filters to hide symbol aliases from built-in Core word display and from autocomplete candidates (`js/gui/vocabulary-state-controller.ts` and `js/gui/gui-application.ts`) to prepare for Core-word wordification while preserving symbol input compatibility.

### Testing
- Searched the codebase for stale Run-related references with ripgrep and confirmed `run-btn` / `runBtn` usages replaced by `input-assist-words-display` (succeeded).
- Ran `npm run check` (TypeScript check) which failed in this environment due to missing `vitest` type declarations preventing a full typecheck (environment limitation).
- Ran `npm run test` which failed because the `vitest` binary is not available in the current execution environment.
- Attempted `npm install` / `npm ci` which failed due to registry/permission restrictions in this environment, so dependency installation and full test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec05ae5afc832697907b361613e7c6)