### PR TITLE
Limit skip-run gesture to desktop and remove mobile triple-tap hint

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -303,7 +303,7 @@ export const createGUI = (): GUI => {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 2) {
+                if (tapCount === 2) {
                     executionController.executeCode(editor.extractValue());
                     tapCount = 0;
                     lastTapAt = 0;

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -25,7 +25,6 @@ const MOBILE_EDITOR_PLACEHOLDER = [
     'Run → Double-tap the editor',
     'Move to Stack → Single-tap Input area',
     'Back to Editor → Single-tap Stack area',
-    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation
- Remove the mobile UI hint and behavior that suggested a triple-tap skip-run so that skip-run remains a desktop-only interaction.

### Description
- Deleted the `Skip-run → Triple-tap (planned)` line from the mobile editor placeholder in `js/gui/gui-layout-state.ts`.
- Changed the mobile touch handler in `js/gui/gui-application.ts` to use `tapCount === 2` so only an exact double-tap triggers run on mobile, preventing triple-tap skip behavior there.
- Desktop triple-click step/skip behavior is unchanged (desktop click handling still triggers step on triple-click).

### Testing
- Ran the TypeScript check with `npm run check`, which completed successfully (no type errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ec89759c8326af61c6e4218970a1)