### PR TITLE
Require double-click to return from Output to Editor on desktop

### DIFF
--- a/js/gui/gui-application.ts
+++ b/js/gui/gui-application.ts
@@ -271,7 +271,7 @@ export const createGUI = (): GUI => {
             testRunner.runAllTests();
         });
 
-        elements.outputArea.addEventListener('click', (e: MouseEvent) => {
+        elements.outputArea.addEventListener('dblclick', (e: MouseEvent) => {
             if ((e.target as HTMLElement).closest('button, a')) return;
             if (!mobile.isMobile() && layoutState.currentLeftMode === 'output') {
                 switchArea('input');


### PR DESCRIPTION
Single-click previously switched the desktop left column from Output back to the editor, which made it easy to lose focus on output with an accidental click. Use dblclick instead so the return gesture is intentional.

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
