### PR TITLE
Improve editor selection tracking and update tap/click interactions (double‑tap to run, desktop multi‑click)

### DIFF
--- a/js/gui/code-input-editor.ts
+++ b/js/gui/code-input-editor.ts
@@ -65,10 +65,8 @@ const lookupSelectionRange = (element: HTMLTextAreaElement): { start: number; en
     end: element.selectionEnd
 });
 
-const MOBILE_BREAKPOINT = 768;
 const MAX_SUGGESTIONS = 10;
 const MIN_SUGGESTION_TRIGGER_LENGTH = 3;
-const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
 
 const extractToken = (
     text: string,
@@ -100,6 +98,7 @@ export const createEditor = (
 
     let currentSuggestions: string[] = [];
     let selectedSuggestionIndex = 0;
+    let lastKnownSelection = lookupSelectionRange(element);
 
     const textareaContainer = element.closest('.input-area');
     const suggestionPanel = document.createElement('div');
@@ -111,6 +110,17 @@ export const createEditor = (
         if (onContentChangeCallback) {
             onContentChangeCallback(element.value);
         }
+    };
+
+    const syncLastKnownSelection = (): void => {
+        lastKnownSelection = lookupSelectionRange(element);
+    };
+
+    const lookupEditableSelectionRange = (): { start: number; end: number } => {
+        if (document.activeElement === element) {
+            syncLastKnownSelection();
+        }
+        return lastKnownSelection;
     };
 
     const hideSuggestions = (): void => {
@@ -179,24 +189,33 @@ export const createEditor = (
         updateElementValue(element, newText);
         const newPos = start + suggestion.length;
         updateSelectionRange(element, newPos, newPos);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
     };
 
     const registerEventListeners = (): void => {
         element.addEventListener('focus', () => {
+            syncLastKnownSelection();
             switchToInputMode();
             refreshSuggestions();
         });
 
         element.addEventListener('blur', () => {
+            syncLastKnownSelection();
             setTimeout(hideSuggestions, 100);
         });
 
         element.addEventListener('input', () => {
+            syncLastKnownSelection();
             emitContentChange();
             refreshSuggestions();
         });
+
+        element.addEventListener('select', syncLastKnownSelection);
+        element.addEventListener('click', syncLastKnownSelection);
+        element.addEventListener('keyup', syncLastKnownSelection);
+        element.addEventListener('touchend', syncLastKnownSelection, { passive: true });
 
         element.addEventListener('keydown', (e) => {
             if (e.key === ' ' && e.ctrlKey) {
@@ -233,6 +252,9 @@ export const createEditor = (
 
     const updateValue = (value: string): void => {
         updateElementValue(element, value);
+        const cursor = value.length;
+        updateSelectionRange(element, cursor, cursor);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
         switchToInputMode();
@@ -240,9 +262,9 @@ export const createEditor = (
 
     const clear = (switchView = true): void => {
         updateElementValue(element, '');
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
+        updateSelectionRange(element, 0, 0);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
         if (switchView) {
@@ -251,39 +273,37 @@ export const createEditor = (
     };
 
     const insertWord = (word: string): void => {
-        const { start, end } = lookupSelectionRange(element);
+        const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, word);
 
         updateElementValue(element, newText);
 
         const newPos = start + word.length;
         updateSelectionRange(element, newPos, newPos);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
         hideSuggestions();
         emitContentChange();
     };
 
     const insertText = (text: string): void => {
-        const { start, end } = lookupSelectionRange(element);
+        const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, text);
 
         updateElementValue(element, newText);
 
         const cursorPos = computeCursorPosition(start, text, true);
         updateSelectionRange(element, cursorPos, cursorPos);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
         hideSuggestions();
         emitContentChange();
     };
 
     const removeLastWord = (): void => {
-        const { start } = lookupSelectionRange(element);
+        const { start } = lookupEditableSelectionRange();
         const before = element.value.substring(0, start);
         const after = element.value.substring(start);
 
@@ -292,10 +312,9 @@ export const createEditor = (
 
         updateElementValue(element, newText);
         updateSelectionRange(element, trimmed.length, trimmed.length);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
-            focusElement(element);
-        }
+        focusElement(element);
         hideSuggestions();
         emitContentChange();
     };

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -196,7 +196,7 @@ export const createGUI = (): GUI => {
             activeMode: ViewMode,
             nextMode: ViewMode
         ): void => {
-            target.addEventListener('dblclick', (e: MouseEvent) => {
+            target.addEventListener('click', (e: MouseEvent) => {
                 if (!mobile.isMobile()) return;
                 if (layoutState.currentMode !== activeMode) return;
                 if ((e.target as HTMLElement).closest('button, a')) return;
@@ -290,7 +290,7 @@ export const createGUI = (): GUI => {
         });
 
         {
-            const TRIPLE_TAP_INTERVAL_MS = 500;
+            const MULTI_TAP_INTERVAL_MS = 500;
             let tapCount = 0;
             let lastTapAt = 0;
 
@@ -299,13 +299,13 @@ export const createGUI = (): GUI => {
                 if (e.changedTouches.length === 0) return;
 
                 const now = Date.now();
-                if (now - lastTapAt <= TRIPLE_TAP_INTERVAL_MS) {
+                if (now - lastTapAt <= MULTI_TAP_INTERVAL_MS) {
                     tapCount += 1;
                 } else {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 3) {
+                if (tapCount >= 2) {
                     executionController.executeCode(editor.extractValue());
                     tapCount = 0;
                     lastTapAt = 0;
@@ -314,6 +314,46 @@ export const createGUI = (): GUI => {
 
                 lastTapAt = now;
             }, { passive: true });
+        }
+
+        {
+            const MULTI_CLICK_INTERVAL_MS = 350;
+            let clickCount = 0;
+            let lastClickAt = 0;
+            let clickTimer: ReturnType<typeof setTimeout> | null = null;
+
+            elements.codeInput.addEventListener('click', () => {
+                if (mobile.isMobile()) return;
+
+                const now = Date.now();
+                if (now - lastClickAt <= MULTI_CLICK_INTERVAL_MS) {
+                    clickCount += 1;
+                } else {
+                    clickCount = 1;
+                }
+                lastClickAt = now;
+
+                if (clickTimer !== null) {
+                    clearTimeout(clickTimer);
+                    clickTimer = null;
+                }
+
+                if (clickCount >= 3) {
+                    executionController.executeStep();
+                    clickCount = 0;
+                    lastClickAt = 0;
+                    return;
+                }
+
+                clickTimer = setTimeout(() => {
+                    if (clickCount === 2) {
+                        executionController.executeCode(editor.extractValue());
+                    }
+                    clickCount = 0;
+                    lastClickAt = 0;
+                    clickTimer = null;
+                }, MULTI_CLICK_INTERVAL_MS);
+            });
         }
 
         window.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -22,7 +22,10 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
 const MOBILE_EDITOR_PLACEHOLDER = [
     'Enter code here',
     '',
-    'Run → Triple-tap the editor',
+    'Run → Double-tap the editor',
+    'Move to Stack → Single-tap Input area',
+    'Back to Editor → Single-tap Stack area',
+    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation
- Keep track of the textarea selection even when the element is not focused so programmatic inserts behave consistently across interactions and devices.
- Simplify focus behavior and remove device-specific focus checks to make editor APIs deterministic.
- Update mobile and desktop tap/click interactions to use double-tap for run on mobile and support multi-click actions on desktop.

### Description
- Track last known selection with a `lastKnownSelection` cache and added `syncLastKnownSelection` and `lookupEditableSelectionRange` to read selection reliably when editor is blurred, and use it for `insertWord`, `insertText`, and `removeLastWord` in `js/gui/code-input-editor.ts`.
- Added event listeners (`select`, `click`, `keyup`, `touchend`, and others) and calls to `syncLastKnownSelection` on focus/blur/input and after programmatic edits to keep the cached selection in sync, and always set selection/focus after updates.
- Removed the `checkIsMobile` branching and always focus the textarea after programmatic changes in `code-input-editor.ts`.
- Changed mobile tap logic in `js/gui/gui-application.ts` so a double-tap runs code (was triple-tap) and replaced a `dblclick` handler with `click` for tap-to-transition; added desktop multi-click handling where double-click runs and triple-click steps the execution.
- Updated mobile editor placeholder text in `js/gui/gui-layout-state.ts` to reflect the new tap interactions.

### Testing
- Ran the TypeScript build with `npm run build` to verify compilation, and it completed successfully.
- Ran the automated unit test suite with `npm test`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef782bb8ec8326b643f5cfef6ce4a2)