### PR TITLE
Improve editor selection persistence and update mobile tap gestures

### DIFF
--- a/js/gui/code-input-editor.ts
+++ b/js/gui/code-input-editor.ts
@@ -65,10 +65,8 @@ const lookupSelectionRange = (element: HTMLTextAreaElement): { start: number; en
     end: element.selectionEnd
 });
 
-const MOBILE_BREAKPOINT = 768;
 const MAX_SUGGESTIONS = 10;
 const MIN_SUGGESTION_TRIGGER_LENGTH = 3;
-const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
 
 const extractToken = (
     text: string,
@@ -100,6 +98,7 @@ export const createEditor = (
 
     let currentSuggestions: string[] = [];
     let selectedSuggestionIndex = 0;
+    let lastKnownSelection = lookupSelectionRange(element);
 
     const textareaContainer = element.closest('.input-area');
     const suggestionPanel = document.createElement('div');
@@ -111,6 +110,17 @@ export const createEditor = (
         if (onContentChangeCallback) {
             onContentChangeCallback(element.value);
         }
+    };
+
+    const syncLastKnownSelection = (): void => {
+        lastKnownSelection = lookupSelectionRange(element);
+    };
+
+    const lookupEditableSelectionRange = (): { start: number; end: number } => {
+        if (document.activeElement === element) {
+            syncLastKnownSelection();
+        }
+        return lastKnownSelection;
     };
 
     const hideSuggestions = (): void => {
@@ -179,24 +189,33 @@ export const createEditor = (
         updateElementValue(element, newText);
         const newPos = start + suggestion.length;
         updateSelectionRange(element, newPos, newPos);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
     };
 
     const registerEventListeners = (): void => {
         element.addEventListener('focus', () => {
+            syncLastKnownSelection();
             switchToInputMode();
             refreshSuggestions();
         });
 
         element.addEventListener('blur', () => {
+            syncLastKnownSelection();
             setTimeout(hideSuggestions, 100);
         });
 
         element.addEventListener('input', () => {
+            syncLastKnownSelection();
             emitContentChange();
             refreshSuggestions();
         });
+
+        element.addEventListener('select', syncLastKnownSelection);
+        element.addEventListener('click', syncLastKnownSelection);
+        element.addEventListener('keyup', syncLastKnownSelection);
+        element.addEventListener('touchend', syncLastKnownSelection, { passive: true });
 
         element.addEventListener('keydown', (e) => {
             if (e.key === ' ' && e.ctrlKey) {
@@ -233,6 +252,9 @@ export const createEditor = (
 
     const updateValue = (value: string): void => {
         updateElementValue(element, value);
+        const cursor = value.length;
+        updateSelectionRange(element, cursor, cursor);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
         switchToInputMode();
@@ -240,9 +262,9 @@ export const createEditor = (
 
     const clear = (switchView = true): void => {
         updateElementValue(element, '');
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
+        updateSelectionRange(element, 0, 0);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
         if (switchView) {
@@ -251,39 +273,37 @@ export const createEditor = (
     };
 
     const insertWord = (word: string): void => {
-        const { start, end } = lookupSelectionRange(element);
+        const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, word);
 
         updateElementValue(element, newText);
 
         const newPos = start + word.length;
         updateSelectionRange(element, newPos, newPos);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
         hideSuggestions();
         emitContentChange();
     };
 
     const insertText = (text: string): void => {
-        const { start, end } = lookupSelectionRange(element);
+        const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, text);
 
         updateElementValue(element, newText);
 
         const cursorPos = computeCursorPosition(start, text, true);
         updateSelectionRange(element, cursorPos, cursorPos);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
         hideSuggestions();
         emitContentChange();
     };
 
     const removeLastWord = (): void => {
-        const { start } = lookupSelectionRange(element);
+        const { start } = lookupEditableSelectionRange();
         const before = element.value.substring(0, start);
         const after = element.value.substring(start);
 
@@ -292,10 +312,9 @@ export const createEditor = (
 
         updateElementValue(element, newText);
         updateSelectionRange(element, trimmed.length, trimmed.length);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
         hideSuggestions();
         emitContentChange();
     };

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -196,7 +196,7 @@ export const createGUI = (): GUI => {
             activeMode: ViewMode,
             nextMode: ViewMode
         ): void => {
-            target.addEventListener('dblclick', (e: MouseEvent) => {
+            target.addEventListener('click', (e: MouseEvent) => {
                 if (!mobile.isMobile()) return;
                 if (layoutState.currentMode !== activeMode) return;
                 if ((e.target as HTMLElement).closest('button, a')) return;
@@ -290,7 +290,7 @@ export const createGUI = (): GUI => {
         });
 
         {
-            const TRIPLE_TAP_INTERVAL_MS = 500;
+            const MULTI_TAP_INTERVAL_MS = 500;
             let tapCount = 0;
             let lastTapAt = 0;
 
@@ -299,13 +299,13 @@ export const createGUI = (): GUI => {
                 if (e.changedTouches.length === 0) return;
 
                 const now = Date.now();
-                if (now - lastTapAt <= TRIPLE_TAP_INTERVAL_MS) {
+                if (now - lastTapAt <= MULTI_TAP_INTERVAL_MS) {
                     tapCount += 1;
                 } else {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 3) {
+                if (tapCount >= 2) {
                     executionController.executeCode(editor.extractValue());
                     tapCount = 0;
                     lastTapAt = 0;

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -22,7 +22,10 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
 const MOBILE_EDITOR_PLACEHOLDER = [
     'Enter code here',
     '',
-    'Run → Triple-tap the editor',
+    'Run → Double-tap the editor',
+    'Move to Stack → Single-tap Input area',
+    'Back to Editor → Single-tap Stack area',
+    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation

- Ensure editor text selection is preserved and usable even when the textarea is not the active document focus to improve mobile/touch reliability.  
- Simplify focus handling by removing mobile-specific focus checks and consistently focusing after programmatic edits.  
- Update mobile interaction model to make running code more discoverable and add clearer guidance in the editor placeholder.

### Description

- Introduced `lastKnownSelection`, `syncLastKnownSelection`, and `lookupEditableSelectionRange` to persist and read selection state when the textarea is not focused and wired `select`, `click`, `keyup`, and `touchend` events to keep it in sync.  
- Replaced direct `lookupSelectionRange` usages with `lookupEditableSelectionRange` in insertion and removal functions, ensured selection is synchronized after updates, and removed the `MOBILE_BREAKPOINT`/`checkIsMobile` conditional so the editor always focuses programmatically after edits.  
- Adjusted mobile tap behaviors by switching tap-to-transition from `dblclick` to `click`, reduced the multi-tap trigger to a double-tap to execute code, and updated the mobile editor placeholder text to reflect the new gestures.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef782bb8ec8326b643f5cfef6ce4a2)