### PR TITLE
feat(vocab): canonical_home + listings model for built-in words

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -258,6 +258,23 @@ All built-in words have English-word-based canonical names (see Section 7). The 
 
 Built-in words are predefined and cannot be redefined or deleted.
 
+Every built-in word has exactly one **canonical home**, either Core or a specific module. The canonical home determines where the implementation lives and, for module-canonical words, which module name `IMPORT` activates them under.
+
+Independent of canonical home, every built-in word has a set of **listings** identifying which dictionary views surface the word for browsing or documentation. The Core listing view and any module listing view are not necessarily disjoint: a word may be listed in both. Such a word is called a **boundary word**, recognising that it has both a semantic role (Core) and a capability role (module).
+
+Listings are presentation-only. A listing does not change name resolution, IMPORT semantics, or qualified-name resolution: bare names resolve through the Core vocabulary first and then through imported modules; `MODULE@WORD` resolves only to that module's canonical entries.
+
+Boundary classes:
+
+- **Core-only words** — canonical home Core; listed only in Core.
+- **Canonical Core + module-listed boundary words** — canonical home Core; additionally surfaced in one or more module or category listing views (e.g. `PRINT` in `IO`, `STR`/`NUM`/`BOOL` in the `CAST` category, `SHAPE`/`RANK` in the `TENSOR` category, `SPAWN`/`AWAIT` in the `RUNTIME` category).
+- **Canonical Module + core-listed boundary words** — canonical home in a module, additionally surfaced in the Core listing view (e.g. `SORT` whose canonical home is `ALGO`).
+- **Module-only words** — canonical home in a module; listed only under that module.
+
+`IMPORT` and `IMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
+
+Categories such as `CAST`, `TEXT`, `TENSOR`, and `RUNTIME` are documentation-only labels used to group Core words by capability surface. They are **not** modules, are not registered in `MODULE_SPECS`, and cannot be supplied to `IMPORT`.
+
 ### 7.0 English-word-based naming
 
 All built-in words — both Core words and module dictionary words — use English-word-based canonical names. Symbol forms (such as `+`, `-`, `*`, `/`, `%`, `=`, `<`, `<=`, `&`, `==`, `=>`, `?`, `!`, `.`, `..`, `,`, `,,`, `~`) are syntactic sugar that the tokenizer maps to canonical English names. The canonical name is the authoritative identifier; the symbol form is convenience surface syntax. Any new built-in word must be introduced under an English-word-based canonical name.
@@ -431,7 +448,7 @@ Words not listed here retain their existing handling of NIL. In particular, cont
 
 Every Coreword (built-in or module-provided) has a machine-readable contract entry in the Coreword registry. The contract is the authoritative description of the word's input requirements, output guarantees, and runtime classification. Tests, documentation, and tooling consume this metadata; narrative text is non-canonical.
 
-A contract entry has the following fields, in addition to the existing identification (`name`, `category`) and effect-classification fields (`purity`, `effects`, `deterministic`, `safe_preview`):
+A contract entry has the following fields, in addition to the existing identification (`name`, `category`), effect-classification fields (`purity`, `effects`, `deterministic`, `safe_preview`), and listing fields (`canonical_home`, `listed_in_core`, `listed_in_modules`, `listed_in_categories`):
 
 | Field | Domain | Meaning |
 |-------|--------|---------|
@@ -442,6 +459,19 @@ A contract entry has the following fields, in addition to the existing identific
 `partiality` and `nil_policy` are independent axes. For example, `~/` (safe-mode division) is `Projecting` with `nil_policy = CreatesNil`, while bare `/` is `Partial` with `nil_policy = Passthrough`.
 
 Contract metadata is reachable from both the Rust runtime and the WASM boundary. Adding a Coreword without a contract entry is a conformance violation.
+
+The listing fields work as follows:
+
+| Field | Domain | Meaning |
+|-------|--------|---------|
+| `canonical_home` | `Core` / `Module(name)` | Where the canonical implementation lives. For module-canonical words this is also the only module that can resolve the word as `MODULE@WORD` and the only module whose `IMPORT` brings the word into bare scope. |
+| `listed_in_core` | `bool` | Whether the word appears in the Core listing view. Does not affect resolution. |
+| `listed_in_modules` | `[module_name]` | Module listing views in which the word appears. A canonical module word always has its own module here. Boundary listings (e.g. `PRINT` in `IO`) are presentation-only. |
+| `listed_in_categories` | `[category_label]` | Documentation-only category labels (e.g. `CAST`, `TEXT`, `TENSOR`, `RUNTIME`). Categories are not modules and cannot be `IMPORT`ed. |
+
+`IMPORT-ONLY` of a selector that is core-listed in the target module's view but not canonically owned by that module is a no-op: the word is already available as a Canonical Core word, so the selector is silently skipped with a single warning line. Selectors that match neither a canonical word nor a listing remain an error.
+
+A bare name may legitimately appear under more than one canonical home (for example core list `GET` and `JSON@GET`). In that case bare-name lookup resolves to the Canonical Core entry — matching the runtime's resolution order — while `MODULE@WORD` always reaches the module entry.
 
 ---
 

--- a/js/gui/vocabulary-state-controller.ts
+++ b/js/gui/vocabulary-state-controller.ts
@@ -346,7 +346,16 @@ export const createVocabularyManager = (
         if (!window.ajisaiInterpreter) return;
 
         try {
-            const coreWords = window.ajisaiInterpreter.collect_core_words_info();
+            // Prefer the listing-based view (canonical core + core-listed
+            // boundary words like SORT). Fall back to the legacy
+            // canonical-core-only collector for older WASM builds.
+            const interp = window.ajisaiInterpreter as unknown as {
+                collect_core_listed_words_info?: () => unknown[][];
+                collect_core_words_info: () => unknown[][];
+            };
+            const coreWords = typeof interp.collect_core_listed_words_info === 'function'
+                ? interp.collect_core_listed_words_info()
+                : interp.collect_core_words_info();
             renderBuiltInWordsSorted(elements.builtInWordsDisplay, coreWords);
         } catch (error) {
             console.error('Failed to render core words:', error);

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -1,6 +1,8 @@
 use crate::builtins::{builtin_specs, BuiltinExecutorKey};
 use crate::interpreter::modules::module_word_metadata_entries;
 use serde::Serialize;
+#[cfg(test)]
+use std::collections::HashSet;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -37,6 +39,19 @@ pub enum SafetyLevel {
     Quarantined,
 }
 
+/// Canonical implementation home for a built-in word.
+///
+/// Every built-in word has exactly one canonical home. `Core` means the word
+/// is implemented as a Canonical Core word in `builtins/`, while `Module(m)`
+/// means the canonical implementation lives in module `m` and is invoked as
+/// `m@WORD` after `IMPORT 'm'`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", content = "module", rename_all = "lowercase")]
+pub enum CanonicalHome {
+    Core,
+    Module(String),
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CorewordMetadata {
@@ -46,10 +61,131 @@ pub struct CorewordMetadata {
     pub effects: Vec<String>,
     pub deterministic: bool,
     pub safe_preview: bool,
+    /// Derived alias of `canonical_home` for backward compatibility. When
+    /// `canonical_home == Module(m)`, this carries `Some(m)`. New code should
+    /// read `canonical_home` directly.
     pub formerly_module: Option<String>,
     pub partiality: Partiality,
     pub nil_policy: NilPolicy,
     pub safety_level: SafetyLevel,
+    /// Where the canonical implementation lives (Core or a specific module).
+    pub canonical_home: CanonicalHome,
+    /// Whether the word appears in the Core word listing view.
+    pub listed_in_core: bool,
+    /// Module names whose dictionary view includes this word. A word may be
+    /// listed in modules other than its canonical home (boundary words).
+    /// Listing is presentation-only — it does not affect IMPORT or execution.
+    pub listed_in_modules: Vec<String>,
+    /// Documentation-only category labels (e.g. CAST, TEXT, TENSOR, RUNTIME)
+    /// used by GUI/docs to group words. These are not real modules and cannot
+    /// be `IMPORT`ed.
+    pub listed_in_categories: Vec<String>,
+}
+
+impl CorewordMetadata {
+    pub fn is_canonical_core(&self) -> bool {
+        matches!(self.canonical_home, CanonicalHome::Core)
+    }
+
+    pub fn is_canonical_module(&self) -> bool {
+        matches!(self.canonical_home, CanonicalHome::Module(_))
+    }
+
+    pub fn canonical_module(&self) -> Option<&str> {
+        match &self.canonical_home {
+            CanonicalHome::Module(m) => Some(m.as_str()),
+            CanonicalHome::Core => None,
+        }
+    }
+
+    pub fn is_core_listed(&self) -> bool {
+        self.listed_in_core
+    }
+
+    pub fn is_module_listed(&self) -> bool {
+        !self.listed_in_modules.is_empty()
+    }
+
+    pub fn is_category_listed(&self) -> bool {
+        !self.listed_in_categories.is_empty()
+    }
+
+    /// A boundary word appears in both the Core listing view and at least one
+    /// module-or-category listing view.
+    pub fn is_boundary_word(&self) -> bool {
+        self.listed_in_core && (self.is_module_listed() || self.is_category_listed())
+    }
+}
+
+/// Boundary listing table. For Canonical Core words that should also appear
+/// in a module listing view (real modules) and/or a documentation category
+/// view (presentation-only labels). Listing is presentation-only — it does
+/// **not** add the word to that module's IMPORT-able set, and it does not
+/// create new module entities.
+///
+/// Entries: `(WORD, &[real_module_listings], &[category_listings])`.
+const CORE_BOUNDARY_LISTINGS: &[(&str, &[&str], &[&str])] = &[
+    ("PRINT", &["IO"], &[]),
+    ("STR", &[], &["CAST"]),
+    ("NUM", &[], &["CAST"]),
+    ("BOOL", &[], &["CAST"]),
+    ("CHR", &[], &["TEXT"]),
+    ("CHARS", &[], &["TEXT"]),
+    ("JOIN", &[], &["TEXT"]),
+    ("MOD", &["MATH"], &[]),
+    ("FLOOR", &["MATH"], &[]),
+    ("CEIL", &["MATH"], &[]),
+    ("ROUND", &["MATH"], &[]),
+    ("SHAPE", &[], &["TENSOR"]),
+    ("RANK", &[], &["TENSOR"]),
+    ("RESHAPE", &[], &["TENSOR"]),
+    ("TRANSPOSE", &[], &["TENSOR"]),
+    ("FILL", &[], &["TENSOR"]),
+    ("SPAWN", &[], &["RUNTIME"]),
+    ("AWAIT", &[], &["RUNTIME"]),
+    ("STATUS", &[], &["RUNTIME"]),
+    ("KILL", &[], &["RUNTIME"]),
+    ("MONITOR", &[], &["RUNTIME"]),
+    ("SUPERVISE", &[], &["RUNTIME"]),
+];
+
+/// Canonical Module words that should additionally appear in the Core listing
+/// view (e.g. `SORT` is canonically `ALGO@SORT`, but is also surfaced in the
+/// Core dictionary because it's central to vector reasoning).
+///
+/// Listing is presentation-only — calling bare `SORT` still requires
+/// `'ALGO' IMPORT` per current execution semantics. This table only affects
+/// `listed_in_core`, never name resolution.
+const MODULE_CORE_LISTINGS: &[&str] = &["SORT"];
+
+fn apply_core_boundary_listings(meta: &mut CorewordMetadata) {
+    if !meta.is_canonical_core() {
+        return;
+    }
+    for (name, modules, categories) in CORE_BOUNDARY_LISTINGS {
+        if *name == meta.name {
+            for m in *modules {
+                if !meta.listed_in_modules.iter().any(|x| x == m) {
+                    meta.listed_in_modules.push((*m).to_string());
+                }
+            }
+            for c in *categories {
+                if !meta.listed_in_categories.iter().any(|x| x == c) {
+                    meta.listed_in_categories.push((*c).to_string());
+                }
+            }
+            return;
+        }
+    }
+}
+
+fn apply_module_to_core_listings(meta: &mut CorewordMetadata) {
+    if !meta.is_canonical_module() {
+        return;
+    }
+    if MODULE_CORE_LISTINGS.iter().any(|n| *n == meta.name) {
+        meta.listed_in_core = true;
+    }
 }
 
 pub fn get_builtin_word_registry() -> Vec<CorewordMetadata> {
@@ -57,15 +193,52 @@ pub fn get_builtin_word_registry() -> Vec<CorewordMetadata> {
         .iter()
         .map(|spec| core_word_metadata(spec.name, spec.category, spec.executor_key))
         .collect();
-    registry.extend(module_word_metadata_entries());
+    for meta in registry.iter_mut() {
+        apply_core_boundary_listings(meta);
+    }
+    let mut module_entries = module_word_metadata_entries();
+    for meta in module_entries.iter_mut() {
+        apply_module_to_core_listings(meta);
+    }
+    registry.extend(module_entries);
     registry
 }
 
+/// Metadata lookup with namespace-aware disambiguation.
+///
+/// - `MODULE@WORD` form returns the canonical module entry (or `None` if the
+///   module does not own that word).
+/// - Bare `WORD` form prefers a Canonical Core entry when one exists; only
+///   when no core entry matches does it fall back to a canonical module
+///   entry. This mirrors the runtime resolution order in
+///   `interpreter/resolve-word.rs`, so callers reasoning about the visible
+///   binding for a bare token see the same word the interpreter would run.
 pub fn get_coreword_metadata(name: &str) -> Option<CorewordMetadata> {
     let upper = name.to_uppercase();
-    get_builtin_word_registry()
-        .into_iter()
-        .find(|word| word.name == upper)
+    let registry = get_builtin_word_registry();
+
+    if let Some((module, word)) = upper.split_once('@') {
+        return registry.into_iter().find(|m| {
+            m.name == word
+                && m.canonical_module()
+                    .map(|cm| cm == module)
+                    .unwrap_or(false)
+        });
+    }
+
+    if let Some(core) = registry
+        .iter()
+        .find(|m| m.name == upper && m.is_canonical_core())
+    {
+        return Some(core.clone());
+    }
+    registry.into_iter().find(|m| m.name == upper)
+}
+
+/// Alias of `get_coreword_metadata`. Use this in new code; the registry
+/// covers all built-in words regardless of canonical home.
+pub fn get_builtin_word_metadata(name: &str) -> Option<CorewordMetadata> {
+    get_coreword_metadata(name)
 }
 
 pub fn get_words_by_category(category: &str) -> Vec<CorewordMetadata> {
@@ -83,10 +256,135 @@ pub fn get_words_by_purity(purity: WordPurity) -> Vec<CorewordMetadata> {
         .collect()
 }
 
+/// Words whose Core listing view includes them (canonical core + core-listed
+/// boundary words).
+pub fn get_core_listed_words() -> Vec<CorewordMetadata> {
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| word.listed_in_core)
+        .collect()
+}
+
+/// Words whose listing includes the given module name. Includes canonical
+/// module words for that module plus core boundary words listed there.
+pub fn get_module_listed_words(module_name: &str) -> Vec<CorewordMetadata> {
+    let needle = module_name.to_uppercase();
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| {
+            word.canonical_module().map(|m| m == needle).unwrap_or(false)
+                || word.listed_in_modules.iter().any(|m| *m == needle)
+        })
+        .collect()
+}
+
+/// Words tagged with the given documentation category (e.g. CAST, TEXT,
+/// TENSOR, RUNTIME). Categories are presentation-only — they are not real
+/// modules and do not participate in IMPORT.
+pub fn get_category_listed_words(category: &str) -> Vec<CorewordMetadata> {
+    let needle = category.to_uppercase();
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| word.listed_in_categories.iter().any(|c| *c == needle))
+        .collect()
+}
+
+pub fn get_canonical_core_words() -> Vec<CorewordMetadata> {
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| word.is_canonical_core())
+        .collect()
+}
+
+/// Canonical Module words. When `module_name` is `Some(m)`, restricts to that
+/// module's canonical words.
+pub fn get_canonical_module_words(module_name: Option<&str>) -> Vec<CorewordMetadata> {
+    let needle = module_name.map(|m| m.to_uppercase());
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| match (&needle, word.canonical_module()) {
+            (Some(n), Some(m)) => n == m,
+            (None, Some(_)) => true,
+            _ => false,
+        })
+        .collect()
+}
+
+pub fn get_boundary_words() -> Vec<CorewordMetadata> {
+    get_builtin_word_registry()
+        .into_iter()
+        .filter(|word| word.is_boundary_word())
+        .collect()
+}
+
+/// Returns true if `word_name` is core-listed only (canonical core, no
+/// canonical module home). Used by IMPORT-ONLY to silently skip selectors
+/// that are core-listed in a module view but not actually owned by that
+/// module.
+pub fn is_listing_only_for_module(word_name: &str, module_name: &str) -> bool {
+    let upper = word_name.to_uppercase();
+    let module_upper = module_name.to_uppercase();
+    let Some(meta) = get_coreword_metadata(&upper) else {
+        return false;
+    };
+    if meta.canonical_module().map(|m| m == module_upper).unwrap_or(false) {
+        return false;
+    }
+    meta.listed_in_modules.iter().any(|m| *m == module_upper)
+        || meta.listed_in_categories.iter().any(|c| *c == module_upper)
+}
+
 pub fn is_safe_preview_word(name: &str) -> bool {
     get_coreword_metadata(name)
         .map(|word| word.safe_preview)
         .unwrap_or(false)
+}
+
+/// Validates that no two registry entries share both `name` AND
+/// `canonical_home`. Two entries with the same bare name but different homes
+/// (e.g. core `GET` vs `JSON@GET`) are legitimate — they live in distinct
+/// runtime namespaces and are disambiguated by `get_coreword_metadata`.
+/// Used internally by tests to guard against accidental true duplicates.
+#[cfg(test)]
+fn collect_duplicate_entries(registry: &[CorewordMetadata]) -> Vec<(String, CanonicalHome)> {
+    let mut seen: HashSet<(String, CanonicalHome)> = HashSet::new();
+    let mut dupes: Vec<(String, CanonicalHome)> = Vec::new();
+    for word in registry {
+        let key = (word.name.clone(), word.canonical_home.clone());
+        if !seen.insert(key.clone()) {
+            dupes.push(key);
+        }
+    }
+    dupes
+}
+
+/// Returns bare names that appear under more than one canonical home. These
+/// are not bugs but require namespace-aware lookup.
+#[cfg(test)]
+fn collect_namespace_overlapping_names(registry: &[CorewordMetadata]) -> Vec<String> {
+    use std::collections::BTreeMap;
+    let mut by_name: BTreeMap<&str, Vec<&CanonicalHome>> = BTreeMap::new();
+    for word in registry {
+        by_name.entry(&word.name).or_default().push(&word.canonical_home);
+    }
+    by_name
+        .into_iter()
+        .filter(|(_, homes)| homes.len() > 1)
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+impl std::hash::Hash for CanonicalHome {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            CanonicalHome::Core => 0u8.hash(state),
+            CanonicalHome::Module(m) => {
+                1u8.hash(state);
+                m.hash(state);
+            }
+        }
+    }
 }
 
 fn core_word_metadata(
@@ -213,6 +511,10 @@ pub(crate) fn pure(name: &str, category: &str) -> CorewordMetadata {
         partiality: Partiality::Total,
         nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::A,
+        canonical_home: CanonicalHome::Core,
+        listed_in_core: true,
+        listed_in_modules: Vec::new(),
+        listed_in_categories: Vec::new(),
     }
 }
 
@@ -233,6 +535,10 @@ pub(crate) fn observable(
         partiality: Partiality::Partial,
         nil_policy: NilPolicy::RejectsNil,
         safety_level: SafetyLevel::C,
+        canonical_home: CanonicalHome::Core,
+        listed_in_core: true,
+        listed_in_modules: Vec::new(),
+        listed_in_categories: Vec::new(),
     }
 }
 
@@ -248,6 +554,10 @@ pub(crate) fn effectful(name: &str, category: &str, effects: &[&str]) -> Corewor
         partiality: Partiality::Partial,
         nil_policy: NilPolicy::RejectsNil,
         safety_level: SafetyLevel::D,
+        canonical_home: CanonicalHome::Core,
+        listed_in_core: true,
+        listed_in_modules: Vec::new(),
+        listed_in_categories: Vec::new(),
     }
 }
 
@@ -262,8 +572,11 @@ mod tests {
     //! the full coreword-registry coverage subset.
 
     use super::{
-        get_builtin_word_registry, get_coreword_metadata, is_safe_preview_word, NilPolicy,
-        Partiality, SafetyLevel, WordPurity,
+        collect_duplicate_entries, collect_namespace_overlapping_names, get_boundary_words,
+        get_builtin_word_metadata, get_builtin_word_registry, get_canonical_core_words,
+        get_canonical_module_words, get_core_listed_words, get_coreword_metadata,
+        get_module_listed_words, is_listing_only_for_module, is_safe_preview_word, CanonicalHome,
+        NilPolicy, Partiality, SafetyLevel, WordPurity,
     };
 
     #[test]
@@ -494,6 +807,247 @@ mod tests {
                 "{} must be Quarantined",
                 name
             );
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // AQ-VER-LISTING — Canonical home / listing tests for the redesigned
+    // built-in word vocabulary.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn aq_ver_listing_a_no_two_entries_share_name_and_home() {
+        let registry = get_builtin_word_registry();
+        let dupes = collect_duplicate_entries(&registry);
+        assert!(
+            dupes.is_empty(),
+            "(name, canonical_home) pair must be unique (duplicates: {:?})",
+            dupes
+        );
+    }
+
+    /// Bare names like `GET` legitimately appear under multiple canonical
+    /// homes (core list `GET` and `JSON@GET`). The registry intentionally
+    /// keeps both entries — they live in distinct runtime namespaces — but
+    /// `get_coreword_metadata("GET")` must always disambiguate to the
+    /// canonical core entry, matching the runtime resolution order.
+    #[test]
+    fn aq_ver_listing_b_namespace_overlap_disambiguates_to_core() {
+        let registry = get_builtin_word_registry();
+        let overlapping = collect_namespace_overlapping_names(&registry);
+        for name in overlapping {
+            let resolved = get_coreword_metadata(&name)
+                .unwrap_or_else(|| panic!("{} must resolve via bare lookup", name));
+            assert!(
+                resolved.is_canonical_core(),
+                "{} bare lookup must prefer the core canonical entry, got {:?}",
+                name,
+                resolved.canonical_home
+            );
+            // The qualified form must reach the module entry instead.
+            if let Some(module_entry) = registry.iter().find(|m| {
+                m.name == name && matches!(m.canonical_home, CanonicalHome::Module(_))
+            }) {
+                let module_name = module_entry
+                    .canonical_module()
+                    .expect("module entry must have canonical_module");
+                let qualified = format!("{}@{}", module_name, name);
+                let qualified_resolved = get_coreword_metadata(&qualified).unwrap_or_else(|| {
+                    panic!("{} must resolve via qualified lookup", qualified)
+                });
+                assert_eq!(
+                    qualified_resolved.canonical_home,
+                    CanonicalHome::Module(module_name.to_string()),
+                    "{} qualified lookup must reach the module entry",
+                    qualified
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_c_every_word_has_at_least_one_listing() {
+        let registry = get_builtin_word_registry();
+        for word in registry {
+            let listed = word.listed_in_core
+                || !word.listed_in_modules.is_empty()
+                || !word.listed_in_categories.is_empty();
+            assert!(
+                listed,
+                "{} must be listed in at least one dictionary view",
+                word.name
+            );
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_d_canonical_module_implies_module_listing() {
+        for word in get_canonical_module_words(None) {
+            let canonical = word
+                .canonical_module()
+                .expect("canonical module word must report canonical_module")
+                .to_string();
+            assert!(
+                word.listed_in_modules.iter().any(|m| *m == canonical),
+                "{} canonical module {} must appear in listed_in_modules ({:?})",
+                word.name,
+                canonical,
+                word.listed_in_modules
+            );
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_e_formerly_module_mirrors_canonical_home() {
+        for word in get_builtin_word_registry() {
+            match &word.canonical_home {
+                CanonicalHome::Core => assert!(
+                    word.formerly_module.is_none(),
+                    "{} is canonical core; formerly_module must be None",
+                    word.name
+                ),
+                CanonicalHome::Module(m) => assert_eq!(
+                    word.formerly_module.as_deref(),
+                    Some(m.as_str()),
+                    "{} formerly_module must mirror canonical home {}",
+                    word.name,
+                    m
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_f_print_is_canonical_core_listed_in_io() {
+        let print = get_builtin_word_metadata("PRINT").expect("PRINT must be in registry");
+        assert_eq!(print.canonical_home, CanonicalHome::Core);
+        assert!(print.is_canonical_core());
+        assert!(print.listed_in_core);
+        assert!(print.listed_in_modules.iter().any(|m| m == "IO"));
+        assert!(print.is_boundary_word());
+    }
+
+    #[test]
+    fn aq_ver_listing_g_sort_is_canonical_algo_and_core_listed() {
+        let sort = get_builtin_word_metadata("SORT").expect("SORT must be in registry");
+        assert_eq!(
+            sort.canonical_home,
+            CanonicalHome::Module("ALGO".to_string())
+        );
+        assert!(sort.is_canonical_module());
+        assert!(sort.listed_in_core, "SORT must be core-listed");
+        assert!(sort.listed_in_modules.iter().any(|m| m == "ALGO"));
+        assert!(sort.is_boundary_word());
+    }
+
+    #[test]
+    fn aq_ver_listing_h_csprng_is_module_only() {
+        let csprng = get_builtin_word_metadata("CSPRNG").expect("CSPRNG must be in registry");
+        assert_eq!(
+            csprng.canonical_home,
+            CanonicalHome::Module("CRYPTO".to_string())
+        );
+        assert!(!csprng.listed_in_core, "CSPRNG must not be core-listed");
+        assert_eq!(csprng.listed_in_modules, vec!["CRYPTO".to_string()]);
+        assert!(csprng.listed_in_categories.is_empty());
+        assert!(!csprng.is_boundary_word());
+    }
+
+    #[test]
+    fn aq_ver_listing_i_import_is_core_only() {
+        for name in &["IMPORT", "IMPORT-ONLY"] {
+            let meta = get_builtin_word_metadata(name)
+                .unwrap_or_else(|| panic!("{} must be in registry", name));
+            assert_eq!(
+                meta.canonical_home,
+                CanonicalHome::Core,
+                "{} must be canonical core",
+                name
+            );
+            assert!(meta.listed_in_core, "{} must be core-listed", name);
+            assert!(
+                meta.listed_in_modules.is_empty(),
+                "{} must not be module-listed",
+                name
+            );
+            assert!(
+                meta.listed_in_categories.is_empty(),
+                "{} must not be category-listed",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_j_known_boundary_words_classified() {
+        let expected = [
+            "PRINT", "STR", "NUM", "BOOL", "CHR", "CHARS", "JOIN", "MOD", "FLOOR", "CEIL",
+            "ROUND", "SHAPE", "RANK", "RESHAPE", "TRANSPOSE", "FILL", "SPAWN", "AWAIT", "STATUS",
+            "KILL", "MONITOR", "SUPERVISE", "SORT",
+        ];
+        let boundary_names: Vec<String> =
+            get_boundary_words().into_iter().map(|w| w.name).collect();
+        for name in expected {
+            assert!(
+                boundary_names.iter().any(|n| n == name),
+                "{} must be classified as a boundary word (got: {:?})",
+                name,
+                boundary_names
+            );
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_k_core_view_includes_core_listed_only() {
+        for word in get_core_listed_words() {
+            assert!(
+                word.listed_in_core,
+                "{} returned by get_core_listed_words must have listed_in_core=true",
+                word.name
+            );
+        }
+    }
+
+    #[test]
+    fn aq_ver_listing_l_module_view_includes_canonical_and_boundary() {
+        let io_view: Vec<String> = get_module_listed_words("IO").into_iter().map(|w| w.name).collect();
+        assert!(
+            io_view.iter().any(|n| n == "PRINT"),
+            "IO view must include the boundary word PRINT (got: {:?})",
+            io_view
+        );
+        let algo_view: Vec<String> = get_module_listed_words("ALGO")
+            .into_iter()
+            .map(|w| w.name)
+            .collect();
+        assert!(
+            algo_view.iter().any(|n| n == "SORT"),
+            "ALGO view must include canonical SORT (got: {:?})",
+            algo_view
+        );
+    }
+
+    #[test]
+    fn aq_ver_listing_m_listing_only_predicate_distinguishes_canonical_from_boundary() {
+        // PRINT is a Core word listed in IO → listing-only relative to IO.
+        assert!(is_listing_only_for_module("PRINT", "IO"));
+        // SORT is canonical to ALGO → NOT listing-only for ALGO.
+        assert!(!is_listing_only_for_module("SORT", "ALGO"));
+        // CSPRNG is canonical to CRYPTO → NOT listing-only for CRYPTO.
+        assert!(!is_listing_only_for_module("CSPRNG", "CRYPTO"));
+        // Unknown word → false.
+        assert!(!is_listing_only_for_module("__NOSUCH__", "IO"));
+    }
+
+    #[test]
+    fn aq_ver_listing_n_canonical_core_helper_excludes_module_words() {
+        for word in get_canonical_core_words() {
+            assert!(
+                word.is_canonical_core(),
+                "{} returned by get_canonical_core_words must be canonical core",
+                word.name
+            );
+            assert!(word.formerly_module.is_none());
         }
     }
 }

--- a/rust/src/interpreter/modules/mod.rs
+++ b/rust/src/interpreter/modules/mod.rs
@@ -31,3 +31,10 @@ pub fn restore_module(interp: &mut Interpreter, module_name: &str) -> bool {
 pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
     module_builtins::module_word_metadata_entries()
 }
+
+/// Look up a module word's user-facing description by qualified name
+/// (e.g. `"ALGO@SORT"`) or by `(module, short_name)`. Returns `None` if no
+/// such canonical module word exists.
+pub fn module_word_description(module_name: &str, short_name: &str) -> Option<&'static str> {
+    module_builtins::module_word_description(module_name, short_name)
+}

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,4 +1,4 @@
-use crate::coreword_registry::{self, CorewordMetadata, WordPurity};
+use crate::coreword_registry::{self, CanonicalHome, CorewordMetadata, WordPurity};
 use crate::interpreter::{audio, datetime, hash, interval_ops, json, random, sort};
 use crate::types::{Capabilities, Stability};
 
@@ -554,6 +554,18 @@ pub(super) const MODULE_SPECS: &[ModuleSpec] = &[
     },
 ];
 
+pub(crate) fn module_word_description(
+    module_name: &str,
+    short_name: &str,
+) -> Option<&'static str> {
+    let module = MODULE_SPECS.iter().find(|m| m.name == module_name)?;
+    module
+        .words
+        .iter()
+        .find(|w| w.short_name == short_name)
+        .map(|w| w.description)
+}
+
 pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
     MODULE_SPECS
         .iter()
@@ -577,7 +589,11 @@ pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
                 };
                 metadata.deterministic = word.deterministic;
                 metadata.safe_preview = word.safe_preview;
+                metadata.canonical_home = CanonicalHome::Module(spec.name.to_string());
                 metadata.formerly_module = Some(spec.name.to_string());
+                metadata.listed_in_core = false;
+                metadata.listed_in_modules = vec![spec.name.to_string()];
+                metadata.listed_in_categories = Vec::new();
                 metadata
             })
         })

--- a/rust/src/interpreter/modules/module_import_execution.rs
+++ b/rust/src/interpreter/modules/module_import_execution.rs
@@ -139,6 +139,7 @@ pub(super) fn op_import_only(interp: &mut Interpreter) -> Result<()> {
         .get(&module_name)
         .ok_or_else(|| AjisaiError::UnknownModule(module_name.clone()))?;
     let mut validated: Vec<(String, bool)> = Vec::new();
+    let mut listing_only_skips: Vec<String> = Vec::new();
     for item in selected {
         let short = item.to_uppercase();
         let qualified = format!("{}@{}", module_name, short);
@@ -146,12 +147,23 @@ pub(super) fn op_import_only(interp: &mut Interpreter) -> Result<()> {
             validated.push((short, true));
         } else if module_dict.sample_words.contains_key(&short) {
             validated.push((short, false));
+        } else if crate::coreword_registry::is_listing_only_for_module(&short, &module_name) {
+            // Boundary word: listed in this module's view but canonically a
+            // Core word. Already available without IMPORT, so silently skip
+            // and emit a single warning line for clarity.
+            listing_only_skips.push(short);
         } else {
             return Err(AjisaiError::from(format!(
                 "Unknown module word '{}' in {}",
                 short, module_name
             )));
         }
+    }
+    for short in &listing_only_skips {
+        interp.output_buffer.push_str(&format!(
+            "Warning: '{}' is listed in {} but is a Canonical Core word and is already available.\n",
+            short, module_name
+        ));
     }
 
     let entry = interp

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -93,6 +93,44 @@ impl AjisaiInterpreter {
         to_value(&builtins::collect_core_builtin_definitions()).unwrap_or(JsValue::NULL)
     }
 
+    /// Returns Core-listed words (canonical core + Canonical Module words
+    /// that are core-listed, e.g. SORT). This is the listing-based Core
+    /// view defined by the redesigned vocabulary system; bare module words
+    /// are surfaced for visibility only — invoking SORT bare still requires
+    /// `'ALGO' IMPORT` per current execution semantics.
+    ///
+    /// Tuple shape: `(name, description, syntax, signature_type)` — same as
+    /// `collect_core_words_info` so the GUI can render either list with the
+    /// same code path.
+    #[wasm_bindgen]
+    pub fn collect_core_listed_words_info(&self) -> JsValue {
+        let mut entries: Vec<(String, String, String, String)> =
+            builtins::collect_core_builtin_definitions()
+                .into_iter()
+                .map(|(n, d, s, t)| (n.to_string(), d.to_string(), s.to_string(), t.to_string()))
+                .collect();
+
+        for word in crate::coreword_registry::get_core_listed_words() {
+            if word.is_canonical_core() {
+                continue;
+            }
+            // Boundary word whose canonical home is a module. Pull the
+            // user-facing description from the owning module spec; module
+            // canonical metadata does not carry syntax/signature, so leave
+            // those blank.
+            let module_name = match word.canonical_module() {
+                Some(m) => m.to_string(),
+                None => continue,
+            };
+            let description = interpreter::modules::module_word_description(&module_name, &word.name)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| word.category.clone());
+            entries.push((word.name.clone(), description, String::new(), "none".to_string()));
+        }
+
+        to_value(&entries).unwrap_or(JsValue::NULL)
+    }
+
     #[wasm_bindgen]
     pub fn collect_builtin_word_registry(&self) -> JsValue {
         to_value(&crate::coreword_registry::get_builtin_word_registry()).unwrap_or(JsValue::NULL)


### PR DESCRIPTION
## Summary

Refactors the built-in word metadata so a word's canonical implementation home and its dictionary listings are independent. This formalises **boundary words** (e.g. `PRINT` listed in `IO`, `SORT` canonical to `ALGO` but core-listed) without duplicating implementations or changing name resolution.

This implements the redesign discussed in the spec, with refinements to the original instruction document around name-collision and listing-vs-execution semantics:

- Listings are **presentation-only**. They never affect IMPORT, never affect bare-name resolution, never enable `MODULE@WORD` aliasing for boundary words.
- Documentation-only categories (`CAST`, `TEXT`, `TENSOR`, `RUNTIME`) are tracked separately from real modules so they can never be `IMPORT`ed by accident.
- Bare names that legitimately appear under multiple canonical homes (e.g. core `GET` vs `JSON@GET`) are kept as distinct registry entries; lookup disambiguates by preferring the Core entry for bare names and routing `MODULE@WORD` to the module entry. The old metadata layer silently returned an arbitrary one of these — the new tests guard against that.

### Key changes

- `CorewordMetadata` gains `canonical_home`, `listed_in_core`, `listed_in_modules`, `listed_in_categories`; `formerly_module` becomes a derived alias.
- New helper APIs: `get_builtin_word_metadata`, `get_core_listed_words`, `get_module_listed_words`, `get_canonical_core_words`, `get_canonical_module_words`, `get_boundary_words`, `get_category_listed_words`, `is_listing_only_for_module`.
- `IMPORT-ONLY` silently skips listing-only selectors with a single warning line instead of failing.
- WASM: `collect_core_listed_words_info` exposes core + core-listed boundary words; GUI's vocabulary panel now shows `SORT` alongside the canonical core words.
- `SPECIFICATION.md` Section 7 documents the canonical_home / listings model and the listing-only IMPORT-ONLY rule; Section 7.14 documents the new metadata fields.

### Tests

`AQ-VER-LISTING-{A..N}` covers:
- canonical-home uniqueness `(name, canonical_home)`,
- namespace-overlap disambiguation,
- every word listed in at least one view,
- `formerly_module` mirrors `canonical_home`,
- canonical PRINT/SORT/CSPRNG/IMPORT classifications,
- boundary-word enumeration,
- core/module view membership,
- the listing-only predicate.

`cargo test --lib` → 774 passed, `npm test` → 23 passed, `npm run build` → clean.

## Test plan

- [ ] Manual smoke: open the GUI, confirm `SORT` appears in the Core word panel and clicking it still requires `'ALGO' IMPORT` first (execution semantics unchanged).
- [ ] Manual smoke: `'IO' [ 'PRINT' ] IMPORT-ONLY` emits a single warning line and does not error.
- [ ] Manual smoke: `'JSON' IMPORT` still imports `JSON@GET` correctly; bare `GET` continues to resolve to the core list operation.
- [ ] CI: `cargo test --all-targets` and `npm test` / `npm run build` all green.

https://claude.ai/code/session_01Mb63tEuLPofqpbKAKPRb1P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mb63tEuLPofqpbKAKPRb1P)_