### PR TITLE
Add runtime error flow trace for SAFE and word errors

### DIFF
--- a/rust/src/interpreter/error-flow-trace-tests.rs
+++ b/rust/src/interpreter/error-flow-trace-tests.rs
@@ -1,0 +1,87 @@
+use crate::error::{ErrorCategory, NilReason};
+use crate::interpreter::error_flow_trace::ErrorFlowEventKind;
+use crate::interpreter::Interpreter;
+
+#[tokio::test]
+async fn error_flow_trace_records_safe_caught_division_by_zero() {
+    let mut interp = Interpreter::new();
+    interp.execute("10 0 ~ /").await.unwrap();
+    let trace = interp.drain_error_flow_trace();
+    assert!(
+        trace.iter().any(|e| e.kind == ErrorFlowEventKind::SafeEnter),
+        "expected SafeEnter event, got {:?}",
+        trace
+    );
+    assert!(
+        trace.iter().any(|e| e.kind == ErrorFlowEventKind::SafeCaught
+            && e.word.as_deref() == Some("DIV")
+            && e.error_category == Some(ErrorCategory::DivisionByZero)),
+        "expected SafeCaught(DIV, DivisionByZero), got {:?}",
+        trace
+    );
+    assert!(
+        trace.iter().any(|e| e.kind == ErrorFlowEventKind::NilProduced
+            && matches!(e.nil_reason, Some(NilReason::SafeCaught(_)))),
+        "expected NilProduced with SafeCaught reason, got {:?}",
+        trace
+    );
+}
+
+#[tokio::test]
+async fn error_flow_trace_records_safe_success() {
+    let mut interp = Interpreter::new();
+    interp.execute("10 2 ~ /").await.unwrap();
+    let trace = interp.drain_error_flow_trace();
+    assert!(
+        trace.iter().any(|e| e.kind == ErrorFlowEventKind::SafeSuccess
+            && e.word.as_deref() == Some("DIV")),
+        "expected SafeSuccess(DIV), got {:?}",
+        trace
+    );
+    assert!(
+        !trace.iter().any(|e| e.kind == ErrorFlowEventKind::SafeCaught),
+        "should not record SafeCaught on success, got {:?}",
+        trace
+    );
+}
+
+#[tokio::test]
+async fn error_flow_trace_records_uncaught_word_error() {
+    let mut interp = Interpreter::new();
+    let result = interp.execute("10 0 /").await;
+    assert!(result.is_err());
+    let trace = interp.drain_error_flow_trace();
+    assert!(
+        trace.iter().any(|e| e.kind == ErrorFlowEventKind::WordError
+            && e.word.as_deref() == Some("DIV")
+            && e.error_category == Some(ErrorCategory::DivisionByZero)),
+        "expected WordError(DIV, DivisionByZero), got {:?}",
+        trace
+    );
+}
+
+#[tokio::test]
+async fn error_flow_trace_drain_clears_log() {
+    let mut interp = Interpreter::new();
+    interp.execute("10 0 ~ /").await.unwrap();
+    let first = interp.drain_error_flow_trace();
+    assert!(!first.is_empty());
+    let second = interp.drain_error_flow_trace();
+    assert!(second.is_empty());
+}
+
+#[tokio::test]
+async fn safe_semantics_are_unchanged() {
+    let mut interp = Interpreter::new();
+    interp.execute("10 0 ~ /").await.unwrap();
+    let stack = interp.get_stack();
+    assert_eq!(
+        stack.len(),
+        3,
+        "stack after `10 0 ~ /` should be [10, 0, NIL] (snapshot restored + NIL)"
+    );
+    let top = stack.last().unwrap();
+    assert!(top.is_nil());
+    let reason = top.nil_reason().cloned();
+    assert!(matches!(reason, Some(NilReason::SafeCaught(_))));
+}

--- a/rust/src/interpreter/error-flow-trace.rs
+++ b/rust/src/interpreter/error-flow-trace.rs
@@ -1,0 +1,21 @@
+use crate::error::{ErrorCategory, NilReason};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorFlowEventKind {
+    WordError,
+    SafeEnter,
+    SafeSuccess,
+    SafeCaught,
+    NilProduced,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorFlowEvent {
+    pub kind: ErrorFlowEventKind,
+    pub word: Option<String>,
+    pub error_category: Option<ErrorCategory>,
+    pub nil_reason: Option<NilReason>,
+    pub stack_len_before: usize,
+    pub stack_len_after: usize,
+    pub message: String,
+}

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -1,7 +1,8 @@
-use crate::error::{AjisaiError, NilReason, Result};
+use crate::error::{AjisaiError, ErrorCategory, NilReason, Result};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, ExecutionLine, Token, Value};
 
+use super::error_flow_trace::{ErrorFlowEvent, ErrorFlowEventKind};
 use super::value_extraction_helpers::create_number_value;
 use super::{modules, ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::SemanticRegistry;
@@ -256,8 +257,75 @@ impl Interpreter {
                         _ => {
                             let upper = canonical;
                             if self.safe_mode {
+                                let stack_len_before = self.stack.len();
+                                self.push_error_flow_trace(ErrorFlowEvent {
+                                    kind: ErrorFlowEventKind::SafeEnter,
+                                    word: Some(upper.to_string()),
+                                    error_category: None,
+                                    nil_reason: None,
+                                    stack_len_before,
+                                    stack_len_after: stack_len_before,
+                                    message: format!("SAFE enter word={}", upper),
+                                });
+
                                 let stack_snapshot = self.stack.clone();
                                 self.safe_mode = false;
+                                match self.execute_word_core(upper.as_ref()) {
+                                    Ok(()) => {
+                                        let stack_len_after = self.stack.len();
+                                        self.push_error_flow_trace(ErrorFlowEvent {
+                                            kind: ErrorFlowEventKind::SafeSuccess,
+                                            word: Some(upper.to_string()),
+                                            error_category: None,
+                                            nil_reason: None,
+                                            stack_len_before,
+                                            stack_len_after,
+                                            message: format!(
+                                                "SAFE success word={} stack_len_before={} stack_len_after={}",
+                                                upper, stack_len_before, stack_len_after
+                                            ),
+                                        });
+                                        self.semantic_registry
+                                            .normalize_to_stack_len(self.stack.len());
+                                        apply_word_hint_override(self, upper.as_ref());
+                                    }
+                                    Err(err) => {
+                                        let category = ErrorCategory::from_error(&err);
+                                        let nil_reason = NilReason::from_error(&err);
+                                        self.stack = stack_snapshot;
+                                        let restored_len = self.stack.len();
+                                        self.push_error_flow_trace(ErrorFlowEvent {
+                                            kind: ErrorFlowEventKind::SafeCaught,
+                                            word: Some(upper.to_string()),
+                                            error_category: Some(category.clone()),
+                                            nil_reason: Some(nil_reason.clone()),
+                                            stack_len_before,
+                                            stack_len_after: restored_len,
+                                            message: format!(
+                                                "SAFE caught word={} error={:?} restored_stack_len={}",
+                                                upper, category, restored_len
+                                            ),
+                                        });
+                                        self.stack.push(Value::nil_with_reason(nil_reason.clone()));
+                                        self.push_error_flow_trace(ErrorFlowEvent {
+                                            kind: ErrorFlowEventKind::NilProduced,
+                                            word: Some(upper.to_string()),
+                                            error_category: Some(category),
+                                            nil_reason: Some(nil_reason),
+                                            stack_len_before: restored_len,
+                                            stack_len_after: self.stack.len(),
+                                            message: format!(
+                                                "NIL produced by SAFE word={} stack_len_after={}",
+                                                upper,
+                                                self.stack.len()
+                                            ),
+                                        });
+                                        self.semantic_registry
+                                            .normalize_to_stack_len(self.stack.len());
+                                    }
+                                }
+                            } else {
+                                let stack_len_before = self.stack.len();
                                 match self.execute_word_core(upper.as_ref()) {
                                     Ok(()) => {
                                         self.semantic_registry
@@ -265,18 +333,22 @@ impl Interpreter {
                                         apply_word_hint_override(self, upper.as_ref());
                                     }
                                     Err(err) => {
-                                        self.stack = stack_snapshot;
-                                        self.stack
-                                            .push(Value::nil_with_reason(NilReason::from_error(&err)));
-                                        self.semantic_registry
-                                            .normalize_to_stack_len(self.stack.len());
+                                        let category = ErrorCategory::from_error(&err);
+                                        self.push_error_flow_trace(ErrorFlowEvent {
+                                            kind: ErrorFlowEventKind::WordError,
+                                            word: Some(upper.to_string()),
+                                            error_category: Some(category),
+                                            nil_reason: None,
+                                            stack_len_before,
+                                            stack_len_after: self.stack.len(),
+                                            message: format!(
+                                                "word error word={} error={}",
+                                                upper, err
+                                            ),
+                                        });
+                                        return Err(err);
                                     }
                                 }
-                            } else {
-                                self.execute_word_core(upper.as_ref())?;
-                                self.semantic_registry
-                                    .normalize_to_stack_len(self.stack.len());
-                                apply_word_hint_override(self, upper.as_ref());
                             }
                             if !modules::is_mode_preserving_word(upper.as_ref()) {
                                 self.reset_execution_modes();

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -197,6 +197,7 @@ pub struct Interpreter {
 
     pub(crate) runtime_metrics: RuntimeMetrics,
     pub(crate) hedged_trace_log: Vec<String>,
+    pub(crate) error_flow_trace_log: Vec<super::error_flow_trace::ErrorFlowEvent>,
     pub(crate) force_no_quant: bool,
 
     // ── Elastic Engine (MVP) ──────────────────────────────────────────────
@@ -249,6 +250,7 @@ impl Interpreter {
             next_supervisor_id: 1,
             runtime_metrics: RuntimeMetrics::default(),
             hedged_trace_log: Vec::new(),
+            error_flow_trace_log: Vec::new(),
             force_no_quant: cfg!(feature = "force-no-quant"),
 
             // Elastic Engine
@@ -352,6 +354,22 @@ impl Interpreter {
 
     pub fn drain_hedged_trace(&mut self) -> Vec<String> {
         std::mem::take(&mut self.hedged_trace_log)
+    }
+
+    pub fn push_error_flow_trace(&mut self, event: super::error_flow_trace::ErrorFlowEvent) {
+        self.error_flow_trace_log.push(event);
+    }
+
+    pub fn drain_error_flow_trace(&mut self) -> Vec<super::error_flow_trace::ErrorFlowEvent> {
+        std::mem::take(&mut self.error_flow_trace_log)
+    }
+
+    pub fn peek_error_flow_trace(&self) -> &[super::error_flow_trace::ErrorFlowEvent] {
+        &self.error_flow_trace_log
+    }
+
+    pub fn clear_error_flow_trace(&mut self) {
+        self.error_flow_trace_log.clear();
     }
 
     pub fn current_epoch_snapshot(&self) -> EpochSnapshot {
@@ -487,6 +505,7 @@ impl Interpreter {
         self.next_supervisor_id = 1;
         self.runtime_metrics = RuntimeMetrics::default();
         self.hedged_trace_log.clear();
+        self.error_flow_trace_log.clear();
         crate::builtins::register_builtins(&mut self.core_vocabulary);
         Ok(())
     }

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -15,6 +15,8 @@ pub mod epoch;
 pub mod execute_def;
 #[path = "execute-del.rs"]
 pub mod execute_del;
+#[path = "error-flow-trace.rs"]
+pub mod error_flow_trace;
 #[path = "execute-lookup.rs"]
 pub mod execute_lookup;
 #[path = "execution_plan_set.rs"]
@@ -112,6 +114,9 @@ mod interpreter_mode_tests;
 #[cfg(test)]
 #[path = "nil-reason-tests.rs"]
 mod nil_reason_tests;
+#[cfg(test)]
+#[path = "error-flow-trace-tests.rs"]
+mod error_flow_trace_tests;
 
 pub use interpreter_core::*;
 

--- a/rust/src/wasm-interpreter-execution.rs
+++ b/rust/src/wasm-interpreter-execution.rs
@@ -27,6 +27,7 @@ impl AjisaiInterpreter {
                     set_js_prop(&obj, "definition_to_load", &(def_str.into()));
                 }
                 set_js_prop(&obj, "hedgedTrace", &(self.collect_hedged_trace()));
+                set_js_prop(&obj, "errorFlowTrace", &(self.collect_error_flow_trace()));
             }
             Err(e) => {
                 let error_msg = e.to_string();
@@ -34,6 +35,7 @@ impl AjisaiInterpreter {
                 set_js_prop(&obj, "message", &(error_msg.into()));
                 set_js_prop(&obj, "error", &(true.into()));
                 set_js_prop(&obj, "hedgedTrace", &(self.collect_hedged_trace()));
+                set_js_prop(&obj, "errorFlowTrace", &(self.collect_error_flow_trace()));
             }
         }
         Ok(obj.into())
@@ -101,6 +103,7 @@ impl AjisaiInterpreter {
                     "importedModules",
                     &(self.collect_imported_modules_array()),
                 );
+                set_js_prop(&obj, "errorFlowTrace", &(self.collect_error_flow_trace()));
             }
             Err(e) => {
                 self.step_mode = false;
@@ -108,6 +111,7 @@ impl AjisaiInterpreter {
                 set_js_prop(&obj, "message", &(e.to_string().into()));
                 set_js_prop(&obj, "error", &(true.into()));
                 set_js_prop(&obj, "hasMore", &(false.into()));
+                set_js_prop(&obj, "errorFlowTrace", &(self.collect_error_flow_trace()));
             }
         }
 

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -321,6 +321,37 @@ impl AjisaiInterpreter {
     }
 
     #[wasm_bindgen]
+    pub fn collect_error_flow_trace(&mut self) -> JsValue {
+        let arr = js_sys::Array::new();
+        for event in self.interpreter.drain_error_flow_trace() {
+            let obj = js_sys::Object::new();
+            set_js_prop(&obj, "kind", &(format!("{:?}", event.kind).into()));
+            if let Some(word) = event.word {
+                set_js_prop(&obj, "word", &(word.into()));
+            }
+            if let Some(category) = event.error_category {
+                set_js_prop(&obj, "errorCategory", &(format!("{:?}", category).into()));
+            }
+            if let Some(nil_reason) = event.nil_reason {
+                set_js_prop(&obj, "nilReason", &(format!("{:?}", nil_reason).into()));
+            }
+            set_js_prop(
+                &obj,
+                "stackLenBefore",
+                &((event.stack_len_before as u32).into()),
+            );
+            set_js_prop(
+                &obj,
+                "stackLenAfter",
+                &((event.stack_len_after as u32).into()),
+            );
+            set_js_prop(&obj, "message", &(event.message.into()));
+            arr.push(&obj);
+        }
+        arr.into()
+    }
+
+    #[wasm_bindgen]
     pub fn push_json_string(&mut self, json_string: &str) -> Result<JsValue, JsValue> {
         let obj = js_sys::Object::new();
 


### PR DESCRIPTION
## Summary
- Adds an observation-only runtime trace log on `Interpreter` that records `SafeEnter` / `SafeSuccess` / `SafeCaught` / `NilProduced` / `WordError` events.
- Exposes the log to Rust callers (`drain_error_flow_trace` / `peek_error_flow_trace` / `clear_error_flow_trace`) and to JS via a new `errorFlowTrace` field on `execute()` and `execute_step()` results, separate from `hedgedTrace`.
- SAFE semantics, stack effects, and error propagation are unchanged — the existing `?`-based error path is replaced with a `match` that records the event and re-raises the same `Err`.

## Spec deviations from the original instruction
- File names follow the repo convention (`error-flow-trace.rs` + `#[path = ...]`) rather than `error_flow_trace.rs`.
- `execute_reset()` also clears `error_flow_trace_log`, mirroring `hedged_trace_log` (the original spec missed this).
- Tests use the existing `get_stack()` accessor and the canonical word name `DIV` (since `/` canonicalizes to `DIV`).

## Test plan
- [x] `cargo test --lib` (779 tests, all passing including 5 new `error_flow_trace_tests`)
- [ ] Wire `errorFlowTrace` into the GUI (out of scope for this PR per spec §9)

https://claude.ai/code/session_01BmcTw9QaBA1LDnTDXRZbXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmcTw9QaBA1LDnTDXRZbXK)_