### PR TITLE
Render LOOKUP reference text as Markdown in output panel

### DIFF
--- a/src/gui/execution-controller.ts
+++ b/src/gui/execution-controller.ts
@@ -20,6 +20,7 @@ export interface ExecutionCallbacks {
     readonly showInfo: (text: string, append: boolean) => void;
     readonly showError: (error: Error | string) => void;
     readonly showExecutionResult: (result: ExecuteResult) => void;
+    readonly showReference: (markdown: string) => void;
     readonly updateDisplays: () => void;
     readonly saveState: () => Promise<void>;
     readonly fullReset: () => Promise<void>;
@@ -49,6 +50,7 @@ export const createExecutionController = (
         showInfo,
         showError,
         showExecutionResult,
+        showReference,
         updateDisplays,
         saveState,
         fullReset,
@@ -100,10 +102,17 @@ export const createExecutionController = (
             showInfo('Input helper inserted', false);
             updateView('input');
         } else if (result.definition_to_load) {
-            updateEditorValue(result.definition_to_load);
+            const text = result.definition_to_load;
             const wordName = code.replace(/\?|LOOKUP/gi, "").trim();
-            showInfo(`Showing definition: ${wordName}`, false);
-            updateView('input');
+            const isUserDefinitionSource = text.trimStart().startsWith('[');
+            if (isUserDefinitionSource) {
+                updateEditorValue(text);
+                showInfo(`Showing definition: ${wordName}`, false);
+                updateView('input');
+            } else {
+                showReference(text);
+                updateView('output');
+            }
         } else if (result.status === 'OK' && !result.error) {
             showExecutionResult(result);
             clearEditor(false);

--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -263,6 +263,7 @@ export const createGUI = (): GUI => {
             showInfo: (text, append) => display.renderInfo(text, append),
             showError: (error) => display.renderError(error),
             showExecutionResult: (result) => display.renderExecutionResult(result),
+            showReference: (markdown) => display.renderReference(markdown),
             updateDisplays: updateAllDisplays,
             saveState: () => persistence.saveCurrentState(),
             fullReset: () => persistence.fullReset(),

--- a/src/gui/markdown-renderer.ts
+++ b/src/gui/markdown-renderer.ts
@@ -1,0 +1,125 @@
+const escapeInline = (text: string, parent: ParentNode): void => {
+    const pattern = /`([^`]+)`/g;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+        if (match.index > lastIndex) {
+            parent.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+        }
+        const code = document.createElement('code');
+        code.className = 'md-inline-code';
+        code.textContent = match[1] ?? '';
+        parent.appendChild(code);
+        lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < text.length) {
+        parent.appendChild(document.createTextNode(text.slice(lastIndex)));
+    }
+};
+
+const renderHeading = (level: number, text: string, container: ParentNode): void => {
+    const tag = `h${Math.min(level, 6)}` as keyof HTMLElementTagNameMap;
+    const heading = document.createElement(tag);
+    heading.className = `md-heading md-h${level}`;
+    escapeInline(text, heading);
+    container.appendChild(heading);
+};
+
+const renderCodeBlock = (lang: string, lines: string[], container: ParentNode): void => {
+    const pre = document.createElement('pre');
+    pre.className = `md-code-block md-code-${lang || 'plain'}`;
+    const code = document.createElement('code');
+    if (lang) code.className = `language-${lang}`;
+    code.textContent = lines.join('\n');
+    pre.appendChild(code);
+    container.appendChild(pre);
+};
+
+const renderList = (items: string[], container: ParentNode): void => {
+    const ul = document.createElement('ul');
+    ul.className = 'md-list';
+    items.forEach(item => {
+        const li = document.createElement('li');
+        escapeInline(item, li);
+        ul.appendChild(li);
+    });
+    container.appendChild(ul);
+};
+
+const renderParagraph = (lines: string[], container: ParentNode): void => {
+    const p = document.createElement('p');
+    p.className = 'md-paragraph';
+    escapeInline(lines.join(' '), p);
+    container.appendChild(p);
+};
+
+export const renderMarkdownToFragment = (markdown: string): DocumentFragment => {
+    const fragment = document.createDocumentFragment();
+    const lines = markdown.split('\n');
+    let i = 0;
+    let paragraph: string[] = [];
+    let listItems: string[] = [];
+
+    const flushParagraph = (): void => {
+        if (paragraph.length > 0) {
+            renderParagraph(paragraph, fragment);
+            paragraph = [];
+        }
+    };
+    const flushList = (): void => {
+        if (listItems.length > 0) {
+            renderList(listItems, fragment);
+            listItems = [];
+        }
+    };
+
+    while (i < lines.length) {
+        const line = lines[i] ?? '';
+        const fenceMatch = line.match(/^```(\w*)\s*$/);
+        if (fenceMatch) {
+            flushParagraph();
+            flushList();
+            const lang = fenceMatch[1] ?? '';
+            const codeLines: string[] = [];
+            i++;
+            while (i < lines.length && !(lines[i] ?? '').match(/^```\s*$/)) {
+                codeLines.push(lines[i] ?? '');
+                i++;
+            }
+            renderCodeBlock(lang, codeLines, fragment);
+            i++;
+            continue;
+        }
+
+        const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+        if (headingMatch) {
+            flushParagraph();
+            flushList();
+            renderHeading((headingMatch[1] ?? '').length, headingMatch[2] ?? '', fragment);
+            i++;
+            continue;
+        }
+
+        const listMatch = line.match(/^[-*]\s+(.+)$/);
+        if (listMatch) {
+            flushParagraph();
+            listItems.push(listMatch[1] ?? '');
+            i++;
+            continue;
+        }
+
+        if (line.trim() === '') {
+            flushParagraph();
+            flushList();
+            i++;
+            continue;
+        }
+
+        flushList();
+        paragraph.push(line);
+        i++;
+    }
+    flushParagraph();
+    flushList();
+    return fragment;
+};

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -2,6 +2,7 @@ import type { Value, ExecuteResult } from '../wasm-interpreter-types';
 import { AUDIO_ENGINE } from '../audio/audio-engine';
 import { formatFractionScientific } from './value-formatter';
 import { pipe } from './functional-result-helpers';
+import { renderMarkdownToFragment } from './markdown-renderer';
 
 export interface DisplayElements {
     outputDisplay: HTMLElement;
@@ -19,6 +20,7 @@ export interface Display {
     readonly renderOutput: (text: string) => void;
     readonly renderError: (error: Error | { message?: string } | string) => void;
     readonly renderInfo: (text: string, append?: boolean) => void;
+    readonly renderReference: (markdown: string) => void;
     readonly renderStack: (stack: Value[]) => void;
     readonly extractState: () => DisplayState;
 }
@@ -497,6 +499,15 @@ export const createDisplay = (elements: DisplayElements): Display => {
         }
     };
 
+    const renderReference = (markdown: string): void => {
+        mainOutput = markdown;
+        clearElement(elements.outputDisplay);
+        const wrapper = document.createElement('div');
+        wrapper.className = 'md-reference';
+        wrapper.appendChild(renderMarkdownToFragment(markdown));
+        elements.outputDisplay.appendChild(wrapper);
+    };
+
     const renderStack = (stack: Value[]): void => {
         const display = elements.stackDisplay;
         clearElement(display);
@@ -539,6 +550,7 @@ export const createDisplay = (elements: DisplayElements): Display => {
         renderOutput,
         renderError,
         renderInfo,
+        renderReference,
         renderStack,
         extractState
     };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -753,3 +753,67 @@
         padding: 0.75rem 0.75rem 0.75rem 0.375rem;
     }
 }
+
+
+/* Rendered Markdown reference (output of `?` for builtin words) */
+.md-reference {
+    font-family: var(--font-family-base, system-ui, -apple-system, sans-serif);
+    color: var(--color-text);
+    line-height: 1.55;
+    white-space: normal;
+}
+
+.md-reference .md-heading {
+    margin: 0.8em 0 0.4em;
+    font-weight: 600;
+    line-height: 1.25;
+}
+.md-reference .md-h1 { font-size: 1.4em; border-bottom: 1px solid var(--color-medium); padding-bottom: 0.2em; }
+.md-reference .md-h2 { font-size: 1.15em; }
+.md-reference .md-h3 { font-size: 1.05em; }
+.md-reference .md-h1:first-child { margin-top: 0; }
+
+.md-reference .md-paragraph {
+    margin: 0.4em 0;
+}
+
+.md-reference .md-list {
+    margin: 0.4em 0;
+    padding-left: 1.4em;
+}
+.md-reference .md-list li {
+    margin: 0.15em 0;
+}
+
+.md-reference .md-inline-code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.92em;
+    padding: 0.08em 0.32em;
+    background: var(--color-medium);
+    border-radius: 3px;
+}
+
+.md-reference .md-code-block {
+    margin: 0.5em 0;
+    padding: 0.6em 0.8em;
+    background: var(--color-light);
+    border: 1px solid var(--color-medium);
+    border-radius: 4px;
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.92em;
+    line-height: 1.45;
+    white-space: pre;
+}
+.md-reference .md-code-block code {
+    background: transparent;
+    padding: 0;
+}
+.md-reference .md-code-ajisai {
+    border-left: 3px solid var(--color-primary);
+}
+.md-reference .md-code-text {
+    border-left: 3px solid var(--color-secondary);
+    color: var(--color-text-light);
+}
+


### PR DESCRIPTION
## Summary

Render the Markdown text returned by `?` (LOOKUP) for built-in words as formatted HTML in the output panel, instead of dumping raw text into the code editor.

### Changes
- New `src/gui/markdown-renderer.ts` — minimal Markdown renderer covering what the built-in reference texts actually use: ATX headings (`#`/`##`/`###`), fenced code blocks (`` ```ajisai `` / `` ```text ``), inline code, bullet lists, paragraphs. Outputs a `DocumentFragment` of real DOM nodes (no `innerHTML`, no XSS surface from doc text).
- `Display.renderReference(markdown)` added in `output-display-renderer.ts`.
- `execution-controller.ts` discriminates the `?` result:
  - Starts with `[` → user-defined word source → load into editor (existing behavior, used for re-editing)
  - Otherwise → built-in description → render as Markdown in the output panel
- Minimal CSS in `components.css` (headings, code blocks with `ajisai`/`text` left-border accents, inline code, lists).

### Out of scope
- No Rust / WASM changes (no rebuild needed)
- No new dependencies; renderer is hand-rolled (~80 lines)

## Test plan
- [x] `npm run check` passes (only pre-existing unrelated vitest module errors remain)
- [ ] Manual: `'ADD' ?` shows rendered Markdown in the output panel (headings, `ajisai` and `text` code blocks visually distinct, inline code styled)
- [ ] Manual: `'<user-word>' ?` still loads the Ajisai source into the editor

https://claude.ai/code/session_01UDmDUTajSD7AaGakHgtMXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDmDUTajSD7AaGakHgtMXz)_