### PR TITLE
Fix mobile tap transitions and double-tap execution; remove triple-tap hint

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -202,8 +202,8 @@ export const createGUI = (): GUI => {
             });
         };
 
-        setupTapToTransition(elements.outputDisplay, 'output', 'stack');
-        setupTapToTransition(elements.stackDisplay, 'stack', 'input');
+        setupTapToTransition(elements.stackDisplay, 'stack', 'output');
+        setupTapToTransition(elements.outputDisplay, 'output', 'input');
 
         window.addEventListener('resize', () => {
             applyAreaState(buildApplyAreaStateDeps(), layoutState.currentMode);
@@ -303,7 +303,7 @@ export const createGUI = (): GUI => {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 2) {
+                if (tapCount === 2) {
                     executionController.executeCode(editor.extractValue());
                     tapCount = 0;
                     lastTapAt = 0;

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -25,7 +25,6 @@ const MOBILE_EDITOR_PLACEHOLDER = [
     'Run → Double-tap the editor',
     'Move to Stack → Single-tap Input area',
     'Back to Editor → Single-tap Stack area',
-    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation
- Improve mobile navigation so single taps move between the correct areas and avoid confusing transitions. 
- Ensure the double-tap-to-run behavior triggers only on an exact double-tap to avoid accidental activation on longer tap sequences. 
- Remove a user-facing hint about a triple-tap feature that is not implemented. 

### Description
- Swap the targets for `setupTapToTransition` so tapping the stack goes to `output` and tapping the output goes to `input`. 
- Change the touch multi-tap check from `tapCount >= 2` to `tapCount === 2` so execution runs only on an exact double-tap. 
- Remove the `Skip-run → Triple-tap (planned)` line from `MOBILE_EDITOR_PLACEHOLDER`. 

### Testing
- Built the TypeScript code successfully using the project's build pipeline (e.g. `tsc`/`npm run build`).
- Ran the existing unit test suite (`npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ec89759c8326af61c6e4218970a1)