### PR TITLE
VTU Phase II PR #2: switch producers to ValueData::Tensor

### DIFF
--- a/bench-baselines/vtu-phase-ii.jsonl
+++ b/bench-baselines/vtu-phase-ii.jsonl
@@ -1,0 +1,6 @@
+{"label":"vtu_tensor_rebuild_count","scenario":"unary_flat_FLOOR_over_3_elements","phase":"pre_phase_ii","value":1,"note":"PR #1 baseline: apply_unary_flat_with_metrics rebuilt FlatTensor -> nested Vector via build_nested_value"}
+{"label":"vtu_tensor_rebuild_count","scenario":"unary_flat_FLOOR_over_3_elements","phase":"post_phase_ii","value":0,"note":"PR #2: FlatTensor::to_value() returns ValueData::Tensor directly; record_rebuild call removed from apply_unary_flat_with_metrics"}
+{"label":"vtu_tensor_rebuild_count","scenario":"binary_broadcast_same_shape","phase":"pre_phase_ii","value":1,"note":"PR #1 baseline: apply_binary_broadcast_with_metrics same-shape branch rebuilt output to nested Vector"}
+{"label":"vtu_tensor_rebuild_count","scenario":"binary_broadcast_same_shape","phase":"post_phase_ii","value":0,"note":"PR #2: output now constructed as ValueData::Tensor directly via FlatTensor::to_value()"}
+{"label":"vtu_tensor_rebuild_count","scenario":"binary_broadcast_projected","phase":"pre_phase_ii","value":1,"note":"PR #1 baseline: projected-broadcast path also rebuilt to nested Vector"}
+{"label":"vtu_tensor_rebuild_count","scenario":"binary_broadcast_projected","phase":"post_phase_ii","value":0,"note":"PR #2: projected-broadcast also returns Tensor directly"}

--- a/rust/src/interpreter/audio/execute-audio-commands.rs
+++ b/rust/src/interpreter/audio/execute-audio-commands.rs
@@ -171,17 +171,13 @@ pub fn op_adsr(interp: &mut Interpreter) -> Result<()> {
     })?;
 
 
-    let param_children = match &params.data {
-        ValueData::Vector(v) => v,
-        _ => {
-            interp.stack.push(target);
-            interp.stack.push(params);
-            return Err(AjisaiError::from("ADSR parameters must be a vector"));
-        }
-    };
+    if !params.is_vector() {
+        interp.stack.push(target);
+        interp.stack.push(params);
+        return Err(AjisaiError::from("ADSR parameters must be a vector"));
+    }
 
-
-    if param_children.len() != 4 {
+    if params.len() != 4 {
         interp.stack.push(target);
         interp.stack.push(params);
         return Err(AjisaiError::from(
@@ -197,22 +193,16 @@ pub fn op_adsr(interp: &mut Interpreter) -> Result<()> {
     }
 
 
-    let attack = param_children[0]
-        .as_scalar()
-        .and_then(|f| f.to_f64())
-        .ok_or_else(|| AjisaiError::from("ADSR attack must be a number"))?;
-    let decay = param_children[1]
-        .as_scalar()
-        .and_then(|f| f.to_f64())
-        .ok_or_else(|| AjisaiError::from("ADSR decay must be a number"))?;
-    let sustain = param_children[2]
-        .as_scalar()
-        .and_then(|f| f.to_f64())
-        .ok_or_else(|| AjisaiError::from("ADSR sustain must be a number"))?;
-    let release = param_children[3]
-        .as_scalar()
-        .and_then(|f| f.to_f64())
-        .ok_or_else(|| AjisaiError::from("ADSR release must be a number"))?;
+    let param_at = |i: usize, label: &str| -> Result<f64> {
+        params
+            .child(i)
+            .and_then(|v| v.as_scalar().and_then(|f| f.to_f64()))
+            .ok_or_else(|| AjisaiError::from(format!("ADSR {} must be a number", label)))
+    };
+    let attack = param_at(0, "attack")?;
+    let decay = param_at(1, "decay")?;
+    let sustain = param_at(2, "sustain")?;
+    let release = param_at(3, "release")?;
 
 
     if attack < 0.0 || decay < 0.0 || release < 0.0 {

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -286,6 +286,22 @@ pub fn op_eq(interp: &mut Interpreter) -> Result<()> {
                         {
                             children[0].data == b_val.data
                         }
+                        (ValueData::Scalar(_), ValueData::Tensor { .. })
+                            if b_val.len() == 1 =>
+                        {
+                            b_val
+                                .child(0)
+                                .map(|c| a_val.data == c.data)
+                                .unwrap_or(false)
+                        }
+                        (ValueData::Tensor { .. }, ValueData::Scalar(_))
+                            if a_val.len() == 1 =>
+                        {
+                            a_val
+                                .child(0)
+                                .map(|c| c.data == b_val.data)
+                                .unwrap_or(false)
+                        }
                         _ => false,
                     }
                 }

--- a/rust/src/interpreter/control-exec-eval-tests.rs
+++ b/rust/src/interpreter/control-exec-eval-tests.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use crate::interpreter::Interpreter;
-    use crate::types::ValueData;
 
 
     #[tokio::test]
@@ -36,15 +35,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 6, "Result should be 6");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -59,15 +58,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 2, "Result should be 2");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -86,15 +85,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 6, "Result should be 6");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -132,15 +131,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 6, "Result should be 6");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -183,15 +182,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 5, "Result should be 5");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -212,15 +211,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 6, "Result should be 6");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -241,15 +240,15 @@ mod tests {
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
 
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 6, "Result should be 6");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }

--- a/rust/src/interpreter/dictionary-operation-tests.rs
+++ b/rust/src/interpreter/dictionary-operation-tests.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use crate::interpreter::Interpreter;
-    use crate::types::ValueData;
 
     #[tokio::test]
     async fn test_cannot_override_builtin_word() {
@@ -33,15 +32,15 @@ mod tests {
 
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 15, "Result should be 15");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -360,12 +359,10 @@ mod tests {
             result.err()
         );
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1);
-                assert_eq!(children[0].as_scalar().unwrap().to_i64().unwrap(), 10);
-            } else {
-                panic!("Expected vector result");
-            }
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1);
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            assert_eq!(only.as_scalar().unwrap().to_i64().unwrap(), 10);
         }
     }
 
@@ -411,15 +408,15 @@ mod tests {
 
         assert_eq!(interp.stack.len(), 1, "Stack should have 1 element");
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
-                if let Some(f) = children[0].as_scalar() {
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
+                if let Some(f) = only.as_scalar() {
                     assert_eq!(f.to_i64().unwrap(), 10, "Result should be 10");
                 } else {
                     panic!("Expected scalar inside vector");
                 }
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -469,14 +466,10 @@ mod tests {
         let result = interp.execute("DEMO@C4").await;
         assert!(result.is_ok(), "Qualified DEMO@C4 should work: {:?}", result.err());
         if let Some(val) = interp.stack.last() {
-            let scalar = val
-                .as_scalar()
-                .or_else(|| {
-                    val.as_vector()
-                        .and_then(|children| children.first())
-                        .and_then(|child| child.as_scalar())
-                })
-                .expect("DEMO@C4 should resolve to a numeric value");
+            let scalar_owned = val.as_scalar().cloned().or_else(|| {
+                val.child(0).and_then(|c| c.as_scalar().cloned())
+            });
+            let scalar = scalar_owned.expect("DEMO@C4 should resolve to a numeric value");
             assert_eq!(scalar.to_i64().unwrap(), 999,
                 "DEMO@C4 should remain the user-defined value");
         }

--- a/rust/src/interpreter/dictionary-resolution-tests.rs
+++ b/rust/src/interpreter/dictionary-resolution-tests.rs
@@ -246,14 +246,10 @@ mod tests {
         let result = interp.execute("DEMO@C4").await;
         assert!(result.is_ok(), "DEMO@C4 should resolve: {:?}", result.err());
         if let Some(val) = interp.stack.last() {
-            let scalar = val
-                .as_scalar()
-                .or_else(|| {
-                    val.as_vector()
-                        .and_then(|children| children.first())
-                        .and_then(|child| child.as_scalar())
-                })
-                .expect("DEMO@C4 should be numeric");
+            let scalar_owned = val.as_scalar().cloned().or_else(|| {
+                val.child(0).and_then(|c| c.as_scalar().cloned())
+            });
+            let scalar = scalar_owned.expect("DEMO@C4 should be numeric");
             assert_eq!(scalar.to_i64().unwrap(), 999);
         }
     }

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -76,7 +76,10 @@ impl Interpreter {
                             "Empty vector is not allowed. Use NIL for empty values.",
                         ));
                     }
-                    values.push(Value::from_vector_with_hint(nested_values, nested_hint));
+                    values.push(Value::from_vector_promoted_with_hint(
+                        nested_values,
+                        nested_hint,
+                    ));
                     has_other = true;
                     i += consumed;
                 }
@@ -201,7 +204,8 @@ impl Interpreter {
                             "Empty vector is not allowed. Use NIL for empty values.",
                         ));
                     }
-                    self.stack.push(Value::from_vector(values));
+                    self.stack
+                        .push(Value::from_vector_promoted(values));
                     self.semantic_registry.push_hint(element_hint);
                     i += consumed;
                     continue;

--- a/rust/src/interpreter/hash.rs
+++ b/rust/src/interpreter/hash.rs
@@ -81,6 +81,19 @@ fn serialize_value_inner_for_hash(val: &Value, bytes: &mut Vec<u8>) {
         for elem in children.iter() {
             serialize_value_inner_for_hash(elem, bytes);
         }
+        return;
+    }
+
+    if matches!(&val.data, ValueData::Tensor { .. }) {
+        let len = val.len();
+        bytes.push(0x04);
+        bytes.extend_from_slice(&(len as u32).to_le_bytes());
+        for i in 0..len {
+            let child = val
+                .child(i)
+                .expect("Tensor child index in 0..len must be valid");
+            serialize_value_inner_for_hash(&child, bytes);
+        }
     }
 }
 

--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -78,7 +78,9 @@ pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
 
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
-                let elem: Value = target_val.get_child(i).unwrap().clone();
+                let elem: Value = target_val
+                    .child(i)
+                    .expect("FOLD: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
                         match execute_hedged_fold_kernel(
@@ -286,14 +288,19 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
                 }
 
                 if is_vector_value(&unwrapped) && unwrapped.len() == 2 {
-                    results.push(unwrapped.get_child(0).unwrap().clone());
+                    let yielded = unwrapped
+                        .child(0)
+                        .expect("len==2 implies child(0) exists");
+                    results.push(yielded);
 
-                    let next_state: &Value = unwrapped.get_child(1).unwrap();
+                    let next_state = unwrapped
+                        .child(1)
+                        .expect("len==2 implies child(1) exists");
                     if next_state.is_nil() {
                         break;
                     }
 
-                    state = Value::from_vector(vec![next_state.clone()]);
+                    state = Value::from_vector(vec![next_state]);
                     continue;
                 }
 
@@ -365,14 +372,19 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
                         }
 
                         if is_vector_value(&unwrapped) && unwrapped.len() == 2 {
-                            results.push(unwrapped.get_child(0).unwrap().clone());
+                            let yielded = unwrapped
+                                .child(0)
+                                .expect("len==2 implies child(0) exists");
+                            results.push(yielded);
 
-                            let next_state: &Value = unwrapped.get_child(1).unwrap();
+                            let next_state = unwrapped
+                                .child(1)
+                                .expect("len==2 implies child(1) exists");
                             if next_state.is_nil() {
                                 break;
                             }
 
-                            state = Value::from_vector(vec![next_state.clone()]);
+                            state = Value::from_vector(vec![next_state]);
                             continue;
                         }
 
@@ -472,7 +484,9 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
 
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
-                let elem: Value = target_val.get_child(i).unwrap().clone();
+                let elem: Value = target_val
+                    .child(i)
+                    .expect("SCAN: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
                         match execute_hedged_fold_kernel(
@@ -539,7 +553,7 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
                     .into_iter()
                     .map(|v| {
                         if is_vector_value(&v) && v.len() == 1 {
-                            v.get_child(0).unwrap().clone()
+                            v.child(0).expect("len==1 implies child(0) exists")
                         } else {
                             v
                         }
@@ -621,7 +635,7 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
                     .into_iter()
                     .map(|v| {
                         if is_vector_value(&v) && v.len() == 1 {
-                            v.get_child(0).unwrap().clone()
+                            v.child(0).expect("len==1 implies child(0) exists")
                         } else {
                             v
                         }

--- a/rust/src/interpreter/higher-order-fold-tests.rs
+++ b/rust/src/interpreter/higher-order-fold-tests.rs
@@ -7,7 +7,7 @@ mod tests {
         if let Some(f) = top.as_scalar() {
             return f.to_i64().expect("scalar i64");
         }
-        let child = top.get_child(0).expect("vector[0]");
+        let child = top.child(0).expect("vector[0]");
         child
             .as_scalar()
             .and_then(|f| f.to_i64())
@@ -80,7 +80,11 @@ mod tests {
         let below_num = below
             .as_scalar()
             .and_then(|f| f.to_i64())
-            .or_else(|| below.get_child(0).and_then(|v| v.as_scalar()).and_then(|f| f.to_i64()));
+            .or_else(|| {
+                below
+                    .child(0)
+                    .and_then(|v| v.as_scalar().and_then(|f| f.to_i64()))
+            });
         assert_eq!(below_num, Some(99));
     }
 

--- a/rust/src/interpreter/higher_order/all.rs
+++ b/rust/src/interpreter/higher_order/all.rs
@@ -56,7 +56,9 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
             let mut result = true;
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
-                let elem = target_val.get_child(i).unwrap().clone();
+                let elem = target_val
+                    .child(i)
+                    .expect("ALL: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
                         match execute_hedged_predicate_kernel(

--- a/rust/src/interpreter/higher_order/any.rs
+++ b/rust/src/interpreter/higher_order/any.rs
@@ -56,7 +56,9 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
             let mut result = false;
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
-                let elem = target_val.get_child(i).unwrap().clone();
+                let elem = target_val
+                    .child(i)
+                    .expect("ANY: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
                         match execute_hedged_predicate_kernel(

--- a/rust/src/interpreter/higher_order/common.rs
+++ b/rust/src/interpreter/higher_order/common.rs
@@ -44,7 +44,10 @@ pub(crate) fn extract_predicate_boolean(condition_result: Value) -> Result<bool>
 
     if is_vector_value(&condition_result) {
         if condition_result.len() == 1 {
-            return Ok(is_truthy_boolean(condition_result.get_child(0).unwrap()));
+            let child = condition_result
+                .child(0)
+                .expect("len==1 implies child(0) exists");
+            return Ok(is_truthy_boolean(&child));
         }
         return Err(AjisaiError::create_structure_error(
             "boolean result from FILTER code",

--- a/rust/src/interpreter/higher_order/count.rs
+++ b/rust/src/interpreter/higher_order/count.rs
@@ -58,7 +58,9 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
             let mut count: i64 = 0;
             let mut error: Option<AjisaiError> = None;
             for i in 0..target_val.len() {
-                let elem = target_val.get_child(i).unwrap().clone();
+                let elem = target_val
+                    .child(i)
+                    .expect("COUNT: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
                         match execute_hedged_predicate_kernel(

--- a/rust/src/interpreter/higher_order/filter.rs
+++ b/rust/src/interpreter/higher_order/filter.rs
@@ -73,7 +73,9 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
 
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
-                let elem: Value = target_val.get_child(i).unwrap().clone();
+                let elem: Value = target_val
+                    .child(i)
+                    .expect("FILTER: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => {
                         match execute_hedged_predicate_kernel(
@@ -146,7 +148,7 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
             if results.is_empty() {
                 interp.stack.push(Value::nil());
             } else {
-                interp.stack.push(Value::from_vector(results));
+                interp.stack.push(Value::from_vector_promoted(results));
             }
         }
         OperationTargetMode::Stack => {

--- a/rust/src/interpreter/higher_order/hedged.rs
+++ b/rust/src/interpreter/higher_order/hedged.rs
@@ -10,7 +10,7 @@ use crate::elastic::{
 use crate::error::Result;
 use crate::interpreter::quantized_block::QuantizedBlock;
 use crate::interpreter::Interpreter;
-use crate::types::{Token, Value};
+use crate::types::{DisplayHint, Token, Value};
 
 fn hedged_mode(mode: ElasticMode) -> bool {
     matches!(mode, ElasticMode::HedgedSafe | ElasticMode::HedgedTrace)
@@ -45,10 +45,13 @@ fn trace_hedged(interp: &Interpreter, msg: &str) {
 }
 
 fn normalize_map_kernel_result(value: Value) -> Value {
+    if value.hint == DisplayHint::String {
+        return value;
+    }
     if value.len() == 1 {
-        if let Some(child) = value.get_child(0) {
+        if let Some(child) = value.child(0) {
             if child.as_scalar().is_some() {
-                return child.clone();
+                return child;
             }
         }
     }
@@ -63,11 +66,12 @@ pub(crate) fn execute_hedged_map_kernel(
     elem: Value,
 ) -> Result<Value> {
     let Some(tokens) = plain_tokens else {
-        return execute_quantized_map_kernel(interp, qb, elem);
+        return execute_quantized_map_kernel(interp, qb, elem).map(normalize_map_kernel_result);
     };
     if fast_guarded_mode(interp.elastic_mode()) {
         if is_quantized_block_guard_valid(interp, qb) {
-            return execute_quantized_map_kernel(interp, qb, elem);
+            return execute_quantized_map_kernel(interp, qb, elem)
+                .map(normalize_map_kernel_result);
         }
         interp.runtime_metrics.hedged_race_fallback_count += 1;
         interp.push_hedged_trace(format!(
@@ -75,10 +79,11 @@ pub(crate) fn execute_hedged_map_kernel(
             op_name
         ));
         let plain_exec = ExecutableCode::CodeBlock(tokens.to_vec());
-        return execute_plain_map_kernel(interp, &plain_exec, elem);
+        return execute_plain_map_kernel(interp, &plain_exec, elem)
+            .map(normalize_map_kernel_result);
     }
     if !hedged_mode(interp.elastic_mode()) || !can_hedge_hof_kernel(op_name) {
-        return execute_quantized_map_kernel(interp, qb, elem);
+        return execute_quantized_map_kernel(interp, qb, elem).map(normalize_map_kernel_result);
     }
     interp.runtime_metrics.hedged_race_started_count += 1;
     interp.push_hedged_trace(format!("hof-race:start op={}", op_name));

--- a/rust/src/interpreter/higher_order/map.rs
+++ b/rust/src/interpreter/higher_order/map.rs
@@ -70,7 +70,9 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
 
             let mut error: Option<AjisaiError> = None;
             for i in 0..n_elements {
-                let elem: Value = target_val.get_child(i).unwrap().clone();
+                let elem: Value = target_val
+                    .child(i)
+                    .expect("MAP: child index in 0..len must be valid");
                 match &executable {
                     ExecutableCode::QuantizedBlock(qb) => match execute_hedged_map_kernel(
                         interp,
@@ -96,11 +98,17 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
                                 Some(result_val) => {
                                     let result_hint: DisplayHint =
                                         interp.semantic_registry.pop_hint();
+                                    let is_string_result = result_hint == DisplayHint::String
+                                        || result_val.hint == DisplayHint::String;
                                     if is_vector_value(&result_val)
                                         && result_val.len() == 1
-                                        && result_hint != DisplayHint::String
+                                        && !is_string_result
                                     {
-                                        results.push(result_val.get_child(0).unwrap().clone());
+                                        results.push(
+                                            result_val
+                                                .child(0)
+                                                .expect("len==1 implies child(0) exists"),
+                                        );
                                     } else {
                                         results.push(result_val);
                                     }
@@ -133,7 +141,7 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
                 return Err(e);
             }
 
-            interp.stack.push(Value::from_vector(results));
+            interp.stack.push(Value::from_vector_promoted(results));
         }
         OperationTargetMode::Stack => {
             let count_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;

--- a/rust/src/interpreter/interpreter-definition-tests.rs
+++ b/rust/src/interpreter/interpreter-definition-tests.rs
@@ -18,38 +18,19 @@ mod tests {
 
         assert_eq!(interp.stack.len(), 1);
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 3, "Result should have 3 elements");
-                assert_eq!(
-                    children[0]
-                        .as_scalar()
-                        .expect("Expected scalar")
-                        .numerator()
-                        .to_string(),
-                    "2",
-                    "First element should be 2"
-                );
-                assert_eq!(
-                    children[1]
-                        .as_scalar()
-                        .expect("Expected scalar")
-                        .numerator()
-                        .to_string(),
-                    "3",
-                    "Second element should be 3"
-                );
-                assert_eq!(
-                    children[2]
-                        .as_scalar()
-                        .expect("Expected scalar")
-                        .numerator()
-                        .to_string(),
-                    "4",
-                    "Third element should be 4"
-                );
-            } else {
-                panic!("Expected vector result");
-            }
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 3, "Result should have 3 elements");
+            let extract = |i: usize| -> String {
+                val.child(i)
+                    .expect("child within len")
+                    .as_scalar()
+                    .expect("Expected scalar")
+                    .numerator()
+                    .to_string()
+            };
+            assert_eq!(extract(0), "2", "First element should be 2");
+            assert_eq!(extract(1), "3", "Second element should be 3");
+            assert_eq!(extract(2), "4", "Third element should be 4");
         }
     }
 
@@ -205,12 +186,10 @@ mod tests {
             vec![3],
             "Vector should have 3 elements including NIL"
         );
-        if let ValueData::Vector(children) = &vec_val.data {
-            assert_eq!(children.len(), 3, "Data should have 3 elements");
-            assert!(children[1].is_nil(), "Second element should be NIL");
-        } else {
-            panic!("Expected vector");
-        }
+        assert!(vec_val.is_vector(), "Expected vector");
+        assert_eq!(vec_val.len(), 3, "Data should have 3 elements");
+        let second = vec_val.child(1).expect("len==3 implies child(1) exists");
+        assert!(second.is_nil(), "Second element should be NIL");
     }
 
     #[tokio::test]

--- a/rust/src/interpreter/interpreter-execution-tests.rs
+++ b/rust/src/interpreter/interpreter-execution-tests.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use crate::interpreter::Interpreter;
-    use crate::types::ValueData;
 
     #[tokio::test]
     async fn test_stack_get_basic() {
@@ -86,10 +85,12 @@ ADDTEST
 
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
                 assert_eq!(
-                    children[0]
+                    only
                         .as_scalar()
                         .expect("Expected scalar")
                         .numerator()
@@ -97,8 +98,6 @@ ADDTEST
                     "8",
                     "Result should be 8"
                 );
-            } else {
-                panic!("Expected vector result from addition");
             }
         }
     }
@@ -144,10 +143,12 @@ ADDTEST
 
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
                 assert_eq!(
-                    children[0]
+                    only
                         .as_scalar()
                         .expect("Expected scalar")
                         .numerator()
@@ -155,8 +156,6 @@ ADDTEST
                     "9",
                     "Result should be 9"
                 );
-            } else {
-                panic!("Expected vector result");
             }
         }
     }
@@ -179,10 +178,12 @@ ADDTEST
 
         assert_eq!(interp.stack.len(), 1, "Stack should have one element");
         if let Some(val) = interp.stack.last() {
-            if let ValueData::Vector(children) = &val.data {
-                assert_eq!(children.len(), 1, "Result should have one element");
+            assert!(val.is_vector(), "Expected vector result");
+            assert_eq!(val.len(), 1, "Result should have one element");
+            let only = val.child(0).expect("len==1 implies child(0) exists");
+            {
                 assert_eq!(
-                    children[0]
+                    only
                         .as_scalar()
                         .expect("Expected scalar")
                         .numerator()
@@ -190,8 +191,6 @@ ADDTEST
                     "150",
                     "Result should be 150"
                 );
-            } else {
-                panic!("Expected vector result");
             }
         }
     }

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -55,7 +55,7 @@ fn stack_top_i64(interp: &Interpreter) -> i64 {
         return f.to_i64().expect("scalar should be representable as i64");
     }
     if top.len() == 1 {
-        if let Some(child) = top.get_child(0) {
+        if let Some(child) = top.child(0) {
             if let Some(f) = child.as_scalar() {
                 return f
                     .to_i64()
@@ -76,7 +76,7 @@ fn stack_top_bool(interp: &Interpreter) -> bool {
         return !f.is_zero();
     }
     if top.len() == 1 {
-        if let Some(child) = top.get_child(0) {
+        if let Some(child) = top.child(0) {
             if let Some(f) = child.as_scalar() {
                 return !f.is_zero();
             }
@@ -442,12 +442,12 @@ fn scan_produces_prefix_sums() {
     let top = stack_top(&interp);
     assert_eq!(top.len(), 3, "SCAN result should have 3 elements");
     // Each child may be a scalar or a single-element vector — extract i64 from either.
-    let extract = |v: &Value| -> i64 {
+    let extract = |v: Value| -> i64 {
         if let Some(f) = v.as_scalar() {
             return f.to_i64().expect("scalar should be i64");
         }
         if v.len() == 1 {
-            if let Some(child) = v.get_child(0) {
+            if let Some(child) = v.child(0) {
                 if let Some(f) = child.as_scalar() {
                     return f.to_i64().expect("inner scalar should be i64");
                 }
@@ -455,7 +455,9 @@ fn scan_produces_prefix_sums() {
         }
         panic!("SCAN element is not a numeric scalar or single-element vector");
     };
-    let vals: Vec<i64> = (0..3).map(|i| extract(top.get_child(i).unwrap())).collect();
+    let vals: Vec<i64> = (0..3)
+        .map(|i| extract(top.child(i).expect("len==3 implies child(i) exists for i<3")))
+        .collect();
     assert_eq!(vals, vec![1, 3, 6]);
 }
 
@@ -824,6 +826,10 @@ fn vtu_unary_flat_increments_counter() {
     let m = interp.runtime_metrics();
     assert!(m.vtu_unary_flat_count >= 1, "unary flat path should fire");
     assert!(m.vtu_tensor_flatten_count >= 1);
-    assert!(m.vtu_tensor_rebuild_count >= 1);
+    // VTU Phase II: outputs are now Tensor directly, no rebuild needed.
+    assert_eq!(
+        m.vtu_tensor_rebuild_count, 0,
+        "rebuild path should be retired after Phase II producer switch"
+    );
     assert!(m.vtu_allocated_elements >= 3);
 }

--- a/rust/src/interpreter/tensor-shape-commands.rs
+++ b/rust/src/interpreter/tensor-shape-commands.rs
@@ -98,12 +98,10 @@ pub fn op_reshape(interp: &mut Interpreter) -> Result<()> {
 
     let mut new_shape: Vec<usize> = Vec::with_capacity(dim_count);
     for i in 0..dim_count {
-        let dim = match shape_val
-            .get_child(i)
-            .unwrap()
-            .as_scalar()
-            .and_then(|f| f.as_usize())
-        {
+        let dim_child = shape_val
+            .child(i)
+            .expect("RESHAPE: child index in 0..len must be valid");
+        let dim = match dim_child.as_scalar().and_then(|f| f.as_usize()) {
             Some(d) => d,
             None => {
                 interp.stack.push(data_val);
@@ -376,8 +374,8 @@ pub fn op_fill(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
-    let fill_value = match args_val.get_child(n - 1).and_then(|v| v.as_scalar()) {
-        Some(f) => f.clone(),
+    let fill_value = match args_val.child(n - 1).and_then(|v| v.as_scalar().cloned()) {
+        Some(f) => f,
         None => {
             interp.stack.push(args_val);
             return Err(AjisaiError::from("FILL value must be a scalar"));
@@ -388,12 +386,10 @@ pub fn op_fill(interp: &mut Interpreter) -> Result<()> {
 
     let mut shape = Vec::with_capacity(shape_len);
     for i in 0..shape_len {
-        let dim = match args_val
-            .get_child(i)
-            .unwrap()
-            .as_scalar()
-            .and_then(|f| f.as_usize())
-        {
+        let dim_child = args_val
+            .child(i)
+            .expect("FILL: child index in 0..len must be valid");
+        let dim = match dim_child.as_scalar().and_then(|f| f.as_usize()) {
             Some(d) if d > 0 => d,
             Some(_) | None => {
                 interp.stack.push(args_val);

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -14,15 +14,6 @@ fn record_flatten(metrics: &mut Option<&mut RuntimeMetrics>, elements: usize) {
     }
 }
 
-#[inline]
-fn record_rebuild(metrics: &mut Option<&mut RuntimeMetrics>, elements: usize) {
-    if let Some(m) = metrics.as_deref_mut() {
-        m.vtu_tensor_rebuild_count = m.vtu_tensor_rebuild_count.saturating_add(1);
-        m.vtu_tensor_rebuilt_elements = m
-            .vtu_tensor_rebuilt_elements
-            .saturating_add(elements as u64);
-    }
-}
 
 #[derive(Debug, Clone)]
 pub(crate) struct FlatTensor {
@@ -95,7 +86,7 @@ impl FlatTensor {
         if self.shape.is_empty() {
             return Value::from_fraction(self.data[0].clone());
         }
-        build_nested_value(&self.data, &self.shape)
+        Value::from_tensor(self.data.clone(), self.shape.clone())
     }
 }
 
@@ -268,11 +259,10 @@ where
             out_data.push(op(&tensor_a.data[i], &tensor_b.data[i])?);
         }
         let out_tensor = FlatTensor::from_shape_and_data(out_shape, out_data)?;
-        record_rebuild(&mut metrics, out_tensor.data.len());
         return Ok(out_tensor.to_value());
     }
 
-    if let Some(m) = metrics.as_deref_mut() {
+    if let Some(m) = metrics {
         m.vtu_projected_broadcast_count = m.vtu_projected_broadcast_count.saturating_add(1);
     }
 
@@ -292,7 +282,6 @@ where
     }
 
     let out_tensor = FlatTensor::from_shape_and_data(out_shape, out_data)?;
-    record_rebuild(&mut metrics, out_tensor.data.len());
     Ok(out_tensor.to_value())
 }
 
@@ -310,7 +299,7 @@ where
     let element_count = tensor.data.len();
     record_flatten(&mut metrics, element_count);
 
-    if let Some(m) = metrics.as_deref_mut() {
+    if let Some(m) = metrics {
         m.vtu_unary_flat_count = m.vtu_unary_flat_count.saturating_add(1);
         m.vtu_allocated_elements = m
             .vtu_allocated_elements
@@ -319,6 +308,5 @@ where
 
     let result_data: Vec<Fraction> = tensor.data.into_iter().map(|f| op(&f)).collect();
     let result_tensor = FlatTensor::from_shape_and_data(tensor.shape, result_data)?;
-    record_rebuild(&mut metrics, result_tensor.data.len());
     Ok(result_tensor.to_value())
 }

--- a/rust/src/interpreter/value-extraction-helpers.rs
+++ b/rust/src/interpreter/value-extraction-helpers.rs
@@ -7,7 +7,7 @@ use num_traits::ToPrimitive;
 
 #[inline]
 pub(crate) fn is_vector_value(val: &Value) -> bool {
-    matches!(&val.data, ValueData::Vector(_))
+    matches!(&val.data, ValueData::Vector(_) | ValueData::Tensor { .. })
 }
 
 #[inline]

--- a/rust/src/interpreter/vector_ops/mod.rs
+++ b/rust/src/interpreter/vector_ops/mod.rs
@@ -16,9 +16,19 @@ pub use structure::{op_concat, op_reverse, op_range, op_reorder, op_collect};
 
 use crate::types::{Value, ValueData};
 
-pub(crate) fn extract_vector_elements(val: &Value) -> &[Value] {
+pub(crate) fn extract_vector_elements(val: &Value) -> Vec<Value> {
     match &val.data {
-        ValueData::Vector(children) | ValueData::Record { pairs: children, .. } => children,
-        _ => &[],
+        ValueData::Vector(children) | ValueData::Record { pairs: children, .. } => {
+            children.as_ref().clone()
+        }
+        ValueData::Tensor { .. } => {
+            let n = val.len();
+            let mut out = Vec::with_capacity(n);
+            for i in 0..n {
+                out.push(val.child(i).expect("Tensor child index in 0..len must be valid"));
+            }
+            out
+        }
+        _ => Vec::new(),
     }
 }

--- a/rust/src/interpreter/vector_ops/position.rs
+++ b/rust/src/interpreter/vector_ops/position.rs
@@ -27,9 +27,14 @@ fn parse_index_element_args(word: &str, args_val: &Value) -> Result<(i64, Value)
         )));
     }
 
-    let index = extract_integer_from_value(args_val.get_child(0).unwrap())
+    let index_child = args_val
+        .child(0)
+        .ok_or_else(|| AjisaiError::from(format!("{} missing index", word)))?;
+    let index = extract_integer_from_value(&index_child)
         .map_err(|_| AjisaiError::from(format!("{} index must be an integer", word)))?;
-    let element = args_val.get_child(1).unwrap().clone();
+    let element = args_val
+        .child(1)
+        .ok_or_else(|| AjisaiError::from(format!("{} missing element", word)))?;
     Ok((index, element))
 }
 
@@ -50,7 +55,9 @@ pub fn op_get(interp: &mut Interpreter) -> Result<()> {
 
                     let actual_index = normalize_index(index, len)
                         .ok_or(AjisaiError::IndexOutOfBounds { index, length: len })?;
-                    Ok(target_val.get_child(actual_index).unwrap().clone())
+                    target_val
+                        .child(actual_index)
+                        .ok_or(AjisaiError::IndexOutOfBounds { index, length: len })
                 })?;
 
             if is_keep_mode {

--- a/rust/src/interpreter/vector_ops/quantity.rs
+++ b/rust/src/interpreter/vector_ops/quantity.rs
@@ -144,7 +144,10 @@ pub fn op_split(interp: &mut Interpreter) -> Result<()> {
 
         let mut sizes = Vec::with_capacity(n);
         for i in 0..n {
-            match extract_bigint_from_value(args_val.get_child(i).unwrap()) {
+            let child = args_val
+                .child(i)
+                .expect("SPLIT: child index in 0..len must be valid");
+            match extract_bigint_from_value(&child) {
                 Ok(bi) => match bi.to_usize() {
                     Some(s) => sizes.push(s),
                     None => {

--- a/rust/src/interpreter/vector_ops/structure.rs
+++ b/rust/src/interpreter/vector_ops/structure.rs
@@ -44,7 +44,7 @@ fn concat_values(values: Vec<Value>, is_reversed: bool) -> Value {
     let mut result_vec = Vec::new();
     for value in ordered {
         if value.is_vector() {
-            result_vec.extend_from_slice(extract_vector_elements(&value));
+            result_vec.extend(extract_vector_elements(&value));
         } else {
             result_vec.push(value);
         }
@@ -54,7 +54,10 @@ fn concat_values(values: Vec<Value>, is_reversed: bool) -> Value {
 }
 
 fn parse_range_bound(args_val: &Value, index: usize, label: &str) -> Result<i64> {
-    let bigint = extract_bigint_from_value(args_val.get_child(index).unwrap())
+    let child = args_val
+        .child(index)
+        .ok_or_else(|| AjisaiError::from(format!("RANGE missing {}", label)))?;
+    let bigint = extract_bigint_from_value(&child)
         .map_err(|_| AjisaiError::from(format!("RANGE {} must be an integer", label)))?;
     bigint
         .to_i64()
@@ -97,7 +100,10 @@ fn parse_reorder_indices(indices_val: &Value) -> Result<Vec<i64>> {
 
         let mut indices = Vec::with_capacity(n);
         for i in 0..n {
-            let idx = extract_integer_from_value(indices_val.get_child(i).unwrap())
+            let child = indices_val
+                .child(i)
+                .ok_or_else(|| AjisaiError::from("REORDER missing index"))?;
+            let idx = extract_integer_from_value(&child)
                 .map_err(|_| AjisaiError::from("REORDER indices must be integers"))?;
             indices.push(idx);
         }
@@ -253,7 +259,12 @@ pub fn op_reorder(interp: &mut Interpreter) -> Result<()> {
                                 index: idx,
                                 length: len,
                             })?;
-                        result.push(target_val.get_child(actual).unwrap().clone());
+                        result.push(target_val.child(actual).ok_or(
+                            AjisaiError::IndexOutOfBounds {
+                                index: idx,
+                                length: len,
+                            },
+                        )?);
                     }
 
                     if result.is_empty() {

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -59,11 +59,28 @@ fn format_value_auto(value: &Value) -> String {
             }
             format_value_recursive(&value.data, 0)
         }
-        ValueData::Tensor { .. } => format_value_recursive(&value.data, 0),
+        ValueData::Tensor { data, shape } => {
+            if shape.len() == 1 && !data.is_empty() && is_fraction_string_like(data) {
+                return format_as_string(&value.data);
+            }
+            format_value_recursive(&value.data, 0)
+        }
         ValueData::CodeBlock(tokens) => format_code_block(tokens),
         ValueData::ProcessHandle(id) => format!("<process:{}>", id),
         ValueData::SupervisorHandle(id) => format!("<supervisor:{}>", id),
     }
+}
+
+fn is_fraction_string_like(data: &[Fraction]) -> bool {
+    data.iter().all(|f| {
+        f.is_integer()
+            && f.to_i64().is_some_and(|n| {
+                (0..=0x10FFFF).contains(&n)
+                    && char::from_u32(n as u32).is_some_and(|c| {
+                        !c.is_control() || c == '\n' || c == '\r' || c == '\t'
+                    })
+            })
+    })
 }
 
 /// Returns whether every element can be interpreted as a printable Unicode code point.

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -231,6 +231,27 @@ impl Value {
         }
     }
 
+    /// Representation-agnostic child accessor. Works for both `Vector` and
+    /// `Tensor` payloads by materializing a sub-Value (Scalar leaf or
+    /// sub-Tensor) when the receiver is dense. Cloning is cheap because
+    /// inner buffers are reference-counted.
+    ///
+    /// Prefer this over [`get_child`] when the call site can be reached with
+    /// a dense `Tensor` input. Use `get_child` only when the caller is known
+    /// to operate on `Record` or already-nested `Vector` payloads.
+    pub fn child(&self, index: usize) -> Option<Value> {
+        match &self.data {
+            ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => v.get(index).cloned(),
+            ValueData::Scalar(_) if index == 0 => Some(self.clone()),
+            ValueData::Tensor { data, shape } => tensor_child(data, shape, index),
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
+        }
+    }
+
     pub fn get_child_mut(&mut self, index: usize) -> Option<&mut Value> {
         if matches!(self.data, ValueData::Tensor { .. }) {
             self.hydrate_tensor_to_vector();
@@ -580,6 +601,109 @@ impl Value {
             hint: DisplayHint::Auto,
             nil_reason: None,
         }
+    }
+
+    /// Like [`from_vector_with_hint`] but promotes the value to a dense
+    /// `Tensor` when every leaf is a Fraction scalar and the shape is
+    /// rectangular. Otherwise the nested form is preserved.
+    ///
+    /// The `String` display hint suppresses promotion at every level so that
+    /// codepoint-based strings retain their nested representation.
+    pub fn from_vector_promoted_with_hint(values: Vec<Value>, hint: DisplayHint) -> Self {
+        if values.is_empty() {
+            return Self::nil_with_reason(NilReason::EmptySequence);
+        }
+        if hint == DisplayHint::String {
+            return Self {
+                data: ValueData::Vector(Rc::new(values)),
+                hint,
+                nil_reason: None,
+            };
+        }
+        if let Some((data, shape)) = try_collect_dense(&values) {
+            return Self {
+                data: ValueData::Tensor {
+                    data: Rc::new(data),
+                    shape: Rc::new(shape),
+                },
+                hint,
+                nil_reason: None,
+            };
+        }
+        Self {
+            data: ValueData::Vector(Rc::new(values)),
+            hint,
+            nil_reason: None,
+        }
+    }
+
+    /// Convenience wrapper around [`from_vector_promoted_with_hint`] using
+    /// `DisplayHint::Auto`.
+    pub fn from_vector_promoted(values: Vec<Value>) -> Self {
+        Self::from_vector_promoted_with_hint(values, DisplayHint::Auto)
+    }
+}
+
+/// Walk a list of `Value`s and return `(flat data, shape)` if every leaf is a
+/// Fraction scalar (or a child Tensor) and the shape is rectangular. Returns
+/// `None` if any leaf is non-numeric (NIL, Record, CodeBlock, Vector with
+/// String hint, etc.) or if shapes disagree.
+fn try_collect_dense(values: &[Value]) -> Option<(Vec<Fraction>, Vec<usize>)> {
+    if values.is_empty() {
+        return None;
+    }
+    let first = try_dense_value(&values[0])?;
+    let inner_shape = first.1;
+    let mut data = first.0;
+    for v in values.iter().skip(1) {
+        let (cdata, cshape) = try_dense_value(v)?;
+        if cshape != inner_shape {
+            return None;
+        }
+        data.extend(cdata);
+    }
+    let mut shape = vec![values.len()];
+    shape.extend(inner_shape);
+    Some((data, shape))
+}
+
+/// Materialize the i-th child of a dense Tensor as an owned `Value`. For 1-D
+/// shape `[n]` the child is a Scalar; for higher rank the child is itself a
+/// dense Tensor with the trailing dimensions.
+fn tensor_child(
+    data: &[Fraction],
+    shape: &[usize],
+    index: usize,
+) -> Option<Value> {
+    if shape.is_empty() {
+        return None;
+    }
+    let outer = shape[0];
+    if index >= outer {
+        return None;
+    }
+    if shape.len() == 1 {
+        return Some(Value::from_fraction(data[index].clone()));
+    }
+    let rest: Vec<usize> = shape[1..].to_vec();
+    let stride: usize = rest.iter().product();
+    let slice: Vec<Fraction> = data[index * stride..(index + 1) * stride].to_vec();
+    Some(Value::from_tensor(slice, rest))
+}
+
+fn try_dense_value(v: &Value) -> Option<(Vec<Fraction>, Vec<usize>)> {
+    if v.hint == DisplayHint::String {
+        return None;
+    }
+    match &v.data {
+        ValueData::Scalar(f) => Some((vec![f.clone()], Vec::new())),
+        ValueData::Tensor { data, shape } => Some(((**data).clone(), (**shape).clone())),
+        ValueData::Vector(children) => try_collect_dense(children),
+        ValueData::Nil
+        | ValueData::Record { .. }
+        | ValueData::CodeBlock(_)
+        | ValueData::ProcessHandle(_)
+        | ValueData::SupervisorHandle(_) => None,
     }
 }
 

--- a/rust/tests/fractional-dataflow-behavior-tests.rs
+++ b/rust/tests/fractional-dataflow-behavior-tests.rs
@@ -29,22 +29,29 @@ fn assert_number(val: &Value, num: i64, denom: i64) {
 
     if let Some(f) = val.as_scalar() {
         assert_eq!(f, &expected, "Expected {}/{}, got {}", num, denom, f);
-    } else if let Some(vec) = val.as_vector() {
-        if vec.len() == 1 {
-            let f = vec[0]
-                .as_scalar()
-                .unwrap_or_else(|| panic!("Expected scalar in vector, got {:?}", vec[0]));
-            assert_eq!(f, &expected, "Expected {}/{}, got {}", num, denom, f);
-        } else {
-            panic!(
-                "Expected single scalar, got vector of length {}: {:?}",
-                vec.len(),
-                val
-            );
-        }
-    } else {
-        panic!("Expected scalar, got {:?}", val);
+        return;
     }
+
+    if val.is_vector() {
+        if val.len() == 1 {
+            let child = val
+                .child(0)
+                .unwrap_or_else(|| panic!("Expected child(0) for len==1, got {:?}", val));
+            let f = child
+                .as_scalar()
+                .cloned()
+                .unwrap_or_else(|| panic!("Expected scalar in vector, got {:?}", child));
+            assert_eq!(f, expected, "Expected {}/{}, got {}", num, denom, f);
+            return;
+        }
+        panic!(
+            "Expected single scalar, got vector of length {}: {:?}",
+            val.len(),
+            val
+        );
+    }
+
+    panic!("Expected scalar, got {:?}", val);
 }
 
 
@@ -353,8 +360,8 @@ async fn test_interpreter_flow_tracking_vector_ops() {
         .unwrap();
     assert_eq!(stack.len(), 1);
 
-    let vec = stack[0].as_vector().unwrap();
-    assert_eq!(vec.len(), 3);
+    assert!(stack[0].is_vector(), "Expected vector result, got {:?}", stack[0]);
+    assert_eq!(stack[0].len(), 3);
     assert!(interp.verify_all_flows().is_ok());
 }
 


### PR DESCRIPTION
## Summary

Phase II PR #2 of the VTU rollout (`docs/dev/vtu-phase-ii-handover.md`).
Producers now construct dense `ValueData::Tensor` values directly:

- Literal `[ N N N ... ]` parses to `Tensor` (was already in execution-loop).
- HOF outputs (`MAP`, `FILTER`) flow through `Value::from_vector_promoted`.
- `FlatTensor::to_value()` returns `Tensor` instead of rebuilding nested
  Vector via `build_nested_value`, retiring the rebuild path that
  `vtu_tensor_rebuild_count` was tracking.

To make this safe with the existing test suite, consumers were updated
to be representation-agnostic where Tensor inputs now reach them:

- New `Value::child(i) -> Option<Value>` materializes a Scalar leaf for
  1-D Tensors and a sub-Tensor for higher rank. Hot paths in
  `vector_ops` (REORDER, GET, SPLIT, RANGE, REVERSE), `higher_order`
  (MAP/FILTER/ANY/ALL/COUNT/FOLD/SCAN/UNFOLD), `hash`, `RESHAPE`/`FILL`,
  and ADSR were migrated.
- `is_vector_value` and `extract_vector_elements` accept `Tensor`.
- `DisplayHint::Auto` renders dense numeric `Tensor`s as strings when
  every leaf is a printable code point (matches the existing Vector
  fallback).
- `EQ` recognizes `Tensor[1]` ↔ `Scalar` equivalence.
- Hedged MAP normalizes per-element results identically to the greedy
  plain path while preserving the `String` hint, so the
  quantized-vs-plain race produces matching shapes.

Tests that pattern-matched `ValueData::Vector` directly were rewritten
to use `is_vector()` / `child(i)` so they pass on either representation.

## Metrics

`bench-baselines/vtu-phase-ii.jsonl` records `vtu_tensor_rebuild_count`
going from 1 to 0 across the unary-flat, same-shape binary, and
projected-broadcast scenarios. The
`vtu_unary_flat_increments_counter` test now asserts
`vtu_tensor_rebuild_count == 0`.

## Test plan

- [x] `cargo test --lib`: 824/824 pass
- [x] `cargo clippy --tests --no-deps`: 100 warnings (unchanged baseline)
- [ ] Manual examples spot check (deferred — same Display output)
- [ ] PR #3 follow-up: full Tensor support in JSON / CAST / SORT / SIMD

https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV)_