### PR TITLE
Remove input-assist widget; add quick-char suggestions and improve editor selection & multi-tap/click behavior

### DIFF
--- a/app-interface.css
+++ b/app-interface.css
@@ -469,15 +469,6 @@
     min-height: 7rem;
 }
 
-.input-assist-words-display {
-    min-height: 2.5rem;
-    flex-shrink: 0;
-}
-
-.input-assist-word {
-    min-width: 2rem;
-}
-
 .empty-words-message {
     width: 100%;
     padding: 0.75rem;
@@ -771,11 +762,6 @@
 
     .words-display {
         cursor: default;
-    }
-
-    .input-assist-word {
-        min-width: 2.25rem;
-        min-height: 2.25rem;
     }
 
     .stack-area {

--- a/index.html
+++ b/index.html
@@ -88,11 +88,6 @@
                     <h2 class="visually-hidden">Input</h2>
                     <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
                     <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
-                    <div
-                        id="input-assist-words-display"
-                        class="words-display input-assist-words-display"
-                        aria-label="Input assist words"
-                    ></div>
                 </section>
             </div>
 

--- a/js/gui/code-input-editor.ts
+++ b/js/gui/code-input-editor.ts
@@ -65,10 +65,21 @@ const lookupSelectionRange = (element: HTMLTextAreaElement): { start: number; en
     end: element.selectionEnd
 });
 
-const MOBILE_BREAKPOINT = 768;
 const MAX_SUGGESTIONS = 10;
 const MIN_SUGGESTION_TRIGGER_LENGTH = 3;
+const MOBILE_BREAKPOINT = 768;
 const checkIsMobile = (): boolean => window.innerWidth <= MOBILE_BREAKPOINT;
+const QUICK_INPUT_SUGGESTIONS: readonly string[] = Object.freeze([
+    '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+    '[', ']', '{', '}', '(', ')',
+    '+', '-', '*', '/', '%',
+    '=', '<', '>',
+    '!', '?', '&', '|', '^', '~',
+    '@', '#', '$', '\\', '_', ':', ';',
+    "'", '"', '`',
+    '.', ',',
+]);
+const QUICK_INPUT_TRIGGER_PATTERN = /^[0-9\[\]{}()+\-*/%=<>!?&|^~@#$\\_:;'".,`]$/;
 
 const extractToken = (
     text: string,
@@ -100,6 +111,7 @@ export const createEditor = (
 
     let currentSuggestions: string[] = [];
     let selectedSuggestionIndex = 0;
+    let lastKnownSelection = lookupSelectionRange(element);
 
     const textareaContainer = element.closest('.input-area');
     const suggestionPanel = document.createElement('div');
@@ -111,6 +123,17 @@ export const createEditor = (
         if (onContentChangeCallback) {
             onContentChangeCallback(element.value);
         }
+    };
+
+    const syncLastKnownSelection = (): void => {
+        lastKnownSelection = lookupSelectionRange(element);
+    };
+
+    const lookupEditableSelectionRange = (): { start: number; end: number } => {
+        if (document.activeElement === element) {
+            syncLastKnownSelection();
+        }
+        return lastKnownSelection;
     };
 
     const hideSuggestions = (): void => {
@@ -159,6 +182,15 @@ export const createEditor = (
 
     const refreshSuggestions = (): void => {
         const { token } = extractToken(element.value, element.selectionStart);
+        if (token.length === 1 && QUICK_INPUT_TRIGGER_PATTERN.test(token)) {
+            currentSuggestions = QUICK_INPUT_SUGGESTIONS
+                .filter(word => word.startsWith(token))
+                .slice(0, MAX_SUGGESTIONS);
+            selectedSuggestionIndex = 0;
+            renderSuggestions();
+            return;
+        }
+
         if (token.length < MIN_SUGGESTION_TRIGGER_LENGTH) {
             hideSuggestions();
             return;
@@ -179,24 +211,33 @@ export const createEditor = (
         updateElementValue(element, newText);
         const newPos = start + suggestion.length;
         updateSelectionRange(element, newPos, newPos);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
     };
 
     const registerEventListeners = (): void => {
         element.addEventListener('focus', () => {
+            syncLastKnownSelection();
             switchToInputMode();
             refreshSuggestions();
         });
 
         element.addEventListener('blur', () => {
+            syncLastKnownSelection();
             setTimeout(hideSuggestions, 100);
         });
 
         element.addEventListener('input', () => {
+            syncLastKnownSelection();
             emitContentChange();
             refreshSuggestions();
         });
+
+        element.addEventListener('select', syncLastKnownSelection);
+        element.addEventListener('click', syncLastKnownSelection);
+        element.addEventListener('keyup', syncLastKnownSelection);
+        element.addEventListener('touchend', syncLastKnownSelection, { passive: true });
 
         element.addEventListener('keydown', (e) => {
             if (e.key === ' ' && e.ctrlKey) {
@@ -233,16 +274,22 @@ export const createEditor = (
 
     const updateValue = (value: string): void => {
         updateElementValue(element, value);
+        const cursor = value.length;
+        updateSelectionRange(element, cursor, cursor);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
         switchToInputMode();
     };
 
     const clear = (switchView = true): void => {
+        const wasFocused = document.activeElement === element;
         updateElementValue(element, '');
-        if (!checkIsMobile()) {
+        if (wasFocused || !checkIsMobile()) {
             focusElement(element);
         }
+        updateSelectionRange(element, 0, 0);
+        syncLastKnownSelection();
         hideSuggestions();
         emitContentChange();
         if (switchView) {
@@ -251,15 +298,17 @@ export const createEditor = (
     };
 
     const insertWord = (word: string): void => {
-        const { start, end } = lookupSelectionRange(element);
+        const wasFocused = document.activeElement === element;
+        const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, word);
 
         updateElementValue(element, newText);
 
         const newPos = start + word.length;
         updateSelectionRange(element, newPos, newPos);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
+        if (wasFocused || !checkIsMobile()) {
             focusElement(element);
         }
         hideSuggestions();
@@ -267,15 +316,17 @@ export const createEditor = (
     };
 
     const insertText = (text: string): void => {
-        const { start, end } = lookupSelectionRange(element);
+        const wasFocused = document.activeElement === element;
+        const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, text);
 
         updateElementValue(element, newText);
 
         const cursorPos = computeCursorPosition(start, text, true);
         updateSelectionRange(element, cursorPos, cursorPos);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
+        if (wasFocused || !checkIsMobile()) {
             focusElement(element);
         }
         hideSuggestions();
@@ -283,7 +334,8 @@ export const createEditor = (
     };
 
     const removeLastWord = (): void => {
-        const { start } = lookupSelectionRange(element);
+        const wasFocused = document.activeElement === element;
+        const { start } = lookupEditableSelectionRange();
         const before = element.value.substring(0, start);
         const after = element.value.substring(start);
 
@@ -292,8 +344,9 @@ export const createEditor = (
 
         updateElementValue(element, newText);
         updateSelectionRange(element, trimmed.length, trimmed.length);
+        syncLastKnownSelection();
 
-        if (!checkIsMobile()) {
+        if (wasFocused || !checkIsMobile()) {
             focusElement(element);
         }
         hideSuggestions();

--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -23,7 +23,6 @@ import {
     ApplyAreaStateDeps
 } from './gui-layout-state';
 import { switchDictionarySheet } from './gui-dictionary-sheet';
-import { createInputAssistWords, InputAssistWords } from './input-assist-words';
 
 declare global {
     interface Window {
@@ -96,7 +95,6 @@ export const createGUI = (): GUI => {
     let persistence: Persistence;
     let executionController: ExecutionController;
     let moduleTabManager: ModuleTabManager;
-    let inputAssistWords: InputAssistWords;
     let layoutState: LayoutState;
 
     const doSwitchDictionarySheet = (sheetId: string): void => {
@@ -196,7 +194,7 @@ export const createGUI = (): GUI => {
             activeMode: ViewMode,
             nextMode: ViewMode
         ): void => {
-            target.addEventListener('dblclick', (e: MouseEvent) => {
+            target.addEventListener('click', (e: MouseEvent) => {
                 if (!mobile.isMobile()) return;
                 if (layoutState.currentMode !== activeMode) return;
                 if ((e.target as HTMLElement).closest('button, a')) return;
@@ -290,7 +288,7 @@ export const createGUI = (): GUI => {
         });
 
         {
-            const TRIPLE_TAP_INTERVAL_MS = 500;
+            const MULTI_TAP_INTERVAL_MS = 500;
             let tapCount = 0;
             let lastTapAt = 0;
 
@@ -299,13 +297,13 @@ export const createGUI = (): GUI => {
                 if (e.changedTouches.length === 0) return;
 
                 const now = Date.now();
-                if (now - lastTapAt <= TRIPLE_TAP_INTERVAL_MS) {
+                if (now - lastTapAt <= MULTI_TAP_INTERVAL_MS) {
                     tapCount += 1;
                 } else {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 3) {
+                if (tapCount >= 2) {
                     executionController.executeCode(editor.extractValue());
                     tapCount = 0;
                     lastTapAt = 0;
@@ -314,6 +312,46 @@ export const createGUI = (): GUI => {
 
                 lastTapAt = now;
             }, { passive: true });
+        }
+
+        {
+            const MULTI_CLICK_INTERVAL_MS = 350;
+            let clickCount = 0;
+            let lastClickAt = 0;
+            let clickTimer: ReturnType<typeof setTimeout> | null = null;
+
+            elements.codeInput.addEventListener('click', () => {
+                if (mobile.isMobile()) return;
+
+                const now = Date.now();
+                if (now - lastClickAt <= MULTI_CLICK_INTERVAL_MS) {
+                    clickCount += 1;
+                } else {
+                    clickCount = 1;
+                }
+                lastClickAt = now;
+
+                if (clickTimer !== null) {
+                    clearTimeout(clickTimer);
+                    clickTimer = null;
+                }
+
+                if (clickCount >= 3) {
+                    executionController.executeStep();
+                    clickCount = 0;
+                    lastClickAt = 0;
+                    return;
+                }
+
+                clickTimer = setTimeout(() => {
+                    if (clickCount === 2) {
+                        executionController.executeCode(editor.extractValue());
+                    }
+                    clickCount = 0;
+                    lastClickAt = 0;
+                    clickTimer = null;
+                }, MULTI_CLICK_INTERVAL_MS);
+            });
         }
 
         window.addEventListener('keydown', (e: KeyboardEvent) => {
@@ -400,19 +438,6 @@ export const createGUI = (): GUI => {
             onSwitchToInputMode: () => switchArea('input'),
             onRequestSuggestions: () => collectAutocompleteWords()
         });
-
-        inputAssistWords = createInputAssistWords(elements.inputAssistWordsDisplay, {
-            onAssistWordClick: (word: string) => {
-                editor.insertText(word);
-            },
-            onBackgroundClick: () => {
-                editor.insertWord(' ');
-            },
-            onBackgroundDoubleClick: () => {
-                editor.removeLastWord();
-            },
-        });
-        inputAssistWords.render();
 
         vocabulary = createVocabularyManager(extractVocabularyElements(elements), {
             onWordClick: (word) => {

--- a/js/gui/gui-dom-cache.ts
+++ b/js/gui/gui-dom-cache.ts
@@ -10,7 +10,6 @@ export interface GUIElements {
     readonly importBtn: HTMLButtonElement;
     readonly outputDisplay: HTMLElement;
     readonly stackDisplay: HTMLElement;
-    readonly inputAssistWordsDisplay: HTMLElement;
     readonly builtInWordsDisplay: HTMLElement;
     readonly userWordsDisplay: HTMLElement;
     readonly builtInWordInfo: HTMLElement;
@@ -43,7 +42,6 @@ export const cacheElements = (): GUIElements => ({
     importBtn: document.getElementById('import-btn') as HTMLButtonElement,
     outputDisplay: document.getElementById('output-display')!,
     stackDisplay: document.getElementById('stack-display')!,
-    inputAssistWordsDisplay: document.getElementById('input-assist-words-display')!,
     builtInWordsDisplay: document.getElementById('core-words-display')!,
     userWordsDisplay: document.getElementById('user-words-display')!,
     builtInWordInfo: document.getElementById('core-word-info')!,

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -22,7 +22,10 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
 const MOBILE_EDITOR_PLACEHOLDER = [
     'Enter code here',
     '',
-    'Run → Triple-tap the editor',
+    'Run → Double-tap the editor',
+    'Move to Stack → Single-tap Input area',
+    'Back to Editor → Single-tap Stack area',
+    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation
- Remove the legacy input-assist UI which was redundant and simplify the DOM/CSS/JS surface. 
- Improve typing/autocomplete UX by providing quick single-character suggestions for common punctuation and symbols. 
- Make editor insertion and commands robust when the textarea is not focused by tracking the last known selection. 
- Align mobile and desktop multi-tap/click gestures to more intuitive actions and avoid accidental focus stealing.

### Description
- Removed the input-assist UI: eliminated the `#input-assist-words-display` element from `index.html`, removed its CSS rules in `app-interface.css`, and removed references from the DOM cache (`gui-dom-cache.ts`) and GUI initialization (`gui-application.ts`).
- Added quick-character autocomplete support in `code-input-editor.ts` by introducing `QUICK_INPUT_SUGGESTIONS`, `QUICK_INPUT_TRIGGER_PATTERN`, and logic in `refreshSuggestions` to show suggestions when a one-character token matches the trigger pattern.
- Implemented stable selection tracking in `code-input-editor.ts` via `lastKnownSelection`, `syncLastKnownSelection`, and `lookupEditableSelectionRange`, and updated `insertWord`, `insertText`, `removeLastWord`, and suggestion application to use this when the textarea is blurred.
- Changed focus behavior to avoid stealing focus on mobile by only refocusing when the editor was previously focused or when not on mobile, and updated selection sync after programmatic edits.
- Updated multi-tap/click gesture handling in `gui-application.ts`: tap-to-transition now listens for `click` (not `dblclick`) on mobile, mobile run is triggered on double-tap instead of triple-tap, and a new desktop multi-click handler was added that executes code on double-click and steps on triple-click; also updated editor placeholder text in `gui-layout-state.ts` to reflect the new gestures.

### Testing
- Performed a TypeScript build (`tsc` / dev build) which completed successfully with no compile errors. 
- Ran the repository's automated checks (`npm run build` / lint) and they completed without failures. 
- The changes contain no new unit tests and did not introduce any test failures in the existing automated pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef782bb8ec8326b643f5cfef6ce4a2)