### PR TITLE
Flatten panel hierarchy: drop area-body/header/main/footer wrappers

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -179,57 +179,16 @@
     min-height: 0;
 }
 
-#editor-panel .input-area,
-#editor-panel .output-area,
-#state-panel .stack-area,
-#state-panel .dictionary-area {
+.input-area,
+.output-area,
+.stack-area,
+.dictionary-area {
     flex: 1;
-    display: flex;
-    flex-direction: column;
-}
-
-
-.area-body {
-    flex: 1;
-    min-height: 0;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-}
-
-.area-header {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.area-header:empty {
-    display: none;
-}
-
-.area-main {
-    flex: 1;
     min-height: 0;
-    display: flex;
-    flex-direction: column;
     position: relative;
-}
-
-.area-footer {
-    flex-shrink: 0;
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.area-footer:empty {
-    display: none;
-}
-
-.input-area .area-footer {
-    display: block;
 }
 
 
@@ -248,15 +207,6 @@
     body[data-active-area="dictionary"] #editor-panel {
         display: none;
     }
-}
-
-
-.output-area,
-.input-area {
-    flex: 1 1 0;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
 }
 
 
@@ -464,7 +414,6 @@
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
-    margin-top: 0.5rem;
 }
 
 .dictionary-sheet .word-info-display {
@@ -473,7 +422,6 @@
     height: 1.25rem;
     line-height: 1.25rem;
     max-width: 100%;
-    margin-bottom: 0.5rem;
     color: var(--color-text);
     white-space: nowrap;
     overflow: hidden;
@@ -551,16 +499,8 @@
 }
 
 
-.dictionary-area {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-}
-
-.dictionary-area .area-header > .dictionary-sheet-select {
-    flex: 1 1 0%;
-    min-width: 0;
+.dictionary-area > .dictionary-sheet-select {
+    flex: 0 0 auto;
 }
 
 .dictionary-sheet-select:focus-visible {
@@ -584,6 +524,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    gap: 0.5rem;
     min-height: 0;
     width: 100%;
     background: var(--gradient-child);
@@ -592,6 +533,10 @@
 
 .dictionary-sheet:not(.active) {
     display: none;
+}
+
+.dictionary-sheet > .dictionary-sheet-select {
+    flex: 0 0 auto;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -79,32 +79,18 @@
                 </div>
                 <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0" hidden>
                     <h2 class="visually-hidden">Output</h2>
-                    <div class="area-body">
-                        <div class="area-header"></div>
-                        <div class="area-main">
-                            <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
-                        </div>
-                        <div class="area-footer">
-                            <button id="copy-output-btn" class="btn-primary" type="button" aria-label="Copy output to clipboard">Copy</button>
-                        </div>
-                    </div>
+                    <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
+                    <button id="copy-output-btn" class="btn-primary" type="button" aria-label="Copy output to clipboard">Copy</button>
                 </section>
                 <section id="input-panel" class="input-area" role="region" aria-label="Input" tabindex="0">
                     <h2 class="visually-hidden">Input</h2>
-                    <div class="area-body">
-                        <div class="area-header"></div>
-                        <div class="area-main">
-                            <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
-                            <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
-                        </div>
-                        <div class="area-footer">
-                            <div
-                                id="input-assist-words-display"
-                                class="words-display input-assist-words-display"
-                                aria-label="Input assist words"
-                            ></div>
-                        </div>
-                    </div>
+                    <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
+                    <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
+                    <div
+                        id="input-assist-words-display"
+                        class="words-display input-assist-words-display"
+                        aria-label="Input assist words"
+                    ></div>
                 </section>
             </div>
 
@@ -124,42 +110,30 @@
                 </div>
                 <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
                     <h2 class="visually-hidden">Stack</h2>
-                    <div class="area-body">
-                        <div class="area-header"></div>
-                        <div class="area-main">
-                            <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
-                        </div>
-                        <div class="area-footer"></div>
-                    </div>
+                    <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
                 </section>
 
                 <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
                     <h2 class="visually-hidden">Dictionary</h2>
-                    <div class="area-body">
-                        <div class="area-header">
-                            <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
-                            <select id="dictionary-sheet-select" class="dictionary-sheet-select">
-                                <option value="core">Core word</option>
-                                <option value="user">User word</option>
-                            </select>
-                            <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
-                            <select id="user-dictionary-select" class="dictionary-sheet-select" hidden>
-                                <option value="DEMO">Demonstration word</option>
-                            </select>
-                        </div>
-                        <div class="area-main">
-                            <div id="dictionary-sheet-core" class="dictionary-sheet active">
-                                <span id="core-word-info" class="word-info-display"></span>
-                                <div id="core-words-display" class="words-display"></div>
-                            </div>
-                            <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
-                                <span id="user-word-info" class="word-info-display"></span>
-                                <div id="user-words-display" class="words-display"></div>
-                            </div>
-                        </div>
-                        <div class="area-footer">
-                            <button id="export-btn" class="btn-primary" type="button" hidden>Export</button>
-                            <button id="import-btn" class="btn-primary" type="button" hidden>Import</button>
+                    <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
+                    <select id="dictionary-sheet-select" class="dictionary-sheet-select">
+                        <option value="core">Core word</option>
+                        <option value="user">User word</option>
+                    </select>
+                    <div id="dictionary-sheet-core" class="dictionary-sheet active">
+                        <span id="core-word-info" class="word-info-display"></span>
+                        <div id="core-words-display" class="words-display"></div>
+                    </div>
+                    <div id="dictionary-sheet-user" class="dictionary-sheet" hidden>
+                        <label for="user-dictionary-select" class="visually-hidden">Select user dictionary</label>
+                        <select id="user-dictionary-select" class="dictionary-sheet-select">
+                            <option value="DEMO">Demonstration word</option>
+                        </select>
+                        <span id="user-word-info" class="word-info-display"></span>
+                        <div id="user-words-display" class="words-display"></div>
+                        <div class="vocabulary-actions">
+                            <button id="export-btn" class="btn-primary" type="button">Export</button>
+                            <button id="import-btn" class="btn-primary" type="button">Import</button>
                         </div>
                     </div>
                 </section>

--- a/js/gui/code-input-editor.ts
+++ b/js/gui/code-input-editor.ts
@@ -101,7 +101,7 @@ export const createEditor = (
     let currentSuggestions: string[] = [];
     let selectedSuggestionIndex = 0;
 
-    const textareaContainer = element.closest('.area-main');
+    const textareaContainer = element.closest('.input-area');
     const suggestionPanel = document.createElement('div');
     suggestionPanel.className = 'editor-suggestions';
     suggestionPanel.style.display = 'none';

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -347,7 +347,7 @@ export const createGUI = (): GUI => {
 
         moduleTabManager = createModuleTabManager({
             selectEl: elements.dictionarySheetSelect,
-            sheetContainerEl: elements.dictionaryArea.querySelector('.area-main') as HTMLElement,
+            sheetContainerEl: elements.dictionaryArea,
             onWordClick: (word: string) => {
                 if (!mobile.isMobile()) {
                     editor.insertWord(word);

--- a/js/gui/gui-dictionary-sheet.ts
+++ b/js/gui/gui-dictionary-sheet.ts
@@ -10,11 +10,4 @@ export const switchDictionarySheet = (containerEl: HTMLElement, sheetId: string)
         target.hidden = false;
         target.classList.add('active');
     }
-
-    const userOnlyIds = ['user-dictionary-select', 'export-btn', 'import-btn'];
-    const showUserControls = sheetId === 'user';
-    for (const id of userOnlyIds) {
-        const el = document.getElementById(id);
-        if (el) (el as HTMLElement).hidden = !showUserControls;
-    }
 };


### PR DESCRIPTION
Alternative to the previous "3-slot GCD" approach. Each section now hosts its content directly with no intermediate wrappers, while preserving the original positioning and behavior of every element. The section element itself becomes the flex column container (gap 0.5rem, position relative).

Per-panel direct children:
- Input:      textarea, clear-btn (absolute), assist-words-display
- Output:     output-display, copy-btn
- Stack:      stack-display
- Dictionary: sheet-select, core-sheet, user-sheet (+ dynamic module sheets)

The user sheet keeps its own select / actions inside it (matching the original layout); switchDictionarySheet no longer toggles outer controls since they live inside the active sheet. .dictionary-sheet uses gap 0.5rem to space its children, replacing scattered margin-* rules. Module sheet mounting goes back to using the section element directly.

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
