### PR TITLE
Add semicolon-mode syntax sugar and tokenizer support for ';' and ';;'

### DIFF
--- a/rust/src/interpreter/core-word-canonicalization-tests.rs
+++ b/rust/src/interpreter/core-word-canonicalization-tests.rs
@@ -35,6 +35,8 @@ async fn symbol_aliases_execute_same_as_canonical_words() {
 async fn syntax_sugar_executes_same_as_canonical_mode_words() {
     assert_same_stack("1 2 . +", "1 2 TOP ADD").await;
     assert_same_stack("1 2 ,, +", "1 2 KEEP ADD").await;
+    assert_same_stack("1 2 ; +", "1 2 . , +").await;
+    assert_same_stack("[1] [2] [3] [3] ;; +", "[1] [2] [3] [3] .. ,, +").await;
     assert_same_stack("[ 1 2 3 ] [ 10 ] ~ GET", "[ 1 2 3 ] [ 10 ] SAFE GET").await;
 }
 

--- a/rust/src/tokenizer-regression-tests-2.rs
+++ b/rust/src/tokenizer-regression-tests-2.rs
@@ -315,14 +315,24 @@ mod tokenizer_regression_tests_2 {
     }
 
     #[test]
-    fn test_colon_and_semicolon_removed() {
+    fn test_colon_removed_and_semicolon_is_sugar() {
         let colon_result = tokenize(": [ 2 ] *");
         assert!(colon_result.is_err());
         assert!(colon_result.unwrap_err().contains("removed"));
 
         let semicolon_result = tokenize("[ 2 ] * ;");
-        assert!(semicolon_result.is_err());
-        assert!(semicolon_result.unwrap_err().contains("removed"));
+        assert!(semicolon_result.is_ok());
+        assert_eq!(
+            semicolon_result.unwrap(),
+            vec![
+                Token::VectorStart,
+                Token::Number("2".into()),
+                Token::VectorEnd,
+                Token::Symbol("*".into()),
+                Token::Symbol(".".into()),
+                Token::Symbol(",".into()),
+            ]
+        );
     }
 
 

--- a/rust/src/tokenizer-regression-tests-2.rs
+++ b/rust/src/tokenizer-regression-tests-2.rs
@@ -125,6 +125,29 @@ mod tokenizer_regression_tests_2 {
     }
 
     #[test]
+    fn test_semicolon_mode_sugar() {
+        let result = tokenize("; +").unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Symbol(".".into()),
+                Token::Symbol(",".into()),
+                Token::Symbol("+".into()),
+            ]
+        );
+
+        let result2 = tokenize(";; +").unwrap();
+        assert_eq!(
+            result2,
+            vec![
+                Token::Symbol("..".into()),
+                Token::Symbol(",,".into()),
+                Token::Symbol("+".into()),
+            ]
+        );
+    }
+
+    #[test]
     fn test_dot_operator_with_vector() {
         let result = tokenize("[ 1 2 3 ] . LENGTH").unwrap();
         assert_eq!(

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -36,7 +36,16 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             return Err("':' (code block start) has been removed. Use '{' and '}' or '(' and ')' for code blocks.".to_string());
         }
         if chars[i] == ';' {
-            return Err("';' (code block end) has been removed. Use '{' and '}' or '(' and ')' for code blocks.".to_string());
+            if i + 1 < chars.len() && chars[i + 1] == ';' {
+                tokens.push(Token::Symbol("..".into()));
+                tokens.push(Token::Symbol(",,".into()));
+                i += 2;
+                continue;
+            }
+            tokens.push(Token::Symbol(".".into()));
+            tokens.push(Token::Symbol(",".into()));
+            i += 1;
+            continue;
         }
         if let Some((token, consumed)) = parse_token_from_single_char(chars[i]) {
             tokens.push(token);


### PR DESCRIPTION
### Motivation

- Introduce syntactic sugar for semicolon-mode operators so `;` and `;;` can be used as shorthand for existing dot/comma operators at the tokenizer and interpreter test levels.

### Description

- Implement tokenization for single `;` to expand into `.` and `,` tokens and for `;;` to expand into `..` and `,,` in `tokenizer.rs`.
- Replace the previous hard error on `';'` with the new semicolon expansion logic and keep existing single-character parsing behavior for other tokens.
- Add a unit test `test_semicolon_mode_sugar` in `tokenizer-regression-tests-2.rs` to assert the tokenizer maps `; +` to `.` `,` `+` and `;; +` to `..` `,,` `+`.
- Extend interpreter tests in `core-word-canonicalization-tests.rs` to verify the semicolon sugar executes the same as the canonical mode words by adding assertions for `;` and `;;` cases.

### Testing

- Ran the unit tokenizer test `test_semicolon_mode_sugar` and it passed as part of the test run.
- Ran the interpreter canonicalization tests including `syntax_sugar_executes_same_as_canonical_mode_words` and they passed as part of the test run.
- Ran the full test suite with `cargo test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88db589f483269d4c3267762fa3a3)