### PR TITLE
Add WASM interpreter API compatibility shim and apply during initialization

### DIFF
--- a/js/entry/entry-common.ts
+++ b/js/entry/entry-common.ts
@@ -1,6 +1,7 @@
 import { GUI_INSTANCE } from '../gui/gui-application';
 import { initWasm } from '../wasm-module-loader';
 import type { WasmModule, AjisaiInterpreter } from '../wasm-interpreter-types';
+import { normalizeInterpreterApi } from '../wasm-interpreter-compat';
 
 declare const __AJISAI_CHANGE_NOTE__: string;
 declare const __AJISAI_BUILD_TIMESTAMP__: string;
@@ -41,7 +42,7 @@ export async function initializeApplication(): Promise<void> {
         window.AjisaiWasm = wasm;
 
         console.log('[Main] Creating main thread interpreter...');
-        window.ajisaiInterpreter = new window.AjisaiWasm.AjisaiInterpreter();
+        window.ajisaiInterpreter = normalizeInterpreterApi(new window.AjisaiWasm.AjisaiInterpreter());
 
         console.log('[Main] Initializing GUI...');
         await GUI_INSTANCE.init();

--- a/js/wasm-interpreter-compat.ts
+++ b/js/wasm-interpreter-compat.ts
@@ -1,0 +1,62 @@
+import type { AjisaiInterpreter } from './wasm-interpreter-types';
+
+type MaybeFn = ((...args: any[]) => any) | undefined;
+
+type LegacyInterpreter = {
+    [key: string]: unknown;
+    get_core_words_info?: MaybeFn;
+    get_idiolect_words_info?: MaybeFn;
+    get_imported_modules?: MaybeFn;
+    get_module_words_info?: MaybeFn;
+    get_stack?: MaybeFn;
+    get_word_definition?: MaybeFn;
+    restore_idiolect?: MaybeFn;
+};
+
+const aliasMethod = (instance: LegacyInterpreter, modernName: string, legacyName: keyof LegacyInterpreter): void => {
+    const modern = instance[modernName] as MaybeFn;
+    const legacy = instance[legacyName] as MaybeFn;
+    if (typeof modern === 'function' || typeof legacy !== 'function') return;
+    Object.defineProperty(instance, modernName, {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: (...args: any[]) => legacy(...args),
+    });
+};
+
+const ensureRequiredMethods = (instance: LegacyInterpreter): string[] => {
+    const required = [
+        'collect_stack',
+        'collect_user_words_info',
+        'collect_core_words_info',
+        'collect_imported_modules',
+        'collect_module_words_info',
+        'lookup_word_definition',
+        'restore_user_words',
+    ];
+
+    return required.filter((name) => typeof instance[name] !== 'function');
+};
+
+export const normalizeInterpreterApi = (interpreter: AjisaiInterpreter): AjisaiInterpreter => {
+    const instance = interpreter as unknown as LegacyInterpreter;
+
+    aliasMethod(instance, 'collect_core_words_info', 'get_core_words_info');
+    aliasMethod(instance, 'collect_user_words_info', 'get_idiolect_words_info');
+    aliasMethod(instance, 'collect_imported_modules', 'get_imported_modules');
+    aliasMethod(instance, 'collect_module_words_info', 'get_module_words_info');
+    aliasMethod(instance, 'collect_stack', 'get_stack');
+    aliasMethod(instance, 'lookup_word_definition', 'get_word_definition');
+    aliasMethod(instance, 'restore_user_words', 'restore_idiolect');
+
+    const missing = ensureRequiredMethods(instance);
+    if (missing.length > 0) {
+        console.warn(
+            '[WASM] Interpreter API mismatch. Rebuild js/pkg from rust sources. Missing methods:',
+            missing.join(', ')
+        );
+    }
+
+    return instance as unknown as AjisaiInterpreter;
+};


### PR DESCRIPTION
### Motivation

- Provide a compatibility layer so the app can work with WASM interpreter builds that expose legacy method names without breaking the rest of the codebase.
- Normalize differing interpreter APIs at app startup to surface a consistent `AjisaiInterpreter` interface to the GUI and other consumers.

### Description

- Add `js/wasm-interpreter-compat.ts` which exports `normalizeInterpreterApi` that aliases legacy method names to modern ones and emits a console warning if required methods are missing.
- Update `js/entry/entry-common.ts` to import `normalizeInterpreterApi` and wrap the newly constructed interpreter via `normalizeInterpreterApi(new window.AjisaiWasm.AjisaiInterpreter())` before assigning `window.ajisaiInterpreter`.
- Implement helper logic in the compat file including `aliasMethod` and `ensureRequiredMethods` to perform safe shims and diagnostics.

### Testing

- Ran `npm run build` to verify TypeScript compilation and bundling, which completed successfully.
- Ran the automated test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5fef05e88326924f3c75692306b4)