### PR TITLE
Share words-display appearance between input-assist and dictionary

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -432,14 +432,12 @@
     color: var(--color-text-light);
 }
 
-.dictionary-sheet .words-display {
-    flex: 1;
+.words-display {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
     align-items: flex-start;
     align-content: flex-start;
-    min-height: 7rem;
     overflow-y: auto;
     background-color: rgba(0, 0, 0, 0.06);
     border-radius: 6px;
@@ -447,15 +445,19 @@
     cursor: pointer;
 }
 
-.dictionary-sheet .words-display.is-empty {
+.words-display.is-empty {
     align-items: center;
     align-content: center;
     justify-content: center;
 }
 
+.dictionary-sheet .words-display {
+    flex: 1;
+    min-height: 7rem;
+}
+
 .input-assist-words-display {
     min-height: 2.5rem;
-    align-content: flex-start;
 }
 
 .input-assist-word {
@@ -775,7 +777,7 @@
         min-height: 80px;
     }
 
-    .dictionary-sheet .words-display {
+    .words-display {
         cursor: default;
     }
 

--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -252,12 +252,16 @@ footer a:hover {
 .display-area,
 .state-display,
 .words-display {
-    background-color: rgba(255, 255, 255, 0.5);
-    padding: 0.75rem;
     min-height: 0;
     overflow-y: auto;
     font-family: var(--font-stack-mono);
     font-size: 0.9rem;
+}
+
+.display-area,
+.state-display {
+    background-color: rgba(255, 255, 255, 0.5);
+    padding: 0.75rem;
 }
 
 


### PR DESCRIPTION
The input-assist row at the bottom of the editor and the word-button area inside each dictionary sheet have the same interaction model (click to insert space, double-click to undo a token), so they should also share the same shape and background.

Hoist appearance properties from .dictionary-sheet .words-display up to plain .words-display so both elements pick them up. Keep dictionary-only layout (flex:1, min-height:7rem) scoped to .dictionary-sheet, and let input-assist keep its own 2.5rem min-height. Drop the now-conflicting white background / 0.75rem padding from the base .words-display rule in ajisai-base.css.

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
