### PR TITLE
Add UNIMPORT/UNIMPORT-ONLY and make module words detachable

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -256,7 +256,13 @@ All built-in words have English-word-based canonical names (see Section 7). The 
 
 ## 7. Built-in Words
 
+Ajisai vocabulary follows the rule: **Core is permanent, Module is detachable, User is editable.**
+
 Built-in words are predefined and cannot be redefined or deleted.
+
+- **Core words** belong to the Ajisai runtime itself. They are always available and cannot be deleted, hidden, unimported, or redefined.
+- **Module words** belong to a module dictionary. Their definitions are built in and cannot be redefined or destructively deleted, but their visibility in the current vocabulary is controlled with `IMPORT`, `IMPORT-ONLY`, `UNIMPORT`, and `UNIMPORT-ONLY`.
+- **User words** belong to a user dictionary. They are editable, and deletion or redefinition is controlled by dependency checks and the force modifier where applicable.
 
 Every built-in word has exactly one **canonical home**, either Core or a specific module. The canonical home determines where the implementation lives and, for module-canonical words, which module name `IMPORT` activates them under.
 
@@ -271,7 +277,7 @@ Boundary classes:
 - **Canonical Module + core-listed boundary words** — canonical home in a module, additionally surfaced in the Core listing view (e.g. `SORT` whose canonical home is `ALGO`).
 - **Module-only words** — canonical home in a module; listed only under that module.
 
-`IMPORT` and `IMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
+`IMPORT`, `IMPORT-ONLY`, `UNIMPORT`, and `UNIMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
 
 Categories such as `CAST`, `TEXT`, `TENSOR`, and `RUNTIME` are documentation-only labels used to group Core words by capability surface. They are **not** modules, are not registered in `MODULE_SPECS`, and cannot be supplied to `IMPORT`.
 
@@ -502,6 +508,8 @@ A code block followed by a name string defines a user word in the active diction
 
 Deletes a user word. The force modifier `!` is required if other words depend on the word being deleted.
 
+`DEL` never destroys module dictionaries or module words. To remove module words from the current vocabulary, use `UNIMPORT` or `UNIMPORT-ONLY`; the module dictionary remains cached as the definition source.
+
 ### 8.4 Recursion
 
 User words may call themselves or other user words recursively. There is no hard-coded call-depth limit as a language semantic rule.
@@ -531,18 +539,26 @@ Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object 
 | `ALGO` | Sorting and other deterministic algorithms |
 | `MATH` | Square root and exact-rational interval arithmetic |
 
-### 9.2 Import syntax
+### 9.2 Import and unimport syntax
 
 ```
 'MODULE-NAME' IMPORT
 'MODULE-NAME' [ 'WORD1' 'WORD2' ] IMPORT-ONLY
+'MODULE-NAME' UNIMPORT
+'MODULE-NAME' [ 'WORD1' 'WORD2' ] UNIMPORT-ONLY
 ```
 
-`IMPORT` loads all words from a module into the current scope. `IMPORT-ONLY` loads only the specified words.
+`IMPORT` loads all public words from a module into the current vocabulary. `IMPORT-ONLY` loads only the specified module words or sample words.
+
+`UNIMPORT` hides unreferenced imported words from the current vocabulary without deleting the module dictionary. If a user word references a module word or module sample word, `UNIMPORT` keeps that referenced item visible and shrinks the module import to an explicit partial-import state.
+
+`UNIMPORT-ONLY` hides only the specified module words or sample words. It fails if a selected item is referenced by a user word; use dictionary-level `UNIMPORT` when the desired operation is to clean up unused module imports while preserving referenced items.
+
+Selectors that name Core words merely listed in a module view are no-ops for `IMPORT-ONLY` and `UNIMPORT-ONLY`, because Core words are always available and cannot be imported or unimported through a module.
 
 ### 9.3 Module-provided sample words
 
-Modules may provide sample user words for demonstration. Sample words require the force modifier `!` to delete.
+Modules may provide sample words for demonstration. Sample words are part of the module dictionary for import visibility: they can be introduced with `IMPORT` / `IMPORT-ONLY` and hidden with `UNIMPORT` / `UNIMPORT-ONLY`, but they are not destructively deleted with `DEL`.
 
 ---
 

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -45,6 +45,8 @@ pub enum BuiltinExecutorKey {
     Lookup,
     Import,
     ImportOnly,
+    Unimport,
+    UnimportOnly,
     Force,
     Print,
     Insert,
@@ -1993,6 +1995,63 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
             "Modifies the dictionary; capability MUTATES_DICT required.",
         ],
         related: &["IMPORT"],
+        stability: "experimental",
+        ..SPEC_DEFAULT
+    },
+
+    BuiltinSpec {
+        name: "UNIMPORT",
+        category: "module",
+        hover_summary: "UNIMPORT — hide imported module words",
+        hover_syntax: "'IO' UNIMPORT",
+        detail_group: BuiltinDetailGroup::IoModule,
+        executor_key: Some(BuiltinExecutorKey::Unimport),
+        summary: "Hide unused imported words from a module while keeping words referenced by user definitions.",
+        syntax_forms: &[BuiltinSyntaxDoc {
+            canonical: "[ name ] UNIMPORT",
+            shorthand: None,
+            description: None,
+        }],
+        stack_effect: "[ name ] -> []",
+        behavior:
+            "Pops a module name and removes unreferenced imported module words from\nthe current vocabulary. Module words referenced by user definitions remain imported.",
+        examples: &[BuiltinExampleDoc {
+            canonical: "'MUSIC' UNIMPORT",
+            shorthand: None,
+            result: Some("(unreferenced MUSIC words hidden)"),
+        }],
+        side_effects: &[
+            "Modifies the import table; capability MUTATES_DICT required.",
+        ],
+        related: &["IMPORT", "IMPORT-ONLY", "UNIMPORT-ONLY"],
+        stability: "experimental",
+        ..SPEC_DEFAULT
+    },
+    BuiltinSpec {
+        name: "UNIMPORT-ONLY",
+        category: "module",
+        hover_summary: "UNIMPORT-ONLY — hide selected module words",
+        hover_syntax: "'json' [ 'parse' ] UNIMPORT-ONLY",
+        detail_group: BuiltinDetailGroup::IoModule,
+        executor_key: Some(BuiltinExecutorKey::UnimportOnly),
+        summary: "Hide only the listed imported module words.",
+        syntax_forms: &[BuiltinSyntaxDoc {
+            canonical: "[ name ] [ words ] UNIMPORT-ONLY",
+            shorthand: None,
+            description: None,
+        }],
+        stack_effect: "[ name ] [ words ] -> []",
+        behavior:
+            "Pops a module name and a vector of word names, removing those words\nfrom the current vocabulary. Referenced module words are rejected.",
+        examples: &[BuiltinExampleDoc {
+            canonical: "'json' [ 'parse' ] UNIMPORT-ONLY",
+            shorthand: None,
+            result: Some("(JSON@PARSE hidden)"),
+        }],
+        side_effects: &[
+            "Modifies the import table; capability MUTATES_DICT required.",
+        ],
+        related: &["IMPORT", "IMPORT-ONLY", "UNIMPORT"],
         stability: "experimental",
         ..SPEC_DEFAULT
     },

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -42,6 +42,8 @@ fn core_builtin_capabilities(key: Option<BuiltinExecutorKey>, name: &str) -> Cap
         (Some(BuiltinExecutorKey::Del), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::Import), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::ImportOnly), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::Unimport), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::UnimportOnly), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::Force), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::Eval), _) => Capabilities::EVAL,
         (Some(BuiltinExecutorKey::Spawn), _) => Capabilities::SPAWN,

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -402,6 +402,10 @@ fn core_word_metadata(
         Some(BuiltinExecutorKey::ImportOnly) => {
             effectful(name, category, &["dictionary-import-only"])
         }
+        Some(BuiltinExecutorKey::Unimport) => effectful(name, category, &["dictionary-unimport"]),
+        Some(BuiltinExecutorKey::UnimportOnly) => {
+            effectful(name, category, &["dictionary-unimport-only"])
+        }
         Some(BuiltinExecutorKey::Force) => effectful(name, category, &["interpreter-mode-write"]),
         Some(BuiltinExecutorKey::Eval) => effectful(name, category, &["code-execution"]),
         Some(BuiltinExecutorKey::Spawn)
@@ -480,7 +484,8 @@ fn apply_contract_overrides(meta: &mut CorewordMetadata, executor_key: Option<Bu
             meta.nil_policy = NilPolicy::PreservesReason;
             meta.safety_level = SafetyLevel::D;
         }
-        Some(Def) | Some(Del) | Some(Import) | Some(ImportOnly) | Some(Force) => {
+        Some(Def) | Some(Del) | Some(Import) | Some(ImportOnly) | Some(Unimport)
+        | Some(UnimportOnly) | Some(Force) => {
             meta.partiality = Partiality::Partial;
             meta.nil_policy = NilPolicy::RejectsNil;
             meta.safety_level = SafetyLevel::D;

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -120,7 +120,9 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
         Eval => imp_heavy,
 
         // ── Dictionary mutators: impure ───────────────────────────────────
-        Def | Del | Import | ImportOnly | Force | Lookup | Precompute => imp_heavy,
+        Def | Del | Import | ImportOnly | Unimport | UnimportOnly | Force | Lookup | Precompute => {
+            imp_heavy
+        }
 
         // ── I/O: impure ───────────────────────────────────────────────────
         Print => imp_heavy,

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -257,6 +257,8 @@ impl Interpreter {
             BuiltinExecutorKey::Lookup => execute_lookup::op_lookup(self),
             BuiltinExecutorKey::Import => modules::op_import(self),
             BuiltinExecutorKey::ImportOnly => modules::op_import_only(self),
+            BuiltinExecutorKey::Unimport => modules::op_unimport(self),
+            BuiltinExecutorKey::UnimportOnly => modules::op_unimport_only(self),
             BuiltinExecutorKey::Force => {
                 self.force_flag = true;
                 Ok(())

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -227,7 +227,7 @@ pub(crate) fn op_def_inner(
             if let Token::Symbol(s) = token {
                 let upper_s = crate::core_word_aliases::canonicalize_core_word_name(s);
                 if let Some((resolved_name, resolved_def)) = interp.resolve_word_entry(&upper_s) {
-                    if !resolved_def.is_builtin {
+                    if !resolved_def.is_builtin || resolved_name.contains('@') {
                         new_dependencies.insert(resolved_name);
                     }
                 }

--- a/rust/src/interpreter/execute-del.rs
+++ b/rust/src/interpreter/execute-del.rs
@@ -16,7 +16,6 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
 
     let upper_name = name.to_uppercase();
 
-
     let (target_dict, word_name) = if let Some((ns, w)) = interp.split_qualified_name(&upper_name) {
         (Some(ns), w)
     } else {
@@ -31,7 +30,6 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
-
     if target_dict.is_none() {
         if interp.user_dictionaries.contains_key(&word_name) {
             interp.user_dictionaries.remove(&word_name);
@@ -45,29 +43,50 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             return Ok(());
         }
 
-        if interp.module_vocabulary.contains_key(&word_name) {
-            interp.module_vocabulary.remove(&word_name);
-            interp.import_table.modules.remove(&word_name);
-            interp.sync_user_words_cache();
-            interp.rebuild_dependencies()?;
-            interp
-                .output_buffer
-                .push_str(&format!("Deleted dictionary: {}\n", word_name));
-            interp.bump_dictionary_epoch();
+        if crate::interpreter::modules::is_known_module(&word_name) {
             interp.force_flag = false;
-            return Ok(());
+            return Err(AjisaiError::from(format!(
+                "Cannot delete module dictionary {}. Use '{}' UNIMPORT to hide imported module words.",
+                word_name, word_name
+            )));
+        }
+
+        if let Some((module_name, is_sample)) = find_imported_module_item(interp, &word_name) {
+            interp.force_flag = false;
+            if is_sample {
+                return Err(AjisaiError::from(format!(
+                    "Cannot delete module sample word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+                    module_name, word_name, module_name, word_name
+                )));
+            }
+            return Err(AjisaiError::from(format!(
+                "Cannot delete module word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+                module_name, word_name, module_name, word_name
+            )));
         }
     }
 
+    if let Some(module_name) = target_dict.as_deref() {
+        if let Some(module) = interp.module_vocabulary.get(module_name) {
+            let qualified = format!("{}@{}", module_name, word_name);
+            if module.words.contains_key(&qualified) || module.sample_words.contains_key(&word_name)
+            {
+                interp.force_flag = false;
+                return Err(AjisaiError::from(format!(
+                    "Cannot delete module word {}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+                    qualified, module_name, word_name
+                )));
+            }
+        }
+    }
 
     let (owner_name, is_module) = find_word_owner(interp, target_dict.as_deref(), &word_name)?;
 
-
-    if is_module && !interp.force_flag {
+    if is_module {
         interp.force_flag = false;
         return Err(AjisaiError::from(format!(
-            "Word '{}' is a module sample word. Use ! '{}' DEL to force delete.",
-            word_name, word_name
+            "Cannot delete module word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+            owner_name, word_name, owner_name, word_name
         )));
     }
 
@@ -81,7 +100,6 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             word_name, dep_list, word_name
         )));
     }
-
 
     let removed_def = if is_module {
         interp
@@ -125,6 +143,25 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
+fn find_imported_module_item(interp: &Interpreter, word_name: &str) -> Option<(String, bool)> {
+    for (module_name, module) in &interp.module_vocabulary {
+        let Some(imported) = interp.import_table.modules.get(module_name) else {
+            continue;
+        };
+        let qualified = format!("{}@{}", module_name, word_name);
+        if module.words.contains_key(&qualified)
+            && (imported.import_all_public || imported.imported_words.contains(word_name))
+        {
+            return Some((module_name.clone(), false));
+        }
+        if module.sample_words.contains_key(word_name)
+            && (imported.import_all_public || imported.imported_samples.contains(word_name))
+        {
+            return Some((module_name.clone(), true));
+        }
+    }
+    None
+}
 
 fn find_word_owner(
     interp: &Interpreter,
@@ -132,7 +169,6 @@ fn find_word_owner(
     word_name: &str,
 ) -> Result<(String, bool)> {
     if let Some(dict_name) = target_dict {
-
         if let Some(dict) = interp.user_dictionaries.get(dict_name) {
             if dict.words.contains_key(word_name) {
                 return Ok((dict_name.to_string(), false));
@@ -148,7 +184,6 @@ fn find_word_owner(
             dict_name, word_name
         )))
     } else {
-
         for (dict_name, dict) in &interp.user_dictionaries {
             if dict.words.contains_key(word_name) {
                 return Ok((dict_name.clone(), false));

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -4,9 +4,9 @@ pub mod cast;
 #[path = "child-runtime.rs"]
 pub mod child_runtime;
 pub mod comparison;
-pub mod comptime;
 #[path = "compiled-plan.rs"]
 pub mod compiled_plan;
+pub mod comptime;
 pub mod control;
 #[path = "control-cond.rs"]
 pub mod control_cond;
@@ -117,6 +117,9 @@ mod interpreter_execution_tests;
 #[cfg(test)]
 #[path = "interpreter-mode-tests.rs"]
 mod interpreter_mode_tests;
+#[cfg(test)]
+#[path = "module-unimport-tests.rs"]
+mod module_unimport_tests;
 #[cfg(test)]
 #[path = "nil-reason-tests.rs"]
 mod nil_reason_tests;

--- a/rust/src/interpreter/module-unimport-tests.rs
+++ b/rust/src/interpreter/module-unimport-tests.rs
@@ -1,0 +1,135 @@
+#[cfg(test)]
+mod tests {
+    use crate::interpreter::Interpreter;
+
+    #[tokio::test]
+    async fn unimport_hides_unreferenced_module_words() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+
+        interp.execute("'json' UNIMPORT").await.unwrap();
+
+        assert!(
+            interp.execute("'[1]' JSON@PARSE").await.is_err(),
+            "UNIMPORT should hide unreferenced module words"
+        );
+        assert!(
+            interp.module_vocabulary.contains_key("JSON"),
+            "UNIMPORT must not destroy the module dictionary cache"
+        );
+        assert!(
+            !interp.import_table.modules.contains_key("JSON"),
+            "UNIMPORT with no references should remove only import-table visibility"
+        );
+    }
+
+    #[tokio::test]
+    async fn unimport_keeps_module_words_referenced_by_user_words() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+        interp
+            .execute("{ JSON@PARSE } 'USE-PARSE' DEF")
+            .await
+            .unwrap();
+
+        interp.execute("'json' UNIMPORT").await.unwrap();
+
+        assert!(
+            interp.execute("'[1]' JSON@PARSE").await.is_ok(),
+            "directly referenced module word should remain visible"
+        );
+        assert!(
+            interp.execute("'[1]' JSON@STRINGIFY").await.is_err(),
+            "unreferenced module word should be hidden"
+        );
+        let imported = interp.import_table.modules.get("JSON").unwrap();
+        assert!(
+            !imported.import_all_public,
+            "UNIMPORT should shrink a full import to explicit referenced selections"
+        );
+        assert!(imported.imported_words.contains("PARSE"));
+        assert!(!imported.imported_words.contains("STRINGIFY"));
+    }
+
+    #[tokio::test]
+    async fn unimport_only_hides_selected_unreferenced_words_after_full_import() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+
+        interp
+            .execute("'json' [ 'stringify' ] UNIMPORT-ONLY")
+            .await
+            .unwrap();
+
+        assert!(interp.execute("'[1]' JSON@PARSE").await.is_ok());
+        assert!(interp.execute("'[1]' JSON@STRINGIFY").await.is_err());
+        let imported = interp.import_table.modules.get("JSON").unwrap();
+        assert!(
+            !imported.import_all_public,
+            "UNIMPORT-ONLY from a full import should expand to explicit selections"
+        );
+    }
+
+    #[tokio::test]
+    async fn unimport_only_rejects_user_referenced_module_words() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+        interp
+            .execute("{ JSON@PARSE } 'USE-PARSE' DEF")
+            .await
+            .unwrap();
+
+        let result = interp.execute("'json' [ 'parse' ] UNIMPORT-ONLY").await;
+
+        assert!(result.is_err(), "referenced module word should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Cannot unimport JSON@PARSE"), "got: {msg}");
+        assert!(msg.contains("DEMO@USE-PARSE"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn del_cannot_destroy_module_dictionary_or_words_even_forced() {
+        let mut interp = Interpreter::new();
+        let before_import = interp.execute("'JSON' DEL").await;
+        assert!(before_import.is_err(), "known modules cannot be deleted before import");
+        assert!(
+            before_import
+                .unwrap_err()
+                .to_string()
+                .contains("Cannot delete module dictionary JSON")
+        );
+
+        interp.execute("'music' IMPORT").await.unwrap();
+
+        for code in ["'MUSIC' DEL", "! 'MUSIC' DEL"] {
+            let result = interp.execute(code).await;
+            assert!(result.is_err(), "{code} should be rejected");
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Cannot delete module dictionary MUSIC"),
+                "{code} should suggest UNIMPORT"
+            );
+            assert!(interp.module_vocabulary.contains_key("MUSIC"));
+        }
+
+        for code in [
+            "'MUSIC@PLAY' DEL",
+            "! 'MUSIC@PLAY' DEL",
+            "'PLAY' DEL",
+            "! 'PLAY' DEL",
+        ] {
+            let result = interp.execute(code).await;
+            assert!(result.is_err(), "{code} should be rejected");
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Cannot delete module word MUSIC@PLAY"),
+                "{code} should suggest UNIMPORT-ONLY"
+            );
+            assert!(interp.module_vocabulary.contains_key("MUSIC"));
+        }
+    }
+}

--- a/rust/src/interpreter/modules/mod.rs
+++ b/rust/src/interpreter/modules/mod.rs
@@ -24,8 +24,23 @@ pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
     module_import_execution::op_import_only(interp)
 }
 
+pub fn op_unimport(interp: &mut Interpreter) -> Result<()> {
+    module_import_execution::op_unimport(interp)
+}
+
+pub fn op_unimport_only(interp: &mut Interpreter) -> Result<()> {
+    module_import_execution::op_unimport_only(interp)
+}
+
 pub fn restore_module(interp: &mut Interpreter, module_name: &str) -> bool {
     module_import_execution::restore_module(interp, module_name)
+}
+
+pub(crate) fn is_known_module(module_name: &str) -> bool {
+    let upper = module_name.to_uppercase();
+    module_builtins::MODULE_SPECS
+        .iter()
+        .any(|module| module.name == upper)
 }
 
 pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {

--- a/rust/src/interpreter/modules/module_import_execution.rs
+++ b/rust/src/interpreter/modules/module_import_execution.rs
@@ -7,23 +7,27 @@ use crate::types::Value;
 
 use super::module_registry::{ensure_module_dictionary, extract_module_name_from_value};
 
-fn parse_only_items(value: &Value) -> Result<Vec<String>> {
+fn parse_only_items(value: &Value, op_name: &str) -> Result<Vec<String>> {
     if is_string_value(value) {
         let s = value_as_string(value)
-            .ok_or_else(|| AjisaiError::from("IMPORT-ONLY expects string selectors"))?;
+            .ok_or_else(|| AjisaiError::from(format!("{} expects string selectors", op_name)))?;
         return Ok(vec![s]);
     }
 
     let Some(items) = value.as_vector() else {
-        return Err(AjisaiError::from(
-            "IMPORT-ONLY expects a vector of word names",
-        ));
+        return Err(AjisaiError::from(format!(
+            "{} expects a vector of word names",
+            op_name
+        )));
     };
 
     let mut result = Vec::new();
     for item in items {
         if !is_string_value(item) {
-            return Err(AjisaiError::from("IMPORT-ONLY selectors must be strings"));
+            return Err(AjisaiError::from(format!(
+                "{} selectors must be strings",
+                op_name
+            )));
         }
         let Some(name) = value_as_string(item) else {
             continue;
@@ -57,6 +61,256 @@ fn emit_import_conflict_warnings(interp: &mut Interpreter, module_name: &str) {
             all_paths.join(" and ")
         ));
     }
+}
+
+fn expand_import_all_to_explicit_selection(
+    interp: &mut Interpreter,
+    module_name: &str,
+) -> Result<()> {
+    ensure_module_dictionary(interp, module_name)?;
+    let module_dict = interp
+        .module_vocabulary
+        .get(module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.to_string()))?;
+
+    let mut imported_words = HashSet::new();
+    let mut imported_samples = HashSet::new();
+    for qualified in module_dict.words.keys() {
+        if let Some((_, short)) = qualified.split_once('@') {
+            imported_words.insert(short.to_string());
+        }
+    }
+    for short in module_dict.sample_words.keys() {
+        imported_samples.insert(short.clone());
+    }
+
+    let entry = interp
+        .import_table
+        .modules
+        .entry(module_name.to_string())
+        .or_insert_with(|| ImportedModule {
+            import_all_public: false,
+            imported_words: HashSet::new(),
+            imported_samples: HashSet::new(),
+        });
+    if entry.import_all_public {
+        entry.import_all_public = false;
+        entry.imported_words = imported_words;
+        entry.imported_samples = imported_samples;
+    }
+    Ok(())
+}
+
+fn referenced_module_items_from_user_words(
+    interp: &Interpreter,
+    module_name: &str,
+) -> (HashSet<String>, HashSet<String>) {
+    let mut words = HashSet::new();
+    let mut samples = HashSet::new();
+    let Some(module_dict) = interp.module_vocabulary.get(module_name) else {
+        return (words, samples);
+    };
+
+    let mut pending = Vec::new();
+    for dict in interp.user_dictionaries.values() {
+        for def in dict.words.values() {
+            for dep in &def.dependencies {
+                if let Some((dep_module, short)) = interp.split_qualified_name(dep) {
+                    if dep_module == module_name {
+                        pending.push(short);
+                    }
+                }
+            }
+        }
+    }
+
+    while let Some(short) = pending.pop() {
+        let qualified = format!("{}@{}", module_name, short);
+        if module_dict.words.contains_key(&qualified) {
+            words.insert(short);
+            continue;
+        }
+        if !module_dict.sample_words.contains_key(&short) || !samples.insert(short.clone()) {
+            continue;
+        }
+        if let Some(sample_def) = module_dict.sample_words.get(&short) {
+            for dep in &sample_def.dependencies {
+                if let Some((dep_module, dep_short)) = interp.split_qualified_name(dep) {
+                    if dep_module == module_name {
+                        pending.push(dep_short);
+                    }
+                }
+            }
+        }
+    }
+
+    (words, samples)
+}
+
+fn referenced_by_user_words(interp: &Interpreter, qualified_name: &str) -> Vec<String> {
+    let mut dependents = Vec::new();
+    for (dict_name, dict) in &interp.user_dictionaries {
+        for (name, def) in &dict.words {
+            if def.dependencies.contains(qualified_name) {
+                dependents.push(format!("{}@{}", dict_name, name));
+            }
+        }
+    }
+    dependents.sort();
+    dependents
+}
+
+pub(super) fn op_unimport(interp: &mut Interpreter) -> Result<()> {
+    let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
+    let value = if is_keep_mode {
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
+    } else {
+        interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
+    };
+
+    let module_name = extract_module_name_from_value(&value)
+        .ok_or_else(|| AjisaiError::UnknownModule(value.to_string()))?
+        .to_uppercase();
+
+    ensure_module_dictionary(interp, &module_name)?;
+    if !interp.import_table.modules.contains_key(&module_name) {
+        interp.output_buffer.push_str(&format!(
+            "Warning: {} is not currently imported.\n",
+            module_name
+        ));
+        return Ok(());
+    }
+
+    interp.rebuild_dependencies()?;
+    let (referenced_words, referenced_samples) =
+        referenced_module_items_from_user_words(interp, &module_name);
+
+    if referenced_words.is_empty() && referenced_samples.is_empty() {
+        interp.import_table.modules.remove(&module_name);
+    } else {
+        let entry = interp
+            .import_table
+            .modules
+            .entry(module_name.clone())
+            .or_insert_with(|| ImportedModule {
+                import_all_public: false,
+                imported_words: HashSet::new(),
+                imported_samples: HashSet::new(),
+            });
+        entry.import_all_public = false;
+        entry.imported_words = referenced_words.clone();
+        entry.imported_samples = referenced_samples.clone();
+    }
+
+    interp.bump_module_epoch();
+    interp.rebuild_dependencies()?;
+    interp
+        .output_buffer
+        .push_str(&format!("Unimported unused words from {}.\n", module_name));
+    let mut kept: Vec<String> = referenced_words
+        .into_iter()
+        .chain(referenced_samples)
+        .collect();
+    kept.sort();
+    if !kept.is_empty() {
+        interp.output_buffer.push_str(&format!(
+            "Kept {} because they are referenced by user words.\n",
+            kept.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn op_unimport_only(interp: &mut Interpreter) -> Result<()> {
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+
+    let selectors = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let module_value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+
+    let module_name = extract_module_name_from_value(&module_value)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_value.to_string()))?
+        .to_uppercase();
+
+    ensure_module_dictionary(interp, &module_name)?;
+    let selected = parse_only_items(&selectors, "UNIMPORT-ONLY")?;
+
+    let module_dict = interp
+        .module_vocabulary
+        .get(&module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.clone()))?;
+    let mut validated: Vec<(String, bool)> = Vec::new();
+    let mut listing_only_skips: Vec<String> = Vec::new();
+    for item in selected {
+        let short = item.to_uppercase();
+        let qualified = format!("{}@{}", module_name, short);
+        if module_dict.words.contains_key(&qualified) {
+            validated.push((short, true));
+        } else if module_dict.sample_words.contains_key(&short) {
+            validated.push((short, false));
+        } else if crate::coreword_registry::is_listing_only_for_module(&short, &module_name) {
+            listing_only_skips.push(short);
+        } else {
+            return Err(AjisaiError::from(format!(
+                "Unknown module word '{}' in {}",
+                short, module_name
+            )));
+        }
+    }
+    for short in &listing_only_skips {
+        interp.output_buffer.push_str(&format!(
+            "Warning: '{}' is listed in {} but is a Canonical Core word and cannot be unimported.\n",
+            short, module_name
+        ));
+    }
+
+    if validated.is_empty() {
+        return Ok(());
+    }
+
+    if !interp.import_table.modules.contains_key(&module_name) {
+        interp.output_buffer.push_str(&format!(
+            "Warning: {} is not currently imported.\n",
+            module_name
+        ));
+        return Ok(());
+    }
+
+    interp.rebuild_dependencies()?;
+    for (short, _) in &validated {
+        let qualified = format!("{}@{}", module_name, short);
+        let dependents = referenced_by_user_words(interp, &qualified);
+        if !dependents.is_empty() {
+            return Err(AjisaiError::from(format!(
+                "Cannot unimport {}: referenced by {}.",
+                qualified,
+                dependents.join(", ")
+            )));
+        }
+    }
+
+    expand_import_all_to_explicit_selection(interp, &module_name)?;
+    if let Some(entry) = interp.import_table.modules.get_mut(&module_name) {
+        for (short, is_word) in validated {
+            if is_word {
+                entry.imported_words.remove(&short);
+            } else {
+                entry.imported_samples.remove(&short);
+            }
+        }
+        if entry.imported_words.is_empty() && entry.imported_samples.is_empty() {
+            interp.import_table.modules.remove(&module_name);
+        }
+    }
+
+    interp.bump_module_epoch();
+    interp.rebuild_dependencies()?;
+    Ok(())
 }
 
 pub(super) fn import_all_public(interp: &mut Interpreter, module_name: &str) -> Result<()> {
@@ -132,7 +386,7 @@ pub(super) fn op_import_only(interp: &mut Interpreter) -> Result<()> {
         .to_uppercase();
 
     ensure_module_dictionary(interp, &module_name)?;
-    let selected = parse_only_items(&selectors)?;
+    let selected = parse_only_items(&selectors, "IMPORT-ONLY")?;
 
     let module_dict = interp
         .module_vocabulary

--- a/rust/src/interpreter/resolve-word.rs
+++ b/rust/src/interpreter/resolve-word.rs
@@ -335,7 +335,7 @@ impl Interpreter {
                         if let Some((resolved_name, resolved_def)) =
                             self.resolve_word_entry(&upper_s)
                         {
-                            if !resolved_def.is_builtin {
+                            if !resolved_def.is_builtin || resolved_name.contains('@') {
                                 dependencies.insert(resolved_name.clone());
                                 self.dependents
                                     .entry(resolved_name)


### PR DESCRIPTION
### Motivation
- Implement the design principle "Core is permanent, Module is detachable, User is editable" so module words can be hidden from the current vocabulary without destroying module dictionaries. 
- Prevent destructive `DEL` operations from removing module dictionaries or built-in module words, and guide users to use unimport operations instead. 
- Ensure dependency tracking records user→module references so `UNIMPORT` safety checks can preserve referenced module items. 

### Description
- Add `UNIMPORT` and `UNIMPORT-ONLY` builtins and runtime handlers, exposed via `BuiltinExecutorKey::Unimport` / `UnimportOnly` and dispatched in `execute-builtin.rs`, with metadata entries in `builtin-word-definitions.rs`. (new/modified: `rust/src/builtins/*`, `rust/src/interpreter/execute-builtin.rs`) 
- Implement unimport logic and helpers in `module_import_execution.rs`: `op_unimport`, `op_unimport_only`, `expand_import_all_to_explicit_selection`, `referenced_module_items_from_user_words`, and `referenced_by_user_words`, plus robust selector parsing with `parse_only_items(..., op_name)`. (modified: `rust/src/interpreter/modules/module_import_execution.rs`) 
- Protect module dictionaries/words in `DEL`: forbid deleting module dictionary or module words (even with `!`), add a helper to detect imported module items and suggest `UNIMPORT`/`UNIMPORT-ONLY`; add `is_known_module` helper and `find_imported_module_item`. (modified: `rust/src/interpreter/execute-del.rs`, `rust/src/interpreter/modules/mod.rs`) 
- Record module-word references in dependency graphs by treating resolved names that contain `@` as dependencies (so user defs depending on `M@W` are tracked); update def/rebuild dependency code accordingly. (modified: `rust/src/interpreter/execute-def.rs`, `rust/src/interpreter/resolve-word.rs`) 
- Update purity/metadata and docs: add capability mapping for unimport ops, update `coreword_registry` and `elastic/purity_table`, and document `UNIMPORT`/`UNIMPORT-ONLY` and `DEL` behavior in `SPECIFICATION.md`. 
- Add unit tests exercising `UNIMPORT` behaviors and `DEL` protections in `rust/src/interpreter/module-unimport-tests.rs`. 

### Testing
- Ran `cargo test module_unimport --lib` and the new test suite passed (5 tests: all passed). 
- Ran full library tests with `cargo test --lib` and the test run completed successfully (all tests passed). 
- Ran `cargo test builtin_specs --lib` to validate added builtin metadata and it succeeded (relevant spec tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa764753548326a8feedd2a0ae618a)