### PR TITLE
Add UNIMPORT / UNIMPORT-ONLY to hide imported module words and UI context menu support

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -256,7 +256,13 @@ All built-in words have English-word-based canonical names (see Section 7). The 
 
 ## 7. Built-in Words
 
+Ajisai vocabulary follows the rule: **Core is permanent, Module is detachable, User is editable.**
+
 Built-in words are predefined and cannot be redefined or deleted.
+
+- **Core words** belong to the Ajisai runtime itself. They are always available and cannot be deleted, hidden, unimported, or redefined.
+- **Module words** belong to a module dictionary. Their definitions are built in and cannot be redefined or destructively deleted, but their visibility in the current vocabulary is controlled with `IMPORT`, `IMPORT-ONLY`, `UNIMPORT`, and `UNIMPORT-ONLY`.
+- **User words** belong to a user dictionary. They are editable, and deletion or redefinition is controlled by dependency checks and the force modifier where applicable.
 
 Every built-in word has exactly one **canonical home**, either Core or a specific module. The canonical home determines where the implementation lives and, for module-canonical words, which module name `IMPORT` activates them under.
 
@@ -271,7 +277,7 @@ Boundary classes:
 - **Canonical Module + core-listed boundary words** — canonical home in a module, additionally surfaced in the Core listing view (e.g. `SORT` whose canonical home is `ALGO`).
 - **Module-only words** — canonical home in a module; listed only under that module.
 
-`IMPORT` and `IMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
+`IMPORT`, `IMPORT-ONLY`, `UNIMPORT`, and `UNIMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
 
 Categories such as `CAST`, `TEXT`, `TENSOR`, and `RUNTIME` are documentation-only labels used to group Core words by capability surface. They are **not** modules, are not registered in `MODULE_SPECS`, and cannot be supplied to `IMPORT`.
 
@@ -502,6 +508,8 @@ A code block followed by a name string defines a user word in the active diction
 
 Deletes a user word. The force modifier `!` is required if other words depend on the word being deleted.
 
+`DEL` never destroys module dictionaries or module words. To remove module words from the current vocabulary, use `UNIMPORT` or `UNIMPORT-ONLY`; the module dictionary remains cached as the definition source.
+
 ### 8.4 Recursion
 
 User words may call themselves or other user words recursively. There is no hard-coded call-depth limit as a language semantic rule.
@@ -531,18 +539,26 @@ Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object 
 | `ALGO` | Sorting and other deterministic algorithms |
 | `MATH` | Square root and exact-rational interval arithmetic |
 
-### 9.2 Import syntax
+### 9.2 Import and unimport syntax
 
 ```
 'MODULE-NAME' IMPORT
 'MODULE-NAME' [ 'WORD1' 'WORD2' ] IMPORT-ONLY
+'MODULE-NAME' UNIMPORT
+'MODULE-NAME' [ 'WORD1' 'WORD2' ] UNIMPORT-ONLY
 ```
 
-`IMPORT` loads all words from a module into the current scope. `IMPORT-ONLY` loads only the specified words.
+`IMPORT` loads all public words from a module into the current vocabulary. `IMPORT-ONLY` loads only the specified module words or sample words.
+
+`UNIMPORT` hides unreferenced imported words from the current vocabulary without deleting the module dictionary. If a user word references a module word or module sample word, `UNIMPORT` keeps that referenced item visible and shrinks the module import to an explicit partial-import state.
+
+`UNIMPORT-ONLY` hides only the specified module words or sample words. It fails if a selected item is referenced by a user word; use dictionary-level `UNIMPORT` when the desired operation is to clean up unused module imports while preserving referenced items.
+
+Selectors that name Core words merely listed in a module view are no-ops for `IMPORT-ONLY` and `UNIMPORT-ONLY`, because Core words are always available and cannot be imported or unimported through a module.
 
 ### 9.3 Module-provided sample words
 
-Modules may provide sample user words for demonstration. Sample words require the force modifier `!` to delete.
+Modules may provide sample words for demonstration. Sample words are part of the module dictionary for import visibility: they can be introduced with `IMPORT` / `IMPORT-ONLY` and hidden with `UNIMPORT` / `UNIMPORT-ONLY`, but they are not destructively deleted with `DEL`.
 
 ---
 

--- a/rust/src/builtins/builtin-word-definitions.rs
+++ b/rust/src/builtins/builtin-word-definitions.rs
@@ -45,6 +45,8 @@ pub enum BuiltinExecutorKey {
     Lookup,
     Import,
     ImportOnly,
+    Unimport,
+    UnimportOnly,
     Force,
     Print,
     Insert,
@@ -1993,6 +1995,63 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
             "Modifies the dictionary; capability MUTATES_DICT required.",
         ],
         related: &["IMPORT"],
+        stability: "experimental",
+        ..SPEC_DEFAULT
+    },
+
+    BuiltinSpec {
+        name: "UNIMPORT",
+        category: "module",
+        hover_summary: "UNIMPORT — hide imported module words",
+        hover_syntax: "'IO' UNIMPORT",
+        detail_group: BuiltinDetailGroup::IoModule,
+        executor_key: Some(BuiltinExecutorKey::Unimport),
+        summary: "Hide unused imported words from a module while keeping words referenced by user definitions.",
+        syntax_forms: &[BuiltinSyntaxDoc {
+            canonical: "[ name ] UNIMPORT",
+            shorthand: None,
+            description: None,
+        }],
+        stack_effect: "[ name ] -> []",
+        behavior:
+            "Pops a module name and removes unreferenced imported module words from\nthe current vocabulary. Module words referenced by user definitions remain imported.",
+        examples: &[BuiltinExampleDoc {
+            canonical: "'MUSIC' UNIMPORT",
+            shorthand: None,
+            result: Some("(unreferenced MUSIC words hidden)"),
+        }],
+        side_effects: &[
+            "Modifies the import table; capability MUTATES_DICT required.",
+        ],
+        related: &["IMPORT", "IMPORT-ONLY", "UNIMPORT-ONLY"],
+        stability: "experimental",
+        ..SPEC_DEFAULT
+    },
+    BuiltinSpec {
+        name: "UNIMPORT-ONLY",
+        category: "module",
+        hover_summary: "UNIMPORT-ONLY — hide selected module words",
+        hover_syntax: "'json' [ 'parse' ] UNIMPORT-ONLY",
+        detail_group: BuiltinDetailGroup::IoModule,
+        executor_key: Some(BuiltinExecutorKey::UnimportOnly),
+        summary: "Hide only the listed imported module words.",
+        syntax_forms: &[BuiltinSyntaxDoc {
+            canonical: "[ name ] [ words ] UNIMPORT-ONLY",
+            shorthand: None,
+            description: None,
+        }],
+        stack_effect: "[ name ] [ words ] -> []",
+        behavior:
+            "Pops a module name and a vector of word names, removing those words\nfrom the current vocabulary. Referenced module words are rejected.",
+        examples: &[BuiltinExampleDoc {
+            canonical: "'json' [ 'parse' ] UNIMPORT-ONLY",
+            shorthand: None,
+            result: Some("(JSON@PARSE hidden)"),
+        }],
+        side_effects: &[
+            "Modifies the import table; capability MUTATES_DICT required.",
+        ],
+        related: &["IMPORT", "IMPORT-ONLY", "UNIMPORT"],
         stability: "experimental",
         ..SPEC_DEFAULT
     },

--- a/rust/src/builtins/mod.rs
+++ b/rust/src/builtins/mod.rs
@@ -42,6 +42,8 @@ fn core_builtin_capabilities(key: Option<BuiltinExecutorKey>, name: &str) -> Cap
         (Some(BuiltinExecutorKey::Del), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::Import), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::ImportOnly), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::Unimport), _) => Capabilities::MUTATES_DICT,
+        (Some(BuiltinExecutorKey::UnimportOnly), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::Force), _) => Capabilities::MUTATES_DICT,
         (Some(BuiltinExecutorKey::Eval), _) => Capabilities::EVAL,
         (Some(BuiltinExecutorKey::Spawn), _) => Capabilities::SPAWN,

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -402,6 +402,10 @@ fn core_word_metadata(
         Some(BuiltinExecutorKey::ImportOnly) => {
             effectful(name, category, &["dictionary-import-only"])
         }
+        Some(BuiltinExecutorKey::Unimport) => effectful(name, category, &["dictionary-unimport"]),
+        Some(BuiltinExecutorKey::UnimportOnly) => {
+            effectful(name, category, &["dictionary-unimport-only"])
+        }
         Some(BuiltinExecutorKey::Force) => effectful(name, category, &["interpreter-mode-write"]),
         Some(BuiltinExecutorKey::Eval) => effectful(name, category, &["code-execution"]),
         Some(BuiltinExecutorKey::Spawn)
@@ -480,7 +484,8 @@ fn apply_contract_overrides(meta: &mut CorewordMetadata, executor_key: Option<Bu
             meta.nil_policy = NilPolicy::PreservesReason;
             meta.safety_level = SafetyLevel::D;
         }
-        Some(Def) | Some(Del) | Some(Import) | Some(ImportOnly) | Some(Force) => {
+        Some(Def) | Some(Del) | Some(Import) | Some(ImportOnly) | Some(Unimport)
+        | Some(UnimportOnly) | Some(Force) => {
             meta.partiality = Partiality::Partial;
             meta.nil_policy = NilPolicy::RejectsNil;
             meta.safety_level = SafetyLevel::D;

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -120,7 +120,9 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
         Eval => imp_heavy,
 
         // ── Dictionary mutators: impure ───────────────────────────────────
-        Def | Del | Import | ImportOnly | Force | Lookup | Precompute => imp_heavy,
+        Def | Del | Import | ImportOnly | Unimport | UnimportOnly | Force | Lookup | Precompute => {
+            imp_heavy
+        }
 
         // ── I/O: impure ───────────────────────────────────────────────────
         Print => imp_heavy,

--- a/rust/src/interpreter/execute-builtin.rs
+++ b/rust/src/interpreter/execute-builtin.rs
@@ -257,6 +257,8 @@ impl Interpreter {
             BuiltinExecutorKey::Lookup => execute_lookup::op_lookup(self),
             BuiltinExecutorKey::Import => modules::op_import(self),
             BuiltinExecutorKey::ImportOnly => modules::op_import_only(self),
+            BuiltinExecutorKey::Unimport => modules::op_unimport(self),
+            BuiltinExecutorKey::UnimportOnly => modules::op_unimport_only(self),
             BuiltinExecutorKey::Force => {
                 self.force_flag = true;
                 Ok(())

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -227,7 +227,7 @@ pub(crate) fn op_def_inner(
             if let Token::Symbol(s) = token {
                 let upper_s = crate::core_word_aliases::canonicalize_core_word_name(s);
                 if let Some((resolved_name, resolved_def)) = interp.resolve_word_entry(&upper_s) {
-                    if !resolved_def.is_builtin {
+                    if !resolved_def.is_builtin || resolved_name.contains('@') {
                         new_dependencies.insert(resolved_name);
                     }
                 }

--- a/rust/src/interpreter/execute-del.rs
+++ b/rust/src/interpreter/execute-del.rs
@@ -16,7 +16,6 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
 
     let upper_name = name.to_uppercase();
 
-
     let (target_dict, word_name) = if let Some((ns, w)) = interp.split_qualified_name(&upper_name) {
         (Some(ns), w)
     } else {
@@ -31,7 +30,6 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
-
     if target_dict.is_none() {
         if interp.user_dictionaries.contains_key(&word_name) {
             interp.user_dictionaries.remove(&word_name);
@@ -45,29 +43,50 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             return Ok(());
         }
 
-        if interp.module_vocabulary.contains_key(&word_name) {
-            interp.module_vocabulary.remove(&word_name);
-            interp.import_table.modules.remove(&word_name);
-            interp.sync_user_words_cache();
-            interp.rebuild_dependencies()?;
-            interp
-                .output_buffer
-                .push_str(&format!("Deleted dictionary: {}\n", word_name));
-            interp.bump_dictionary_epoch();
+        if crate::interpreter::modules::is_known_module(&word_name) {
             interp.force_flag = false;
-            return Ok(());
+            return Err(AjisaiError::from(format!(
+                "Cannot delete module dictionary {}. Use '{}' UNIMPORT to hide imported module words.",
+                word_name, word_name
+            )));
+        }
+
+        if let Some((module_name, is_sample)) = find_imported_module_item(interp, &word_name) {
+            interp.force_flag = false;
+            if is_sample {
+                return Err(AjisaiError::from(format!(
+                    "Cannot delete module sample word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+                    module_name, word_name, module_name, word_name
+                )));
+            }
+            return Err(AjisaiError::from(format!(
+                "Cannot delete module word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+                module_name, word_name, module_name, word_name
+            )));
         }
     }
 
+    if let Some(module_name) = target_dict.as_deref() {
+        if let Some(module) = interp.module_vocabulary.get(module_name) {
+            let qualified = format!("{}@{}", module_name, word_name);
+            if module.words.contains_key(&qualified) || module.sample_words.contains_key(&word_name)
+            {
+                interp.force_flag = false;
+                return Err(AjisaiError::from(format!(
+                    "Cannot delete module word {}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+                    qualified, module_name, word_name
+                )));
+            }
+        }
+    }
 
     let (owner_name, is_module) = find_word_owner(interp, target_dict.as_deref(), &word_name)?;
 
-
-    if is_module && !interp.force_flag {
+    if is_module {
         interp.force_flag = false;
         return Err(AjisaiError::from(format!(
-            "Word '{}' is a module sample word. Use ! '{}' DEL to force delete.",
-            word_name, word_name
+            "Cannot delete module word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
+            owner_name, word_name, owner_name, word_name
         )));
     }
 
@@ -81,7 +100,6 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
             word_name, dep_list, word_name
         )));
     }
-
 
     let removed_def = if is_module {
         interp
@@ -125,6 +143,25 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
+fn find_imported_module_item(interp: &Interpreter, word_name: &str) -> Option<(String, bool)> {
+    for (module_name, module) in &interp.module_vocabulary {
+        let Some(imported) = interp.import_table.modules.get(module_name) else {
+            continue;
+        };
+        let qualified = format!("{}@{}", module_name, word_name);
+        if module.words.contains_key(&qualified)
+            && (imported.import_all_public || imported.imported_words.contains(word_name))
+        {
+            return Some((module_name.clone(), false));
+        }
+        if module.sample_words.contains_key(word_name)
+            && (imported.import_all_public || imported.imported_samples.contains(word_name))
+        {
+            return Some((module_name.clone(), true));
+        }
+    }
+    None
+}
 
 fn find_word_owner(
     interp: &Interpreter,
@@ -132,7 +169,6 @@ fn find_word_owner(
     word_name: &str,
 ) -> Result<(String, bool)> {
     if let Some(dict_name) = target_dict {
-
         if let Some(dict) = interp.user_dictionaries.get(dict_name) {
             if dict.words.contains_key(word_name) {
                 return Ok((dict_name.to_string(), false));
@@ -148,7 +184,6 @@ fn find_word_owner(
             dict_name, word_name
         )))
     } else {
-
         for (dict_name, dict) in &interp.user_dictionaries {
             if dict.words.contains_key(word_name) {
                 return Ok((dict_name.clone(), false));

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -4,9 +4,9 @@ pub mod cast;
 #[path = "child-runtime.rs"]
 pub mod child_runtime;
 pub mod comparison;
-pub mod comptime;
 #[path = "compiled-plan.rs"]
 pub mod compiled_plan;
+pub mod comptime;
 pub mod control;
 #[path = "control-cond.rs"]
 pub mod control_cond;
@@ -117,6 +117,9 @@ mod interpreter_execution_tests;
 #[cfg(test)]
 #[path = "interpreter-mode-tests.rs"]
 mod interpreter_mode_tests;
+#[cfg(test)]
+#[path = "module-unimport-tests.rs"]
+mod module_unimport_tests;
 #[cfg(test)]
 #[path = "nil-reason-tests.rs"]
 mod nil_reason_tests;

--- a/rust/src/interpreter/module-unimport-tests.rs
+++ b/rust/src/interpreter/module-unimport-tests.rs
@@ -1,0 +1,135 @@
+#[cfg(test)]
+mod tests {
+    use crate::interpreter::Interpreter;
+
+    #[tokio::test]
+    async fn unimport_hides_unreferenced_module_words() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+
+        interp.execute("'json' UNIMPORT").await.unwrap();
+
+        assert!(
+            interp.execute("'[1]' JSON@PARSE").await.is_err(),
+            "UNIMPORT should hide unreferenced module words"
+        );
+        assert!(
+            interp.module_vocabulary.contains_key("JSON"),
+            "UNIMPORT must not destroy the module dictionary cache"
+        );
+        assert!(
+            !interp.import_table.modules.contains_key("JSON"),
+            "UNIMPORT with no references should remove only import-table visibility"
+        );
+    }
+
+    #[tokio::test]
+    async fn unimport_keeps_module_words_referenced_by_user_words() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+        interp
+            .execute("{ JSON@PARSE } 'USE-PARSE' DEF")
+            .await
+            .unwrap();
+
+        interp.execute("'json' UNIMPORT").await.unwrap();
+
+        assert!(
+            interp.execute("'[1]' JSON@PARSE").await.is_ok(),
+            "directly referenced module word should remain visible"
+        );
+        assert!(
+            interp.execute("'[1]' JSON@STRINGIFY").await.is_err(),
+            "unreferenced module word should be hidden"
+        );
+        let imported = interp.import_table.modules.get("JSON").unwrap();
+        assert!(
+            !imported.import_all_public,
+            "UNIMPORT should shrink a full import to explicit referenced selections"
+        );
+        assert!(imported.imported_words.contains("PARSE"));
+        assert!(!imported.imported_words.contains("STRINGIFY"));
+    }
+
+    #[tokio::test]
+    async fn unimport_only_hides_selected_unreferenced_words_after_full_import() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+
+        interp
+            .execute("'json' [ 'stringify' ] UNIMPORT-ONLY")
+            .await
+            .unwrap();
+
+        assert!(interp.execute("'[1]' JSON@PARSE").await.is_ok());
+        assert!(interp.execute("'[1]' JSON@STRINGIFY").await.is_err());
+        let imported = interp.import_table.modules.get("JSON").unwrap();
+        assert!(
+            !imported.import_all_public,
+            "UNIMPORT-ONLY from a full import should expand to explicit selections"
+        );
+    }
+
+    #[tokio::test]
+    async fn unimport_only_rejects_user_referenced_module_words() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT").await.unwrap();
+        interp
+            .execute("{ JSON@PARSE } 'USE-PARSE' DEF")
+            .await
+            .unwrap();
+
+        let result = interp.execute("'json' [ 'parse' ] UNIMPORT-ONLY").await;
+
+        assert!(result.is_err(), "referenced module word should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Cannot unimport JSON@PARSE"), "got: {msg}");
+        assert!(msg.contains("DEMO@USE-PARSE"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn del_cannot_destroy_module_dictionary_or_words_even_forced() {
+        let mut interp = Interpreter::new();
+        let before_import = interp.execute("'JSON' DEL").await;
+        assert!(before_import.is_err(), "known modules cannot be deleted before import");
+        assert!(
+            before_import
+                .unwrap_err()
+                .to_string()
+                .contains("Cannot delete module dictionary JSON")
+        );
+
+        interp.execute("'music' IMPORT").await.unwrap();
+
+        for code in ["'MUSIC' DEL", "! 'MUSIC' DEL"] {
+            let result = interp.execute(code).await;
+            assert!(result.is_err(), "{code} should be rejected");
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Cannot delete module dictionary MUSIC"),
+                "{code} should suggest UNIMPORT"
+            );
+            assert!(interp.module_vocabulary.contains_key("MUSIC"));
+        }
+
+        for code in [
+            "'MUSIC@PLAY' DEL",
+            "! 'MUSIC@PLAY' DEL",
+            "'PLAY' DEL",
+            "! 'PLAY' DEL",
+        ] {
+            let result = interp.execute(code).await;
+            assert!(result.is_err(), "{code} should be rejected");
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("Cannot delete module word MUSIC@PLAY"),
+                "{code} should suggest UNIMPORT-ONLY"
+            );
+            assert!(interp.module_vocabulary.contains_key("MUSIC"));
+        }
+    }
+}

--- a/rust/src/interpreter/modules/mod.rs
+++ b/rust/src/interpreter/modules/mod.rs
@@ -24,8 +24,23 @@ pub fn op_import_only(interp: &mut Interpreter) -> Result<()> {
     module_import_execution::op_import_only(interp)
 }
 
+pub fn op_unimport(interp: &mut Interpreter) -> Result<()> {
+    module_import_execution::op_unimport(interp)
+}
+
+pub fn op_unimport_only(interp: &mut Interpreter) -> Result<()> {
+    module_import_execution::op_unimport_only(interp)
+}
+
 pub fn restore_module(interp: &mut Interpreter, module_name: &str) -> bool {
     module_import_execution::restore_module(interp, module_name)
+}
+
+pub(crate) fn is_known_module(module_name: &str) -> bool {
+    let upper = module_name.to_uppercase();
+    module_builtins::MODULE_SPECS
+        .iter()
+        .any(|module| module.name == upper)
 }
 
 pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {

--- a/rust/src/interpreter/modules/module_import_execution.rs
+++ b/rust/src/interpreter/modules/module_import_execution.rs
@@ -7,23 +7,27 @@ use crate::types::Value;
 
 use super::module_registry::{ensure_module_dictionary, extract_module_name_from_value};
 
-fn parse_only_items(value: &Value) -> Result<Vec<String>> {
+fn parse_only_items(value: &Value, op_name: &str) -> Result<Vec<String>> {
     if is_string_value(value) {
         let s = value_as_string(value)
-            .ok_or_else(|| AjisaiError::from("IMPORT-ONLY expects string selectors"))?;
+            .ok_or_else(|| AjisaiError::from(format!("{} expects string selectors", op_name)))?;
         return Ok(vec![s]);
     }
 
     let Some(items) = value.as_vector() else {
-        return Err(AjisaiError::from(
-            "IMPORT-ONLY expects a vector of word names",
-        ));
+        return Err(AjisaiError::from(format!(
+            "{} expects a vector of word names",
+            op_name
+        )));
     };
 
     let mut result = Vec::new();
     for item in items {
         if !is_string_value(item) {
-            return Err(AjisaiError::from("IMPORT-ONLY selectors must be strings"));
+            return Err(AjisaiError::from(format!(
+                "{} selectors must be strings",
+                op_name
+            )));
         }
         let Some(name) = value_as_string(item) else {
             continue;
@@ -57,6 +61,256 @@ fn emit_import_conflict_warnings(interp: &mut Interpreter, module_name: &str) {
             all_paths.join(" and ")
         ));
     }
+}
+
+fn expand_import_all_to_explicit_selection(
+    interp: &mut Interpreter,
+    module_name: &str,
+) -> Result<()> {
+    ensure_module_dictionary(interp, module_name)?;
+    let module_dict = interp
+        .module_vocabulary
+        .get(module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.to_string()))?;
+
+    let mut imported_words = HashSet::new();
+    let mut imported_samples = HashSet::new();
+    for qualified in module_dict.words.keys() {
+        if let Some((_, short)) = qualified.split_once('@') {
+            imported_words.insert(short.to_string());
+        }
+    }
+    for short in module_dict.sample_words.keys() {
+        imported_samples.insert(short.clone());
+    }
+
+    let entry = interp
+        .import_table
+        .modules
+        .entry(module_name.to_string())
+        .or_insert_with(|| ImportedModule {
+            import_all_public: false,
+            imported_words: HashSet::new(),
+            imported_samples: HashSet::new(),
+        });
+    if entry.import_all_public {
+        entry.import_all_public = false;
+        entry.imported_words = imported_words;
+        entry.imported_samples = imported_samples;
+    }
+    Ok(())
+}
+
+fn referenced_module_items_from_user_words(
+    interp: &Interpreter,
+    module_name: &str,
+) -> (HashSet<String>, HashSet<String>) {
+    let mut words = HashSet::new();
+    let mut samples = HashSet::new();
+    let Some(module_dict) = interp.module_vocabulary.get(module_name) else {
+        return (words, samples);
+    };
+
+    let mut pending = Vec::new();
+    for dict in interp.user_dictionaries.values() {
+        for def in dict.words.values() {
+            for dep in &def.dependencies {
+                if let Some((dep_module, short)) = interp.split_qualified_name(dep) {
+                    if dep_module == module_name {
+                        pending.push(short);
+                    }
+                }
+            }
+        }
+    }
+
+    while let Some(short) = pending.pop() {
+        let qualified = format!("{}@{}", module_name, short);
+        if module_dict.words.contains_key(&qualified) {
+            words.insert(short);
+            continue;
+        }
+        if !module_dict.sample_words.contains_key(&short) || !samples.insert(short.clone()) {
+            continue;
+        }
+        if let Some(sample_def) = module_dict.sample_words.get(&short) {
+            for dep in &sample_def.dependencies {
+                if let Some((dep_module, dep_short)) = interp.split_qualified_name(dep) {
+                    if dep_module == module_name {
+                        pending.push(dep_short);
+                    }
+                }
+            }
+        }
+    }
+
+    (words, samples)
+}
+
+fn referenced_by_user_words(interp: &Interpreter, qualified_name: &str) -> Vec<String> {
+    let mut dependents = Vec::new();
+    for (dict_name, dict) in &interp.user_dictionaries {
+        for (name, def) in &dict.words {
+            if def.dependencies.contains(qualified_name) {
+                dependents.push(format!("{}@{}", dict_name, name));
+            }
+        }
+    }
+    dependents.sort();
+    dependents
+}
+
+pub(super) fn op_unimport(interp: &mut Interpreter) -> Result<()> {
+    let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
+    let value = if is_keep_mode {
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
+    } else {
+        interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
+    };
+
+    let module_name = extract_module_name_from_value(&value)
+        .ok_or_else(|| AjisaiError::UnknownModule(value.to_string()))?
+        .to_uppercase();
+
+    ensure_module_dictionary(interp, &module_name)?;
+    if !interp.import_table.modules.contains_key(&module_name) {
+        interp.output_buffer.push_str(&format!(
+            "Warning: {} is not currently imported.\n",
+            module_name
+        ));
+        return Ok(());
+    }
+
+    interp.rebuild_dependencies()?;
+    let (referenced_words, referenced_samples) =
+        referenced_module_items_from_user_words(interp, &module_name);
+
+    if referenced_words.is_empty() && referenced_samples.is_empty() {
+        interp.import_table.modules.remove(&module_name);
+    } else {
+        let entry = interp
+            .import_table
+            .modules
+            .entry(module_name.clone())
+            .or_insert_with(|| ImportedModule {
+                import_all_public: false,
+                imported_words: HashSet::new(),
+                imported_samples: HashSet::new(),
+            });
+        entry.import_all_public = false;
+        entry.imported_words = referenced_words.clone();
+        entry.imported_samples = referenced_samples.clone();
+    }
+
+    interp.bump_module_epoch();
+    interp.rebuild_dependencies()?;
+    interp
+        .output_buffer
+        .push_str(&format!("Unimported unused words from {}.\n", module_name));
+    let mut kept: Vec<String> = referenced_words
+        .into_iter()
+        .chain(referenced_samples)
+        .collect();
+    kept.sort();
+    if !kept.is_empty() {
+        interp.output_buffer.push_str(&format!(
+            "Kept {} because they are referenced by user words.\n",
+            kept.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn op_unimport_only(interp: &mut Interpreter) -> Result<()> {
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+
+    let selectors = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+    let module_value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
+
+    let module_name = extract_module_name_from_value(&module_value)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_value.to_string()))?
+        .to_uppercase();
+
+    ensure_module_dictionary(interp, &module_name)?;
+    let selected = parse_only_items(&selectors, "UNIMPORT-ONLY")?;
+
+    let module_dict = interp
+        .module_vocabulary
+        .get(&module_name)
+        .ok_or_else(|| AjisaiError::UnknownModule(module_name.clone()))?;
+    let mut validated: Vec<(String, bool)> = Vec::new();
+    let mut listing_only_skips: Vec<String> = Vec::new();
+    for item in selected {
+        let short = item.to_uppercase();
+        let qualified = format!("{}@{}", module_name, short);
+        if module_dict.words.contains_key(&qualified) {
+            validated.push((short, true));
+        } else if module_dict.sample_words.contains_key(&short) {
+            validated.push((short, false));
+        } else if crate::coreword_registry::is_listing_only_for_module(&short, &module_name) {
+            listing_only_skips.push(short);
+        } else {
+            return Err(AjisaiError::from(format!(
+                "Unknown module word '{}' in {}",
+                short, module_name
+            )));
+        }
+    }
+    for short in &listing_only_skips {
+        interp.output_buffer.push_str(&format!(
+            "Warning: '{}' is listed in {} but is a Canonical Core word and cannot be unimported.\n",
+            short, module_name
+        ));
+    }
+
+    if validated.is_empty() {
+        return Ok(());
+    }
+
+    if !interp.import_table.modules.contains_key(&module_name) {
+        interp.output_buffer.push_str(&format!(
+            "Warning: {} is not currently imported.\n",
+            module_name
+        ));
+        return Ok(());
+    }
+
+    interp.rebuild_dependencies()?;
+    for (short, _) in &validated {
+        let qualified = format!("{}@{}", module_name, short);
+        let dependents = referenced_by_user_words(interp, &qualified);
+        if !dependents.is_empty() {
+            return Err(AjisaiError::from(format!(
+                "Cannot unimport {}: referenced by {}.",
+                qualified,
+                dependents.join(", ")
+            )));
+        }
+    }
+
+    expand_import_all_to_explicit_selection(interp, &module_name)?;
+    if let Some(entry) = interp.import_table.modules.get_mut(&module_name) {
+        for (short, is_word) in validated {
+            if is_word {
+                entry.imported_words.remove(&short);
+            } else {
+                entry.imported_samples.remove(&short);
+            }
+        }
+        if entry.imported_words.is_empty() && entry.imported_samples.is_empty() {
+            interp.import_table.modules.remove(&module_name);
+        }
+    }
+
+    interp.bump_module_epoch();
+    interp.rebuild_dependencies()?;
+    Ok(())
 }
 
 pub(super) fn import_all_public(interp: &mut Interpreter, module_name: &str) -> Result<()> {
@@ -132,7 +386,7 @@ pub(super) fn op_import_only(interp: &mut Interpreter) -> Result<()> {
         .to_uppercase();
 
     ensure_module_dictionary(interp, &module_name)?;
-    let selected = parse_only_items(&selectors)?;
+    let selected = parse_only_items(&selectors, "IMPORT-ONLY")?;
 
     let module_dict = interp
         .module_vocabulary

--- a/rust/src/interpreter/resolve-word.rs
+++ b/rust/src/interpreter/resolve-word.rs
@@ -335,7 +335,7 @@ impl Interpreter {
                         if let Some((resolved_name, resolved_def)) =
                             self.resolve_word_entry(&upper_s)
                         {
-                            if !resolved_def.is_builtin {
+                            if !resolved_def.is_builtin || resolved_name.contains('@') {
                                 dependencies.insert(resolved_name.clone());
                                 self.dependents
                                     .entry(resolved_name)

--- a/rust/src/wasm-interpreter-state.rs
+++ b/rust/src/wasm-interpreter-state.rs
@@ -213,8 +213,14 @@ impl AjisaiInterpreter {
     pub fn collect_module_sample_words_info(&self, module_name: &str) -> JsValue {
         let upper = module_name.to_uppercase();
         let arr = js_sys::Array::new();
+        let Some(imported) = self.interpreter.import_table.modules.get(&upper) else {
+            return arr.into();
+        };
         if let Some(module_dict) = self.interpreter.module_vocabulary.get(&upper) {
             for (name, def) in &module_dict.sample_words {
+                if !imported.import_all_public && !imported.imported_samples.contains(name) {
+                    continue;
+                }
                 let item = js_sys::Array::new();
                 item.push(&JsValue::from_str(name));
                 item.push(
@@ -233,8 +239,18 @@ impl AjisaiInterpreter {
     pub fn collect_module_words_info(&self, module_name: &str) -> JsValue {
         let upper = module_name.to_uppercase();
         let arr = js_sys::Array::new();
+        let Some(imported) = self.interpreter.import_table.modules.get(&upper) else {
+            return arr.into();
+        };
         if let Some(module_dict) = self.interpreter.module_vocabulary.get(&upper) {
             for (name, def) in &module_dict.words {
+                let short_name = name
+                    .split_once('@')
+                    .map(|(_, short)| short)
+                    .unwrap_or(name.as_str());
+                if !imported.import_all_public && !imported.imported_words.contains(short_name) {
+                    continue;
+                }
                 let item = js_sys::Array::new();
                 item.push(&JsValue::from_str(name));
                 item.push(

--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -34,6 +34,46 @@ export interface ModuleActionConfig {
     readonly onClick: () => void;
 }
 
+
+type ContextMenuAction = {
+    readonly label: string;
+    readonly onClick: () => void;
+    readonly disabled?: boolean;
+};
+
+const createContextMenuElement = (): HTMLDivElement => {
+    const menu = document.createElement('div');
+    menu.hidden = true;
+    menu.className = 'context-menu module-context-menu';
+    document.body.appendChild(menu);
+    return menu;
+};
+
+const renderContextMenu = (
+    menu: HTMLDivElement,
+    event: MouseEvent,
+    actions: readonly ContextMenuAction[]
+): void => {
+    menu.innerHTML = '';
+    for (const action of actions) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = action.label;
+        button.disabled = Boolean(action.disabled);
+        button.addEventListener('click', (clickEvent) => {
+            clickEvent.stopPropagation();
+            menu.hidden = true;
+            if (!action.disabled) action.onClick();
+        });
+        menu.appendChild(button);
+    }
+    menu.hidden = false;
+    menu.style.left = `${event.clientX}px`;
+    menu.style.top = `${event.clientY}px`;
+};
+
+const quoteAjisaiString = (value: string): string => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
 export interface ModuleTabManagerOptions {
     readonly selectEl: HTMLSelectElement;
     readonly sheetContainerEl: HTMLElement;
@@ -57,10 +97,55 @@ export const createModuleTabManager = (
         onWordClick,
         onBackgroundClick,
         onBackgroundDoubleClick,
+        onUpdateDisplays,
+        onSaveState,
+        showInfo,
     } = options;
 
     const sheets: ModuleSheet[] = [];
     let searchFilter = '';
+    const contextMenu = createContextMenuElement();
+
+    const hideContextMenu = (): void => {
+        contextMenu.hidden = true;
+    };
+
+    document.addEventListener('click', hideContextMenu);
+    window.addEventListener('blur', hideContextMenu);
+
+    const runUnimportCode = async (code: string, successMessage: string): Promise<void> => {
+        if (!window.ajisaiInterpreter) return;
+        try {
+            const result = await window.ajisaiInterpreter.execute(code);
+            if (result.status === 'ERROR') {
+                const message = result.message ?? 'Unknown error';
+                showInfo?.(message, true);
+                alert(message);
+                return;
+            }
+            onUpdateDisplays?.();
+            await onSaveState?.();
+            showInfo?.(successMessage, true);
+        } catch (error) {
+            const message = `Failed to unimport module item: ${error}`;
+            showInfo?.(message, true);
+            alert(message);
+        }
+    };
+
+    const unimportModule = (moduleName: string): void => {
+        const quotedModule = quoteAjisaiString(moduleName);
+        void runUnimportCode(`'${quotedModule}' UNIMPORT`, `Unimported unused words from ${moduleName}`);
+    };
+
+    const unimportModuleWord = (moduleName: string, shortName: string): void => {
+        const quotedModule = quoteAjisaiString(moduleName);
+        const quotedWord = quoteAjisaiString(shortName);
+        void runUnimportCode(
+            `'${quotedModule}' [ '${quotedWord}' ] UNIMPORT-ONLY`,
+            `Unimported ${moduleName}@${shortName}`
+        );
+    };
 
     const createOptionElement = (moduleName: string, sheetId: string): HTMLOptionElement => {
         const option = document.createElement('option');
@@ -80,10 +165,23 @@ export const createModuleTabManager = (
         resetWordInfoDisplay(wordInfoDisplay);
         sheet.appendChild(wordInfoDisplay);
 
+        const hint = document.createElement('div');
+        hint.className = 'module-unimport-hint';
+        hint.textContent = 'Right-click module words to Unimport; right-click empty module space to Unimport this module.';
+        sheet.appendChild(hint);
+
         const wordsDisplay = document.createElement('div');
         wordsDisplay.className = 'words-display module-words-display';
         sheet.appendChild(wordsDisplay);
         registerBackgroundClickListeners(wordsDisplay, onBackgroundClick, onBackgroundDoubleClick);
+        wordsDisplay.addEventListener('contextmenu', (event) => {
+            if ((event.target as HTMLElement).closest('.word-button')) return;
+            event.preventDefault();
+            renderContextMenu(contextMenu, event, [{
+                label: `Unimport this module (${moduleName})`,
+                onClick: () => unimportModule(moduleName),
+            }]);
+        });
 
         const actions = options.moduleActions?.[moduleName];
         if (actions) {
@@ -126,14 +224,28 @@ export const createModuleTabManager = (
                 const name = wordData[0];
                 const shortName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
                 const description = wordData[1] || name;
+                const moduleTitle = `${shortName}
+Built-in word from module ${moduleSheet.moduleName}.
+Right-click to unimport this word.`;
+                const moduleInfo = `${description}
+
+Built-in word from module ${moduleSheet.moduleName}.
+Right-click to unimport this word.`;
 
                 const button = createWordButtonElement(
                     shortName,
-                    description,
-                    'word-button module',
+                    moduleTitle,
+                    'word-button core module',
                     () => onWordClick(shortName),
-                    () => { renderWordInfo(wordInfo as HTMLElement, description); },
-                    () => { resetWordInfoDisplay(wordInfo as HTMLElement); }
+                    () => { renderWordInfo(wordInfo as HTMLElement, moduleInfo); },
+                    () => { resetWordInfoDisplay(wordInfo as HTMLElement); },
+                    (event) => renderContextMenu(contextMenu, event, [{
+                        label: `Unimport ${moduleSheet.moduleName}@${shortName}`,
+                        onClick: () => unimportModuleWord(moduleSheet.moduleName, shortName),
+                    }, {
+                        label: `Unimport this module (${moduleSheet.moduleName})`,
+                        onClick: () => unimportModule(moduleSheet.moduleName),
+                    }])
                 );
 
                 wordsDisplay.appendChild(button);
@@ -224,6 +336,16 @@ export const createModuleTabManager = (
             renderModuleWords(sheet);
         }
     };
+
+    selectEl.addEventListener('contextmenu', (event) => {
+        const activeSheet = sheets.find(sheet => sheet.sheetId === selectEl.value);
+        if (!activeSheet) return;
+        event.preventDefault();
+        renderContextMenu(contextMenu, event, [{
+            label: `Unimport this module (${activeSheet.moduleName})`,
+            onClick: () => unimportModule(activeSheet.moduleName),
+        }]);
+    });
 
     return {
         syncModuleTabs,

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -373,6 +373,44 @@
 }
 
 
+
+.context-menu {
+    position: fixed;
+    z-index: 1000;
+    min-width: 12rem;
+    padding: 0.125rem;
+    background: #fff;
+    border: var(--border-main);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.context-menu button {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    background: transparent;
+    color: var(--color-text);
+    border: none;
+    text-align: left;
+    cursor: pointer;
+}
+
+.context-menu button:hover:not(:disabled) {
+    background: var(--color-light);
+}
+
+.context-menu button:disabled {
+    color: var(--color-text-light);
+    cursor: not-allowed;
+}
+
+.module-unimport-hint {
+    margin: 0.125rem 0 0.375rem;
+    color: var(--color-text-light);
+    font-size: 0.72rem;
+    line-height: 1.2;
+}
+
 .no-results-message {
     width: 100%;
     color: var(--color-text-light);
@@ -548,10 +586,11 @@
 }
 
 
+/* Module words are built-ins too: keep the same visual treatment as Core words. */
 .word-button.module {
-    border-color: var(--color-module, #0277BD);
+    border-color: var(--color-core);
     background: #fff;
-    color: var(--color-module, #0277BD);
+    color: var(--color-core);
     box-shadow: 0 2px 0 var(--color-medium);
     transition: transform 0.1s ease, box-shadow 0.1s ease;
 }


### PR DESCRIPTION
### Motivation

- Provide a way to hide imported module words from the current vocabulary without deleting module dictionaries or module-provided sample words, and prevent `DEL` from destructively removing module dictionaries or words.
- Make module import visibility explicit and maintain safe dependency semantics so user definitions that reference module items keep those items visible.
- Surface unimport actions in the GUI so users can unimport a whole module or specific module words from the module sheet.

### Description

- Introduces two new core builtins `UNIMPORT` and `UNIMPORT-ONLY` with specs, executor keys, metadata, and purity/contract updates, and wires them into the interpreter via `modules::op_unimport` and `modules::op_unimport_only`.
- Adds interpreter-side behavior in `module_import_execution.rs` to compute referenced module items from user words, shrink full imports to explicit selections, validate selectors, enforce dependency checks, update the `import_table`, and update module/dictionary epochs and dependency structures.
- Changes `DEL` semantics so known modules, module words, and module samples cannot be deleted and now yield user-friendly errors suggesting `UNIMPORT`/`UNIMPORT-ONLY`; also treats module-qualified names as dependencies where appropriate in `execute-def.rs` and resolution code updates in `resolve-word.rs`.
- Updates WASM bindings to only list imported module words/samples in the UI, adds `is_known_module` helper, updates coreword metadata and purity tables to account for the new keys, and exposes module visibility correctly.
- Adds a UI context menu to module sheets with actions to run `UNIMPORT` and `UNIMPORT-ONLY`, creates a context menu component and CSS styling, inserts hints in module sheets, and adjusts module word buttons to allow right-click unimport actions.
- Adds test module `module-unimport-tests.rs` and registers it in the interpreter test suite.

### Testing

- Added `module_unimport_tests` with multiple async unit tests exercising full import, `UNIMPORT`, `UNIMPORT-ONLY`, reference-preservation, rejection of unimporting referenced words, and `DEL` rejection for modules, and these tests run as part of the interpreter test suite.
- Ran the automated test suite (`cargo test`) including the new module unimport tests and report that all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa764753548326a8feedd2a0ae618a)