### PR TITLE
Remove module unimport hint message above word buttons

### DIFF
--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -165,11 +165,6 @@ export const createModuleTabManager = (
         resetWordInfoDisplay(wordInfoDisplay);
         sheet.appendChild(wordInfoDisplay);
 
-        const hint = document.createElement('div');
-        hint.className = 'module-unimport-hint';
-        hint.textContent = 'Right-click module words to Unimport; right-click empty module space to Unimport this module.';
-        sheet.appendChild(hint);
-
         const wordsDisplay = document.createElement('div');
         wordsDisplay.className = 'words-display module-words-display';
         sheet.appendChild(wordsDisplay);


### PR DESCRIPTION
## Summary
- Module word ボタン区画の上部に表示されていた "Right-click module words to Unimport; right-click empty module space to Unimport this module." というヒントメッセージを廃止しました。
- `src/gui/module-selector-sheets.ts` の `createSheetElement` 内でヒント用 `div` (`module-unimport-hint`) を生成・追加していたブロックを削除。CSS クラス名は他で参照されていないため、追加のクリーンアップは不要です。

## Test plan
- [ ] 任意のモジュールタブを開き、ワードボタン区画の上部にヒントメッセージが表示されないことを確認
- [ ] 右クリックでの Unimport 操作（個別ワード／モジュール全体）は従来どおり動作することを確認

https://claude.ai/code/session_012isCEDh9VdTdBv7bkWUUTw

---
_Generated by [Claude Code](https://claude.ai/code/session_012isCEDh9VdTdBv7bkWUUTw)_