### PR TITLE
Introduce Coreword Registry with WordPurity and safePreview metadata

### DIFF
--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -1,0 +1,228 @@
+use crate::builtins::{builtin_specs, BuiltinExecutorKey};
+use crate::interpreter::modules::module_word_metadata_entries;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WordPurity {
+    Pure,
+    Observable,
+    Effectful,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CorewordMetadata {
+    pub name: String,
+    pub category: String,
+    pub purity: WordPurity,
+    pub effects: Vec<String>,
+    pub deterministic: bool,
+    pub safe_preview: bool,
+    pub formerly_module: Option<String>,
+}
+
+pub fn get_builtin_word_registry() -> Vec<CorewordMetadata> {
+    let mut registry: Vec<CorewordMetadata> = builtin_specs()
+        .iter()
+        .map(|spec| core_word_metadata(spec.name, spec.category, spec.executor_key))
+        .collect();
+    registry.extend(module_word_metadata_entries());
+    registry
+}
+
+pub fn get_coreword_metadata(name: &str) -> Option<CorewordMetadata> {
+    let upper = name.to_uppercase();
+    get_builtin_word_registry()
+        .into_iter()
+        .find(|word| word.name == upper)
+}
+
+pub fn get_words_by_category(category: &str) -> Vec<CorewordMetadata> {
+    let needle = category.to_lowercase();
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| word.category == needle)
+        .collect()
+}
+
+pub fn get_words_by_purity(purity: WordPurity) -> Vec<CorewordMetadata> {
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| word.purity == purity)
+        .collect()
+}
+
+pub fn is_safe_preview_word(name: &str) -> bool {
+    get_coreword_metadata(name)
+        .map(|word| word.safe_preview)
+        .unwrap_or(false)
+}
+
+fn core_word_metadata(
+    name: &str,
+    category: &str,
+    executor_key: Option<BuiltinExecutorKey>,
+) -> CorewordMetadata {
+    match executor_key {
+        Some(BuiltinExecutorKey::Print) => effectful(name, category, &["console-write"]),
+        Some(BuiltinExecutorKey::Def) => {
+            effectful(name, category, &["dictionary-write", "dictionary-register"])
+        }
+        Some(BuiltinExecutorKey::Del) => effectful(name, category, &["dictionary-delete"]),
+        Some(BuiltinExecutorKey::Import) => effectful(name, category, &["dictionary-import"]),
+        Some(BuiltinExecutorKey::ImportOnly) => {
+            effectful(name, category, &["dictionary-import-only"])
+        }
+        Some(BuiltinExecutorKey::Force) => effectful(name, category, &["interpreter-mode-write"]),
+        Some(BuiltinExecutorKey::Eval) => effectful(name, category, &["code-execution"]),
+        Some(BuiltinExecutorKey::Spawn)
+        | Some(BuiltinExecutorKey::Await)
+        | Some(BuiltinExecutorKey::Status)
+        | Some(BuiltinExecutorKey::Kill)
+        | Some(BuiltinExecutorKey::Monitor)
+        | Some(BuiltinExecutorKey::Supervise) => effectful(name, category, &["runtime-control"]),
+        Some(BuiltinExecutorKey::Lookup) => {
+            observable(name, category, &["dictionary-read"], Some(true))
+        }
+        _ => pure(name, category),
+    }
+}
+
+pub(crate) fn pure(name: &str, category: &str) -> CorewordMetadata {
+    CorewordMetadata {
+        name: name.to_string(),
+        category: category.to_lowercase(),
+        purity: WordPurity::Pure,
+        effects: vec![],
+        deterministic: true,
+        safe_preview: true,
+        formerly_module: None,
+    }
+}
+
+pub(crate) fn observable(
+    name: &str,
+    category: &str,
+    effects: &[&str],
+    deterministic_override: Option<bool>,
+) -> CorewordMetadata {
+    CorewordMetadata {
+        name: name.to_string(),
+        category: category.to_lowercase(),
+        purity: WordPurity::Observable,
+        effects: effects.iter().map(|x| x.to_string()).collect(),
+        deterministic: deterministic_override.unwrap_or(false),
+        safe_preview: false,
+        formerly_module: None,
+    }
+}
+
+pub(crate) fn effectful(name: &str, category: &str, effects: &[&str]) -> CorewordMetadata {
+    CorewordMetadata {
+        name: name.to_string(),
+        category: category.to_lowercase(),
+        purity: WordPurity::Effectful,
+        effects: effects.iter().map(|x| x.to_string()).collect(),
+        deterministic: false,
+        safe_preview: false,
+        formerly_module: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_builtin_word_registry, WordPurity};
+
+    #[test]
+    fn metadata_exists_for_all_builtin_words() {
+        let registry = get_builtin_word_registry();
+        assert!(!registry.is_empty(), "registry must not be empty");
+        for word in registry {
+            assert!(!word.name.is_empty(), "name must not be empty");
+            assert!(
+                !word.category.is_empty(),
+                "{} has empty category",
+                word.name
+            );
+            assert!(
+                matches!(
+                    word.purity,
+                    WordPurity::Pure | WordPurity::Observable | WordPurity::Effectful
+                ),
+                "{} has invalid purity",
+                word.name
+            );
+        }
+    }
+
+    #[test]
+    fn pure_words_must_be_safe_and_deterministic_without_effects() {
+        let registry = get_builtin_word_registry();
+        for word in registry.iter().filter(|w| w.purity == WordPurity::Pure) {
+            assert!(
+                word.effects.is_empty(),
+                "{} pure words must have no effects",
+                word.name
+            );
+            assert!(
+                word.deterministic,
+                "{} pure words must be deterministic",
+                word.name
+            );
+            assert!(
+                word.safe_preview,
+                "{} pure words must be safe preview",
+                word.name
+            );
+        }
+    }
+
+    #[test]
+    fn effectful_words_must_not_be_safe_preview() {
+        let registry = get_builtin_word_registry();
+        for word in registry
+            .iter()
+            .filter(|w| w.purity == WordPurity::Effectful)
+        {
+            assert!(
+                !word.safe_preview,
+                "{} effectful words must disable safe preview",
+                word.name
+            );
+            assert!(
+                !word.effects.is_empty(),
+                "{} effectful words must declare effects",
+                word.name
+            );
+        }
+    }
+
+    #[test]
+    fn observable_words_are_nondeterministic_and_not_safe_preview_by_default() {
+        let registry = get_builtin_word_registry();
+        for word in registry
+            .iter()
+            .filter(|w| w.purity == WordPurity::Observable)
+        {
+            assert!(
+                !word.effects.is_empty(),
+                "{} observable words must declare effects",
+                word.name
+            );
+            // LOOKUP reads interpreter dictionary state and is deterministic for the same interpreter snapshot.
+            if word.name != "LOOKUP" {
+                assert!(
+                    !word.deterministic,
+                    "{} observable words are expected to be non-deterministic by default",
+                    word.name
+                );
+            }
+            assert!(
+                !word.safe_preview,
+                "{} observable words must not run in auto preview",
+                word.name
+            );
+        }
+    }
+}

--- a/rust/src/interpreter/coreword-registry-import-compat-tests.rs
+++ b/rust/src/interpreter/coreword-registry-import-compat-tests.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+mod tests {
+    use crate::interpreter::Interpreter;
+
+    #[tokio::test]
+    async fn import_and_import_only_remain_compatible_for_standard_modules() {
+        let mut interp = Interpreter::new();
+
+        for module_name in ["MATH", "JSON", "IO", "TIME", "CRYPTO", "ALGO", "MUSIC"] {
+            let code = format!("'{}' IMPORT", module_name);
+            interp
+                .execute(&code)
+                .await
+                .unwrap_or_else(|e| panic!("IMPORT failed for {}: {}", module_name, e));
+            assert!(
+                interp.import_table.modules.contains_key(module_name),
+                "module should be present in import table: {}",
+                module_name
+            );
+        }
+
+        interp
+            .execute("'MATH' [ 'SQRT' ] IMPORT-ONLY")
+            .await
+            .expect("IMPORT-ONLY for MATH@SQRT should succeed");
+    }
+}

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -133,6 +133,9 @@ mod compiled_plan_tests;
 #[path = "core-word-canonicalization-tests.rs"]
 mod core_word_canonicalization_tests;
 #[cfg(test)]
+#[path = "coreword-registry-import-compat-tests.rs"]
+mod coreword_registry_import_compat_tests;
+#[cfg(test)]
 #[path = "differential-tests.rs"]
 mod differential_tests;
 #[cfg(test)]

--- a/rust/src/interpreter/modules/mod.rs
+++ b/rust/src/interpreter/modules/mod.rs
@@ -4,6 +4,7 @@ mod module_registry;
 mod module_samples;
 mod module_word_types;
 
+use crate::coreword_registry::CorewordMetadata;
 use crate::error::Result;
 use crate::interpreter::Interpreter;
 
@@ -25,4 +26,8 @@ pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
 
 pub fn restore_module(interp: &mut Interpreter, module_name: &str) -> bool {
     module_import_execution::restore_module(interp, module_name)
+}
+
+pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
+    module_builtins::module_word_metadata_entries()
 }

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,82 +1,585 @@
+use crate::coreword_registry::{self, CorewordMetadata, WordPurity};
 use crate::interpreter::{audio, datetime, hash, interval_ops, json, random, sort};
 use crate::types::{Capabilities, Stability};
 
 use super::module_word_types::{ModuleSpec, ModuleWord, SampleWord};
 
+macro_rules! module_word {
+    ($name:expr, $description:expr, $executor:expr, $purity:expr, $effects:expr, $det:expr, $preview:expr, $preserves:expr, $stability:expr, $caps:expr) => {
+        ModuleWord {
+            short_name: $name,
+            description: $description,
+            executor: $executor,
+            purity: $purity,
+            effects: $effects,
+            deterministic: $det,
+            safe_preview: $preview,
+            preserves_modes: $preserves,
+            stability: $stability,
+            capabilities: $caps,
+        }
+    };
+}
+
 const MUSIC_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "SEQ", description: "Set sequential playback mode", executor: audio::op_seq, preserves_modes: true, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "SIM", description: "Set simultaneous playback mode", executor: audio::op_sim, preserves_modes: true, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "SLOT", description: "Set slot duration in seconds", executor: audio::op_slot, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "GAIN", description: "Set volume level (0.0-1.0)", executor: audio::op_gain, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "GAIN-RESET", description: "Reset volume to default (1.0)", executor: audio::op_gain_reset, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "PAN", description: "Set stereo position (-1.0 left to 1.0 right)", executor: audio::op_pan, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "PAN-RESET", description: "Reset pan to center (0.0)", executor: audio::op_pan_reset, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "FX-RESET", description: "Reset all audio effects to defaults", executor: audio::op_fx_reset, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "PLAY", description: "Play audio", executor: audio::op_play, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "CHORD", description: "Mark vector as chord (simultaneous)", executor: audio::op_chord, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "ADSR", description: "Set ADSR envelope", executor: audio::op_adsr, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "SINE", description: "Set sine waveform", executor: audio::op_sine, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "SQUARE", description: "Set square waveform", executor: audio::op_square, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "SAW", description: "Set sawtooth waveform", executor: audio::op_saw, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "TRI", description: "Set triangle waveform", executor: audio::op_tri, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    module_word!(
+        "SEQ",
+        "Set sequential playback mode",
+        audio::op_seq,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        true,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "SIM",
+        "Set simultaneous playback mode",
+        audio::op_sim,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        true,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "SLOT",
+        "Set slot duration in seconds",
+        audio::op_slot,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "GAIN",
+        "Set volume level (0.0-1.0)",
+        audio::op_gain,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "GAIN-RESET",
+        "Reset volume to default (1.0)",
+        audio::op_gain_reset,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "PAN",
+        "Set stereo position (-1.0 left to 1.0 right)",
+        audio::op_pan,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "PAN-RESET",
+        "Reset pan to center (0.0)",
+        audio::op_pan_reset,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "FX-RESET",
+        "Reset all audio effects to defaults",
+        audio::op_fx_reset,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "PLAY",
+        "Play audio",
+        audio::op_play,
+        WordPurity::Effectful,
+        &["audio-output"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "CHORD",
+        "Mark vector as chord (simultaneous)",
+        audio::op_chord,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "ADSR",
+        "Set ADSR envelope",
+        audio::op_adsr,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "SINE",
+        "Set sine waveform",
+        audio::op_sine,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "SQUARE",
+        "Set square waveform",
+        audio::op_square,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "SAW",
+        "Set sawtooth waveform",
+        audio::op_saw,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "TRI",
+        "Set triangle waveform",
+        audio::op_tri,
+        WordPurity::Effectful,
+        &["audio-control"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
 ];
 
 const JSON_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "PARSE", description: "Parse JSON string to Ajisai value", executor: json::op_parse, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "STRINGIFY", description: "Convert Ajisai value to JSON string", executor: json::op_stringify, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "GET", description: "Get value by key from JSON object", executor: json::op_json_get, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "KEYS", description: "Get all keys from JSON object", executor: json::op_json_keys, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "SET", description: "Set key-value in JSON object", executor: json::op_json_set, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "EXPORT", description: "Export stack top as JSON file download", executor: json::op_json_export, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    module_word!(
+        "PARSE",
+        "Parse JSON string to Ajisai value",
+        json::op_parse,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "STRINGIFY",
+        "Convert Ajisai value to JSON string",
+        json::op_stringify,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "GET",
+        "Get value by key from JSON object",
+        json::op_json_get,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "KEYS",
+        "Get all keys from JSON object",
+        json::op_json_keys,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "SET",
+        "Set key-value in JSON object",
+        json::op_json_set,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "EXPORT",
+        "Export stack top as JSON file download",
+        json::op_json_export,
+        WordPurity::Effectful,
+        &["file-write"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
 ];
 
 const IO_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "INPUT", description: "Read text from input buffer", executor: json::op_input, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
-    ModuleWord { short_name: "OUTPUT", description: "Write value to output buffer", executor: json::op_output, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::IO },
+    module_word!(
+        "INPUT",
+        "Read text from input buffer",
+        json::op_input,
+        WordPurity::Observable,
+        &["io-read"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
+    module_word!(
+        "OUTPUT",
+        "Write value to output buffer",
+        json::op_output,
+        WordPurity::Effectful,
+        &["io-write"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::IO
+    ),
 ];
 
 const TIME_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "NOW", description: "Get current Unix timestamp", executor: datetime::op_now, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::TIME },
-    ModuleWord { short_name: "DATETIME", description: "Convert timestamp to datetime vector", executor: datetime::op_datetime, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::TIME },
-    ModuleWord { short_name: "TIMESTAMP", description: "Convert datetime vector to timestamp", executor: datetime::op_timestamp, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::TIME },
+    module_word!(
+        "NOW",
+        "Get current Unix timestamp",
+        datetime::op_now,
+        WordPurity::Observable,
+        &["time-read"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::TIME
+    ),
+    module_word!(
+        "DATETIME",
+        "Convert timestamp to datetime vector",
+        datetime::op_datetime,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::TIME
+    ),
+    module_word!(
+        "TIMESTAMP",
+        "Convert datetime vector to timestamp",
+        datetime::op_timestamp,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::TIME
+    ),
 ];
 
 const CRYPTO_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "CSPRNG", description: "Generate cryptographically secure random numbers", executor: random::op_csprng, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::RANDOM.union(Capabilities::CRYPTO) },
-    ModuleWord { short_name: "HASH", description: "Compute hash value", executor: hash::op_hash, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE.union(Capabilities::CRYPTO) },
+    // RANDOM handling: CSPRNG reads an external entropy source, so it is modeled as observable.
+    module_word!(
+        "CSPRNG",
+        "Generate cryptographically secure random numbers",
+        random::op_csprng,
+        WordPurity::Observable,
+        &["random-read"],
+        false,
+        false,
+        false,
+        Stability::Stable,
+        Capabilities::RANDOM.union(Capabilities::CRYPTO)
+    ),
+    module_word!(
+        "HASH",
+        "Compute hash value",
+        hash::op_hash,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE.union(Capabilities::CRYPTO)
+    ),
 ];
 
-const ALGO_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "SORT", description: "Sort vector elements in ascending order", executor: sort::op_sort, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-];
+const ALGO_WORDS: &[ModuleWord] = &[module_word!(
+    "SORT",
+    "Sort vector elements in ascending order",
+    sort::op_sort,
+    WordPurity::Pure,
+    &[],
+    true,
+    true,
+    false,
+    Stability::Stable,
+    Capabilities::PURE
+)];
 
 const MATH_WORDS: &[ModuleWord] = &[
-    ModuleWord { short_name: "SQRT", description: "Map: Square root. Exact rational roots stay exact; otherwise returns sound interval.", executor: interval_ops::op_sqrt, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "SQRT-EPS", description: "Form: Square root with explicit interval width bound eps.", executor: interval_ops::op_sqrt_eps, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "INTERVAL", description: "Form: Create interval [lo, hi].", executor: interval_ops::op_interval, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "LOWER", description: "Map: Lower endpoint of number/interval.", executor: interval_ops::op_lower, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "UPPER", description: "Map: Upper endpoint of number/interval.", executor: interval_ops::op_upper, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "WIDTH", description: "Map: Interval width hi-lo.", executor: interval_ops::op_width, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
-    ModuleWord { short_name: "IS-EXACT", description: "Map: True for exact number or degenerate interval.", executor: interval_ops::op_is_exact, preserves_modes: false, stability: Stability::Stable, capabilities: Capabilities::PURE },
+    module_word!(
+        "SQRT",
+        "Map: Square root. Exact rational roots stay exact; otherwise returns sound interval.",
+        interval_ops::op_sqrt,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "SQRT-EPS",
+        "Form: Square root with explicit interval width bound eps.",
+        interval_ops::op_sqrt_eps,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "INTERVAL",
+        "Form: Create interval [lo, hi].",
+        interval_ops::op_interval,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "LOWER",
+        "Map: Lower endpoint of number/interval.",
+        interval_ops::op_lower,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "UPPER",
+        "Map: Upper endpoint of number/interval.",
+        interval_ops::op_upper,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "WIDTH",
+        "Map: Interval width hi-lo.",
+        interval_ops::op_width,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "IS-EXACT",
+        "Map: True for exact number or degenerate interval.",
+        interval_ops::op_is_exact,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
 ];
 
 const MUSIC_SAMPLES: &[SampleWord] = &[
-    SampleWord { name: "C4", definition: "264", description: "純正律 C4 / ド (264Hz)" },
-    SampleWord { name: "D4", definition: "C4 9 * 8 /", description: "純正律 D4 / レ (297Hz)" },
-    SampleWord { name: "E4", definition: "C4 5 * 4 /", description: "純正律 E4 / ミ (330Hz)" },
-    SampleWord { name: "F4", definition: "C4 4 * 3 /", description: "純正律 F4 / ファ (352Hz)" },
-    SampleWord { name: "G4", definition: "C4 3 * 2 /", description: "純正律 G4 / ソ (396Hz)" },
-    SampleWord { name: "A4", definition: "C4 5 * 3 /", description: "純正律 A4 / ラ (440Hz)" },
-    SampleWord { name: "B4", definition: "C4 15 * 8 /", description: "純正律 B4 / シ (495Hz)" },
-    SampleWord { name: "C5", definition: "C4 2 *", description: "純正律 C5 / 高いド (528Hz)" },
+    SampleWord {
+        name: "C4",
+        definition: "264",
+        description: "純正律 C4 / ド (264Hz)",
+    },
+    SampleWord {
+        name: "D4",
+        definition: "C4 9 * 8 /",
+        description: "純正律 D4 / レ (297Hz)",
+    },
+    SampleWord {
+        name: "E4",
+        definition: "C4 5 * 4 /",
+        description: "純正律 E4 / ミ (330Hz)",
+    },
+    SampleWord {
+        name: "F4",
+        definition: "C4 4 * 3 /",
+        description: "純正律 F4 / ファ (352Hz)",
+    },
+    SampleWord {
+        name: "G4",
+        definition: "C4 3 * 2 /",
+        description: "純正律 G4 / ソ (396Hz)",
+    },
+    SampleWord {
+        name: "A4",
+        definition: "C4 5 * 3 /",
+        description: "純正律 A4 / ラ (440Hz)",
+    },
+    SampleWord {
+        name: "B4",
+        definition: "C4 15 * 8 /",
+        description: "純正律 B4 / シ (495Hz)",
+    },
+    SampleWord {
+        name: "C5",
+        definition: "C4 2 *",
+        description: "純正律 C5 / 高いド (528Hz)",
+    },
 ];
 
 pub(super) const MODULE_SPECS: &[ModuleSpec] = &[
-    ModuleSpec { name: "MUSIC", words: MUSIC_WORDS, sample_words: MUSIC_SAMPLES },
-    ModuleSpec { name: "JSON", words: JSON_WORDS, sample_words: &[] },
-    ModuleSpec { name: "IO", words: IO_WORDS, sample_words: &[] },
-    ModuleSpec { name: "TIME", words: TIME_WORDS, sample_words: &[] },
-    ModuleSpec { name: "CRYPTO", words: CRYPTO_WORDS, sample_words: &[] },
-    ModuleSpec { name: "ALGO", words: ALGO_WORDS, sample_words: &[] },
-    ModuleSpec { name: "MATH", words: MATH_WORDS, sample_words: &[] },
+    ModuleSpec {
+        name: "MUSIC",
+        words: MUSIC_WORDS,
+        sample_words: MUSIC_SAMPLES,
+    },
+    ModuleSpec {
+        name: "JSON",
+        words: JSON_WORDS,
+        sample_words: &[],
+    },
+    ModuleSpec {
+        name: "IO",
+        words: IO_WORDS,
+        sample_words: &[],
+    },
+    ModuleSpec {
+        name: "TIME",
+        words: TIME_WORDS,
+        sample_words: &[],
+    },
+    ModuleSpec {
+        name: "CRYPTO",
+        words: CRYPTO_WORDS,
+        sample_words: &[],
+    },
+    ModuleSpec {
+        name: "ALGO",
+        words: ALGO_WORDS,
+        sample_words: &[],
+    },
+    ModuleSpec {
+        name: "MATH",
+        words: MATH_WORDS,
+        sample_words: &[],
+    },
 ];
+
+pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
+    MODULE_SPECS
+        .iter()
+        .flat_map(|spec| {
+            spec.words.iter().map(move |word| {
+                let mut metadata = match word.purity {
+                    WordPurity::Pure => {
+                        coreword_registry::pure(word.short_name, &spec.name.to_lowercase())
+                    }
+                    WordPurity::Observable => coreword_registry::observable(
+                        word.short_name,
+                        &spec.name.to_lowercase(),
+                        word.effects,
+                        Some(word.deterministic),
+                    ),
+                    WordPurity::Effectful => coreword_registry::effectful(
+                        word.short_name,
+                        &spec.name.to_lowercase(),
+                        word.effects,
+                    ),
+                };
+                metadata.deterministic = word.deterministic;
+                metadata.safe_preview = word.safe_preview;
+                metadata.formerly_module = Some(spec.name.to_string());
+                metadata
+            })
+        })
+        .collect()
+}

--- a/rust/src/interpreter/modules/module_import_execution.rs
+++ b/rust/src/interpreter/modules/module_import_execution.rs
@@ -96,6 +96,8 @@ pub(super) fn import_all_public(interp: &mut Interpreter, module_name: &str) -> 
 }
 
 pub(super) fn op_import(interp: &mut Interpreter) -> Result<()> {
+    // TODO: Module dictionaries are being migrated toward Coreword Registry.
+    // IMPORT should eventually become a compatibility no-op or category-view operation.
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
     let value = if is_keep_mode {
         interp

--- a/rust/src/interpreter/modules/module_word_types.rs
+++ b/rust/src/interpreter/modules/module_word_types.rs
@@ -1,3 +1,4 @@
+use crate::coreword_registry::WordPurity;
 use crate::error::Result;
 use crate::interpreter::Interpreter;
 use crate::types::{Capabilities, Stability};
@@ -9,6 +10,10 @@ pub(super) struct ModuleWord {
     pub short_name: &'static str,
     pub description: &'static str,
     pub executor: ModuleExecutor,
+    pub purity: WordPurity,
+    pub effects: &'static [&'static str],
+    pub deterministic: bool,
+    pub safe_preview: bool,
     pub preserves_modes: bool,
     pub stability: Stability,
     pub capabilities: Capabilities,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,6 @@
 mod builtins;
 pub mod core_word_aliases;
+pub mod coreword_registry;
 pub mod elastic;
 mod error;
 pub mod interpreter;

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -94,6 +94,16 @@ impl AjisaiInterpreter {
     }
 
     #[wasm_bindgen]
+    pub fn collect_builtin_word_registry(&self) -> JsValue {
+        to_value(&crate::coreword_registry::get_builtin_word_registry()).unwrap_or(JsValue::NULL)
+    }
+
+    #[wasm_bindgen]
+    pub fn is_safe_preview_word(&self, name: &str) -> bool {
+        crate::coreword_registry::is_safe_preview_word(name)
+    }
+
+    #[wasm_bindgen]
     pub fn collect_core_word_aliases_info(&self) -> JsValue {
         to_value(&crate::core_word_aliases::collect_core_word_aliases()).unwrap_or(JsValue::NULL)
     }


### PR DESCRIPTION
### Motivation
- The boundary between Core words and Module words is causing classification ambiguity; we need a Registry that lets module words be integrated into Coreword tooling while retaining side-effect metadata. 
- Preserve safety for preview/auto-evaluation and enable future migration of Module dictionaries into a unified Coreword Registry without breaking existing `IMPORT` / `IMPORT-ONLY` behavior. 

### Description
- Add a new `coreword_registry` module with `WordPurity` (`pure|observable|effectful`) and `CorewordMetadata` (name, category, purity, effects, deterministic, safe_preview, formerly_module) and JSON-serializable exports. 
- Provide registry accessors: `get_builtin_word_registry`, `get_coreword_metadata`, `get_words_by_category`, `get_words_by_purity`, and `is_safe_preview_word`, plus wasm bindings `collect_builtin_word_registry` and `is_safe_preview_word` for the UI. 
- Annotate module words and module specs with purity/effects/determinism/safePreview and add `module_word_metadata_entries()` to convert module entries into `CorewordMetadata` while setting `formerly_module`. 
- Add metadata fields to module word types, introduce a `module_word!` constructor macro, and keep `IMPORT`/`IMPORT-ONLY` semantics unchanged while adding a TODO noting the migration direction. 
- Add unit tests that assert metadata completeness and purity rules and a compatibility test ensuring `IMPORT` / `IMPORT-ONLY` for standard modules remains functional. 

### Testing
- Ran formatting: `cargo fmt --manifest-path rust/Cargo.toml` completed successfully. 
- Ran unit tests for the new registry: `cargo test coreword_registry --manifest-path rust/Cargo.toml`, and the added tests passed (unit test run completed with the registry tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f016040aa08326aef83dd7536de809)