### PR TITLE
Normalize WASM interpreter API and filter non-canonical core words

### DIFF
--- a/js/entry/entry-common.ts
+++ b/js/entry/entry-common.ts
@@ -1,6 +1,7 @@
 import { GUI_INSTANCE } from '../gui/gui-application';
 import { initWasm } from '../wasm-module-loader';
 import type { WasmModule, AjisaiInterpreter } from '../wasm-interpreter-types';
+import { normalizeInterpreterApi } from '../wasm-interpreter-compat';
 
 declare const __AJISAI_CHANGE_NOTE__: string;
 declare const __AJISAI_BUILD_TIMESTAMP__: string;
@@ -41,7 +42,7 @@ export async function initializeApplication(): Promise<void> {
         window.AjisaiWasm = wasm;
 
         console.log('[Main] Creating main thread interpreter...');
-        window.ajisaiInterpreter = new window.AjisaiWasm.AjisaiInterpreter();
+        window.ajisaiInterpreter = normalizeInterpreterApi(new window.AjisaiWasm.AjisaiInterpreter());
 
         console.log('[Main] Initializing GUI...');
         await GUI_INSTANCE.init();

--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -84,6 +84,8 @@ const clearElement = (element: HTMLElement): void => {
 
 const DEFAULT_WORD_INFO_MESSAGE = 'Hover over a word button to view its usage.';
 
+const isCanonicalCoreWordName = (name: string): boolean => /^[A-Z][A-Z0-9-]*$/.test(name);
+
 const renderWordInfo = (element: HTMLElement, text: string, isPlaceholder = false): void => {
     element.textContent = text;
     element.classList.toggle('is-placeholder', isPlaceholder);
@@ -239,8 +241,13 @@ export const createVocabularyManager = (
             (wd): wd is unknown[] =>
                 Array.isArray(wd)
                 && typeof wd[0] === 'string'
+                && isCanonicalCoreWordName(wd[0])
         );
 
+        const droppedCount = coreWords.length - filtered.length;
+        if (droppedCount > 0) {
+            console.info(`[Vocabulary] Filtered out ${droppedCount} non-canonical core word entries from WASM payload.`);
+        }
 
         const sorted = [...filtered].sort((a, b) =>
             compareWordName(a[0] as string, b[0] as string)

--- a/js/wasm-interpreter-compat.ts
+++ b/js/wasm-interpreter-compat.ts
@@ -1,0 +1,62 @@
+import type { AjisaiInterpreter } from './wasm-interpreter-types';
+
+type MaybeFn = ((...args: any[]) => any) | undefined;
+
+type LegacyInterpreter = {
+    [key: string]: unknown;
+    get_core_words_info?: MaybeFn;
+    get_idiolect_words_info?: MaybeFn;
+    get_imported_modules?: MaybeFn;
+    get_module_words_info?: MaybeFn;
+    get_stack?: MaybeFn;
+    get_word_definition?: MaybeFn;
+    restore_idiolect?: MaybeFn;
+};
+
+const aliasMethod = (instance: LegacyInterpreter, modernName: string, legacyName: keyof LegacyInterpreter): void => {
+    const modern = instance[modernName] as MaybeFn;
+    const legacy = instance[legacyName] as MaybeFn;
+    if (typeof modern === 'function' || typeof legacy !== 'function') return;
+    Object.defineProperty(instance, modernName, {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: (...args: any[]) => legacy(...args),
+    });
+};
+
+const ensureRequiredMethods = (instance: LegacyInterpreter): string[] => {
+    const required = [
+        'collect_stack',
+        'collect_user_words_info',
+        'collect_core_words_info',
+        'collect_imported_modules',
+        'collect_module_words_info',
+        'lookup_word_definition',
+        'restore_user_words',
+    ];
+
+    return required.filter((name) => typeof instance[name] !== 'function');
+};
+
+export const normalizeInterpreterApi = (interpreter: AjisaiInterpreter): AjisaiInterpreter => {
+    const instance = interpreter as unknown as LegacyInterpreter;
+
+    aliasMethod(instance, 'collect_core_words_info', 'get_core_words_info');
+    aliasMethod(instance, 'collect_user_words_info', 'get_idiolect_words_info');
+    aliasMethod(instance, 'collect_imported_modules', 'get_imported_modules');
+    aliasMethod(instance, 'collect_module_words_info', 'get_module_words_info');
+    aliasMethod(instance, 'collect_stack', 'get_stack');
+    aliasMethod(instance, 'lookup_word_definition', 'get_word_definition');
+    aliasMethod(instance, 'restore_user_words', 'restore_idiolect');
+
+    const missing = ensureRequiredMethods(instance);
+    if (missing.length > 0) {
+        console.warn(
+            '[WASM] Interpreter API mismatch. Rebuild js/pkg from rust sources. Missing methods:',
+            missing.join(', ')
+        );
+    }
+
+    return instance as unknown as AjisaiInterpreter;
+};


### PR DESCRIPTION
### Motivation
- Ensure the frontend works with both legacy and modern WASM interpreter exports by adapting older method names to the current API shape.
- Prevent malformed or unexpected core-word entries from the WASM payload from polluting the GUI word list.

### Description
- Add a compatibility shim `js/wasm-interpreter-compat.ts` that aliases legacy interpreter methods (e.g. `get_core_words_info`, `get_idiolect_words_info`, `get_stack`, etc.) to the modern names (`collect_core_words_info`, `collect_user_words_info`, `collect_stack`, etc.) and logs missing required methods.
- Update `js/entry/entry-common.ts` to wrap the created `AjisaiInterpreter` instance with `normalizeInterpreterApi` so the app can consume interpreters with either naming convention.
- Update `js/gui/vocabulary-state-controller.ts` to introduce `isCanonicalCoreWordName` (regex `^[A-Z][A-Z0-9-]*$`), filter out non-canonical core-word entries from the WASM payload when rendering built-in words, and log how many entries were dropped.

### Testing
- Performed a production build using `npm run build`, which completed successfully.
- Ran the existing test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5fef05e88326924f3c75692306b4)