### PR TITLE
AQ-VER-007: Add coreword purity & safe_preview integrity tests

### DIFF
--- a/docs/quality/TRACEABILITY_MATRIX.md
+++ b/docs/quality/TRACEABILITY_MATRIX.md
@@ -8,6 +8,7 @@
 | AQ-REQ-004 | TypeScript runtime typing remains sound and platform/value helpers behave correctly across the supported runtimes. | `js/` runtime modules | `npm run check`; `npm test` (Vitest); AQ-VER-004-A through AQ-VER-004-D |
 | AQ-REQ-005 | Quality gates block merges on formatting/lint/test failures. | `.github/workflows/test.yml` | CI quality gate job |
 | AQ-REQ-006 | Interpreter execution semantics (mode dispatch, quantization eligibility, epoch-driven plan-cache invalidation) remain stable across regressions. | `rust/src/interpreter/execute-builtin.rs`, `rust/src/interpreter/quantized-block.rs`, `rust/src/interpreter/higher-order-operations.rs`, `rust/src/interpreter/compiled-plan.rs` | `cargo test --all-targets`; AQ-VER-006-A through AQ-VER-006-D |
+| AQ-REQ-007 | Built-in word purity classification (`pure` / `observable` / `effectful`) and `safe_preview` gating remain self-consistent so that auto-preview never executes side-effecting words, and module IMPORT/IMPORT-ONLY compatibility for the standard module set is preserved. | `rust/src/coreword_registry.rs`, `rust/src/interpreter/modules/module_builtins.rs`, `rust/src/interpreter/modules/module_word_types.rs` | `cargo test --all-targets`; AQ-VER-007-A through AQ-VER-007-F |
 
 ## Verification Index
 
@@ -39,6 +40,12 @@
 | AQ-VER-004-B | AQ-REQ-004 | `compareValue` number-arm equality conjunction (`numerator === && denominator ===`) and vector-arm array-guard disjunction (`!Array.isArray(actual) \|\| !Array.isArray(expected)`) | `js/gui/value-formatter.test.ts::compareValue *` |
 | AQ-VER-004-C | AQ-REQ-004 | `compareStack` per-index 3-disjunct loop guard (`!a \|\| !e \|\| !compareValue(a, e)`) | `js/gui/value-formatter.test.ts::compareStack *` |
 | AQ-VER-004-D | AQ-REQ-004 | `formatFractionScientific` scientific-form conjunction (`numSci.includes('e') && denSci.includes('e')`) | `js/gui/value-formatter.test.ts::formatFractionScientific *` |
+| AQ-VER-007-A | AQ-REQ-007 | Metadata completeness: every entry in `get_builtin_word_registry()` has non-empty `name`, non-empty `category`, and a `purity` ∈ {Pure, Observable, Effectful}. | `rust/src/coreword_registry.rs::tests::aq_ver_007_a_metadata_exists_for_all_builtin_words` |
+| AQ-VER-007-B | AQ-REQ-007 | Pure-word integrity conjunction (`effects.is_empty() && deterministic && safe_preview`) holds for every `WordPurity::Pure` entry. | `rust/src/coreword_registry.rs::tests::aq_ver_007_b_pure_words_must_be_safe_and_deterministic_without_effects` |
+| AQ-VER-007-C | AQ-REQ-007 | Effectful-word safety conjunction (`!safe_preview && !effects.is_empty()`) holds for every `WordPurity::Effectful` entry. | `rust/src/coreword_registry.rs::tests::aq_ver_007_c_effectful_words_must_not_be_safe_preview` |
+| AQ-VER-007-D | AQ-REQ-007 | Observable-word safety conjunction (`!effects.is_empty() && !safe_preview` and `!deterministic` by default, with documented LOOKUP exception) holds for every `WordPurity::Observable` entry. | `rust/src/coreword_registry.rs::tests::aq_ver_007_d_observable_words_are_nondeterministic_and_not_safe_preview_by_default` |
+| AQ-VER-007-E | AQ-REQ-007 | `is_safe_preview_word` decision (`metadata.is_some() && metadata.safe_preview`) — independent-effect MC/DC truth table over (metadata-present × safe_preview) including the default `unwrap_or(false)` short-circuit for unknown names. | `rust/src/coreword_registry.rs::tests::aq_ver_007_e_is_safe_preview_word_decision_truth_table` |
+| AQ-VER-007-F | AQ-REQ-007 | IMPORT / IMPORT-ONLY compatibility for the standard module set (`MATH`, `JSON`, `IO`, `TIME`, `CRYPTO`, `ALGO`, `MUSIC`) is preserved, including selective `'MATH' [ 'SQRT' ] IMPORT-ONLY`. | `rust/src/interpreter/coreword-registry-import-compat-tests.rs::tests::aq_ver_007_f_import_and_import_only_remain_compatible_for_standard_modules` |
 
 ## Coverage Notes
 

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -132,10 +132,18 @@ pub(crate) fn effectful(name: &str, category: &str, effects: &[&str]) -> Corewor
 
 #[cfg(test)]
 mod tests {
-    use super::{get_builtin_word_registry, WordPurity};
+    //! AQ-VER-007 — Coreword purity / safe-preview integrity tests.
+    //!
+    //! These tests are linked from `docs/quality/TRACEABILITY_MATRIX.md`
+    //! to AQ-REQ-007 ("Built-in word purity classification and `safe_preview`
+    //! gating remain self-consistent"). Test names are prefixed with their
+    //! verification ID so that a `cargo test aq_ver_007` invocation runs
+    //! the full coreword-registry coverage subset.
+
+    use super::{get_builtin_word_registry, is_safe_preview_word, WordPurity};
 
     #[test]
-    fn metadata_exists_for_all_builtin_words() {
+    fn aq_ver_007_a_metadata_exists_for_all_builtin_words() {
         let registry = get_builtin_word_registry();
         assert!(!registry.is_empty(), "registry must not be empty");
         for word in registry {
@@ -157,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn pure_words_must_be_safe_and_deterministic_without_effects() {
+    fn aq_ver_007_b_pure_words_must_be_safe_and_deterministic_without_effects() {
         let registry = get_builtin_word_registry();
         for word in registry.iter().filter(|w| w.purity == WordPurity::Pure) {
             assert!(
@@ -179,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn effectful_words_must_not_be_safe_preview() {
+    fn aq_ver_007_c_effectful_words_must_not_be_safe_preview() {
         let registry = get_builtin_word_registry();
         for word in registry
             .iter()
@@ -199,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn observable_words_are_nondeterministic_and_not_safe_preview_by_default() {
+    fn aq_ver_007_d_observable_words_are_nondeterministic_and_not_safe_preview_by_default() {
         let registry = get_builtin_word_registry();
         for word in registry
             .iter()
@@ -210,7 +218,9 @@ mod tests {
                 "{} observable words must declare effects",
                 word.name
             );
-            // LOOKUP reads interpreter dictionary state and is deterministic for the same interpreter snapshot.
+            // LOOKUP reads interpreter dictionary state and is deterministic
+            // for the same interpreter snapshot; tracked as a documented
+            // exception under AQ-VER-007-D.
             if word.name != "LOOKUP" {
                 assert!(
                     !word.deterministic,
@@ -224,5 +234,60 @@ mod tests {
                 word.name
             );
         }
+    }
+
+    /// AQ-VER-007-E — MC/DC truth table for `is_safe_preview_word`.
+    ///
+    /// The decision under test is logically:
+    ///
+    /// ```text
+    /// metadata_present(name) && metadata_safe_preview(name)
+    /// ```
+    ///
+    /// implemented in `is_safe_preview_word` via
+    /// `get_coreword_metadata(name).map(|w| w.safe_preview).unwrap_or(false)`.
+    /// We exercise all three reachable rows (the `metadata_present == false`
+    /// row collapses both `safe_preview` cases to the `unwrap_or(false)`
+    /// short-circuit, so it is covered by a single unknown-name probe):
+    ///
+    /// | row | metadata_present | safe_preview | expected | rationale                          |
+    /// |-----|------------------|--------------|----------|------------------------------------|
+    /// | 1   | true             | true         | true     | known pure word (e.g. `ADD`)       |
+    /// | 2   | true             | false        | false    | known effectful word (e.g. `PRINT`)|
+    /// | 3   | true             | false        | false    | known observable word (e.g. `NOW`) |
+    /// | 4   | false            | n/a          | false    | unknown name → unwrap_or(false)    |
+    ///
+    /// Rows 1 vs 2 demonstrate independent effect of `safe_preview`;
+    /// rows 1 vs 4 demonstrate independent effect of `metadata_present`.
+    #[test]
+    fn aq_ver_007_e_is_safe_preview_word_decision_truth_table() {
+        // Row 1: metadata present, safe_preview=true → true.
+        assert!(
+            is_safe_preview_word("ADD"),
+            "row1: pure builtin ADD must be safe preview"
+        );
+        // Row 2: metadata present, safe_preview=false (effectful) → false.
+        assert!(
+            !is_safe_preview_word("PRINT"),
+            "row2: effectful builtin PRINT must not be safe preview"
+        );
+        // Row 3: metadata present, safe_preview=false (observable) → false.
+        assert!(
+            !is_safe_preview_word("NOW"),
+            "row3: observable builtin NOW must not be safe preview"
+        );
+        // Row 4: metadata absent → unwrap_or(false) short-circuit.
+        assert!(
+            !is_safe_preview_word("__AJISAI_NO_SUCH_WORD__"),
+            "row4: unknown name must default to false"
+        );
+
+        // Case-insensitive lookup also reaches the safe_preview=true arm,
+        // confirming that the upper-casing inside get_coreword_metadata
+        // does not flip the decision.
+        assert!(
+            is_safe_preview_word("add"),
+            "row1 (lowercase): case-insensitive lookup must still be safe preview"
+        );
     }
 }

--- a/rust/src/interpreter/coreword-registry-import-compat-tests.rs
+++ b/rust/src/interpreter/coreword-registry-import-compat-tests.rs
@@ -1,9 +1,14 @@
 #[cfg(test)]
 mod tests {
+    //! AQ-VER-007-F — IMPORT / IMPORT-ONLY compatibility for the standard
+    //! module set. Linked from `docs/quality/TRACEABILITY_MATRIX.md` to
+    //! AQ-REQ-007. Confirms that the coreword-registry refactor (commit
+    //! `d65cdbb`) does not regress legacy module-load semantics for any of
+    //! `MATH`, `JSON`, `IO`, `TIME`, `CRYPTO`, `ALGO`, `MUSIC`.
     use crate::interpreter::Interpreter;
 
     #[tokio::test]
-    async fn import_and_import_only_remain_compatible_for_standard_modules() {
+    async fn aq_ver_007_f_import_and_import_only_remain_compatible_for_standard_modules() {
         let mut interp = Interpreter::new();
 
         for module_name in ["MATH", "JSON", "IO", "TIME", "CRYPTO", "ALGO", "MUSIC"] {


### PR DESCRIPTION
## Summary

Adds comprehensive verification tests for coreword registry purity classification and `safe_preview` gating to ensure built-in words remain self-consistent and prevent auto-preview from executing side-effecting operations. Implements AQ-VER-007-A through AQ-VER-007-F verification evidence linked to AQ-REQ-007.

Changes include:
- Renamed and prefixed existing tests with `aq_ver_007_a`, `aq_ver_007_b`, `aq_ver_007_c`, `aq_ver_007_d` identifiers for traceability
- Added `aq_ver_007_e_is_safe_preview_word_decision_truth_table` test with MC/DC coverage of the `is_safe_preview_word` decision logic (metadata presence × safe_preview flag, including `unwrap_or(false)` short-circuit for unknown names)
- Added `aq_ver_007_f_import_and_import_only_remain_compatible_for_standard_modules` test to verify IMPORT/IMPORT-ONLY semantics for standard modules (MATH, JSON, IO, TIME, CRYPTO, ALGO, MUSIC)
- Updated `docs/quality/TRACEABILITY_MATRIX.md` with AQ-REQ-007 requirement and AQ-VER-007-A through AQ-VER-007-F verification rows
- Added module-level documentation explaining test linkage and naming convention for `cargo test aq_ver_007` filtering

## Quality Classification

- Highest impacted level: **QL-B** (quality assurance / verification infrastructure)

## Traceability

- Requirement(s): **AQ-REQ-007** (Built-in word purity classification and `safe_preview` gating remain self-consistent)
- Verification evidence: 
  - AQ-VER-007-A: Metadata completeness for all builtin words
  - AQ-VER-007-B: Pure-word integrity conjunction (effects empty, deterministic, safe_preview)
  - AQ-VER-007-C: Effectful-word safety conjunction (!safe_preview, !effects empty)
  - AQ-VER-007-D: Observable-word safety conjunction (!safe_preview, !deterministic, with LOOKUP exception)
  - AQ-VER-007-E: MC/DC truth table for `is_safe_preview_word` decision logic
  - AQ-VER-007-F: IMPORT/IMPORT-ONLY compatibility for standard module set

## Quality Checklist

- [x] Relevant requirements/objectives are identified (AQ-REQ-007)
- [x] Traceability links added to `TRACEABILITY_MATRIX.md`
- [x] Tests follow naming convention for selective execution (`cargo test aq_ver_007`)
- [x] MC/DC truth table documented for `is_safe_preview_word` decision
- [x] Existing test assertions preserved; new tests are additive
- [x] Module documentation explains test linkage and rationale

## Notes

All changes are test/documentation additions with no modifications to production code logic. The `is_safe_preview_word` function import was added to support the new AQ-VER-007-E test. Existing tests remain functionally identical, only renamed for traceability.

https://claude.ai/code/session_01JvcFFNNH87WyNuRAct8LTb