### PR TITLE
Move rendered LOOKUP reference back to the input panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
                     <h2 class="visually-hidden">Input</h2>
                     <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
                     <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
+                    <div id="reference-display" class="md-reference-overlay" role="region" aria-label="Reference" tabindex="0" hidden></div>
                 </section>
             </div>
 

--- a/src/gui/code-input-editor.ts
+++ b/src/gui/code-input-editor.ts
@@ -1,4 +1,4 @@
-
+import { renderMarkdownToFragment } from './markdown-renderer';
 
 export interface EditorCallbacks {
     readonly onContentChange?: (content: string) => void;
@@ -14,7 +14,13 @@ export interface Editor {
     readonly insertText: (text: string) => void;
     readonly removeLastWord: () => void;
     readonly focus: () => void;
+    readonly showReference: (markdown: string) => void;
     readonly registerContentChangeCallback: (callback: (content: string) => void) => void;
+}
+
+export interface EditorElements {
+    readonly textarea: HTMLTextAreaElement;
+    readonly referenceDisplay: HTMLElement;
 }
 
 const insertAt = (
@@ -98,9 +104,11 @@ const extractToken = (
 };
 
 export const createEditor = (
-    element: HTMLTextAreaElement,
+    elements: EditorElements,
     callbacks: EditorCallbacks = {}
 ): Editor => {
+    const element = elements.textarea;
+    const referenceDisplay = elements.referenceDisplay;
     let onContentChangeCallback = callbacks.onContentChange;
     const switchToInputMode = callbacks.onSwitchToInputMode ?? (() => {});
     const requestSuggestions = callbacks.onRequestSuggestions ?? (() => []);
@@ -276,11 +284,34 @@ export const createEditor = (
     if (element.value.trim() === '') {
         updateElementValue(element, '');
     }
+
+    const inputArea = element.closest('.input-area');
+
+    const hideReference = (): void => {
+        if (referenceDisplay.hidden) return;
+        referenceDisplay.hidden = true;
+        referenceDisplay.replaceChildren();
+        element.hidden = false;
+        inputArea?.classList.remove('is-showing-reference');
+    };
+
+    const showReference = (markdown: string): void => {
+        referenceDisplay.classList.add('md-reference');
+        referenceDisplay.replaceChildren(renderMarkdownToFragment(markdown));
+        referenceDisplay.hidden = false;
+        element.hidden = true;
+        inputArea?.classList.add('is-showing-reference');
+        updateElementValue(element, '');
+        hideSuggestions();
+        emitContentChange();
+    };
+
     registerEventListeners();
 
     const extractValue = (): string => element.value.trim();
 
     const updateValue = (value: string): void => {
+        hideReference();
         updateElementValue(element, value);
         const cursor = value.length;
         updateSelectionRange(element, cursor, cursor);
@@ -291,6 +322,7 @@ export const createEditor = (
     };
 
     const clear = (switchView = true): void => {
+        hideReference();
         const wasFocused = document.activeElement === element;
         updateElementValue(element, '');
         if (wasFocused || !checkIsMobile()) {
@@ -306,6 +338,7 @@ export const createEditor = (
     };
 
     const insertWord = (word: string): void => {
+        hideReference();
         const wasFocused = document.activeElement === element;
         const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, word);
@@ -324,6 +357,7 @@ export const createEditor = (
     };
 
     const insertText = (text: string): void => {
+        hideReference();
         const wasFocused = document.activeElement === element;
         const { start, end } = lookupEditableSelectionRange();
         const newText = insertAt(element.value, start, end, text);
@@ -342,6 +376,7 @@ export const createEditor = (
     };
 
     const removeLastWord = (): void => {
+        hideReference();
         const wasFocused = document.activeElement === element;
         const { start } = lookupEditableSelectionRange();
         const before = element.value.substring(0, start);
@@ -362,6 +397,7 @@ export const createEditor = (
     };
 
     const focus = (): void => {
+        hideReference();
         focusElement(element);
         switchToInputMode();
         refreshSuggestions();
@@ -379,6 +415,7 @@ export const createEditor = (
         insertText,
         removeLastWord,
         focus,
+        showReference,
         registerContentChangeCallback
     };
 };

--- a/src/gui/execution-controller.ts
+++ b/src/gui/execution-controller.ts
@@ -107,12 +107,11 @@ export const createExecutionController = (
             const isUserDefinitionSource = text.trimStart().startsWith('[');
             if (isUserDefinitionSource) {
                 updateEditorValue(text);
-                showInfo(`Showing definition: ${wordName}`, false);
-                updateView('input');
             } else {
                 showReference(text);
-                updateView('output');
             }
+            showInfo(`Showing definition: ${wordName}`, false);
+            updateView('input');
         } else if (result.status === 'OK' && !result.error) {
             showExecutionResult(result);
             clearEditor(false);

--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -228,7 +228,10 @@ export const createGUI = (): GUI => {
         });
         await persistence.init();
 
-        editor = createEditor(elements.codeInput, {
+        editor = createEditor({
+            textarea: elements.codeInput,
+            referenceDisplay: elements.referenceDisplay
+        }, {
             onContentChange: (content) => updateHighlights(elements, content),
             onSwitchToInputMode: () => layoutController.setArea('input'),
             onRequestSuggestions: () => collectAutocompleteWords()
@@ -263,7 +266,7 @@ export const createGUI = (): GUI => {
             showInfo: (text, append) => display.renderInfo(text, append),
             showError: (error) => display.renderError(error),
             showExecutionResult: (result) => display.renderExecutionResult(result),
-            showReference: (markdown) => display.renderReference(markdown),
+            showReference: (markdown) => editor.showReference(markdown),
             updateDisplays: updateAllDisplays,
             saveState: () => persistence.saveCurrentState(),
             fullReset: () => persistence.fullReset(),

--- a/src/gui/gui-dom-cache.ts
+++ b/src/gui/gui-dom-cache.ts
@@ -5,6 +5,7 @@ import type { MobileElements } from './mobile-view-switcher';
 export interface GUIElements {
     readonly codeInput: HTMLTextAreaElement;
     readonly clearBtn: HTMLButtonElement;
+    readonly referenceDisplay: HTMLElement;
     readonly testBtn: HTMLButtonElement;
     readonly exportBtn: HTMLButtonElement;
     readonly importBtn: HTMLButtonElement;
@@ -70,6 +71,7 @@ function requireElementBySelector<T extends HTMLElement>(selector: string, expec
 export const cacheElements = (): GUIElements => ({
     codeInput: requireElementById('code-input', HTMLTextAreaElement),
     clearBtn: requireElementById('clear-btn', HTMLButtonElement),
+    referenceDisplay: requireElementById('reference-display', HTMLElement),
     testBtn: requireElementById('test-btn', HTMLButtonElement),
     exportBtn: requireElementById('export-btn', HTMLButtonElement),
     importBtn: requireElementById('import-btn', HTMLButtonElement),

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -2,7 +2,6 @@ import type { Value, ExecuteResult } from '../wasm-interpreter-types';
 import { AUDIO_ENGINE } from '../audio/audio-engine';
 import { formatFractionScientific } from './value-formatter';
 import { pipe } from './functional-result-helpers';
-import { renderMarkdownToFragment } from './markdown-renderer';
 
 export interface DisplayElements {
     outputDisplay: HTMLElement;
@@ -20,7 +19,6 @@ export interface Display {
     readonly renderOutput: (text: string) => void;
     readonly renderError: (error: Error | { message?: string } | string) => void;
     readonly renderInfo: (text: string, append?: boolean) => void;
-    readonly renderReference: (markdown: string) => void;
     readonly renderStack: (stack: Value[]) => void;
     readonly extractState: () => DisplayState;
 }
@@ -499,15 +497,6 @@ export const createDisplay = (elements: DisplayElements): Display => {
         }
     };
 
-    const renderReference = (markdown: string): void => {
-        mainOutput = markdown;
-        clearElement(elements.outputDisplay);
-        const wrapper = document.createElement('div');
-        wrapper.className = 'md-reference';
-        wrapper.appendChild(renderMarkdownToFragment(markdown));
-        elements.outputDisplay.appendChild(wrapper);
-    };
-
     const renderStack = (stack: Value[]): void => {
         const display = elements.stackDisplay;
         clearElement(display);
@@ -550,7 +539,6 @@ export const createDisplay = (elements: DisplayElements): Display => {
         renderOutput,
         renderError,
         renderInfo,
-        renderReference,
         renderStack,
         extractState
     };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -212,6 +212,10 @@
     display: none;
 }
 
+.input-area.is-showing-reference #clear-btn {
+    display: inline-flex;
+}
+
 
 .editor-suggestions {
     position: absolute;
@@ -756,6 +760,16 @@
 
 
 /* Rendered Markdown reference (output of `?` for builtin words) */
+#reference-display.md-reference-overlay {
+    flex: 1;
+    min-height: 0;
+    padding: 0.75rem 1rem;
+    overflow-y: auto;
+    background-color: var(--code-bg);
+    color: var(--color-text);
+    cursor: text;
+}
+
 .md-reference {
     font-family: var(--font-family-base, system-ui, -apple-system, sans-serif);
     color: var(--color-text);


### PR DESCRIPTION
## Summary

Restore the original location of the `?` (LOOKUP) reference display: the input/editor area, not the output panel. Keep the Markdown rendering introduced in #843.

### Behavior
- `'ADD' ?` → renders the built-in description as formatted Markdown (headings, fenced code blocks, inline code, lists) inside the input area, replacing the textarea view.
- `'<user-word>' ?` → still loads the Ajisai source into the textarea for re-editing.
- Dismissal: any edit operation (clear, type, insert, focus) hides the reference and restores the textarea. The existing `×` clear button stays visible while a reference is shown so the user has an explicit dismiss control (a scoped CSS rule overrides the default `:placeholder-shown` hide).

### Implementation
- New `<div id="reference-display">` in `index.html` as a sibling of the textarea inside `#input-panel`.
- `editor.showReference(markdown)` toggles between textarea and reference div using the `is-showing-reference` class on `.input-area`.
- All editor mutation methods now call `hideReference()` first to restore editability.
- Removed the unused `Display.renderReference` path added in #843.

## Test plan
- [x] `npm run check` passes (only pre-existing unrelated vitest module errors)
- [ ] Manual: `'ADD' ?` shows rendered Markdown in the input area, output panel untouched
- [ ] Manual: `×` button clears the reference and returns the empty textarea
- [ ] Manual: typing in the input area (after dismissal) works normally
- [ ] Manual: `'<user-word>' ?` still loads source into the textarea

https://claude.ai/code/session_01UDmDUTajSD7AaGakHgtMXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDmDUTajSD7AaGakHgtMXz)_