### PR TITLE
Introduce Virtual Tensor Unit (VTU) classification and metrics

### DIFF
--- a/docs/dev/virtual-tensor-unit-design.md
+++ b/docs/dev/virtual-tensor-unit-design.md
@@ -1,0 +1,119 @@
+# Virtual Tensor Unit (VTU) — Design Note
+
+Status: **Non-canonical** (developer note).
+Authority: this document does not define Ajisai semantics. The canonical
+source is `SPECIFICATION.md`. If anything here conflicts with the
+specification, the specification wins.
+
+## What VTU is
+
+A **Virtual Tensor Unit (VTU)** is an *internal classification* applied to
+pure, shape-aware Ajisai computations. It marks blocks that would, in
+principle, be schedulable onto a vectorized backend (CPU loop, Wasm SIMD,
+NPU, GPU, ...) without changing what the program returns.
+
+VTU is **not** a physical accelerator. It is not StableHLO, not MLIR, not
+XLA, not WebGPU, not a TPU backend. The current implementation only
+*observes* and *labels* — it never reroutes execution.
+
+## What VTU does today
+
+- Classifies each `QuantizedBlock` with a `VtuHint` describing
+  suitability, candidate backends, and approximate data-movement cost.
+- Increments observational counters in `RuntimeMetrics` for: tensor
+  flatten / rebuild, broadcast paths, unary flat ops, allocated output
+  elements, SIMD fast-path uses, candidate vs. rejected blocks, and
+  fusion candidates.
+- Surfaces these counters through `Interpreter::runtime_metrics()` for
+  tests and tooling.
+
+## What VTU does *not* do today
+
+- It does not change the result of any Ajisai program.
+- It does not reorder or reschedule operations.
+- It does not affect `Fraction` exactness.
+- It does not enter `GuardSignature`. VTU is explanation, not contract;
+  including it in the guard would cause spurious cache invalidation on
+  what is purely classifying information.
+- It does not measure real energy. The counters are *proxies* for energy
+  / data-movement cost, not joules or watt-hours.
+
+## Existing components, mapped
+
+```
+FlatTensor        -> shape-aware dense representation
+QuantizedBlock    -> kernel candidate detection
+KernelKind        -> virtual kernel classification
+PurityInfo        -> safety for cache / reorder / fusion
+RuntimeMetrics    -> energy-aware proxy metrics
+Wasm SIMD         -> one concrete backend-like fast path
+```
+
+## Classification policy
+
+`infer_vtu_hint(kernel_kind, purity)` produces a `VtuHint` with these
+defaults:
+
+| Kernel               | Purity         | Suitability       | Notes                                  |
+|----------------------|----------------|-------------------|----------------------------------------|
+| `MapUnaryPure`       | Pure           | StrongCandidate   | Embarrassingly parallel.               |
+| `PredicateUnaryPure` | Pure           | StrongCandidate   | Pure boolean elementwise.              |
+| `FoldBinaryPure`     | Pure           | WeakCandidate     | Reductions need an Approx boundary.    |
+| `ScanBinaryPure`     | Pure           | WeakCandidate     | Accumulator-carrying, not parallel.    |
+| `GenericCompiled`    | Pure           | WeakCandidate     | Pure but unspecialized.                |
+| `GenericCompiled`    | Unknown        | NotSuitable       | Conservative.                          |
+| `GenericCompiled`    | SideEffecting  | NotSuitable       |                                        |
+| `NonQuantizable`     | any            | NotSuitable       |                                        |
+| any                  | SideEffecting  | NotSuitable       | Hard rule.                             |
+
+The default for `VtuHint` is `NotSuitable`. We never *upgrade* a hint
+opportunistically.
+
+## Counter semantics
+
+| Counter                                  | Bumped when                                    |
+|------------------------------------------|------------------------------------------------|
+| `vtu_tensor_flatten_count`               | Each successful `FlatTensor::from_value`.      |
+| `vtu_tensor_flattened_elements`          | Sum of element counts over those flattens.     |
+| `vtu_tensor_rebuild_count`               | Each rebuild back into nested `Value`.         |
+| `vtu_tensor_rebuilt_elements`            | Sum of rebuilt element counts.                 |
+| `vtu_broadcast_count`                    | Each binary broadcast that begins executing.   |
+| `vtu_unary_flat_count`                   | Each unary flat op that begins executing.      |
+| `vtu_allocated_elements`                 | Output buffer size of tensor ops.              |
+| `vtu_same_shape_elementwise_count`       | Same-shape fast path inside binary broadcast.  |
+| `vtu_projected_broadcast_count`          | Index-projection path inside binary broadcast. |
+| `vtu_simd_kernel_use_count`              | A SIMD fast path in `arithmetic.rs` succeeds.  |
+| `vtu_candidate_block_count`              | A built block's `VtuHint` is Strong or Weak.   |
+| `vtu_rejected_block_count`               | A built block's `VtuHint` is NotSuitable.      |
+| `vtu_fusion_candidate_count`             | A built block reports `eligible_for_fusion` or `can_fuse`. |
+
+Counters are bumped at *block build time* and at *operation start time*.
+Cache hits do not double-count classifications.
+
+These are observational only: they describe what shape-aware work the
+runtime did, not what it cost in energy. The names deliberately avoid
+verbs like `energy_saved`.
+
+## Future scope (not implemented)
+
+- `ajisai trace --vtu` / `ajisai trace --energy` displays.
+- `ajisai explain --vtu <word>` per-word classification dump.
+- Fusion-candidate detection across consecutive elementwise ops.
+- Safe-by-construction fusion execution.
+- `ExecutionValue::FlatTensor` / `TensorView` to defer rebuild.
+- An explicit `EXACT` / `APPROX` boundary (e.g. `TO-F32`, `TO-BF16`)
+  before any approximate backend may run.
+- StableHLO / MLIR-style textual dump.
+- Real WebGPU / NPU / TPU backends.
+
+## Design message
+
+> Ajisai does not assume a physical TPU. It models pure, shape-aware
+> computations as VTU plans that *could* be dispatched onto CPU, SIMD,
+> Wasm, NPU, GPU, or — eventually — TPU.
+>
+> Today it does not redirect execution. It only makes wasted work,
+> wasted rebuilds, and wasted data movement visible.
+>
+> Ajisai is a debuggable, exact-by-default, virtual-accelerator-aware
+> language.

--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -2,7 +2,7 @@ use crate::error::{AjisaiError, Result};
 use crate::interpreter::interval_ops::{interval_to_value, value_to_interval};
 use crate::interpreter::optimization_hooks;
 use crate::interpreter::simd_ops;
-use crate::interpreter::tensor_ops::apply_binary_broadcast;
+use crate::interpreter::tensor_ops::apply_binary_broadcast_with_metrics;
 use crate::interpreter::value_extraction_helpers::{
     extract_integer_from_value, extract_operands_with_flow, nil_passthrough_binary,
     push_flow_result, push_result,
@@ -50,7 +50,12 @@ where
                 ]
             });
 
-            let result = match apply_binary_broadcast(a_val, b_val, op) {
+            let result = match apply_binary_broadcast_with_metrics(
+                a_val,
+                b_val,
+                op,
+                Some(&mut interp.runtime_metrics),
+            ) {
                 Ok(r) => r,
                 Err(e) => {
                     if !is_keep_mode {
@@ -159,6 +164,10 @@ pub fn op_add(interp: &mut Interpreter) -> Result<()> {
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
             ];
+            interp.runtime_metrics.vtu_simd_kernel_use_count = interp
+                .runtime_metrics
+                .vtu_simd_kernel_use_count
+                .saturating_add(1);
             if interp.consumption_mode != ConsumptionMode::Keep {
                 interp.stack.pop();
                 interp.stack.pop();
@@ -174,6 +183,10 @@ pub fn op_add(interp: &mut Interpreter) -> Result<()> {
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
             ];
+            interp.runtime_metrics.vtu_simd_kernel_use_count = interp
+                .runtime_metrics
+                .vtu_simd_kernel_use_count
+                .saturating_add(1);
             if interp.consumption_mode != ConsumptionMode::Keep {
                 interp.stack.pop();
                 interp.stack.pop();
@@ -214,6 +227,10 @@ pub fn op_sub(interp: &mut Interpreter) -> Result<()> {
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
             ];
+            interp.runtime_metrics.vtu_simd_kernel_use_count = interp
+                .runtime_metrics
+                .vtu_simd_kernel_use_count
+                .saturating_add(1);
             if interp.consumption_mode != ConsumptionMode::Keep {
                 interp.stack.pop();
                 interp.stack.pop();
@@ -254,6 +271,10 @@ pub fn op_mul(interp: &mut Interpreter) -> Result<()> {
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
             ];
+            interp.runtime_metrics.vtu_simd_kernel_use_count = interp
+                .runtime_metrics
+                .vtu_simd_kernel_use_count
+                .saturating_add(1);
             if interp.consumption_mode != ConsumptionMode::Keep {
                 interp.stack.pop();
                 interp.stack.pop();
@@ -269,6 +290,10 @@ pub fn op_mul(interp: &mut Interpreter) -> Result<()> {
                 optimization_hooks::check_in_place_candidate(a, None),
                 optimization_hooks::check_in_place_candidate(b, None),
             ];
+            interp.runtime_metrics.vtu_simd_kernel_use_count = interp
+                .runtime_metrics
+                .vtu_simd_kernel_use_count
+                .saturating_add(1);
             if interp.consumption_mode != ConsumptionMode::Keep {
                 interp.stack.pop();
                 interp.stack.pop();

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -148,6 +148,38 @@ pub struct RuntimeMetrics {
     pub redundancy_degrade_compiled: u64,
     /// Times the auto-degrade threshold was crossed (demotion to PlainOnly).
     pub redundancy_auto_degrade_count: u64,
+
+    // ── Virtual Tensor Unit / Energy-aware Execution ──────────────────────
+    // These counters are observational proxies for energy / data-movement
+    // cost. They never alter execution semantics; they only describe how
+    // much shape-aware work the runtime did. See
+    // `docs/dev/virtual-tensor-unit-design.md`.
+    /// Number of times a Value was flattened into FlatTensor form.
+    pub vtu_tensor_flatten_count: u64,
+    /// Total scalar elements observed during flattening.
+    pub vtu_tensor_flattened_elements: u64,
+    /// Number of times a FlatTensor was rebuilt into nested Value form.
+    pub vtu_tensor_rebuild_count: u64,
+    /// Total scalar elements rebuilt into Value form.
+    pub vtu_tensor_rebuilt_elements: u64,
+    /// Number of binary broadcast operations that began executing.
+    pub vtu_broadcast_count: u64,
+    /// Number of unary flat tensor operations that began executing.
+    pub vtu_unary_flat_count: u64,
+    /// Output scalar elements allocated by tensor operations.
+    pub vtu_allocated_elements: u64,
+    /// Same-shape elementwise fast paths taken inside tensor ops.
+    pub vtu_same_shape_elementwise_count: u64,
+    /// Real broadcast index-projection paths taken inside tensor ops.
+    pub vtu_projected_broadcast_count: u64,
+    /// SIMD fast paths actually taken (target-arch dependent).
+    pub vtu_simd_kernel_use_count: u64,
+    /// QuantizedBlocks classified as VTU candidates (Strong or Weak).
+    pub vtu_candidate_block_count: u64,
+    /// QuantizedBlocks rejected as not suitable for VTU.
+    pub vtu_rejected_block_count: u64,
+    /// QuantizedBlocks whose VtuHint marked them as fusion candidates.
+    pub vtu_fusion_candidate_count: u64,
 }
 
 pub struct Interpreter {

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -1,6 +1,9 @@
 use crate::error::{AjisaiError, Result};
+use crate::interpreter::interpreter_core::RuntimeMetrics;
+use crate::interpreter::tensor_ops::{
+    apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics, FlatTensor,
+};
 use crate::interpreter::value_extraction_helpers::extract_integer_from_value;
-use crate::interpreter::tensor_ops::{apply_binary_broadcast, apply_unary_flat, FlatTensor};
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use crate::types::{Value, ValueData};
@@ -28,14 +31,17 @@ fn compute_inverted_fraction(f: &Fraction) -> Fraction {
     }
 }
 
-fn compute_inverted_value(val: &Value) -> Result<Value> {
+fn compute_inverted_value(
+    val: &Value,
+    metrics: Option<&mut RuntimeMetrics>,
+) -> Result<Value> {
     if val.is_nil() {
         return Ok(Value::nil());
     }
     if let Some(f) = val.as_scalar() {
         return Ok(Value::from_fraction(compute_inverted_fraction(f)));
     }
-    apply_unary_flat(val, compute_inverted_fraction)
+    apply_unary_flat_with_metrics(val, compute_inverted_fraction, metrics)
 }
 
 pub fn op_not(interp: &mut Interpreter) -> Result<()> {
@@ -53,7 +59,7 @@ pub fn op_not(interp: &mut Interpreter) -> Result<()> {
                 interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
             };
 
-            let result = match compute_inverted_value(&val) {
+            let result = match compute_inverted_value(&val, Some(&mut interp.runtime_metrics)) {
                 Ok(v) => v,
                 Err(e) => {
                     if !is_keep_mode {
@@ -70,7 +76,7 @@ pub fn op_not(interp: &mut Interpreter) -> Result<()> {
             let source: Vec<Value> = interp.stack.iter().cloned().collect();
             let mut results: Vec<Value> = Vec::with_capacity(source.len());
             for value in &source {
-                results.push(compute_inverted_value(value)?);
+                results.push(compute_inverted_value(value, Some(&mut interp.runtime_metrics))?);
             }
 
             if is_keep_mode {
@@ -126,11 +132,16 @@ pub fn op_and(interp: &mut Interpreter) -> Result<()> {
                 return Ok(());
             }
 
-            let result = apply_binary_broadcast(&a_val, &b_val, |a, b| {
-                let a_truthy = !a.is_zero();
-                let b_truthy = !b.is_zero();
-                Ok(Fraction::from(if a_truthy && b_truthy { 1 } else { 0 }))
-            })?;
+            let result = apply_binary_broadcast_with_metrics(
+                &a_val,
+                &b_val,
+                |a, b| {
+                    let a_truthy = !a.is_zero();
+                    let b_truthy = !b.is_zero();
+                    Ok(Fraction::from(if a_truthy && b_truthy { 1 } else { 0 }))
+                },
+                Some(&mut interp.runtime_metrics),
+            )?;
             interp.stack.push(result);
             Ok(())
         }
@@ -217,11 +228,16 @@ pub fn op_or(interp: &mut Interpreter) -> Result<()> {
                 return Ok(());
             }
 
-            let result = apply_binary_broadcast(&a_val, &b_val, |a, b| {
-                let a_truthy = !a.is_zero();
-                let b_truthy = !b.is_zero();
-                Ok(Fraction::from(if a_truthy || b_truthy { 1 } else { 0 }))
-            })?;
+            let result = apply_binary_broadcast_with_metrics(
+                &a_val,
+                &b_val,
+                |a, b| {
+                    let a_truthy = !a.is_zero();
+                    let b_truthy = !b.is_zero();
+                    Ok(Fraction::from(if a_truthy || b_truthy { 1 } else { 0 }))
+                },
+                Some(&mut interp.runtime_metrics),
+            )?;
             interp.stack.push(result);
             Ok(())
         }

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -1,5 +1,6 @@
 use crate::interpreter::quantized_block::{
     is_quantizable_block, quantize_code_block, KernelKind, QuantizedArity, QuantizedPurity,
+    VtuSuitability,
 };
 use crate::interpreter::Interpreter;
 use crate::types::{Token, Value};
@@ -706,4 +707,123 @@ fn arity_fully_known_still_fixed() {
     let qb = quantize_code_block(&tokens, &mut interp).unwrap();
     assert_eq!(qb.input_arity, QuantizedArity::Fixed(1));
     assert_eq!(qb.output_arity, QuantizedArity::Fixed(1));
+}
+
+// ---------------------------------------------------------------------------
+// Virtual Tensor Unit (VTU) classification
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vtu_hint_map_unary_is_strong_candidate() {
+    // `[ 1 ] +` is the const-vector pattern detected as MapUnaryPure.
+    let mut interp = make_interp();
+    let tokens = vec![
+        Token::VectorStart,
+        num("1"),
+        Token::VectorEnd,
+        sym("+"),
+    ];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::MapUnaryPure);
+    assert_eq!(qb.vtu_hint.suitability, VtuSuitability::StrongCandidate);
+    assert!(qb.vtu_hint.is_candidate());
+}
+
+#[test]
+fn vtu_hint_predicate_unary_is_strong_candidate() {
+    let mut interp = make_interp();
+    let tokens = vec![sym("NOT")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::PredicateUnaryPure);
+    assert_eq!(qb.vtu_hint.suitability, VtuSuitability::StrongCandidate);
+}
+
+#[test]
+fn vtu_hint_fold_binary_is_weak_candidate() {
+    // A bare `+` with no const-vector wrapper is FoldBinaryPure.
+    let mut interp = make_interp();
+    let tokens = vec![sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::FoldBinaryPure);
+    // Reductions are weak candidates because parallel reduction needs an
+    // Approx boundary; Ajisai is exact-by-default.
+    assert_eq!(qb.vtu_hint.suitability, VtuSuitability::WeakCandidate);
+}
+
+#[test]
+fn vtu_hint_generic_pure_is_weak_candidate() {
+    // Two pushes plus DUP — quantizable but no kernel pattern, so generic.
+    let mut interp = make_interp();
+    let tokens = vec![num("1"), num("2"), sym("DUP")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert_eq!(qb.kernel_kind, KernelKind::GenericCompiled);
+    assert_eq!(qb.purity, QuantizedPurity::Pure);
+    assert_eq!(qb.vtu_hint.suitability, VtuSuitability::WeakCandidate);
+}
+
+#[test]
+fn vtu_metrics_increment_on_quantize() {
+    let mut interp = make_interp();
+    let baseline = interp.runtime_metrics().vtu_candidate_block_count;
+    let tokens = vec![sym("NOT")];
+    let _ = quantize_code_block(&tokens, &mut interp).unwrap();
+    let after = interp.runtime_metrics().vtu_candidate_block_count;
+    assert_eq!(after, baseline + 1);
+}
+
+#[test]
+fn vtu_default_metrics_are_zero() {
+    let interp = make_interp();
+    let m = interp.runtime_metrics();
+    assert_eq!(m.vtu_tensor_flatten_count, 0);
+    assert_eq!(m.vtu_tensor_flattened_elements, 0);
+    assert_eq!(m.vtu_tensor_rebuild_count, 0);
+    assert_eq!(m.vtu_tensor_rebuilt_elements, 0);
+    assert_eq!(m.vtu_broadcast_count, 0);
+    assert_eq!(m.vtu_unary_flat_count, 0);
+    assert_eq!(m.vtu_allocated_elements, 0);
+    assert_eq!(m.vtu_same_shape_elementwise_count, 0);
+    assert_eq!(m.vtu_projected_broadcast_count, 0);
+    assert_eq!(m.vtu_simd_kernel_use_count, 0);
+    assert_eq!(m.vtu_candidate_block_count, 0);
+    assert_eq!(m.vtu_rejected_block_count, 0);
+    assert_eq!(m.vtu_fusion_candidate_count, 0);
+}
+
+#[test]
+fn vtu_same_shape_broadcast_increments_counters() {
+    // `[ 1 2 3 ] [ 4 5 6 ] +` -> same-shape elementwise.
+    let interp = run_code("[ 1 2 3 ] [ 4 5 6 ] +");
+    let m = interp.runtime_metrics();
+    assert!(m.vtu_broadcast_count >= 1, "broadcast count should fire");
+    assert!(
+        m.vtu_same_shape_elementwise_count >= 1,
+        "same-shape fast path should fire"
+    );
+    assert_eq!(m.vtu_projected_broadcast_count, 0);
+    assert!(m.vtu_tensor_flatten_count >= 2, "two operands flattened");
+    assert!(m.vtu_allocated_elements >= 3);
+}
+
+#[test]
+fn vtu_projected_broadcast_increments_counters() {
+    // Scalar broadcast over a 3-vector exercises the projection path.
+    let interp = run_code("[ 1 2 3 ] [ 10 ] +");
+    let m = interp.runtime_metrics();
+    assert!(m.vtu_broadcast_count >= 1);
+    assert!(
+        m.vtu_projected_broadcast_count >= 1,
+        "projection path should fire when shapes differ"
+    );
+}
+
+#[test]
+fn vtu_unary_flat_increments_counter() {
+    // FLOOR over a vector exercises apply_unary_flat_with_metrics.
+    let interp = run_code("[ 1/2 3/2 5/2 ] FLOOR");
+    let m = interp.runtime_metrics();
+    assert!(m.vtu_unary_flat_count >= 1, "unary flat path should fire");
+    assert!(m.vtu_tensor_flatten_count >= 1);
+    assert!(m.vtu_tensor_rebuild_count >= 1);
+    assert!(m.vtu_allocated_elements >= 3);
 }

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -22,6 +22,81 @@ pub enum QuantizedPurity {
     Unknown,
 }
 
+// ── Virtual Tensor Unit (VTU) classification ─────────────────────────────
+//
+// VTU is *not* a physical accelerator. It is an internal classification of
+// pure, shape-aware kernels that lets the runtime explain (and, in the
+// future, schedule) work onto the most appropriate execution surface.
+//
+// Important invariants:
+//   - VtuHint never affects execution semantics. Including it in
+//     `GuardSignature` would cause spurious guard invalidations on what is
+//     fundamentally an explanation field, so it is intentionally kept out.
+//   - All variants are forward-looking; only `CpuScalar`, `WasmSimd`, and
+//     `DenseTensorLoop` map to surfaces Ajisai actually executes today.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VtuBackendCandidate {
+    CpuScalar,
+    WasmSimd,
+    DenseTensorLoop,
+    #[allow(dead_code)]
+    NpuCandidate,
+    #[allow(dead_code)]
+    GpuCandidate,
+    #[allow(dead_code)]
+    TpuCandidate,
+    FallbackInterpreter,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VtuSuitability {
+    StrongCandidate,
+    WeakCandidate,
+    NotSuitable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataMovementClass {
+    None,
+    Low,
+    Medium,
+    #[allow(dead_code)]
+    High,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VtuHint {
+    pub suitability: VtuSuitability,
+    pub backend_candidates: Vec<VtuBackendCandidate>,
+    pub data_movement: DataMovementClass,
+    pub reason: &'static str,
+}
+
+impl Default for VtuHint {
+    fn default() -> Self {
+        Self::not_suitable("default")
+    }
+}
+
+impl VtuHint {
+    pub fn not_suitable(reason: &'static str) -> Self {
+        Self {
+            suitability: VtuSuitability::NotSuitable,
+            backend_candidates: vec![VtuBackendCandidate::FallbackInterpreter],
+            data_movement: DataMovementClass::Unknown,
+            reason,
+        }
+    }
+
+    pub fn is_candidate(&self) -> bool {
+        matches!(
+            self.suitability,
+            VtuSuitability::StrongCandidate | VtuSuitability::WeakCandidate
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KernelKind {
     MapUnaryPure,
@@ -60,6 +135,9 @@ pub struct QuantizedBlock {
     pub can_fuse: bool,
     pub can_short_circuit: bool,
     pub dependency_words: Vec<String>,
+    /// Observational VTU classification. Never participates in
+    /// `GuardSignature`; never affects execution semantics.
+    pub vtu_hint: VtuHint,
 }
 
 /// Returns (inputs_consumed, outputs_produced) for well-known pure builtins.
@@ -400,6 +478,65 @@ fn detect_kernel_kind(
     KernelKind::GenericCompiled
 }
 
+/// Derive a `VtuHint` from kernel classification + purity. This is purely
+/// observational; the runtime ignores the hint when picking an execution
+/// path. The conservative defaults below ensure that side-effecting,
+/// unknown-purity, or non-quantizable blocks never surface as candidates.
+fn infer_vtu_hint(kernel_kind: KernelKind, purity: QuantizedPurity) -> VtuHint {
+    use DataMovementClass::*;
+    use VtuBackendCandidate::*;
+    use VtuSuitability::*;
+
+    if matches!(purity, QuantizedPurity::SideEffecting) {
+        return VtuHint::not_suitable("side-effecting block");
+    }
+
+    match kernel_kind {
+        KernelKind::MapUnaryPure => VtuHint {
+            suitability: StrongCandidate,
+            backend_candidates: vec![
+                CpuScalar,
+                WasmSimd,
+                DenseTensorLoop,
+                NpuCandidate,
+                GpuCandidate,
+            ],
+            data_movement: Low,
+            reason: "elementwise pure map; embarrassingly parallel",
+        },
+        KernelKind::PredicateUnaryPure => VtuHint {
+            suitability: StrongCandidate,
+            backend_candidates: vec![CpuScalar, WasmSimd, DenseTensorLoop],
+            data_movement: Low,
+            reason: "elementwise pure predicate",
+        },
+        KernelKind::FoldBinaryPure => VtuHint {
+            suitability: WeakCandidate,
+            backend_candidates: vec![CpuScalar, DenseTensorLoop],
+            data_movement: Medium,
+            reason: "reduction may depend on order/associativity; \
+                     parallelization requires Approx boundary",
+        },
+        KernelKind::ScanBinaryPure => VtuHint {
+            suitability: WeakCandidate,
+            backend_candidates: vec![CpuScalar, DenseTensorLoop],
+            data_movement: Medium,
+            reason: "scan carries an accumulator; not embarrassingly parallel",
+        },
+        KernelKind::GenericCompiled => match purity {
+            QuantizedPurity::Pure => VtuHint {
+                suitability: WeakCandidate,
+                backend_candidates: vec![CpuScalar, FallbackInterpreter],
+                data_movement: Unknown,
+                reason: "pure but unspecialized",
+            },
+            QuantizedPurity::Unknown => VtuHint::not_suitable("unknown purity"),
+            QuantizedPurity::SideEffecting => VtuHint::not_suitable("side-effecting block"),
+        },
+        KernelKind::NonQuantizable => VtuHint::not_suitable("non-quantizable block"),
+    }
+}
+
 pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option<QuantizedBlock> {
     if !is_quantizable_block(tokens) {
         return None;
@@ -454,6 +591,28 @@ pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option
         KernelKind::MapUnaryPure | KernelKind::PredicateUnaryPure
     );
 
+    let vtu_hint = infer_vtu_hint(kernel_kind, purity);
+
+    // Count VTU classifications at build time. Cache hits do not bump these
+    // counters, so the totals reflect distinct block builds, not uses.
+    if vtu_hint.is_candidate() {
+        interp.runtime_metrics.vtu_candidate_block_count = interp
+            .runtime_metrics
+            .vtu_candidate_block_count
+            .saturating_add(1);
+    } else {
+        interp.runtime_metrics.vtu_rejected_block_count = interp
+            .runtime_metrics
+            .vtu_rejected_block_count
+            .saturating_add(1);
+    }
+    if eligible_for_fusion || can_fuse {
+        interp.runtime_metrics.vtu_fusion_candidate_count = interp
+            .runtime_metrics
+            .vtu_fusion_candidate_count
+            .saturating_add(1);
+    }
+
     #[cfg(feature = "trace-quant")]
     eprintln!(
         "[trace-quant] quantized block generated: input={:?} output={:?} purity={:?} deps={:?}",
@@ -475,5 +634,6 @@ pub fn quantize_code_block(tokens: &[Token], interp: &mut Interpreter) -> Option
         can_fuse,
         can_short_circuit,
         dependency_words,
+        vtu_hint,
     })
 }

--- a/rust/src/interpreter/tensor-shape-commands.rs
+++ b/rust/src/interpreter/tensor-shape-commands.rs
@@ -7,7 +7,8 @@ use crate::types::fraction::Fraction;
 use crate::types::Value;
 
 use super::tensor_ops::{
-    apply_binary_broadcast, apply_unary_flat, build_nested_value, FlatTensor,
+    apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics, build_nested_value,
+    FlatTensor,
 };
 
 fn apply_tensor_metadata(
@@ -251,7 +252,7 @@ where
     }
 
     if val.is_vector() {
-        match apply_unary_flat(&val, op) {
+        match apply_unary_flat_with_metrics(&val, op, Some(&mut interp.runtime_metrics)) {
             Ok(result) => {
                 interp.stack.push(result);
                 return Ok(());
@@ -323,13 +324,18 @@ pub fn op_mod(interp: &mut Interpreter) -> Result<()> {
         interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
     };
 
-    let result = apply_binary_broadcast(&a_val, &b_val, |x, y| {
-        if y.is_zero() {
-            Err(AjisaiError::from("Modulo by zero"))
-        } else {
-            Ok(x.modulo(y))
-        }
-    });
+    let result = apply_binary_broadcast_with_metrics(
+        &a_val,
+        &b_val,
+        |x, y| {
+            if y.is_zero() {
+                Err(AjisaiError::from("Modulo by zero"))
+            } else {
+                Ok(x.modulo(y))
+            }
+        },
+        Some(&mut interp.runtime_metrics),
+    );
 
     match result {
         Ok(r) => {

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -1,7 +1,28 @@
 use crate::error::{AjisaiError, Result};
+use crate::interpreter::interpreter_core::RuntimeMetrics;
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, Value, ValueData};
 use std::rc::Rc;
+
+#[inline]
+fn record_flatten(metrics: &mut Option<&mut RuntimeMetrics>, elements: usize) {
+    if let Some(m) = metrics.as_deref_mut() {
+        m.vtu_tensor_flatten_count = m.vtu_tensor_flatten_count.saturating_add(1);
+        m.vtu_tensor_flattened_elements = m
+            .vtu_tensor_flattened_elements
+            .saturating_add(elements as u64);
+    }
+}
+
+#[inline]
+fn record_rebuild(metrics: &mut Option<&mut RuntimeMetrics>, elements: usize) {
+    if let Some(m) = metrics.as_deref_mut() {
+        m.vtu_tensor_rebuild_count = m.vtu_tensor_rebuild_count.saturating_add(1);
+        m.vtu_tensor_rebuilt_elements = m
+            .vtu_tensor_rebuilt_elements
+            .saturating_add(elements as u64);
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct FlatTensor {
@@ -192,7 +213,18 @@ pub(crate) fn build_nested_value(data: &[Fraction], shape: &[usize]) -> Value {
     }
 }
 
-pub(crate) fn apply_binary_broadcast<F>(a: &Value, b: &Value, op: F) -> Result<Value>
+/// Metrics-aware tensor broadcast.
+///
+/// When `metrics` is `Some`, observational VTU counters are incremented at
+/// the points where work actually begins, so NIL-rejection and
+/// shape-mismatch errors do not bump them. Pass `None` to skip metrics
+/// accounting (e.g. internal helpers without access to an interpreter).
+pub(crate) fn apply_binary_broadcast_with_metrics<F>(
+    a: &Value,
+    b: &Value,
+    op: F,
+    mut metrics: Option<&mut RuntimeMetrics>,
+) -> Result<Value>
 where
     F: Fn(&Fraction, &Fraction) -> Result<Fraction> + Copy,
 {
@@ -201,7 +233,9 @@ where
     }
 
     let tensor_a = FlatTensor::from_value(a)?;
+    record_flatten(&mut metrics, tensor_a.data.len());
     let tensor_b = FlatTensor::from_value(b)?;
+    record_flatten(&mut metrics, tensor_b.data.len());
 
     let out_shape = broadcast_shape(&tensor_a.shape, &tensor_b.shape)?;
     let out_size: usize = if out_shape.is_empty() {
@@ -210,14 +244,27 @@ where
         out_shape.iter().product()
     };
 
+    if let Some(m) = metrics.as_deref_mut() {
+        m.vtu_broadcast_count = m.vtu_broadcast_count.saturating_add(1);
+        m.vtu_allocated_elements = m.vtu_allocated_elements.saturating_add(out_size as u64);
+    }
 
     if tensor_a.shape == tensor_b.shape {
+        if let Some(m) = metrics.as_deref_mut() {
+            m.vtu_same_shape_elementwise_count =
+                m.vtu_same_shape_elementwise_count.saturating_add(1);
+        }
         let mut out_data = Vec::with_capacity(out_size);
         for i in 0..out_size {
             out_data.push(op(&tensor_a.data[i], &tensor_b.data[i])?);
         }
         let out_tensor = FlatTensor::from_shape_and_data(out_shape, out_data)?;
+        record_rebuild(&mut metrics, out_tensor.data.len());
         return Ok(out_tensor.to_value());
+    }
+
+    if let Some(m) = metrics.as_deref_mut() {
+        m.vtu_projected_broadcast_count = m.vtu_projected_broadcast_count.saturating_add(1);
     }
 
     let out_strides = compute_strides(&out_shape);
@@ -236,17 +283,33 @@ where
     }
 
     let out_tensor = FlatTensor::from_shape_and_data(out_shape, out_data)?;
+    record_rebuild(&mut metrics, out_tensor.data.len());
     Ok(out_tensor.to_value())
 }
 
-pub(crate) fn apply_unary_flat<F>(val: &Value, op: F) -> Result<Value>
+/// Metrics-aware unary flat tensor operation. See
+/// [`apply_binary_broadcast_with_metrics`] for the metrics contract.
+pub(crate) fn apply_unary_flat_with_metrics<F>(
+    val: &Value,
+    op: F,
+    mut metrics: Option<&mut RuntimeMetrics>,
+) -> Result<Value>
 where
     F: Fn(&Fraction) -> Fraction,
 {
     let tensor = FlatTensor::from_value(val)?;
+    let element_count = tensor.data.len();
+    record_flatten(&mut metrics, element_count);
 
+    if let Some(m) = metrics.as_deref_mut() {
+        m.vtu_unary_flat_count = m.vtu_unary_flat_count.saturating_add(1);
+        m.vtu_allocated_elements = m
+            .vtu_allocated_elements
+            .saturating_add(element_count as u64);
+    }
 
     let result_data: Vec<Fraction> = tensor.data.into_iter().map(|f| op(&f)).collect();
     let result_tensor = FlatTensor::from_shape_and_data(tensor.shape, result_data)?;
+    record_rebuild(&mut metrics, result_tensor.data.len());
     Ok(result_tensor.to_value())
 }


### PR DESCRIPTION
## Summary

Adds an **observation-only** Virtual Tensor Unit (VTU) layer per the改修指示書. Pure, shape-aware blocks now carry a `VtuHint` describing suitability and candidate backends, and `RuntimeMetrics` gains 13 proxy counters for tensor flatten/rebuild, broadcast paths, SIMD use, and VTU candidacy.

**Crucially, no execution semantics, `Fraction` exactness, or evaluation order change.** VTU is deliberately kept out of `GuardSignature` so it can never invalidate caches. The counters are energy *proxies* (allocated_elements, flatten_count, etc.), not measurements.

### Validity check on the instruction

The instruction was sound; I implemented it as-written, with these small refinements:

- Removed the no-metrics `apply_binary_broadcast` / `apply_unary_flat` shims after switching all in-tree callers to the metrics-aware variants — the unused shims would have produced new clippy warnings.
- Added `#[allow(dead_code)]` to forward-looking enum variants (`NpuCandidate`, `GpuCandidate`, `TpuCandidate`, `DataMovementClass::High`) instead of leaving them as dead-code warnings.
- Kept `VtuHint::default()` returning `NotSuitable` (the safe-side default the instruction calls for).

### What changed

- New observational types in `quantized_block`: `VtuHint`, `VtuSuitability`, `VtuBackendCandidate`, `DataMovementClass`, plus `infer_vtu_hint(kernel_kind, purity)`.
- `apply_binary_broadcast_with_metrics` / `apply_unary_flat_with_metrics` thread `Option<&mut RuntimeMetrics>` so `arithmetic`, `logic`, and `tensor_cmds` can record counts without affecting results.
- SIMD fast paths in `arithmetic` bump `vtu_simd_kernel_use_count` on each successful use.
- `quantize_code_block` populates `vtu_hint` and bumps candidate/rejected/fusion-candidate counters at build time (not at use time, to avoid double-counting cache hits).
- 9 new tests in `quantized-block-tests.rs` covering default zeroing, hint inference per `KernelKind`, and counter increments for elementwise / projected-broadcast / unary-flat paths.
- New `docs/dev/virtual-tensor-unit-design.md` (non-canonical) explicitly stating that VTU is not a physical TPU and that counters are proxies, not joules.

### Acceptance criteria from the instruction

- [x] `cargo test --lib` passes (817/817).
- [x] No new clippy warnings (100 baseline → 100).
- [x] Existing metrics, examples, and `QuantizedBlock` build behavior unchanged.
- [x] `vtu_hint` is observational only; not in `GuardSignature`.
- [x] Doc clearly states VTU ≠ physical TPU and counters ≠ real energy.

## Test plan

- [x] `cargo test --manifest-path rust/Cargo.toml --lib` — 817 passed.
- [x] `cargo clippy --tests` — no new warnings introduced.
- [ ] Watch CI on the PR.

https://claude.ai/code/session_01YUHPjVopuyXbtzq3reS2gq

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUHPjVopuyXbtzq3reS2gq)_