### PR TITLE
Stop button stretch in flex columns; soften select focus indication

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -90,7 +90,8 @@
     flex-shrink: 0;
 }
 
-.area-selector select {
+.area-selector select,
+.dictionary-sheet-select {
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;
@@ -100,6 +101,18 @@
     color: var(--color-text);
     width: 100%;
     cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.area-selector select:hover,
+.area-selector select:focus,
+.area-selector select:focus-visible,
+.dictionary-sheet-select:hover,
+.dictionary-sheet-select:focus,
+.dictionary-sheet-select:focus-visible {
+    outline: none;
+    box-shadow: none;
+    background: var(--gradient-parent, #e4e1ec);
 }
 
 
@@ -504,23 +517,6 @@
 
 .dictionary-area > .dictionary-sheet-select {
     flex: 0 0 auto;
-}
-
-.dictionary-sheet-select:focus-visible {
-    outline-offset: -2px;
-    box-shadow: none;
-}
-
-.dictionary-sheet-select {
-    font-family: var(--font-stack-mono);
-    font-size: 0.8rem;
-    padding: 0.25rem 0.5rem;
-    border: 1px solid var(--color-border-strong, #999);
-    border-radius: 3px;
-    background: var(--gradient-child, #fff);
-    color: var(--color-text);
-    width: 100%;
-    cursor: pointer;
 }
 
 .dictionary-sheet {

--- a/public/ajisai-base.css
+++ b/public/ajisai-base.css
@@ -201,6 +201,7 @@ footer a:hover {
 .btn-secondary {
     display: inline-flex;
     align-items: center;
+    align-self: flex-end;
     justify-content: center;
     gap: 0.5rem;
     min-height: 2.125rem;


### PR DESCRIPTION
1. Add align-self: flex-end to .btn-primary / .btn-secondary so any button using the shared button styles keeps its intrinsic width regardless of whether its parent flexes as a row (header, action row) or a column (output panel). The Copy button no longer stretches across the output panel and now matches the header buttons in shape.

2. Replace the loud purple focus ring on <select> elements with a subtle background darken on hover/focus. Both the panel selectors (.area-selector select) and the dictionary selectors (.dictionary-sheet-select) share the same rule. The duplicated .dictionary-sheet-select base block and its old focus-visible override are removed.

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
