### PR TITLE
Make input-assist always full; let textarea absorb height changes

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -458,6 +458,7 @@
 
 .input-assist-words-display {
     min-height: 2.5rem;
+    flex-shrink: 0;
 }
 
 .input-assist-word {
@@ -766,11 +767,6 @@
         min-height: 0;
     }
 
-    #code-input {
-        min-height: 180px;
-        max-height: none;
-    }
-
     .display-area,
     .state-display,
     .words-display {
@@ -784,11 +780,6 @@
     .input-assist-word {
         min-width: 2.25rem;
         min-height: 2.25rem;
-    }
-
-    .input-assist-words-display {
-        max-height: 7rem;
-        overflow-y: auto;
     }
 
     .stack-area {


### PR DESCRIPTION
On mobile the input-assist row was capped (max-height 7rem + overflow-y auto) and the textarea had a hard min-height of 180px, which forced the assist row into an internal scroll once it had a few rows of buttons. Reverse the responsibility: the assist row now reserves its full natural height (flex-shrink 0, no max-height, no internal scroll) and the textarea absorbs the remaining space (no mobile min-height override) and scrolls its own text content if it gets squeezed.

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
