### PR TITLE
Adjust mobile gesture mappings for run and panel transitions

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -196,7 +196,7 @@ export const createGUI = (): GUI => {
             activeMode: ViewMode,
             nextMode: ViewMode
         ): void => {
-            target.addEventListener('dblclick', (e: MouseEvent) => {
+            target.addEventListener('click', (e: MouseEvent) => {
                 if (!mobile.isMobile()) return;
                 if (layoutState.currentMode !== activeMode) return;
                 if ((e.target as HTMLElement).closest('button, a')) return;
@@ -290,7 +290,7 @@ export const createGUI = (): GUI => {
         });
 
         {
-            const TRIPLE_TAP_INTERVAL_MS = 500;
+            const MULTI_TAP_INTERVAL_MS = 500;
             let tapCount = 0;
             let lastTapAt = 0;
 
@@ -299,13 +299,13 @@ export const createGUI = (): GUI => {
                 if (e.changedTouches.length === 0) return;
 
                 const now = Date.now();
-                if (now - lastTapAt <= TRIPLE_TAP_INTERVAL_MS) {
+                if (now - lastTapAt <= MULTI_TAP_INTERVAL_MS) {
                     tapCount += 1;
                 } else {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 3) {
+                if (tapCount >= 2) {
                     executionController.executeCode(editor.extractValue());
                     tapCount = 0;
                     lastTapAt = 0;

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -22,7 +22,10 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
 const MOBILE_EDITOR_PLACEHOLDER = [
     'Enter code here',
     '',
-    'Run → Triple-tap the editor',
+    'Run → Double-tap the editor',
+    'Move to Stack → Single-tap Input area',
+    'Back to Editor → Single-tap Stack area',
+    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation
- Simplify and remap mobile touch gestures so the editor `Run` action is triggered by fewer taps and area transitions are performed with single taps for a more ergonomic mobile experience.
- Reserve triple-tap for a future `skip-run` behavior and update user-facing guidance accordingly.
- Keep the editor placeholder text in sync with the new gesture mappings.

### Description
- Change mobile editor execution trigger from triple-tap to double-tap by treating two consecutive `touchend` events within `500ms` as a run command in `js/gui/gui-application.ts` (multi-tap handler renamed and threshold adjusted).
- Change mobile panel transitions (Input→Stack and Stack→Input) from `dblclick` to single `click` so a single tap performs the area switch in `js/gui/gui-application.ts` (via `setupTapToTransition`).
- Update the mobile editor placeholder text in `js/gui/gui-layout-state.ts` to reflect the new gestures and note triple-tap as a planned `skip-run` feature.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`) and it completed successfully.
- No automated UI interaction tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef782bb8ec8326b643f5cfef6ce4a2)