### PR TITLE
VTU Phase II PR #1: Add ValueData::Tensor variant (read-side)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -142,6 +142,19 @@ Numeric display is guided by the semantic plane (see Section 12) and does not af
 
 An ordered, indexable sequence of values. Vectors may be nested (tensor-like). Index base is 0. Negative indices count from the end: `-1` is the last element.
 
+#### 4.3.1 Internal representation classes
+
+A Vector value is internally represented in one of two classes:
+
+- **nested** — a tree of `Value` elements (`Vec<Value>`). Any element type may appear, including mixed types (Scalars, Vectors, Strings, NIL, etc.).
+- **dense** — a flat buffer of Fractions plus a `shape` (`Vec<Fraction>` + `Vec<usize>`). Every leaf is a Fraction; the shape encodes a (possibly multi-dimensional) rectangular structure.
+
+The class is chosen at construction time. Observable semantics — `Display`, ordering, equality, NIL-ness, `SHAPE`, `LENGTH`, indexing, iteration order — are identical between the two classes. Operations are free to take a fast path when the input is dense.
+
+Equality across classes: a dense Vector and a nested Vector compare equal when (1) flattening the nested Vector into its leaf Fractions yields the same sequence as the dense buffer, and (2) the shape inferred from the nested Vector matches the dense Vector's shape. No language-visible word distinguishes the two classes; they are interchangeable from the user's perspective.
+
+This dual representation exists for the Virtual Tensor Unit (VTU) data-movement optimizations (see `docs/dev/virtual-tensor-unit-design.md`). It does not introduce approximate numeric types: all numeric leaves remain exact Fractions.
+
 ### 4.4 Record
 
 A collection of named fields. Each field has a string key and an associated value. Field insertion order is preserved.

--- a/docs/dev/virtual-tensor-unit-design.md
+++ b/docs/dev/virtual-tensor-unit-design.md
@@ -94,13 +94,33 @@ These are observational only: they describe what shape-aware work the
 runtime did, not what it cost in energy. The names deliberately avoid
 verbs like `energy_saved`.
 
+## Phase II — Dense Vector representation (in progress)
+
+Phase II is now under way. See `docs/dev/vtu-phase-ii-handover.md` for the
+multi-PR plan. The first concrete change is a parallel `Tensor` variant
+on `ValueData`:
+
+- `Vector(Rc<Vec<Value>>)` remains the **nested** form — used for mixed-type
+  vectors and any tree-shaped data.
+- `Tensor { data: Rc<Vec<Fraction>>, shape: Rc<Vec<usize>> }` is the new
+  **dense** form — used when every leaf is a Fraction and the shape is
+  rectangular.
+
+Observable semantics are identical between the two; classification is a
+construction-time decision. PR #1 (this work) only adds the variant and
+makes every consumer match-exhaustive against it. No producer is wired yet,
+so the existing test suite is unchanged. PR #2 will switch the literal
+parser and `apply_*_with_metrics` outputs over to `Tensor`, at which point
+`vtu_tensor_rebuild_count` should drop sharply.
+
 ## Future scope (not implemented)
 
 - `ajisai trace --vtu` / `ajisai trace --energy` displays.
 - `ajisai explain --vtu <word>` per-word classification dump.
-- Fusion-candidate detection across consecutive elementwise ops.
-- Safe-by-construction fusion execution.
-- `ExecutionValue::FlatTensor` / `TensorView` to defer rebuild.
+- Plan-level fusion execution (Phase II PR #4).
+- In-place mutation of dense `Tensor.data` (Phase II PR #5).
+- Pure-plan result memoisation keyed on Fraction digests (Phase II PR #6).
+- Integer-Fraction SIMD extension for `MAP` / `FILTER` kernels (Phase II PR #7).
 - An explicit `EXACT` / `APPROX` boundary (e.g. `TO-F32`, `TO-BF16`)
   before any approximate backend may run.
 - StableHLO / MLIR-style textual dump.

--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -18,6 +18,8 @@ fn extract_scalar_from_value(val: &Value) -> Option<&Fraction> {
             extract_scalar_from_value(&children[0])
         }
         ValueData::Vector(_) => None,
+        ValueData::Tensor { data, .. } if data.len() == 1 => Some(&data[0]),
+        ValueData::Tensor { .. } => None,
         ValueData::Nil => None,
         ValueData::Record { .. } => None,
         ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {

--- a/rust/src/interpreter/cast-value-helpers.rs
+++ b/rust/src/interpreter/cast-value-helpers.rs
@@ -21,6 +21,21 @@ pub(crate) fn is_string_value_with_hint(val: &Value, hint: DisplayHint) -> bool 
     let children: &Vec<Value> = match &val.data {
         ValueData::Vector(v) if !v.is_empty() => v,
         ValueData::Vector(_) => return false,
+        ValueData::Tensor { data, .. } => {
+            if data.is_empty() {
+                return false;
+            }
+            return data.iter().all(|f| {
+                let n: i64 = match f.to_i64() {
+                    Some(n) if (0..=0x10FFFF).contains(&n) => n,
+                    _ => return false,
+                };
+                match char::from_u32(n as u32) {
+                    Some(c) => !c.is_control() || c == '\n' || c == '\r' || c == '\t',
+                    None => false,
+                }
+            });
+        }
         ValueData::Scalar(_) => return false,
         ValueData::Nil => return false,
         ValueData::Record { .. } => return false,
@@ -35,6 +50,7 @@ fn check_char_scalar(child: &Value) -> bool {
     let f: &Fraction = match &child.data {
         ValueData::Scalar(f) => f,
         ValueData::Vector(_) => return false,
+        ValueData::Tensor { .. } => return false,
         ValueData::Nil => return false,
         ValueData::Record { .. } => return false,
         ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
@@ -200,6 +216,9 @@ pub(crate) fn format_value_to_string_repr_with_hint(
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_fractions(c)).collect(),
+            ValueData::Tensor { data, .. } => {
+                data.iter().map(format_fraction_to_string).collect()
+            }
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => vec!["<code>".to_string()],

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -30,6 +30,15 @@ fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
             }
             Ok(tensor.data[0].clone())
         }
+        ValueData::Tensor { data, .. } => {
+            if data.len() != 1 {
+                return Err(AjisaiError::create_structure_error(
+                    "scalar value",
+                    "non-scalar value",
+                ));
+            }
+            Ok(data[0].clone())
+        }
         ValueData::Nil => Err(AjisaiError::create_structure_error(
             "scalar value",
             "non-scalar value",

--- a/rust/src/interpreter/execute-def.rs
+++ b/rust/src/interpreter/execute-def.rs
@@ -25,6 +25,18 @@ fn extract_string_from_value(val: &Value) -> Result<String> {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_chars(c)).collect(),
+            ValueData::Tensor { data, .. } => data
+                .iter()
+                .filter_map(|f| {
+                    f.to_i64().and_then(|n| {
+                        if (0..=0x10FFFF).contains(&n) {
+                            char::from_u32(n as u32)
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect(),
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => vec![],
@@ -52,6 +64,9 @@ fn is_string_like(val: &Value) -> bool {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().all(|c| check_codepoints(c)),
+            ValueData::Tensor { data, .. } => data
+                .iter()
+                .all(|f| f.to_i64().map(|n| (0..=0x10FFFF).contains(&n)).unwrap_or(false)),
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => false,

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -20,6 +20,7 @@ fn check_value_has_truthy(val: &Value) -> bool {
                 false
             }
         }
+        ValueData::Tensor { data, .. } => data.iter().any(|f| !f.is_zero()),
     }
 }
 

--- a/rust/src/interpreter/simd-vector-operations.rs
+++ b/rust/src/interpreter/simd-vector-operations.rs
@@ -5,6 +5,22 @@ const SIMD_THRESHOLD: usize = 8;
 pub fn extract_integer_vector(val: &Value) -> Option<Vec<i64>> {
     let children: &Vec<Value> = match &val.data {
         ValueData::Vector(v) => v,
+        ValueData::Tensor { data, shape } => {
+            if shape.len() != 1 || data.len() < SIMD_THRESHOLD {
+                return None;
+            }
+            let mut result: Vec<i64> = Vec::with_capacity(data.len());
+            for f in data.iter() {
+                if !f.is_integer() {
+                    return None;
+                }
+                match f.to_i64() {
+                    Some(n) => result.push(n),
+                    None => return None,
+                }
+            }
+            return Some(result);
+        }
         ValueData::Scalar(_)
         | ValueData::Record { .. }
         | ValueData::Nil
@@ -24,6 +40,7 @@ pub fn extract_integer_vector(val: &Value) -> Option<Vec<i64>> {
             },
             ValueData::Scalar(_)
             | ValueData::Vector(_)
+            | ValueData::Tensor { .. }
             | ValueData::Record { .. }
             | ValueData::Nil
             | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
@@ -42,6 +59,7 @@ fn extract_integer_scalar(value: &Value) -> Option<i64> {
         ValueData::Scalar(f) if f.is_integer() => f.to_i64(),
         ValueData::Scalar(_)
         | ValueData::Vector(_)
+        | ValueData::Tensor { .. }
         | ValueData::Record { .. }
         | ValueData::Nil
         | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,

--- a/rust/src/interpreter/sort.rs
+++ b/rust/src/interpreter/sort.rs
@@ -28,12 +28,29 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                 interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
             };
 
-            let children = match &val.data {
-                ValueData::Vector(children) => children,
-                ValueData::Record {
-                    pairs: children, ..
-                } => children,
-                ValueData::Scalar(_) | ValueData::Nil | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            let materialized_children: Option<Vec<Value>> = match &val.data {
+                ValueData::Tensor { data, .. } => Some(
+                    data.iter().map(|f| Value::from_fraction(f.clone())).collect(),
+                ),
+                _ => None,
+            };
+            let children: &Vec<Value> = match (&val.data, &materialized_children) {
+                (_, Some(v)) => v,
+                (ValueData::Vector(children), _) => children,
+                (
+                    ValueData::Record {
+                        pairs: children, ..
+                    },
+                    _,
+                ) => children,
+                (
+                    ValueData::Scalar(_)
+                    | ValueData::Nil
+                    | ValueData::CodeBlock(_)
+                    | ValueData::ProcessHandle(_)
+                    | ValueData::SupervisorHandle(_),
+                    _,
+                ) => {
                     if !is_keep_mode {
                         interp.stack.push(val);
                     }
@@ -42,6 +59,7 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                         "other format",
                     ));
                 }
+                (ValueData::Tensor { .. }, _) => unreachable!(),
             };
 
             if children.is_empty() {

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -54,6 +54,15 @@ impl FlatTensor {
                     strides,
                 })
             }
+            ValueData::Tensor { data, shape } => {
+                let shape_vec: Vec<usize> = (**shape).clone();
+                let strides: Vec<usize> = compute_strides(&shape_vec);
+                Ok(Self {
+                    data: (**data).clone(),
+                    shape: shape_vec,
+                    strides,
+                })
+            }
             ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::from(
                 "Tensor conversion requires scalar or vector",
             )),

--- a/rust/src/interpreter/value-extraction-helpers.rs
+++ b/rust/src/interpreter/value-extraction-helpers.rs
@@ -35,6 +35,18 @@ pub(crate) fn value_as_string(val: &Value) -> Option<String> {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().flat_map(|c| collect_chars(c)).collect(),
+            ValueData::Tensor { data, .. } => data
+                .iter()
+                .filter_map(|f| {
+                    f.to_i64().and_then(|n| {
+                        if (0..=0x10FFFF).contains(&n) {
+                            char::from_u32(n as u32)
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect(),
             ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => vec![],
         }
     }
@@ -67,6 +79,19 @@ fn extract_integer_bigint(value: &Value) -> Result<BigInt> {
             "single-element value with integer",
             "multi-element vector",
         )),
+        ValueData::Tensor { data, .. } => {
+            if data.len() == 1 {
+                if !data[0].is_integer() {
+                    return Err(AjisaiError::create_structure_error("integer", "fraction"));
+                }
+                Ok(data[0].numerator())
+            } else {
+                Err(AjisaiError::create_structure_error(
+                    "single-element value with integer",
+                    "multi-element vector",
+                ))
+            }
+        }
         ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::create_structure_error(
             "single-element value with integer",
             "code block",

--- a/rust/src/interpreter/vector-execution-operations.rs
+++ b/rust/src/interpreter/vector-execution-operations.rs
@@ -58,6 +58,52 @@ fn format_value_to_source_inner(val: &Value, depth: usize) -> Result<String> {
                 Ok(joined)
             }
         }
+        ValueData::Tensor { data, shape } => {
+            format_tensor_to_source(data, shape, depth)
+        }
+    }
+}
+
+fn format_tensor_to_source(
+    data: &[crate::types::fraction::Fraction],
+    shape: &[usize],
+    depth: usize,
+) -> Result<String> {
+    if shape.is_empty() || shape.len() == 1 {
+        let inner: Vec<String> = data
+            .iter()
+            .map(|f| {
+                if f.is_integer() {
+                    format!("{}", f.numerator())
+                } else {
+                    format!("{}/{}", f.numerator(), f.denominator())
+                }
+            })
+            .collect();
+        let joined = inner.join(" ");
+        if depth > 0 {
+            Ok(format!("[ {} ]", joined))
+        } else {
+            Ok(joined)
+        }
+    } else {
+        let outer = shape[0];
+        let rest = &shape[1..];
+        let stride: usize = rest.iter().product();
+        let mut parts: Vec<String> = Vec::with_capacity(outer);
+        for i in 0..outer {
+            parts.push(format_tensor_to_source(
+                &data[i * stride..(i + 1) * stride],
+                rest,
+                depth + 1,
+            )?);
+        }
+        let joined = parts.join(" ");
+        if depth > 0 {
+            Ok(format!("[ {} ]", joined))
+        } else {
+            Ok(joined)
+        }
     }
 }
 

--- a/rust/src/types/arena.rs
+++ b/rust/src/types/arena.rs
@@ -14,6 +14,10 @@ pub enum NodeKind {
     Vector {
         children: Vec<NodeId>,
     },
+    Tensor {
+        data: Vec<Fraction>,
+        shape: Vec<usize>,
+    },
     Record {
         pairs: Vec<NodeId>,
         index: HashMap<String, usize>,
@@ -47,6 +51,15 @@ impl ValueArena {
 
     pub fn alloc_vector(&mut self, children: Vec<NodeId>, hint: DisplayHint) -> NodeId {
         self.alloc_node(NodeKind::Vector { children }, hint)
+    }
+
+    pub fn alloc_tensor(
+        &mut self,
+        data: Vec<Fraction>,
+        shape: Vec<usize>,
+        hint: DisplayHint,
+    ) -> NodeId {
+        self.alloc_node(NodeKind::Tensor { data, shape }, hint)
     }
 
     pub fn alloc_record(
@@ -90,7 +103,12 @@ impl ValueArena {
         match self.kind(id) {
             NodeKind::Vector { children } => children.as_slice(),
             NodeKind::Record { pairs, .. } => pairs.as_slice(),
-            _ => &[],
+            NodeKind::Tensor { .. }
+            | NodeKind::Nil
+            | NodeKind::Scalar(_)
+            | NodeKind::CodeBlock(_)
+            | NodeKind::ProcessHandle(_)
+            | NodeKind::SupervisorHandle(_) => &[],
         }
     }
 }
@@ -107,6 +125,11 @@ pub fn value_to_arena(root: &Value) -> (ValueArena, NodeId) {
                     .collect();
                 arena.alloc_vector(child_ids, value.hint)
             }
+            ValueData::Tensor { data, shape } => arena.alloc_tensor(
+                (**data).clone(),
+                (**shape).clone(),
+                value.hint,
+            ),
             ValueData::Record { pairs, index } => {
                 let pair_ids = pairs
                     .iter()
@@ -158,6 +181,14 @@ pub fn arena_to_value(arena: &ValueArena, root: NodeId) -> Value {
                     nil_reason: None,
                 }
             }
+            NodeKind::Tensor { data, shape } => Value {
+                data: ValueData::Tensor {
+                    data: Rc::new(data.clone()),
+                    shape: Rc::new(shape.clone()),
+                },
+                hint: arena.hint(id),
+                nil_reason: None,
+            },
             NodeKind::Record { pairs, index } => {
                 let values = pairs
                     .iter()
@@ -281,6 +312,9 @@ pub fn arena_node_to_json(arena: &ValueArena, root: NodeId) -> JsonValue {
                 .collect();
             JsonValue::Array(arr)
         }
+        NodeKind::Tensor { data, shape } => {
+            tensor_to_json(arena.hint(root), data, shape)
+        }
         NodeKind::Record { pairs, .. } => {
             let mut map = serde_json::Map::new();
             for pair_id in pairs {
@@ -303,6 +337,49 @@ pub fn arena_node_to_json(arena: &ValueArena, root: NodeId) -> JsonValue {
             JsonValue::Null
         }
     }
+}
+
+fn fraction_to_json(frac: &Fraction) -> JsonValue {
+    if frac.is_integer() {
+        if let Some(int_val) = frac.to_i64() {
+            return JsonValue::Number(serde_json::Number::from(int_val));
+        }
+    }
+    let pair = frac.numerator().to_f64().zip(frac.denominator().to_f64());
+    if let Some((n, d)) = pair {
+        if let Some(num) = serde_json::Number::from_f64(n / d) {
+            return JsonValue::Number(num);
+        }
+    }
+    JsonValue::Null
+}
+
+fn tensor_to_json(hint: DisplayHint, data: &[Fraction], shape: &[usize]) -> JsonValue {
+    if hint == DisplayHint::String && (shape.is_empty() || shape.len() == 1) {
+        let mut buf = String::new();
+        for codepoint in data {
+            if let Some(n) = codepoint.to_i64() {
+                if let Some(ch) = char::from_u32(n as u32) {
+                    buf.push(ch);
+                }
+            }
+        }
+        return JsonValue::String(buf);
+    }
+    if shape.is_empty() || shape.len() == 1 {
+        let arr = data.iter().map(fraction_to_json).collect();
+        return JsonValue::Array(arr);
+    }
+    let outer = shape[0];
+    let rest = &shape[1..];
+    let stride: usize = rest.iter().product();
+    if outer == 0 || stride == 0 {
+        return JsonValue::Array(Vec::new());
+    }
+    let arr = (0..outer)
+        .map(|i| tensor_to_json(hint, &data[i * stride..(i + 1) * stride], rest))
+        .collect();
+    JsonValue::Array(arr)
 }
 
 #[cfg(test)]
@@ -434,5 +511,34 @@ mod tests {
         let mut arena = ValueArena::new();
         let root = arena.alloc_string("AB");
         assert_eq!(arena.hint(root), DisplayHint::String);
+    }
+
+    #[test]
+    fn tensor_roundtrip_through_arena_preserves_dense_form() {
+        use crate::types::Value;
+
+        let value = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![2, 2],
+        );
+        let (arena, root) = value_to_arena(&value);
+        assert!(matches!(arena.kind(root), NodeKind::Tensor { .. }));
+        let rebuilt = arena_to_value(&arena, root);
+        assert_eq!(rebuilt, value);
+        assert!(rebuilt.is_tensor());
+    }
+
+    #[test]
+    fn tensor_arena_node_to_json_emits_nested_array() {
+        use crate::types::Value;
+
+        let value = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![2, 2],
+        );
+        let (arena, root) = value_to_arena(&value);
+        let json = arena_node_to_json(&arena, root);
+        let expected = serde_json::json!([[1, 2], [3, 4]]);
+        assert_eq!(json, expected);
     }
 }

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -39,6 +39,11 @@ fn format_as_interval(value: &Value) -> String {
             };
             format!("[{}, {}]", lo, hi)
         }
+        ValueData::Tensor { data, shape }
+            if shape.as_slice() == [2] && data.len() == 2 =>
+        {
+            format!("[{}, {}]", format_fraction(&data[0]), format_fraction(&data[1]))
+        }
         _ => format_value_recursive(&value.data, 0),
     }
 }
@@ -54,6 +59,7 @@ fn format_value_auto(value: &Value) -> String {
             }
             format_value_recursive(&value.data, 0)
         }
+        ValueData::Tensor { .. } => format_value_recursive(&value.data, 0),
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
         ValueData::ProcessHandle(id) => format!("<process:{}>", id),
         ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
@@ -105,10 +111,36 @@ fn format_value_recursive(data: &ValueData, depth: usize) -> String {
 
             format!("{} {} {}", open, inner.join(" "), close)
         }
+        ValueData::Tensor { data, shape } => {
+            format_tensor_recursive(data, shape, depth)
+        }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
         ValueData::ProcessHandle(id) => format!("<process:{}>", id),
         ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
+}
+
+fn format_tensor_recursive(data: &[Fraction], shape: &[usize], _depth: usize) -> String {
+    if shape.is_empty() {
+        return "[ ]".to_string();
+    }
+    if shape.len() == 1 {
+        if data.is_empty() {
+            return "[ ]".to_string();
+        }
+        let inner: Vec<String> = data.iter().map(format_fraction).collect();
+        return format!("[ {} ]", inner.join(" "));
+    }
+    let outer = shape[0];
+    let rest = &shape[1..];
+    let stride: usize = rest.iter().product();
+    if outer == 0 || stride == 0 {
+        return "[ ]".to_string();
+    }
+    let inner: Vec<String> = (0..outer)
+        .map(|i| format_tensor_recursive(&data[i * stride..(i + 1) * stride], rest, _depth + 1))
+        .collect();
+    format!("[ {} ]", inner.join(" "))
 }
 
 fn format_code_block(tokens: &[super::Token]) -> String {
@@ -181,6 +213,24 @@ fn format_as_string(data: &ValueData) -> String {
 
             format!("'{}'", chars)
         }
+        ValueData::Tensor { data, .. } => {
+            if data.is_empty() {
+                return "''".to_string();
+            }
+            let chars: String = data
+                .iter()
+                .filter_map(|f| {
+                    f.to_i64().and_then(|n| {
+                        if n >= 0 && n <= 0x10FFFF {
+                            char::from_u32(n as u32)
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .collect();
+            format!("'{}'", chars)
+        }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
         ValueData::ProcessHandle(id) => format!("<process:{}>", id),
         ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
@@ -229,8 +279,33 @@ fn format_as_boolean(data: &ValueData) -> String {
                             "TRUE"
                         }
                     }
+                    ValueData::Tensor { data, .. } => {
+                        if data.is_empty() {
+                            "FALSE"
+                        } else {
+                            "TRUE"
+                        }
+                    }
                     ValueData::CodeBlock(_) => "TRUE",
                     ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => "TRUE",
+                })
+                .collect();
+            format!("{{ {} }}", inner.join(" "))
+        }
+        ValueData::Tensor { data, .. } => {
+            if data.is_empty() {
+                return "FALSE".to_string();
+            }
+            let inner: Vec<&str> = data
+                .iter()
+                .map(|f| {
+                    if f.is_nil() {
+                        "NIL"
+                    } else if f.is_zero() {
+                        "FALSE"
+                    } else {
+                        "TRUE"
+                    }
                 })
                 .collect();
             format!("{{ {} }}", inner.join(" "))
@@ -251,7 +326,9 @@ fn format_as_datetime(data: &ValueData) -> String {
                 format!("@{}/{}", f.numerator(), f.denominator())
             }
         }
-        ValueData::Vector(_) | ValueData::Record { .. } => format_value_recursive(data, 0),
+        ValueData::Vector(_)
+        | ValueData::Tensor { .. }
+        | ValueData::Record { .. } => format_value_recursive(data, 0),
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
         ValueData::ProcessHandle(id) => format!("<process:{}>", id),
         ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),

--- a/rust/src/types/flow-token.rs
+++ b/rust/src/types/flow-token.rs
@@ -51,6 +51,16 @@ impl FlowToken {
                 }
                 acc
             }
+            ValueData::Tensor { data, .. } => {
+                let mut acc = Fraction::from(0);
+                for f in data.iter() {
+                    if f.is_nil() {
+                        continue;
+                    }
+                    acc = acc.add(&f.abs());
+                }
+                acc
+            }
             ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Fraction::from(0),
         }
     }

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -45,10 +45,14 @@ pub enum DisplayHint {
     Nil,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum ValueData {
     Scalar(Fraction),
     Vector(Rc<Vec<Value>>),
+    Tensor {
+        data: Rc<Vec<self::fraction::Fraction>>,
+        shape: Rc<Vec<usize>>,
+    },
     Record {
         pairs: Rc<Vec<Value>>,
         index: HashMap<String, usize>,
@@ -57,6 +61,96 @@ pub enum ValueData {
     CodeBlock(Vec<Token>),
     ProcessHandle(u64),
     SupervisorHandle(u64),
+}
+
+impl PartialEq for ValueData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ValueData::Scalar(a), ValueData::Scalar(b)) => a == b,
+            (ValueData::Vector(a), ValueData::Vector(b)) => a == b,
+            (
+                ValueData::Tensor { data: a_data, shape: a_shape },
+                ValueData::Tensor { data: b_data, shape: b_shape },
+            ) => a_data == b_data && a_shape == b_shape,
+            (
+                ValueData::Vector(v),
+                ValueData::Tensor { data, shape },
+            )
+            | (
+                ValueData::Tensor { data, shape },
+                ValueData::Vector(v),
+            ) => tensor_eq_vector(data, shape, v),
+            (
+                ValueData::Record { pairs: ap, index: ai },
+                ValueData::Record { pairs: bp, index: bi },
+            ) => ap == bp && ai == bi,
+            (ValueData::Nil, ValueData::Nil) => true,
+            (ValueData::CodeBlock(a), ValueData::CodeBlock(b)) => a == b,
+            (ValueData::ProcessHandle(a), ValueData::ProcessHandle(b)) => a == b,
+            (ValueData::SupervisorHandle(a), ValueData::SupervisorHandle(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+fn tensor_eq_vector(
+    data: &[self::fraction::Fraction],
+    shape: &[usize],
+    v: &[Value],
+) -> bool {
+    let nested_shape = nested_vector_shape(v);
+    if nested_shape != shape {
+        return false;
+    }
+    let mut idx = 0usize;
+    nested_flatten_matches(v, data, &mut idx) && idx == data.len()
+}
+
+fn nested_vector_shape(v: &[Value]) -> Vec<usize> {
+    if v.is_empty() {
+        return vec![0];
+    }
+    let first_shape = v[0].shape();
+    let all_same = v.iter().skip(1).all(|c| c.shape() == first_shape);
+    if all_same && !first_shape.is_empty() {
+        let mut s = vec![v.len()];
+        s.extend(first_shape);
+        s
+    } else {
+        vec![v.len()]
+    }
+}
+
+fn nested_flatten_matches(
+    v: &[Value],
+    data: &[self::fraction::Fraction],
+    idx: &mut usize,
+) -> bool {
+    for child in v {
+        match &child.data {
+            ValueData::Scalar(f) => {
+                if *idx >= data.len() || data[*idx] != *f {
+                    return false;
+                }
+                *idx += 1;
+            }
+            ValueData::Vector(inner) => {
+                if !nested_flatten_matches(inner, data, idx) {
+                    return false;
+                }
+            }
+            ValueData::Tensor { data: inner_data, .. } => {
+                for f in inner_data.iter() {
+                    if *idx >= data.len() || data[*idx] != *f {
+                        return false;
+                    }
+                    *idx += 1;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
 }
 
 #[derive(Debug, Clone)]

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -152,7 +152,15 @@ impl Value {
 
     #[inline]
     pub fn is_vector(&self) -> bool {
-        matches!(self.data, ValueData::Vector(_) | ValueData::Record { .. })
+        matches!(
+            self.data,
+            ValueData::Vector(_) | ValueData::Tensor { .. } | ValueData::Record { .. }
+        )
+    }
+
+    #[inline]
+    pub fn is_tensor(&self) -> bool {
+        matches!(self.data, ValueData::Tensor { .. })
     }
 
     #[inline]
@@ -160,6 +168,9 @@ impl Value {
         match &self.data {
             ValueData::Scalar(_) | ValueData::Nil => true,
             ValueData::Vector(rc) => Rc::strong_count(rc) == 1,
+            ValueData::Tensor { data, shape } => {
+                Rc::strong_count(data) == 1 && Rc::strong_count(shape) == 1
+            }
             ValueData::Record { pairs, .. } => Rc::strong_count(pairs) == 1,
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -175,6 +186,9 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 !v.is_empty() && !v.iter().all(|c| !c.is_truthy())
             }
+            ValueData::Tensor { data, .. } => {
+                !data.is_empty() && !data.iter().all(|f| f.is_zero() || f.is_nil())
+            }
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => true,
@@ -187,6 +201,13 @@ impl Value {
             ValueData::Nil => 0,
             ValueData::Scalar(_) => 1,
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.len(),
+            ValueData::Tensor { data, shape } => {
+                if shape.is_empty() {
+                    data.len()
+                } else {
+                    shape[0]
+                }
+            }
             ValueData::CodeBlock(tokens) => tokens.len(),
             ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => 1,
         }
@@ -200,6 +221,7 @@ impl Value {
     pub fn get_child(&self, index: usize) -> Option<&Value> {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.get(index),
+            ValueData::Tensor { .. } => None,
             ValueData::Scalar(_) if index == 0 => Some(self),
             ValueData::Scalar(_)
             | ValueData::Nil
@@ -210,11 +232,15 @@ impl Value {
     }
 
     pub fn get_child_mut(&mut self, index: usize) -> Option<&mut Value> {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 Rc::make_mut(v).get_mut(index)
             }
-            ValueData::Scalar(_)
+            ValueData::Tensor { .. }
+            | ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -231,6 +257,7 @@ impl Value {
     pub fn last(&self) -> Option<&Value> {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.last(),
+            ValueData::Tensor { .. } => None,
             ValueData::Scalar(_) => Some(self),
             ValueData::Nil => None,
             ValueData::CodeBlock(_)
@@ -239,7 +266,21 @@ impl Value {
         }
     }
 
+    /// Convert a `ValueData::Tensor` in-place to a nested `ValueData::Vector`
+    /// so that mutating helpers (push/pop/insert/remove/replace) can operate
+    /// on a uniform `Vec<Value>` representation.
+    fn hydrate_tensor_to_vector(&mut self) {
+        let ValueData::Tensor { data, shape } = &self.data else {
+            return;
+        };
+        let children = tensor_to_nested_values(data, shape);
+        self.data = ValueData::Vector(Rc::new(children));
+    }
+
     pub fn push_child(&mut self, child: Value) {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 Rc::make_mut(v).push(child);
@@ -251,16 +292,21 @@ impl Value {
                 let old = Value::from_fraction(f.clone());
                 self.data = ValueData::Vector(Rc::new(vec![old, child]));
             }
-            ValueData::CodeBlock(_)
+            ValueData::Tensor { .. }
+            | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => {}
         }
     }
 
     pub fn pop_child(&mut self) -> Option<Value> {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v).pop(),
-            ValueData::Scalar(_)
+            ValueData::Tensor { .. }
+            | ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -269,9 +315,13 @@ impl Value {
     }
 
     pub fn insert_child(&mut self, index: usize, child: Value) {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_)
+            ValueData::Tensor { .. }
+            | ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -283,9 +333,13 @@ impl Value {
     }
 
     pub fn remove_child(&mut self, index: usize) -> Option<Value> {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_)
+            ValueData::Tensor { .. }
+            | ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -299,9 +353,13 @@ impl Value {
     }
 
     pub fn replace_child(&mut self, index: usize, child: Value) -> Option<Value> {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         let v: &mut Vec<Value> = match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Rc::make_mut(v),
-            ValueData::Scalar(_)
+            ValueData::Tensor { .. }
+            | ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -319,6 +377,7 @@ impl Value {
         match &self.data {
             ValueData::Scalar(f) => Some(f),
             ValueData::Vector(_)
+            | ValueData::Tensor { .. }
             | ValueData::Record { .. }
             | ValueData::Nil
             | ValueData::CodeBlock(_)
@@ -332,6 +391,7 @@ impl Value {
         match &mut self.data {
             ValueData::Scalar(f) => Some(f),
             ValueData::Vector(_)
+            | ValueData::Tensor { .. }
             | ValueData::Record { .. }
             | ValueData::Nil
             | ValueData::CodeBlock(_)
@@ -354,6 +414,7 @@ impl Value {
     pub fn as_vector(&self) -> Option<&Vec<Value>> {
         match &self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Some(v),
+            ValueData::Tensor { .. } => None,
             ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
@@ -364,9 +425,13 @@ impl Value {
 
     #[inline]
     pub fn as_vector_mut(&mut self) -> Option<&mut Vec<Value>> {
+        if matches!(self.data, ValueData::Tensor { .. }) {
+            self.hydrate_tensor_to_vector();
+        }
         match &mut self.data {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => Some(Rc::make_mut(v)),
-            ValueData::Scalar(_)
+            ValueData::Tensor { .. }
+            | ValueData::Scalar(_)
             | ValueData::Nil
             | ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
@@ -389,6 +454,9 @@ impl Value {
                     child.collect_fractions_flat_into(buf);
                 }
             }
+            ValueData::Tensor { data, .. } => {
+                buf.extend(data.iter().cloned());
+            }
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => {}
@@ -402,6 +470,7 @@ impl Value {
             ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
                 v.iter().map(|c| c.count_fractions()).sum()
             }
+            ValueData::Tensor { data, .. } => data.len(),
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => 0,
@@ -427,6 +496,7 @@ impl Value {
                     }
                 }
             }
+            ValueData::Tensor { shape, .. } => (**shape).clone(),
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => vec![],
@@ -481,10 +551,120 @@ impl Value {
         match &self.data {
             ValueData::Nil => DisplayHint::Nil,
             ValueData::Scalar(_) => DisplayHint::Number,
-            ValueData::Vector(_) | ValueData::Record { .. } => DisplayHint::Auto,
+            ValueData::Vector(_) | ValueData::Tensor { .. } | ValueData::Record { .. } => {
+                DisplayHint::Auto
+            }
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)
             | ValueData::SupervisorHandle(_) => DisplayHint::Auto,
         }
+    }
+
+    /// Construct a dense `Tensor` value. `data.len()` must equal the product of
+    /// `shape` (or `shape` may be empty for a flat 1-D buffer; in that case
+    /// `[data.len()]` is used).
+    pub fn from_tensor(data: Vec<Fraction>, shape: Vec<usize>) -> Self {
+        if data.is_empty() {
+            return Self::nil_with_reason(NilReason::EmptySequence);
+        }
+        let resolved_shape = if shape.is_empty() {
+            vec![data.len()]
+        } else {
+            shape
+        };
+        Self {
+            data: ValueData::Tensor {
+                data: Rc::new(data),
+                shape: Rc::new(resolved_shape),
+            },
+            hint: DisplayHint::Auto,
+            nil_reason: None,
+        }
+    }
+}
+
+/// Materialize a dense Tensor (`data` + `shape`) as a tree of nested `Value`s.
+/// Used by mutating helpers that need a uniform `Vec<Value>` representation,
+/// and by display fallbacks.
+pub(super) fn tensor_to_nested_values(
+    data: &[Fraction],
+    shape: &[usize],
+) -> Vec<Value> {
+    if shape.is_empty() {
+        return data.iter().map(|f| Value::from_fraction(f.clone())).collect();
+    }
+    if shape.len() == 1 {
+        return data.iter().map(|f| Value::from_fraction(f.clone())).collect();
+    }
+    let outer = shape[0];
+    let rest = &shape[1..];
+    let stride: usize = rest.iter().product();
+    let mut out = Vec::with_capacity(outer);
+    for i in 0..outer {
+        let slice = &data[i * stride..(i + 1) * stride];
+        let inner = tensor_to_nested_values(slice, rest);
+        out.push(Value::from_children(inner));
+    }
+    out
+}
+
+#[cfg(test)]
+mod vtu_tensor_tests {
+    use super::*;
+
+    #[test]
+    fn tensor_and_nested_vector_compare_equal_when_flatten_matches() {
+        let dense = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![2, 2],
+        );
+        let nested = Value::from_children(vec![
+            Value::from_children(vec![Value::from_int(1), Value::from_int(2)]),
+            Value::from_children(vec![Value::from_int(3), Value::from_int(4)]),
+        ]);
+        assert_eq!(dense.data, nested.data);
+        assert_eq!(nested.data, dense.data);
+    }
+
+    #[test]
+    fn tensor_shape_matches_nested_shape() {
+        let dense = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![2, 2],
+        );
+        assert_eq!(dense.shape(), vec![2, 2]);
+        assert_eq!(dense.count_fractions(), 4);
+        assert_eq!(dense.collect_fractions_flat().len(), 4);
+    }
+
+    #[test]
+    fn tensor_with_different_shape_compares_unequal_to_nested() {
+        let dense = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![4],
+        );
+        let nested = Value::from_children(vec![
+            Value::from_children(vec![Value::from_int(1), Value::from_int(2)]),
+            Value::from_children(vec![Value::from_int(3), Value::from_int(4)]),
+        ]);
+        assert_ne!(dense.data, nested.data);
+    }
+
+    #[test]
+    fn tensor_is_vector_predicate_holds() {
+        let dense = Value::from_tensor(vec![Fraction::from(1)], vec![1]);
+        assert!(dense.is_vector());
+        assert!(dense.is_tensor());
+    }
+
+    #[test]
+    fn tensor_hydrates_to_vector_on_push_child() {
+        let mut dense = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2)],
+            vec![2],
+        );
+        dense.push_child(Value::from_int(3));
+        assert!(matches!(dense.data, ValueData::Vector(_)));
+        assert_eq!(dense.len(), 3);
     }
 }

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -152,6 +152,48 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
     }
 }
 
+fn tensor_data_to_js_array(
+    data: &[crate::types::fraction::Fraction],
+    shape: &[usize],
+) -> js_sys::Array {
+    let arr = js_sys::Array::new();
+    if shape.is_empty() || shape.len() == 1 {
+        for f in data {
+            let num_obj = js_sys::Object::new();
+            js_sys::Reflect::set(
+                &num_obj,
+                &"numerator".into(),
+                &f.numerator().to_string().into(),
+            )
+            .unwrap();
+            js_sys::Reflect::set(
+                &num_obj,
+                &"denominator".into(),
+                &f.denominator().to_string().into(),
+            )
+            .unwrap();
+            let elem = js_sys::Object::new();
+            js_sys::Reflect::set(&elem, &"type".into(), &"number".into()).unwrap();
+            js_sys::Reflect::set(&elem, &"value".into(), &num_obj).unwrap();
+            js_sys::Reflect::set(&elem, &"displayHint".into(), &"number".into()).unwrap();
+            arr.push(&elem);
+        }
+    } else {
+        let outer = shape[0];
+        let rest = &shape[1..];
+        let stride: usize = rest.iter().product();
+        for i in 0..outer {
+            let inner = tensor_data_to_js_array(&data[i * stride..(i + 1) * stride], rest);
+            let elem = js_sys::Object::new();
+            js_sys::Reflect::set(&elem, &"type".into(), &"vector".into()).unwrap();
+            js_sys::Reflect::set(&elem, &"value".into(), &inner).unwrap();
+            js_sys::Reflect::set(&elem, &"displayHint".into(), &"auto".into()).unwrap();
+            arr.push(&elem);
+        }
+    }
+    arr
+}
+
 pub(crate) fn arena_node_to_js(
     arena: &ValueArena,
     root_id: NodeId,
@@ -238,6 +280,22 @@ pub(crate) fn arena_node_to_js(
                 for child in children {
                     js_array.push(&arena_node_to_js(arena, *child, child_external));
                 }
+                js_sys::Reflect::set(&obj, &"type".into(), &"vector".into()).unwrap();
+                js_sys::Reflect::set(&obj, &"value".into(), &js_array).unwrap();
+            }
+        }
+        NodeKind::Tensor { data, shape } => {
+            // Hydrate a dense Tensor at the WASM boundary so the GUI/TS layer
+            // can keep treating values uniformly as nested Vectors.
+            if effective_hint == DisplayHint::String && shape.len() <= 1 {
+                let text: String = data
+                    .iter()
+                    .filter_map(|f| f.to_i64().and_then(|n| char::from_u32(n as u32)))
+                    .collect();
+                js_sys::Reflect::set(&obj, &"type".into(), &"string".into()).unwrap();
+                js_sys::Reflect::set(&obj, &"value".into(), &text.into()).unwrap();
+            } else {
+                let js_array = tensor_data_to_js_array(data, shape);
                 js_sys::Reflect::set(&obj, &"type".into(), &"vector".into()).unwrap();
                 js_sys::Reflect::set(&obj, &"value".into(), &js_array).unwrap();
             }


### PR DESCRIPTION
## Summary

This is **PR #1 of the VTU Phase II plan** described in
`docs/dev/vtu-phase-ii-handover.md`. It introduces a parallel dense
Vector representation — `ValueData::Tensor { data, shape }` — alongside
the existing nested `Vector(Rc<Vec<Value>>)`, but **does not wire any
producer yet**. The behaviour of all existing words is unchanged.

Per the handover plan, this PR is intentionally read-side only:

- Spec & docs: SPECIFICATION.md gains §4.3.1 documenting the
  dense/nested duality; the VTU design doc records that Phase II is
  underway.
- New variant: `ValueData::Tensor { data: Rc<Vec<Fraction>>, shape: Rc<Vec<usize>> }`.
- Custom `PartialEq` for `ValueData`: a dense Tensor and a nested
  Vector compare equal exactly when their flattened Fraction sequences
  and inferred shapes match. This is the spec invariant.
- Match exhaustiveness: every `match` against `ValueData` and arena
  `NodeKind` now has an explicit `Tensor` arm — no wildcard fallbacks,
  so future variants will keep being caught at compile time.
- Hydration shims: mutating helpers (`push_child`, `pop_child`,
  `insert_child`, `remove_child`, `replace_child`, `as_vector_mut`)
  hydrate a `Tensor` back to a nested `Vector` before touching it, so
  the existing `Vec<Value>` contract still holds.
- Arena round-trip: `value_to_arena` / `arena_to_value` preserve dense
  form; `arena_node_to_json` emits the expected nested JSON arrays.
- WASM boundary: `wasm-value-conversion.rs` hydrates Tensor → JS
  vector at the boundary (per Section 6 item 5 of the handover), so
  the GUI/TS layer can stay unaware of dense form for now.
- 7 new unit tests cover Tensor equality with nested vectors, shape /
  count round-trips, hydration on `push_child`, arena round-trip, and
  JSON emission.

## Out of scope (deliberately left for later PRs)

- PR #2: switching the literal parser and `apply_*_with_metrics`
  outputs to actually emit Tensor (this is what will start moving the
  `vtu_tensor_rebuild_count` metric).
- PR #3: Tensor fast paths in HOFs / SIMD / cast / shape ops.
- PR #4–#8: fusion execution, in-place mutation, memoisation, SIMD
  extension, `explain --vtu`.

## Test plan

- [x] `cargo build --tests` (workspace clean)
- [x] `cargo test --lib` — **824 passed, 0 failed** (817 pre-existing
      + 7 new VTU Tensor tests)
- [x] `cargo clippy --tests --no-deps` — **100 warnings**, identical
      to baseline before this PR (no new lints introduced)
- [ ] Manual inspection of `bench-baselines/` — deferred to PR #2,
      where the `vtu_*` counters are expected to actually move

https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV)_