### PR TITLE
Apply signature-based color coding to module word buttons

### DIFF
--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -106,6 +106,24 @@ export const createModuleTabManager = (
     let searchFilter = '';
     const contextMenu = createContextMenuElement();
 
+    const buildSignatureTypeIndex = (): Map<string, string> => {
+        const index = new Map<string, string>();
+        if (!window.ajisaiInterpreter) return index;
+        try {
+            const coreWords = window.ajisaiInterpreter.collect_core_words_info();
+            for (const tuple of coreWords) {
+                const name = tuple[0];
+                const sig = tuple[3];
+                if (typeof name === 'string' && typeof sig === 'string' && sig !== 'none') {
+                    index.set(name.toUpperCase(), sig);
+                }
+            }
+        } catch (error) {
+            console.error('Failed to build signature type index for module words:', error);
+        }
+        return index;
+    };
+
     const hideContextMenu = (): void => {
         contextMenu.hidden = true;
     };
@@ -214,6 +232,7 @@ export const createModuleTabManager = (
             const sorted = [...moduleWords].sort((a, b) => compareWordName(a[0], b[0]));
             const matched = sorted.filter(wd => checkWordMatchesFilter(wd[0], searchFilter));
             const prefix = `${moduleSheet.moduleName}@`;
+            const signatureIndex = buildSignatureTypeIndex();
 
             matched.forEach(wordData => {
                 const name = wordData[0];
@@ -226,11 +245,13 @@ Right-click to unimport this word.`;
 
 Built-in word from module ${moduleSheet.moduleName}.
 Right-click to unimport this word.`;
+                const signatureType = signatureIndex.get(shortName.toUpperCase()) ?? 'none';
+                const sigClass = signatureType !== 'none' ? ` signature-${signatureType}` : '';
 
                 const button = createWordButtonElement(
                     shortName,
                     moduleTitle,
-                    'word-button core module',
+                    `word-button core module${sigClass}`,
                     () => onWordClick(shortName),
                     () => { renderWordInfo(wordInfo as HTMLElement, moduleInfo); },
                     () => { resetWordInfoDisplay(wordInfo as HTMLElement); },


### PR DESCRIPTION
## Summary
- module word のワードボタンに、core word と同じ signature ベースの色分け（map / form / fold）を適用しました。
- core word と module word はどちらも built-in word なので、背景色・枠線色の意味合いが揃うようにしています。
- 実装: `module-selector-sheets.ts` 内で `collect_core_words_info()` の戻り値（BUILTIN_SPECS の `signature_type` を含む）から `name → signature_type` の Map を構築し、各 module word ボタンの className に `signature-${type}` クラスを付与。CSS 側 (`.word-button.signature-{map|form|fold}`) は既存定義のまま流用できます。
- `signature_type` を持たない module word（例: ALGO@SORT）は core 既定の白背景となり、core 側の同条件と一貫します。

## Test plan
- [ ] ALGO 以外のモジュール（例: 高階系を含むモジュール）を import して、`MAP` 等の module word ボタンが core 側と同じ signature 色で表示されることを確認
- [ ] ALGO@SORT のように signature_type を持たない module word が、core word と同じ白背景・core 色枠線で表示されることを確認
- [ ] core word 側の表示（4 色分け）が従来どおりであることを確認

https://claude.ai/code/session_012isCEDh9VdTdBv7bkWUUTw

---
_Generated by [Claude Code](https://claude.ai/code/session_012isCEDh9VdTdBv7bkWUUTw)_