### PR TITLE
Fix mobile tap transitions and double-tap run behavior; remove triple-tap placeholder

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -202,8 +202,8 @@ export const createGUI = (): GUI => {
             });
         };
 
-        setupTapToTransition(elements.outputDisplay, 'output', 'stack');
-        setupTapToTransition(elements.stackDisplay, 'stack', 'input');
+        setupTapToTransition(elements.stackDisplay, 'stack', 'output');
+        setupTapToTransition(elements.outputDisplay, 'output', 'input');
 
         window.addEventListener('resize', () => {
             applyAreaState(buildApplyAreaStateDeps(), layoutState.currentMode);
@@ -303,8 +303,9 @@ export const createGUI = (): GUI => {
                     tapCount = 1;
                 }
 
-                if (tapCount >= 2) {
+                if (tapCount === 2) {
                     executionController.executeCode(editor.extractValue());
+                    switchArea('stack');
                     tapCount = 0;
                     lastTapAt = 0;
                     return;

--- a/js/gui/gui-layout-state.ts
+++ b/js/gui/gui-layout-state.ts
@@ -25,7 +25,6 @@ const MOBILE_EDITOR_PLACEHOLDER = [
     'Run → Double-tap the editor',
     'Move to Stack → Single-tap Input area',
     'Back to Editor → Single-tap Stack area',
-    'Skip-run → Triple-tap (planned)',
     'Input assist → Tap words below',
     'Autocomplete → Tap suggestions while typing'
 ].join('\n');


### PR DESCRIPTION
### Motivation
- Correct mobile touch navigation so single taps move between Input, Stack, and Output in the intended directions and simplify the run-on-double-tap behavior, and remove an outdated triple-tap note from the UI placeholder.

### Description
- Swap `setupTapToTransition` invocations so the correct elements receive the `activeMode`/`nextMode` pair and single taps transition Input↔Stack↔Output as intended.
- Change the multi-tap handler to treat a run as exactly two taps (`tapCount === 2`) and call `switchArea('stack')` after executing code to return to the stack view.
- Remove the `'Skip-run → Triple-tap (planned)'` line from the mobile editor placeholder text in `gui-layout-state.ts`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ec89759c8326af61c6e4218970a1)