### PR TITLE
Persist imported modules and unify module dictionary placeholder

### DIFF
--- a/src/gui/dictionary-element-builders.ts
+++ b/src/gui/dictionary-element-builders.ts
@@ -1,3 +1,14 @@
+export const DEFAULT_WORD_INFO_MESSAGE = 'Hover over a word button to view its usage.';
+
+export const renderWordInfo = (element: HTMLElement, text: string, isPlaceholder = false): void => {
+    element.textContent = text;
+    element.classList.toggle('is-placeholder', isPlaceholder);
+};
+
+export const resetWordInfoDisplay = (element: HTMLElement): void => {
+    renderWordInfo(element, DEFAULT_WORD_INFO_MESSAGE, true);
+};
+
 export const compareWordName = (a: string, b: string): number => {
     const aIsAlpha = /^[A-Za-z]/.test(a);
     const bIsAlpha = /^[A-Za-z]/.test(b);

--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -7,6 +7,8 @@ import {
     checkWordMatchesFilter,
     registerBackgroundClickListeners,
     compareWordName,
+    renderWordInfo,
+    resetWordInfoDisplay,
 } from './dictionary-element-builders';
 import { formatDictionaryTabName } from './vocabulary-state-controller';
 
@@ -75,6 +77,7 @@ export const createModuleTabManager = (
 
         const wordInfoDisplay = document.createElement('span');
         wordInfoDisplay.className = 'word-info-display module-word-info';
+        resetWordInfoDisplay(wordInfoDisplay);
         sheet.appendChild(wordInfoDisplay);
 
         const wordsDisplay = document.createElement('div');
@@ -109,6 +112,7 @@ export const createModuleTabManager = (
         if (!wordsDisplay || !wordInfo) return;
 
         wordsDisplay.innerHTML = '';
+        resetWordInfoDisplay(wordInfo as HTMLElement);
 
         try {
             const moduleWords: Array<[string, string | null]> =
@@ -128,8 +132,8 @@ export const createModuleTabManager = (
                     description,
                     'word-button module',
                     () => onWordClick(shortName),
-                    () => { (wordInfo as HTMLElement).textContent = description; },
-                    () => { (wordInfo as HTMLElement).textContent = ''; }
+                    () => { renderWordInfo(wordInfo as HTMLElement, description); },
+                    () => { resetWordInfoDisplay(wordInfo as HTMLElement); }
                 );
 
                 wordsDisplay.appendChild(button);

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -1,12 +1,15 @@
 
 
 import {
+    DEFAULT_WORD_INFO_MESSAGE,
     checkWordMatchesFilter,
     compareWordName,
     createEmptyWordsElement,
     createNoResultsElement,
     createWordButtonElement,
     registerBackgroundClickListeners,
+    renderWordInfo,
+    resetWordInfoDisplay,
 } from './dictionary-element-builders';
 
 export interface WordInfo {
@@ -82,18 +85,7 @@ const clearElement = (element: HTMLElement): void => {
     element.innerHTML = '';
 };
 
-const DEFAULT_WORD_INFO_MESSAGE = 'Hover over a word button to view its usage.';
-
 const isCanonicalCoreWordName = (name: string): boolean => /^[A-Z][A-Z0-9-]*$/.test(name);
-
-const renderWordInfo = (element: HTMLElement, text: string, isPlaceholder = false): void => {
-    element.textContent = text;
-    element.classList.toggle('is-placeholder', isPlaceholder);
-};
-
-const resetWordInfoDisplay = (element: HTMLElement): void => {
-    renderWordInfo(element, DEFAULT_WORD_INFO_MESSAGE, true);
-};
 
 const DEPENDENCY_DELETE_ERROR = 'Cannot delete';
 

--- a/src/platform/tauri/tauri-persistence.ts
+++ b/src/platform/tauri/tauri-persistence.ts
@@ -98,6 +98,7 @@ export class TauriPersistence implements Persistence {
             key: 'interpreter_state',
             stack: state.stack,
             userWords: state.userWords,
+            importedModules: state.importedModules,
             demoWordsVersion: state.demoWordsVersion,
             updatedAt: new Date().toISOString()
         };
@@ -115,6 +116,7 @@ export class TauriPersistence implements Persistence {
         return {
             stack: state.stack as InterpreterStateSnapshot['stack'],
             userWords: state.userWords as InterpreterStateSnapshot['userWords'],
+            importedModules: state.importedModules as InterpreterStateSnapshot['importedModules'],
             demoWordsVersion: state.demoWordsVersion
         };
     }

--- a/src/platform/web/web-persistence.ts
+++ b/src/platform/web/web-persistence.ts
@@ -16,6 +16,7 @@ interface InterpreterState {
     key: string;
     stack: unknown;
     userWords: unknown;
+    importedModules?: unknown;
     demoWordsVersion?: number;
     updatedAt: string;
 
@@ -155,6 +156,7 @@ class WebPersistence implements Persistence {
             return {
                 stack: result.stack as InterpreterStateSnapshot['stack'],
                 userWords: (result.userWords ?? result.customWords) as InterpreterStateSnapshot['userWords'],
+                importedModules: result.importedModules as InterpreterStateSnapshot['importedModules'],
                 demoWordsVersion: result.demoWordsVersion ?? result.sampleWordsVersion
             };
         });


### PR DESCRIPTION
## Summary

Fixes two issues with module dictionaries reported by the user:

1. **Persistence bug**: After importing a module dictionary, reloading the browser caused the import to disappear. `collectCurrentState` and `saveInterpreterState` already collected/wrote `importedModules`, but both `web-persistence.ts` (IndexedDB) and `tauri-persistence.ts` dropped the field on `loadInterpreterState`, so `restore_imported_modules` was never invoked on reload. The Tauri saver also didn't write the field at all. Both paths now round-trip `importedModules`.

2. **Initial placeholder bug**: The word-info area above the module word buttons stayed blank, while the corword dictionary shows "Hover over a word button to view its usage." The placeholder helpers (`DEFAULT_WORD_INFO_MESSAGE`, `renderWordInfo`, `resetWordInfoDisplay`) were private to `vocabulary-state-controller.ts`. Moved them into `dictionary-element-builders.ts` so module sheets reuse them — they now show the initial message and reset to it on mouse-leave, matching the corword dictionary.

## Changes
- `src/platform/web/web-persistence.ts`: include `importedModules` in `InterpreterState` and `loadInterpreterState` return value.
- `src/platform/tauri/tauri-persistence.ts`: persist and restore `importedModules`.
- `src/gui/dictionary-element-builders.ts`: export shared word-info placeholder helpers.
- `src/gui/vocabulary-state-controller.ts`: import the helpers from the shared module.
- `src/gui/module-selector-sheets.ts`: initialize the module word-info display with the placeholder, reset it on render and on word-button mouse-leave.

## Test plan
- [ ] Import a module dictionary, reload the browser, confirm the module sheet and its words are restored.
- [ ] Open the module dictionary sheet with no hover; confirm "Hover over a word button to view its usage." is displayed.
- [ ] Hover a module word button; confirm the description shows. Move pointer away; confirm placeholder returns.
- [ ] Confirm corword dictionary placeholder behavior is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCx6aG5VN5uKy1vmztXFCz)_