### PR TITLE
Remove hardcoded CORE_WORDS filter from builtin definitions

### DIFF
--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -866,13 +866,8 @@ pub fn collect_builtin_definitions() -> Vec<(&'static str, &'static str, &'stati
 
 pub fn collect_core_builtin_definitions(
 ) -> Vec<(&'static str, &'static str, &'static str, &'static str)> {
-    const CORE_WORDS: &[&str] = &[
-        "ADD", "SUB", "MUL", "DIV", "MOD", "EQ", "LT", "LTE", "TOP", "STAK", "EAT", "KEEP", "SAFE",
-        "FORC",
-    ];
     BUILTIN_SPECS
         .iter()
-        .filter(|spec| CORE_WORDS.contains(&spec.name))
         .map(|spec| {
             (
                 spec.name,


### PR DESCRIPTION
## Summary

Removed the hardcoded `CORE_WORDS` constant and its associated filter logic from `collect_core_builtin_definitions()`. This function now returns all builtin specifications without filtering, simplifying the code and removing a maintenance burden of keeping the word list in sync.

## Quality Classification

- Highest impacted level: QL-D

## Traceability

- Requirement(s): N/A
- Verification evidence: Existing unit tests for builtin definitions

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This is a straightforward refactoring that removes unnecessary filtering logic. The change simplifies maintenance by eliminating the need to keep a separate hardcoded list of core words in sync with the actual builtin specifications.

https://claude.ai/code/session_01FEhTYg6bNDTb3Th4CqmFrx