### PR TITLE
Unify panel DOM hierarchy with shared .area-body wrapper

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -192,6 +192,13 @@
     flex-direction: column;
 }
 
+.area-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
 
 @media (min-width: 769px) {
     body[data-active-area] .main-layout section {

--- a/index.html
+++ b/index.html
@@ -79,22 +79,26 @@
                 </div>
                 <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0" hidden>
                     <h2 class="visually-hidden">Output</h2>
-                    <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
-                    <div class="vocabulary-actions">
-                        <button id="copy-output-btn" class="btn-primary" type="button" aria-label="Copy output to clipboard">Copy</button>
+                    <div class="area-body">
+                        <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
+                        <div class="vocabulary-actions">
+                            <button id="copy-output-btn" class="btn-primary" type="button" aria-label="Copy output to clipboard">Copy</button>
+                        </div>
                     </div>
                 </section>
                 <section id="input-panel" class="input-area" role="region" aria-label="Input" tabindex="0">
                     <h2 class="visually-hidden">Input</h2>
-                    <div class="textarea-wrapper">
-                        <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
-                        <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
+                    <div class="area-body">
+                        <div class="textarea-wrapper">
+                            <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
+                            <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
+                        </div>
+                        <div
+                            id="input-assist-words-display"
+                            class="words-display input-assist-words-display"
+                            aria-label="Input assist words"
+                        ></div>
                     </div>
-                    <div
-                        id="input-assist-words-display"
-                        class="words-display input-assist-words-display"
-                        aria-label="Input assist words"
-                    ></div>
                 </section>
             </div>
 
@@ -114,34 +118,38 @@
                 </div>
                 <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
                     <h2 class="visually-hidden">Stack</h2>
-                    <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
-                    <!-- Empty slot for future stack-related buttons. Preserved for structural symmetry with other panels; do not remove. -->
-                    <div class="vocabulary-actions"></div>
+                    <div class="area-body">
+                        <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
+                        <!-- Empty slot for future stack-related buttons. Preserved for structural symmetry with other panels; do not remove. -->
+                        <div class="vocabulary-actions"></div>
+                    </div>
                 </section>
 
                 <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
-                    <div class="dictionary-toolbar">
-                        <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
-                        <select id="dictionary-sheet-select" class="dictionary-sheet-select">
-                            <option value="core">Core word</option>
-                            <option value="user">User word</option>
-                        </select>
-                    </div>
-                    <div id="dictionary-sheet-core" class="dictionary-sheet words-area active">
-                        <span id="core-word-info" class="word-info-display"></span>
-                        <div id="core-words-display" class="words-display"></div>
-                        <div class="vocabulary-actions"></div>
-                    </div>
-                    <div id="dictionary-sheet-user" class="dictionary-sheet words-area" hidden>
-                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                        <select id="user-dictionary-select" class="dictionary-sheet-select">
-                            <option value="DEMO">Demonstration word</option>
-                        </select>
-                        <span id="user-word-info" class="word-info-display"></span>
-                        <div id="user-words-display" class="words-display"></div>
-                        <div class="vocabulary-actions">
-                            <button id="export-btn" class="btn-primary" type="button">Export</button>
-                            <button id="import-btn" class="btn-primary" type="button">Import</button>
+                    <div class="area-body">
+                        <div class="dictionary-toolbar">
+                            <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
+                            <select id="dictionary-sheet-select" class="dictionary-sheet-select">
+                                <option value="core">Core word</option>
+                                <option value="user">User word</option>
+                            </select>
+                        </div>
+                        <div id="dictionary-sheet-core" class="dictionary-sheet words-area active">
+                            <span id="core-word-info" class="word-info-display"></span>
+                            <div id="core-words-display" class="words-display"></div>
+                            <div class="vocabulary-actions"></div>
+                        </div>
+                        <div id="dictionary-sheet-user" class="dictionary-sheet words-area" hidden>
+                            <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                            <select id="user-dictionary-select" class="dictionary-sheet-select">
+                                <option value="DEMO">Demonstration word</option>
+                            </select>
+                            <span id="user-word-info" class="word-info-display"></span>
+                            <div id="user-words-display" class="words-display"></div>
+                            <div class="vocabulary-actions">
+                                <button id="export-btn" class="btn-primary" type="button">Export</button>
+                                <button id="import-btn" class="btn-primary" type="button">Import</button>
+                            </div>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
### Motivation
- The Input, Output, Stack and Dictionary panels had inconsistent DOM nesting which made layout/visual debugging and future structural changes harder to reason about.
- Introduce a minimal common wrapper to make the four areas share the same section-level hierarchy (a maximum-common-denominator approach).

### Description
- Added an `.area-body` wrapper inside each panel `section` for Output, Input, Stack and Dictionary in `index.html` so each area follows the same `section > h2 + .area-body` pattern.
- Moved existing toolbar / content / action nodes into the new `.area-body` wrapper while preserving all existing `id` and class attributes used by JS (e.g. `#output-display`, `#code-input`, `#stack-display`, dictionary sheets), to minimize behavioral changes.
- Added `.area-body` layout rules to `app-interface.css` (`flex: 1; min-height: 0; display: flex; flex-direction: column;`) to keep previous flex column behavior and scrolling semantics.
- Files changed: `index.html` and `app-interface.css`.

### Testing
- Ran the TypeScript build with `npm run build` and `tsc` completed successfully. 
- No other automated tests were run as part of this change; runtime UI screenshots/visual checks were not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed75c128608326b1b716bf676acef6)