### PR TITLE
Remove FRAME support and normalize comparison results to scalar booleans

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -303,7 +303,6 @@ Tensor operations operate on nested vectors treated as multi-dimensional arrays.
 | `RESHAPE` | — | Reshape to new dimension sizes |
 | `TRANSPOSE` | — | Transpose a 2D tensor |
 | `FILL` | — | Create a tensor of given shape filled with a value |
-| `FRAME` | — | Collect stack values into a tensor frame |
 
 Tensor operation implementations must follow the staged pipeline:
 1. Flatten input
@@ -651,7 +650,7 @@ The `,,` (keep/bifurcation) modifier retains source context while also pushing t
 - Keep control flow shallow and phase-separated.
 - Separate semantic changes from structural cleanup in change management.
 - Maintain single canonical implementations; do not allow dual-mode drift.
-- Source code files must contain no inline comments or block comments. All explanatory text must reside in external specification and documentation files.
+- Source code comments are allowed when they clarify intent, invariants, traceability, or non-obvious behavior. When source code is changed, nearby comments must be reviewed and updated so they remain accurate. Comments that merely restate obvious code should be avoided.
 
 ### 14.2 Advisory
 

--- a/rust/src/arithmetic-operation-tests.rs
+++ b/rust/src/arithmetic-operation-tests.rs
@@ -328,7 +328,7 @@ mod interval_tests {
     async fn test_interval_comparison_policy() {
         let mut interp = Interpreter::new();
         interp.execute("1 2 INTERVAL 3 4 INTERVAL <").await.unwrap();
-        assert_eq!(format!("{}", interp.get_stack()[0]), "[ 1 ]");
+        assert_eq!(format!("{}", interp.get_stack()[0]), "1");
 
         let mut interp_undetermined = Interpreter::new();
         let result = interp_undetermined
@@ -341,7 +341,7 @@ mod interval_tests {
             .execute("1 5 INTERVAL 2 4 INTERVAL =")
             .await
             .unwrap();
-        assert_eq!(format!("{}", interp_eq.get_stack()[0]), "[ 0 ]");
+        assert_eq!(format!("{}", interp_eq.get_stack()[0]), "0");
     }
 
     #[tokio::test]

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -150,15 +150,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         None
     ),
     builtin_spec!(
-        "FRAME",
-        "vector",
-        "Generate empty vector structure from shape. Shape Vector -> Vector",
-        "[ 2 3 ] FRAME → [ [ ] [ ] [ ] ] [ [ ] [ ] [ ] ]",
-        "none",
-        BuiltinDetailGroup::VectorOps,
-        None
-    ),
-    builtin_spec!(
         "GET",
         "vector",
         "Form: Extract element at index. Vector, Index Vector -> element",

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -65,7 +65,6 @@ fn core_builtin_capabilities(key: Option<BuiltinExecutorKey>, name: &str) -> Cap
         (Some(BuiltinExecutorKey::Monitor), _) => Capabilities::SPAWN,
         (Some(BuiltinExecutorKey::Supervise), _) => Capabilities::SPAWN,
         (Some(BuiltinExecutorKey::Print), _) => Capabilities::IO,
-        (None, "FRAME") => Capabilities::PURE.union(Capabilities::INPUT_HELPER),
         _ => Capabilities::PURE,
     }
 }

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -9,9 +9,7 @@ use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, Value, ValueData};
 
 fn push_boolean_result(interp: &mut Interpreter, result: bool) {
-    interp
-        .stack
-        .push(Value::from_vector(vec![Value::from_bool(result)]));
+    interp.stack.push(Value::from_bool(result));
     let stack_len = interp.stack.len();
     interp.semantic_registry.normalize_to_stack_len(stack_len);
     interp

--- a/rust/src/interpreter/dictionary-tier-tests.rs
+++ b/rust/src/interpreter/dictionary-tier-tests.rs
@@ -22,11 +22,7 @@ mod tests {
         assert_eq!(def.stability, Stability::Stable);
         assert_eq!(def.capabilities, Capabilities::MUTATES_DICT);
 
-        let frame = interp.core_vocabulary.get("FRAME").unwrap();
-        assert_eq!(
-            frame.capabilities,
-            Capabilities::PURE.union(Capabilities::INPUT_HELPER)
-        );
+        assert!(interp.core_vocabulary.get("FRAME").is_none());
 
         assert!(!interp.core_vocabulary.contains_key("'"));
     }

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -21,7 +21,7 @@ fn apply_word_hint_override(interp: &mut Interpreter, word: &str) {
         "BOOL" | "LT" | "LTE" | "EQ" | "AND" | "OR" | "NOT" => Some(DisplayHint::Boolean),
         "NOW" | "DATETIME" | "TIMESTAMP" => Some(DisplayHint::DateTime),
         "CHARS" | "MAP" | "FILTER" | "SCAN" | "UNFOLD" | "REVERSE" | "CONCAT" | "SORT" | "TAKE"
-        | "REORDER" | "SPLIT" | "COLLECT" | "RESHAPE" | "TRANSPOSE" | "FILL" | "FRAME" => {
+        | "REORDER" | "SPLIT" | "COLLECT" | "RESHAPE" | "TRANSPOSE" | "FILL" => {
             Some(DisplayHint::Auto)
         }
         _ => None,

--- a/rust/src/interpreter/higher_order/filter.rs
+++ b/rust/src/interpreter/higher_order/filter.rs
@@ -1,5 +1,5 @@
 use super::common::{
-    execute_executable_code, extract_executable_code, is_truthy_boolean, ExecutableCode,
+    execute_executable_code, extract_executable_code, extract_predicate_boolean, ExecutableCode,
 };
 use super::hedged::execute_hedged_predicate_kernel;
 use super::runners::{execute_plain_predicate_kernel, execute_quantized_predicate_kernel};
@@ -109,22 +109,13 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
                                     }
                                 };
 
-                                let is_true: bool = if is_vector_value(&condition_result) {
-                                    if condition_result.len() == 1 {
-                                        is_truthy_boolean(condition_result.get_child(0).unwrap())
-                                    } else {
-                                        error = Some(AjisaiError::create_structure_error(
-                                            "boolean result from FILTER code",
-                                            "other format",
-                                        ));
+                                let is_true: bool = match extract_predicate_boolean(condition_result)
+                                {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        error = Some(e);
                                         break;
                                     }
-                                } else {
-                                    error = Some(AjisaiError::create_structure_error(
-                                        "boolean vector result from FILTER code",
-                                        "other format",
-                                    ));
-                                    break;
                                 };
 
                                 if is_true {

--- a/rust/src/interpreter/interpreter-execution-tests.rs
+++ b/rust/src/interpreter/interpreter-execution-tests.rs
@@ -29,10 +29,11 @@ mod tests {
         assert_eq!(interp.stack.len(), 4);
         let val = &interp.stack[3];
 
-        assert_eq!(val.len(), 1, "Expected single-element vector boolean");
-        let inner = val.get_child(0).expect("Expected inner element");
         assert!(
-            !inner.as_scalar().expect("Expected scalar in result").is_zero(),
+            !val
+                .as_scalar()
+                .expect("Expected scalar boolean result")
+                .is_zero(),
             "Expected TRUE from comparison"
         );
     }
@@ -195,4 +196,16 @@ ADDTEST
         }
     }
 
+}
+
+#[tokio::test]
+async fn comparison_words_return_scalar_booleans() {
+    let cases = [("1 2 LT", true), ("2 2 LTE", true), ("2 1 LT", false), ("1 1 EQ", true), ("1 2 EQ", false)];
+    for (program, expected) in cases {
+        let mut interp = crate::interpreter::Interpreter::new();
+        interp.execute(program).await.unwrap();
+        assert_eq!(interp.stack.len(), 1, "program: {program}");
+        let scalar = interp.stack[0].as_scalar().expect("comparison should return scalar boolean");
+        assert_eq!(scalar.is_zero(), !expected, "program: {program}");
+    }
 }

--- a/rust/src/wasm-interpreter-execution.rs
+++ b/rust/src/wasm-interpreter-execution.rs
@@ -1,7 +1,6 @@
-use super::wasm_value_conversion::{build_bracket_structure_from_shape, is_vector_value};
 use super::{set_js_prop, AjisaiInterpreter};
 use crate::tokenizer;
-use crate::types::{ExecutionLine, ValueData};
+use crate::types::ExecutionLine;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -10,90 +9,6 @@ impl AjisaiInterpreter {
     pub async fn execute(&mut self, code: &str) -> Result<JsValue, JsValue> {
         self.interpreter.definition_to_load = None;
         let obj = js_sys::Object::new();
-
-        let trimmed = code.trim();
-        let upper_code = trimmed.to_uppercase();
-
-        if upper_code.ends_with("FRAME") {
-            let prefix_len = upper_code.len() - 5;
-            let is_valid = if prefix_len == 0 {
-                true
-            } else {
-                upper_code
-                    .chars()
-                    .nth(prefix_len - 1)
-                    .map_or(false, |c| c.is_whitespace())
-            };
-
-            if is_valid {
-                if prefix_len > 0 {
-                    let prefix_code = &trimmed[..prefix_len].trim();
-                    if !prefix_code.is_empty() {
-                        if let Err(e) = self.interpreter.execute(prefix_code).await {
-                            set_js_prop(&obj, "status", &("ERROR".into()));
-                            set_js_prop(&obj, "message", &(e.to_string().into()));
-                            set_js_prop(&obj, "error", &(true.into()));
-                            return Ok(obj.into());
-                        }
-                    }
-                }
-
-                let shape = if let Some(top) = self.interpreter.stack.last() {
-                    if is_vector_value(top) && !top.is_nil() {
-                        let mut dims = Vec::new();
-                        let mut valid = top.len() >= 1 && top.len() <= 9;
-                        if valid {
-                            if let ValueData::Vector(children) = &top.data {
-                                for child in children.iter() {
-                                    if let Some(val) = child.as_usize() {
-                                        if val >= 1 && val <= 100 {
-                                            dims.push(val);
-                                        } else {
-                                            valid = false;
-                                            break;
-                                        }
-                                    } else {
-                                        valid = false;
-                                        break;
-                                    }
-                                }
-                            } else {
-                                valid = false;
-                            }
-                        }
-                        if valid {
-                            Some(dims)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                if let Some(shape_vec) = shape {
-                    self.interpreter.stack.pop();
-                    let helper_text = build_bracket_structure_from_shape(&shape_vec);
-                    set_js_prop(&obj, "inputHelper", &(helper_text.into()));
-                    set_js_prop(&obj, "status", &("OK".into()));
-                    set_js_prop(&obj, "stack", &(self.collect_stack()));
-                    set_js_prop(&obj, "userWords", &(self.collect_user_words_for_state()));
-                    set_js_prop(
-                        &obj,
-                        "importedModules",
-                        &(self.collect_imported_modules_array()),
-                    );
-                    return Ok(obj.into());
-                } else {
-                    set_js_prop(&obj, "status", &("ERROR".into()));
-                    set_js_prop(&obj, "message", &("FRAME requires a shape vector [ dim1 dim2 ... ] (1-9 dimensions, values 1-100)".into()));
-                    set_js_prop(&obj, "error", &(true.into()));
-                    return Ok(obj.into());
-                }
-            }
-        }
 
         match self.interpreter.execute(code).await {
             Ok(()) => {


### PR DESCRIPTION
### Motivation

- `FRAME` is an obsolete input-helper built-in; it must be removed from the language spec, runtime and WASM helpers to avoid dead/unsupported special-casing. 
- Comparison words (`LT`/`LTE`/`EQ`) returned single-element vector booleans in some paths, which is inconsistent with `TRUE`/`FALSE`; these should return scalar booleans for a simpler, consistent value model. 
- The repository comment policy banning inline comments is too strict; allow clarifying comments while requiring nearby-comment review on code changes.

### Description

- Removed `FRAME` from `SPECIFICATION.md` and replaced the comment-prohibition rule with a comment-allowed + review obligation sentence. 
- Deleted the `FRAME` builtin spec entry and removed the core capability special-case that treated `FRAME` as an `INPUT_HELPER`. 
- Eliminated `FRAME`-specific handling in the interpreter hint list and removed the WASM execution path and imports that implemented `FRAME` input-helper behavior. 
- Unified comparison outputs by changing `push_boolean_result` to push scalar booleans (`Value::from_bool`) and updated `FILTER`/predicate handling to use the shared `extract_predicate_boolean` helper so predicates accept scalar booleans and legacy vector forms; updated and added tests accordingly.

### Testing

- Ran `cargo test --workspace` in the `rust/` crate and the full test suite completed successfully (all unit tests passed). 
- Ran focused test runs for the updated comparison test (`comparison_words_return_scalar_booleans`) and the adjusted execution tests; these targeted tests passed. 
- Verified that the dictionary/core-vocabulary test now asserts `FRAME` is absent and that interval/comparison tests were updated to match scalar-boolean expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40943311c8326bd5f25b9a6e1570c)