### PR TITLE
Wrap PRECOMPUTE sandbox runtime errors with PRECOMPUTE prefix

### DIFF
--- a/rust/src/interpreter/comptime/sandbox.rs
+++ b/rust/src/interpreter/comptime/sandbox.rs
@@ -12,13 +12,14 @@ pub(crate) fn run_precompute_block(interp: &Interpreter, block_body_tokens: &[To
     sandbox.module_vocabulary = interp.module_vocabulary.clone();
     sandbox.active_user_dictionary = interp.active_user_dictionary.clone();
     sandbox.max_execution_steps = PRECOMPUTE_STEP_LIMIT;
-    sandbox.execute_section_core(block_body_tokens, 0)?;
-
-    if sandbox.execution_step_count >= PRECOMPUTE_STEP_LIMIT {
-        return Err(AjisaiError::from(
-            "PRECOMPUTE failed: execution exceeded step limit",
-        ));
-    }
+    sandbox
+        .execute_section_core(block_body_tokens, 0)
+        .map_err(|e| match e {
+            AjisaiError::ExecutionLimitExceeded { .. } => {
+                AjisaiError::from("PRECOMPUTE failed: execution exceeded step limit")
+            }
+            other => AjisaiError::from(format!("PRECOMPUTE failed: {}", other)),
+        })?;
 
     Ok(sandbox.stack)
 }

--- a/rust/src/interpreter/interpreter-definition-tests.rs
+++ b/rust/src/interpreter/interpreter-definition-tests.rs
@@ -444,6 +444,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_precompute_runtime_error_is_wrapped() {
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("{ { 1 0 DIV } PRECOMPUTE } 'BAD' DEF")
+            .await;
+        assert!(result.is_err(), "division by zero in PRECOMPUTE should fail DEF");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("PRECOMPUTE"),
+            "runtime error inside PRECOMPUTE must mention PRECOMPUTE: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
     async fn test_precompute_rejects_impure_builtin() {
         let mut interp = Interpreter::new();
         let result = interp


### PR DESCRIPTION
## Phase 2/3 評価結果

Codexの Phase 2 (commit 57dfc2d) と Phase 3 (commit 96e71d9) を改めて精査しました。両Phaseとも方向性は妥当で、PR #858 で対応した不備（Phase 3 のデッドコード残置、Phase 2 の `TIME/RANDOM/CRYPTO/INPUT_HELPER` capability チェック漏れ、正常系テスト不足）以外には大きな欠陥は見つかりませんでした。

## 残っていた小さな問題

仕様書 §11.1 では `PRECOMPUTE` 関連エラーは `PRECOMPUTE` を含めるよう要求していますが、sandbox 実行時の **runtime エラー** は `execute_section_core` の生のエラー（例: `Execution step limit (20000) exceeded`、`Division by zero`）がそのまま伝播していました。これだと利用者は失敗が定義時の事前計算で起きたのか通常実行で起きたのか判別しづらいため、ラップして `PRECOMPUTE failed: ...` 形式に整えました。

加えて、`sandbox.rs` 末尾の `if count >= PRECOMPUTE_STEP_LIMIT` post-check は実質デッドコードでした（`execute-builtin.rs` の `count > limit` チェックが先に発火して `Err` が返るため）。step-limit ケースを `ExecutionLimitExceeded` variant に対するパターンマッチに統合し、post-check は除去。

## 変更点

- `sandbox.rs`: `execute_section_core` のエラーを `PRECOMPUTE failed:` 接頭辞付きにマップ（step-limit 時は仕様文言 `PRECOMPUTE failed: execution exceeded step limit` を使用）
- `interpreter-definition-tests.rs`: 0除算を含む PRECOMPUTE block の DEF が失敗し、エラーメッセージに `PRECOMPUTE` が含まれることを確認する回帰テストを追加

## 検証

`cargo test --lib` で 803 tests pass。


---
_Generated by [Claude Code](https://claude.ai/code/session_013gb1XLmtMqYCr3pKrCj5Nx)_