### PR TITLE
Add PRECOMPUTE staging: comptime pre-evaluation, sandboxing, and spec updates

### DIFF
--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -77,6 +77,7 @@ pub enum BuiltinExecutorKey {
     Kill,
     Monitor,
     Supervise,
+    Precompute,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1490,6 +1491,35 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
     },
 
     // === Dictionary ===
+    BuiltinSpec {
+        name: "PRECOMPUTE",
+        category: "Control / Staging",
+        hover_summary: "PRECOMPUTE — definition-time precompute marker",
+        hover_syntax: "{ ... } PRECOMPUTE",
+        signature_type: "CodeBlock -- value* (definition-time only)",
+        detail_group: BuiltinDetailGroup::ControlHigherOrder,
+        executor_key: Some(BuiltinExecutorKey::Precompute),
+        summary: "Definition-time staging marker (not a macro).",
+        role: Some("Definition-time only"),
+        syntax_forms: &[BuiltinSyntaxDoc {
+            canonical: "{ ... } PRECOMPUTE",
+            shorthand: None,
+            description: Some("Evaluates the preceding CodeBlock during DEF and embeds result values as literals."),
+        }],
+        stack_effect: "CodeBlock -- value* (during DEF rewrite)",
+        behavior: "Not a macro: PRECOMPUTE does not generate arbitrary syntax and errors when executed at runtime.",
+        examples: &[BuiltinExampleDoc {
+            canonical: "{ { 1 2 ADD } PRECOMPUTE 3 MUL } 'X' DEF",
+            shorthand: None,
+            result: Some("X evaluates to 9"),
+        }],
+        failure: Some("Runtime error if executed outside DEF staging."),
+        related: &["DEF", "EVAL"],
+        side_effects: &["None at runtime; DEF-time rewrite marker only."],
+        stability: "stable",
+        modifier_interaction: None,
+        ..SPEC_DEFAULT
+    },
     BuiltinSpec {
         name: "DEF",
         category: "dictionary",

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -51,6 +51,7 @@ fn core_builtin_capabilities(key: Option<BuiltinExecutorKey>, name: &str) -> Cap
         (Some(BuiltinExecutorKey::Monitor), _) => Capabilities::SPAWN,
         (Some(BuiltinExecutorKey::Supervise), _) => Capabilities::SPAWN,
         (Some(BuiltinExecutorKey::Print), _) => Capabilities::IO,
+        (Some(BuiltinExecutorKey::Precompute), _) => Capabilities::MUTATES_DICT,
         _ => Capabilities::PURE,
     }
 }

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -454,6 +454,11 @@ fn apply_contract_overrides(meta: &mut CorewordMetadata, executor_key: Option<Bu
             meta.nil_policy = NilPolicy::PreservesReason;
             meta.safety_level = SafetyLevel::A;
         }
+        Some(Precompute) => {
+            meta.partiality = Partiality::Partial;
+            meta.nil_policy = NilPolicy::RejectsNil;
+            meta.safety_level = SafetyLevel::B;
+        }
         Some(Str) | Some(Num) | Some(Bool) | Some(Chr) | Some(Chars) | Some(Join) => {
             meta.partiality = Partiality::Partial;
             meta.nil_policy = NilPolicy::RejectsNil;

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -120,7 +120,7 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
         Eval => imp_heavy,
 
         // ── Dictionary mutators: impure ───────────────────────────────────
-        Def | Del | Import | ImportOnly | Force | Lookup => imp_heavy,
+        Def | Del | Import | ImportOnly | Force | Lookup | Precompute => imp_heavy,
 
         // ── I/O: impure ───────────────────────────────────────────────────
         Print => imp_heavy,

--- a/rust/src/interpreter/comptime/mod.rs
+++ b/rust/src/interpreter/comptime/mod.rs
@@ -1,0 +1,6 @@
+mod policy;
+mod precompute_tokens;
+mod sandbox;
+mod value_to_tokens;
+
+pub(crate) use precompute_tokens::precompute_definition_tokens;

--- a/rust/src/interpreter/comptime/policy.rs
+++ b/rust/src/interpreter/comptime/policy.rs
@@ -1,0 +1,55 @@
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::Interpreter;
+use crate::types::{Capabilities, Token};
+use std::collections::HashSet;
+
+pub(crate) fn assert_comptime_safe_tokens(
+    interp: &mut Interpreter,
+    tokens: &[Token],
+    visiting: &mut HashSet<String>,
+) -> Result<()> {
+    for token in tokens {
+        if let Token::Symbol(name) = token {
+            if name.eq_ignore_ascii_case("PRECOMPUTE") {
+                return Err(AjisaiError::from(
+                    "PRECOMPUTE rejected: nested PRECOMPUTE is not supported in Phase 1",
+                ));
+            }
+
+            let Some((resolved_name, def)) = interp.resolve_word_entry(name) else {
+                return Err(AjisaiError::from(format!(
+                    "PRECOMPUTE rejected: unresolved word {}",
+                    name
+                )));
+            };
+
+            if def.is_builtin {
+                if !def.capabilities.contains(Capabilities::PURE)
+                    || def.capabilities.contains(Capabilities::EVAL)
+                    || def.capabilities.contains(Capabilities::IO)
+                    || def.capabilities.contains(Capabilities::SPAWN)
+                    || def.capabilities.contains(Capabilities::MUTATES_DICT)
+                {
+                    return Err(AjisaiError::from(format!(
+                        "PRECOMPUTE rejected: word {} is not comptime-safe",
+                        name
+                    )));
+                }
+            } else {
+                if visiting.contains(&resolved_name) {
+                    return Err(AjisaiError::from(format!(
+                        "PRECOMPUTE rejected: recursive dependency detected at {}",
+                        resolved_name
+                    )));
+                }
+                visiting.insert(resolved_name.clone());
+                for line in def.lines.iter() {
+                    assert_comptime_safe_tokens(interp, &line.body_tokens, visiting)?;
+                }
+                visiting.remove(&resolved_name);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/interpreter/comptime/precompute_tokens.rs
+++ b/rust/src/interpreter/comptime/precompute_tokens.rs
@@ -1,0 +1,60 @@
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::comptime::policy::assert_comptime_safe_tokens;
+use crate::interpreter::comptime::sandbox::run_precompute_block;
+use crate::interpreter::comptime::value_to_tokens::stack_to_literal_tokens;
+use crate::interpreter::Interpreter;
+use crate::types::Token;
+use std::collections::HashSet;
+
+fn extract_block(tokens: &[Token], start: usize) -> Result<(Vec<Token>, usize)> {
+    let mut depth = 0usize;
+    let mut out = Vec::new();
+    let mut i = start;
+    while i < tokens.len() {
+        match &tokens[i] {
+            Token::BlockStart => {
+                depth += 1;
+                out.push(tokens[i].clone());
+            }
+            Token::BlockEnd => {
+                if depth == 0 {
+                    return Err(AjisaiError::from("PRECOMPUTE rejected: malformed block"));
+                }
+                depth -= 1;
+                out.push(tokens[i].clone());
+                if depth == 0 {
+                    return Ok((out, i));
+                }
+            }
+            _ => out.push(tokens[i].clone()),
+        }
+        i += 1;
+    }
+    Err(AjisaiError::from("PRECOMPUTE rejected: unterminated block"))
+}
+
+pub(crate) fn precompute_definition_tokens(
+    interp: &mut Interpreter,
+    tokens: &[Token],
+) -> Result<Vec<Token>> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < tokens.len() {
+        if matches!(tokens[i], Token::BlockStart) {
+            let (block_tokens, block_end) = extract_block(tokens, i)?;
+            if matches!(tokens.get(block_end + 1), Some(Token::Symbol(s)) if s.eq_ignore_ascii_case("PRECOMPUTE"))
+            {
+                let block_body_tokens = &block_tokens[1..block_tokens.len() - 1];
+                assert_comptime_safe_tokens(interp, block_body_tokens, &mut HashSet::new())?;
+                let stack = run_precompute_block(interp, block_body_tokens)?;
+                out.extend(stack_to_literal_tokens(&stack)?);
+                i = block_end + 2;
+                continue;
+            }
+        }
+        out.push(tokens[i].clone());
+        i += 1;
+    }
+
+    Ok(out)
+}

--- a/rust/src/interpreter/comptime/sandbox.rs
+++ b/rust/src/interpreter/comptime/sandbox.rs
@@ -1,0 +1,24 @@
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::Interpreter;
+use crate::types::{Token, Value};
+
+pub(crate) const PRECOMPUTE_STEP_LIMIT: usize = 20_000;
+
+pub(crate) fn run_precompute_block(interp: &Interpreter, block_body_tokens: &[Token]) -> Result<Vec<Value>> {
+    let mut sandbox = Interpreter::new();
+    sandbox.core_vocabulary = interp.core_vocabulary.clone();
+    sandbox.user_words = interp.user_words.clone();
+    sandbox.user_dictionaries = interp.user_dictionaries.clone();
+    sandbox.module_vocabulary = interp.module_vocabulary.clone();
+    sandbox.active_user_dictionary = interp.active_user_dictionary.clone();
+    sandbox.max_execution_steps = PRECOMPUTE_STEP_LIMIT;
+    sandbox.execute_section_core(block_body_tokens, 0)?;
+
+    if sandbox.execution_step_count >= PRECOMPUTE_STEP_LIMIT {
+        return Err(AjisaiError::from(
+            "PRECOMPUTE failed: execution exceeded step limit",
+        ));
+    }
+
+    Ok(sandbox.stack)
+}

--- a/rust/src/interpreter/comptime/value_to_tokens.rs
+++ b/rust/src/interpreter/comptime/value_to_tokens.rs
@@ -1,0 +1,34 @@
+use crate::error::{AjisaiError, Result};
+use crate::types::{Token, Value, ValueData};
+
+fn value_to_literal_tokens(value: &Value) -> Result<Vec<Token>> {
+    match &value.data {
+        ValueData::Scalar(n) => Ok(vec![Token::Number(n.to_string().into())]),
+        ValueData::Vector(values) => {
+            let mut tokens = vec![Token::VectorStart];
+            for child in values.iter() {
+                match &child.data {
+                    ValueData::Scalar(n) => tokens.push(Token::Number(n.to_string().into())),
+                    _ => {
+                        return Err(AjisaiError::from(
+                            "PRECOMPUTE failed: result contains unsupported value type",
+                        ))
+                    }
+                }
+            }
+            tokens.push(Token::VectorEnd);
+            Ok(tokens)
+        }
+        _ => Err(AjisaiError::from(
+            "PRECOMPUTE failed: result contains unsupported value type",
+        )),
+    }
+}
+
+pub(crate) fn stack_to_literal_tokens(stack: &[Value]) -> Result<Vec<Token>> {
+    let mut out = Vec::new();
+    for value in stack {
+        out.extend(value_to_literal_tokens(value)?);
+    }
+    Ok(out)
+}

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -292,6 +292,9 @@ impl Interpreter {
             BuiltinExecutorKey::Kill => self.op_kill(),
             BuiltinExecutorKey::Monitor => self.op_monitor(),
             BuiltinExecutorKey::Supervise => self.op_supervise(),
+            BuiltinExecutorKey::Precompute => Err(AjisaiError::from(
+                "PRECOMPUTE can only be used during definition-time precomputation",
+            )),
         }
     }
 

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -1,4 +1,5 @@
 use crate::error::{AjisaiError, Result};
+use crate::interpreter::comptime::precompute_definition_tokens;
 use crate::interpreter::value_extraction_helpers::extract_word_name_from_value;
 use crate::interpreter::vector_exec::format_vector_to_source;
 use crate::interpreter::{Interpreter, OperationTargetMode, WordDefinition};
@@ -218,7 +219,8 @@ pub(crate) fn op_def_inner(
         }
     }
 
-    let lines = parse_definition_body(tokens)?;
+    let staged_tokens = precompute_definition_tokens(interp, tokens)?;
+    let lines = parse_definition_body(&staged_tokens)?;
 
     let mut new_dependencies = HashSet::new();
     for line in &lines {

--- a/rust/src/interpreter/interpreter-definition-tests.rs
+++ b/rust/src/interpreter/interpreter-definition-tests.rs
@@ -384,4 +384,28 @@ mod tests {
             err_msg
         );
     }
+
+    #[tokio::test]
+    async fn test_precompute_rejects_impure_builtin() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("{ { 'hello' PRINT } PRECOMPUTE } 'BAD' DEF")
+            .await;
+        assert!(result.is_err(), "impure PRECOMPUTE block should fail");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("PRECOMPUTE"));
+        assert!(err.contains("not comptime-safe"));
+        assert!(err.contains("PRINT"));
+    }
+
+    #[tokio::test]
+    async fn test_precompute_rejects_recursive_user_word() {
+        let mut interp = Interpreter::new();
+        interp.execute("{ REC } 'REC' DEF").await.unwrap();
+        let result = interp.execute("{ { REC } PRECOMPUTE } 'BAD' DEF").await;
+        assert!(result.is_err(), "recursive PRECOMPUTE should fail");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("PRECOMPUTE"));
+        assert!(err.contains("recursive dependency"));
+    }
 }

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -4,6 +4,7 @@ pub mod cast;
 #[path = "child-runtime.rs"]
 pub mod child_runtime;
 pub mod comparison;
+pub mod comptime;
 #[path = "compiled-plan.rs"]
 pub mod compiled_plan;
 pub mod control;


### PR DESCRIPTION
### Motivation
- Introduce a definition-time staging marker `PRECOMPUTE` to allow evaluating code blocks at `DEF` time and embed their results as literals into the definition.
- Ensure precomputation is safe by restricting allowed operations and preventing recursive or impure computations.

### Description
- Add a new builtin `PRECOMPUTE` with documentation entry in `builtin-word-definitions.rs` and register its executor key and capabilities so it is treated as a dictionary-mutating, definition-time construct.
- Implement a new `interpreter::comptime` module with `policy.rs`, `precompute_tokens.rs`, `sandbox.rs`, and `value_to_tokens.rs` to validate tokens for comptime-safety, execute blocks in a sandboxed interpreter with a step limit, and convert computed values to literal tokens.
- Integrate precomputation into definition parsing by calling `precompute_definition_tokens` from `execute-def.rs` before `parse_definition_body`, and make runtime execution of `PRECOMPUTE` return an error in `execute-builtin.rs`.
- Update purity and metadata tables in `purity_table.rs` and `coreword_registry.rs` to account for `Precompute`, and export the new `comptime` module in `interpreter/mod.rs`.

### Testing
- Added unit tests `test_precompute_rejects_impure_builtin` and `test_precompute_rejects_recursive_user_word` in `interpreter-definition-tests.rs` to assert impure builtins and recursive user words are rejected during precompute, and both tests are included in the test suite.
- Ran `cargo test` and the test suite including the new tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92fe423ec8326abf135445e6a4003)