### PR TITLE
Persist active dictionary sheet across browser reloads

### DIFF
--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -287,8 +287,20 @@ export const createGUI = (): GUI => {
         vocabulary.renderBuiltInWords();
         updateAllDisplays();
 
-        await persistence.loadDatabaseData();
+        const restored = await persistence.loadDatabaseData();
         updateAllDisplays();
+
+        if (restored.activeUserDictionary) {
+            vocabulary.setSelectedDictionary(restored.activeUserDictionary);
+        }
+        if (restored.activeDictionarySheet) {
+            const targetSheetEl = document.getElementById(`dictionary-sheet-${restored.activeDictionarySheet}`);
+            if (targetSheetEl) {
+                elements.dictionarySheetSelect.value = restored.activeDictionarySheet;
+                doSwitchDictionarySheet(restored.activeDictionarySheet);
+            }
+        }
+
         await initializeWorkers();
 
         console.log('[GUI] GUI initialization completed');

--- a/src/gui/gui-event-bindings.ts
+++ b/src/gui/gui-event-bindings.ts
@@ -44,7 +44,8 @@ function bindLayoutEvents(context: GuiEventBindingContext): void {
         layoutState,
         switchArea,
         doSwitchDictionarySheet,
-        layoutController
+        layoutController,
+        persistence
     } = context;
 
     elements.leftPanelSelect.addEventListener('change', () => {
@@ -59,6 +60,7 @@ function bindLayoutEvents(context: GuiEventBindingContext): void {
 
     elements.dictionarySheetSelect.addEventListener('change', () => {
         doSwitchDictionarySheet(elements.dictionarySheetSelect.value);
+        void persistence.saveCurrentState();
     });
 
     const setupDoubleTapToTransition = (

--- a/src/gui/interpreter-state-persistence.ts
+++ b/src/gui/interpreter-state-persistence.ts
@@ -10,6 +10,13 @@ export interface InterpreterState {
     readonly userWords: UserWord[];
     readonly importedModules?: string[];
     readonly demoWordsVersion?: number;
+    readonly activeDictionarySheet?: string;
+    readonly activeUserDictionary?: string;
+}
+
+export interface RestoredSelection {
+    readonly activeDictionarySheet?: string;
+    readonly activeUserDictionary?: string;
 }
 
 export interface PersistenceCallbacks {
@@ -21,7 +28,7 @@ export interface PersistenceCallbacks {
 export interface Persistence {
     readonly init: () => Promise<void>;
     readonly saveCurrentState: () => Promise<void>;
-    readonly loadDatabaseData: () => Promise<void>;
+    readonly loadDatabaseData: () => Promise<RestoredSelection>;
     readonly fullReset: () => Promise<void>;
     readonly exportUserWords: () => void;
     readonly importUserWords: () => void;
@@ -44,17 +51,33 @@ const toUserWord = (
     definition: getDefinition(`${wordData[0]}@${wordData[1]}`)
 });
 
+const readActiveSelections = (): {
+    activeDictionarySheet?: string;
+    activeUserDictionary?: string;
+} => {
+    const sheetSelect = document.getElementById('dictionary-sheet-select') as HTMLSelectElement | null;
+    const userDictSelect = document.getElementById('user-dictionary-select') as HTMLSelectElement | null;
+    return {
+        activeDictionarySheet: sheetSelect?.value || undefined,
+        activeUserDictionary: userDictSelect?.value || undefined
+    };
+};
+
 const collectCurrentState = (interpreter: AjisaiInterpreter): InterpreterState => {
     const userWordsInfo = interpreter.collect_user_words_info();
     const userWords: UserWord[] = userWordsInfo.map(wordData =>
         toUserWord(wordData, name => interpreter.lookup_word_definition(name))
     );
 
+    const selections = readActiveSelections();
+
     return {
         stack: interpreter.collect_stack(),
         userWords,
         importedModules: interpreter.collect_imported_modules(),
-        demoWordsVersion: DEMO_WORDS_VERSION
+        demoWordsVersion: DEMO_WORDS_VERSION,
+        activeDictionarySheet: selections.activeDictionarySheet,
+        activeUserDictionary: selections.activeUserDictionary
     };
 };
 
@@ -142,12 +165,12 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
         }
     };
 
-    const loadDatabaseData = async (): Promise<void> => {
-        if (!window.ajisaiInterpreter) return;
+    const loadDatabaseData = async (): Promise<RestoredSelection> => {
+        if (!window.ajisaiInterpreter) return {};
         if (!dbInitialized) {
             console.warn('Database not initialized, loading sample words instead.');
             await loadDemoWords();
-            return;
+            return {};
         }
 
         try {
@@ -211,12 +234,19 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
                 } else {
                     await loadDemoWords();
                 }
+
+                return {
+                    activeDictionarySheet: state.activeDictionarySheet,
+                    activeUserDictionary: state.activeUserDictionary
+                };
             } else {
                 await loadDemoWords();
+                return {};
             }
         } catch (error) {
             console.error('Failed to load database data:', error);
             showError?.(error as Error);
+            return {};
         }
     };
 

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -40,6 +40,7 @@ export interface VocabularyManager {
     readonly renderBuiltInWords: () => void;
     readonly updateUserWords: (userWordsInfo: Array<[string, string, string | null, boolean]>) => void;
     readonly updateSearchFilter: (filter: string) => void;
+    readonly setSelectedDictionary: (dictionary: string) => void;
 }
 
 const DICTIONARY_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.freeze({
@@ -384,15 +385,27 @@ export const createVocabularyManager = (
         renderUserWordButtons(elements.userWordsDisplay, words);
     };
 
+    const setSelectedDictionary = (dictionary: string): void => {
+        if (!dictionary) return;
+        const optionExists = Array.from(elements.userDictionarySelect.options).some(opt => opt.value === dictionary);
+        if (!optionExists) return;
+        selectedDictionary = dictionary;
+        elements.userDictionarySelect.value = dictionary;
+        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
+        renderUserWordButtons(elements.userWordsDisplay, words);
+    };
+
     elements.userDictionarySelect.addEventListener('change', () => {
         selectedDictionary = elements.userDictionarySelect.value;
         const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
         renderUserWordButtons(elements.userWordsDisplay, words);
+        void onSaveState?.();
     });
 
     return {
         renderBuiltInWords,
         updateUserWords,
-        updateSearchFilter
+        updateSearchFilter,
+        setSelectedDictionary
     };
 };

--- a/src/platform/platform-adapter.ts
+++ b/src/platform/platform-adapter.ts
@@ -5,6 +5,8 @@ export interface InterpreterStateSnapshot {
     readonly userWords: UserWord[];
     readonly importedModules?: string[];
     readonly demoWordsVersion?: number;
+    readonly activeDictionarySheet?: string;
+    readonly activeUserDictionary?: string;
 }
 
 export interface TablePayload {
@@ -25,6 +27,8 @@ export interface ExportData {
         readonly userWords: unknown;
         readonly importedModules?: unknown;
         readonly demoWordsVersion?: number;
+        readonly activeDictionarySheet?: string;
+        readonly activeUserDictionary?: string;
         readonly updatedAt: string;
     } | null;
 }

--- a/src/platform/tauri/tauri-persistence.ts
+++ b/src/platform/tauri/tauri-persistence.ts
@@ -100,6 +100,8 @@ export class TauriPersistence implements Persistence {
             userWords: state.userWords,
             importedModules: state.importedModules,
             demoWordsVersion: state.demoWordsVersion,
+            activeDictionarySheet: state.activeDictionarySheet,
+            activeUserDictionary: state.activeUserDictionary,
             updatedAt: new Date().toISOString()
         };
         await writeStoredData(current);
@@ -117,7 +119,9 @@ export class TauriPersistence implements Persistence {
             stack: state.stack as InterpreterStateSnapshot['stack'],
             userWords: state.userWords as InterpreterStateSnapshot['userWords'],
             importedModules: state.importedModules as InterpreterStateSnapshot['importedModules'],
-            demoWordsVersion: state.demoWordsVersion
+            demoWordsVersion: state.demoWordsVersion,
+            activeDictionarySheet: state.activeDictionarySheet,
+            activeUserDictionary: state.activeUserDictionary
         };
     }
 

--- a/src/platform/web/web-persistence.ts
+++ b/src/platform/web/web-persistence.ts
@@ -18,6 +18,8 @@ interface InterpreterState {
     userWords: unknown;
     importedModules?: unknown;
     demoWordsVersion?: number;
+    activeDictionarySheet?: string;
+    activeUserDictionary?: string;
     updatedAt: string;
 
     customWords?: unknown;
@@ -157,7 +159,9 @@ class WebPersistence implements Persistence {
                 stack: result.stack as InterpreterStateSnapshot['stack'],
                 userWords: (result.userWords ?? result.customWords) as InterpreterStateSnapshot['userWords'],
                 importedModules: result.importedModules as InterpreterStateSnapshot['importedModules'],
-                demoWordsVersion: result.demoWordsVersion ?? result.sampleWordsVersion
+                demoWordsVersion: result.demoWordsVersion ?? result.sampleWordsVersion,
+                activeDictionarySheet: result.activeDictionarySheet,
+                activeUserDictionary: result.activeUserDictionary
             };
         });
     }


### PR DESCRIPTION
## 概要

ブラウザを再読み込みした際に、再読み込み前に表示していた辞書シートが復元されるようにしました。これまでは保存されていた状態を復元したあと、`updateAllDisplays()` が「新しく追加されたシート」のうち最後の 1 つに自動的に切り替える仕様でした。再読み込み時はインポート済み全モジュールが「新規」とみなされるため、Rust 側の `HashMap<String, ImportedModule>`（`rust/src/interpreter/interpreter-core.rs:45`）のイテレーション順で最後に来るシート（実環境ではほぼ常に IO）が選ばれていました。

## 原因

- `InterpreterStateSnapshot` には現在表示中のシート ID を保存するフィールドがなかった (`src/platform/platform-adapter.ts`)。
- `selectedDictionary` は `vocabulary-state-controller.ts:184` でハードコードされ永続化されていなかった。
- `gui-application.ts:139-146` の自動シート切替が、リロード時に保存済みの選択を上書きしていた。

## 変更内容

- `InterpreterStateSnapshot` に `activeDictionarySheet` と `activeUserDictionary` を追加し、Web/Tauri 両方の永続化レイヤーで保存・復元する。
- `interpreter-state-persistence.ts` の `collectCurrentState` で DOM から現在の選択を読み取り、`loadDatabaseData()` は復元すべき選択を返却するようにした。
- `VocabularyManager` に `setSelectedDictionary` を公開し、ユーザー辞書セレクタ変更時に状態を保存する。
- `gui-application.ts` の `init()` で、`loadDatabaseData()` 後に `updateAllDisplays()` の自動切替を上書きして保存済みのシートを復元する。
- `dictionarySheetSelect` の change イベントで状態を保存するよう追加 (`gui-event-bindings.ts`)。

## Test plan

- [ ] DEMO 表示の状態でリロード → DEMO のままになる
- [ ] `'IO' IMPORT` → IO シートに切替 → リロードで IO のまま
- [ ] `'IO' IMPORT` → `'JSON' IMPORT` → JSON シートに切替 → リロードで JSON のまま
- [ ] IO/JSON 両方インポート後、Core word に手動で切替 → リロードで Core のまま
- [ ] ユーザー辞書セレクタを別の辞書に切替 → リロードで同じ辞書のまま

https://claude.ai/code/session_01XsxLUrXCEpd1rVRoyvNGsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsxLUrXCEpd1rVRoyvNGsR)_