### PR TITLE
VTU Phase III: HOF bulk fast paths over 1-D dense Tensor

### DIFF
--- a/rust/src/interpreter/higher-order-fold-operations.rs
+++ b/rust/src/interpreter/higher-order-fold-operations.rs
@@ -67,6 +67,40 @@ pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
                 return Ok(());
             }
 
+            // VTU Phase III bulk fast path: 1-D dense Tensor + fast binary
+            // fold kernel + scalar/Tensor[1] init → fold over Fractions
+            // directly. Disabled in hedged modes so the race observes events.
+            if let ExecutableCode::QuantizedBlock(qb) = &executable {
+                if !crate::interpreter::higher_order::hedged_mode_active(interp) {
+                    if let Some(bulk) =
+                        crate::interpreter::higher_order::try_bulk_quantized_fold_pub(
+                            interp,
+                            qb,
+                            &init_val,
+                            &target_val,
+                        )
+                    {
+                        match bulk {
+                            Ok(result) => {
+                                if is_keep_mode {
+                                    interp.stack.push(target_val);
+                                }
+                                interp.stack.push(result);
+                                return Ok(());
+                            }
+                            Err(e) => {
+                                if !is_keep_mode {
+                                    interp.stack.push(target_val);
+                                }
+                                interp.stack.push(init_val);
+                                interp.stack.push(code_val);
+                                return Err(e);
+                            }
+                        }
+                    }
+                }
+            }
+
             let mut accumulator: Value = init_val;
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);

--- a/rust/src/interpreter/higher_order/all.rs
+++ b/rust/src/interpreter/higher_order/all.rs
@@ -46,6 +46,20 @@ pub fn op_all(interp: &mut Interpreter) -> Result<()> {
                 ));
             }
 
+            // VTU Phase III bulk fast path: ALL over a 1-D dense Tensor with
+            // a fast unary predicate. Disabled in hedged modes.
+            if let ExecutableCode::QuantizedBlock(qb) = &executable {
+                if !super::hedged_mode_active(interp) {
+                    if let Some(bulk) =
+                        super::try_bulk_quantized_predicate_pub(interp, qb, &target_val)
+                    {
+                        let result = bulk.flags.into_iter().all(|b| b);
+                        interp.stack.push(Value::from_bool(result));
+                        return Ok(());
+                    }
+                }
+            }
+
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);
             let saved_target = interp.operation_target_mode;

--- a/rust/src/interpreter/higher_order/any.rs
+++ b/rust/src/interpreter/higher_order/any.rs
@@ -46,6 +46,20 @@ pub fn op_any(interp: &mut Interpreter) -> Result<()> {
                 ));
             }
 
+            // VTU Phase III bulk fast path: ANY over a 1-D dense Tensor with
+            // a fast unary predicate. Disabled in hedged modes.
+            if let ExecutableCode::QuantizedBlock(qb) = &executable {
+                if !super::hedged_mode_active(interp) {
+                    if let Some(bulk) =
+                        super::try_bulk_quantized_predicate_pub(interp, qb, &target_val)
+                    {
+                        let result = bulk.flags.into_iter().any(|b| b);
+                        interp.stack.push(Value::from_bool(result));
+                        return Ok(());
+                    }
+                }
+            }
+
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);
             let saved_target = interp.operation_target_mode;

--- a/rust/src/interpreter/higher_order/count.rs
+++ b/rust/src/interpreter/higher_order/count.rs
@@ -46,6 +46,22 @@ pub fn op_count(interp: &mut Interpreter) -> Result<()> {
                 ));
             }
 
+            // VTU Phase III bulk fast path: COUNT over a 1-D dense Tensor
+            // with a fast unary predicate. Disabled in hedged modes.
+            if let ExecutableCode::QuantizedBlock(qb) = &executable {
+                if !super::hedged_mode_active(interp) {
+                    if let Some(bulk) =
+                        super::try_bulk_quantized_predicate_pub(interp, qb, &target_val)
+                    {
+                        let count: i64 = bulk.flags.into_iter().filter(|b| *b).count() as i64;
+                        interp
+                            .stack
+                            .push(Value::from_vector(vec![Value::from_int(count)]));
+                        return Ok(());
+                    }
+                }
+            }
+
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);
             let saved_hints: Vec<DisplayHint> =

--- a/rust/src/interpreter/higher_order/fast_kernels.rs
+++ b/rust/src/interpreter/higher_order/fast_kernels.rs
@@ -115,6 +115,231 @@ pub(super) fn try_execute_fast_quantized_map_kernel(
     execute_fast_unary_map_kernel(&kernel, elem)
 }
 
+/// Apply a unary fast kernel to every Fraction in `data`, producing a fresh
+/// `Vec<Fraction>` of the same length. Returns `Err` for division/modulo by
+/// zero. Caller is responsible for wrapping the output as a `Tensor` with
+/// the appropriate shape.
+fn apply_fast_unary_map_to_data(
+    kernel: &FastUnaryMapKernel,
+    data: &[Fraction],
+) -> Result<Vec<Fraction>> {
+    let mut out = Vec::with_capacity(data.len());
+    match kernel {
+        FastUnaryMapKernel::AddConst(c) => {
+            for x in data {
+                out.push(x.add(c));
+            }
+        }
+        FastUnaryMapKernel::SubConst(c) => {
+            for x in data {
+                out.push(x.sub(c));
+            }
+        }
+        FastUnaryMapKernel::MulConst(c) => {
+            for x in data {
+                out.push(x.mul(c));
+            }
+        }
+        FastUnaryMapKernel::DivConst(c) => {
+            if c.is_zero() {
+                return Err(AjisaiError::from("MAP fast kernel: division by zero"));
+            }
+            for x in data {
+                out.push(x.div(c));
+            }
+        }
+        FastUnaryMapKernel::ModConst(c) => {
+            if c.is_zero() {
+                return Err(AjisaiError::from("MAP fast kernel: modulo by zero"));
+            }
+            for x in data {
+                out.push(x.modulo(c));
+            }
+        }
+        FastUnaryMapKernel::EqConst(c) => {
+            for x in data {
+                out.push(if x == c { Fraction::from(1_i64) } else { Fraction::from(0_i64) });
+            }
+        }
+        FastUnaryMapKernel::LtConst(c) => {
+            for x in data {
+                out.push(if x.lt(c) { Fraction::from(1_i64) } else { Fraction::from(0_i64) });
+            }
+        }
+        FastUnaryMapKernel::Abs => {
+            for x in data {
+                out.push(x.abs());
+            }
+        }
+        FastUnaryMapKernel::Neg => {
+            let neg_one = Fraction::from(-1_i64);
+            for x in data {
+                out.push(x.mul(&neg_one));
+            }
+        }
+        FastUnaryMapKernel::Not => {
+            for x in data {
+                out.push(if x.is_zero() { Fraction::from(1_i64) } else { Fraction::from(0_i64) });
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn apply_fast_unary_predicate_to_data(
+    kernel: &FastUnaryPredicateKernel,
+    data: &[Fraction],
+) -> Vec<bool> {
+    let mut out = Vec::with_capacity(data.len());
+    match kernel {
+        FastUnaryPredicateKernel::EqConst(c) => {
+            for x in data {
+                out.push(x == c);
+            }
+        }
+        FastUnaryPredicateKernel::LtConst(c) => {
+            for x in data {
+                out.push(x.lt(c));
+            }
+        }
+        FastUnaryPredicateKernel::Not => {
+            for x in data {
+                out.push(x.is_zero());
+            }
+        }
+    }
+    out
+}
+
+fn fold_fast_binary_over_data(
+    kernel: FastBinaryFoldKernel,
+    init: Fraction,
+    data: &[Fraction],
+) -> Result<Fraction> {
+    let mut acc = init;
+    match kernel {
+        FastBinaryFoldKernel::Add => {
+            for x in data {
+                acc = acc.add(x);
+            }
+        }
+        FastBinaryFoldKernel::Sub => {
+            for x in data {
+                acc = acc.sub(x);
+            }
+        }
+        FastBinaryFoldKernel::Mul => {
+            for x in data {
+                acc = acc.mul(x);
+            }
+        }
+        FastBinaryFoldKernel::Div => {
+            for x in data {
+                if x.is_zero() {
+                    return Err(AjisaiError::from("FOLD fast kernel: division by zero"));
+                }
+                acc = acc.div(x);
+            }
+        }
+        FastBinaryFoldKernel::Mod => {
+            for x in data {
+                if x.is_zero() {
+                    return Err(AjisaiError::from("FOLD fast kernel: modulo by zero"));
+                }
+                acc = acc.modulo(x);
+            }
+        }
+    }
+    Ok(acc)
+}
+
+/// Result of an attempted bulk Tensor MAP. `None` means the input was not a
+/// 1-D dense Tensor or the kernel is not fast-bulk eligible — caller falls
+/// back to the per-element path.
+pub(crate) struct BulkMapResult {
+    pub data: Vec<Fraction>,
+}
+
+pub(super) fn try_bulk_quantized_map(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    target: &Value,
+) -> Option<Result<BulkMapResult>> {
+    let (data, shape) = target.as_dense_tensor()?;
+    if shape.len() != 1 {
+        return None;
+    }
+    let line = qb.compiled_plan.lines.first()?;
+    let kernel = detect_fast_unary_map_kernel(&line.source_tokens)?;
+    interp.runtime_metrics.quantized_block_use_count += data.len() as u64;
+    interp.runtime_metrics.vtu_bulk_kernel_use_count =
+        interp.runtime_metrics.vtu_bulk_kernel_use_count.saturating_add(1);
+    Some(apply_fast_unary_map_to_data(&kernel, data).map(|d| BulkMapResult { data: d }))
+}
+
+pub(crate) struct BulkPredicateResult {
+    pub flags: Vec<bool>,
+}
+
+pub(super) fn try_bulk_quantized_predicate(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    target: &Value,
+) -> Option<BulkPredicateResult> {
+    let (data, shape) = target.as_dense_tensor()?;
+    if shape.len() != 1 {
+        return None;
+    }
+    let line = qb.compiled_plan.lines.first()?;
+    let kernel = detect_fast_unary_predicate_kernel(&line.source_tokens)?;
+    interp.runtime_metrics.quantized_block_use_count += data.len() as u64;
+    interp.runtime_metrics.vtu_bulk_kernel_use_count =
+        interp.runtime_metrics.vtu_bulk_kernel_use_count.saturating_add(1);
+    Some(BulkPredicateResult {
+        flags: apply_fast_unary_predicate_to_data(&kernel, data),
+    })
+}
+
+/// Extract the single Fraction inside a length-1 vector/tensor or a Scalar.
+fn singleton_scalar(v: &Value) -> Option<Fraction> {
+    if let Some(f) = v.as_scalar() {
+        return Some(f.clone());
+    }
+    if v.len() == 1 {
+        let child = v.child(0)?;
+        return child.as_scalar().cloned();
+    }
+    None
+}
+
+pub(super) fn try_bulk_quantized_fold(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    init: &Value,
+    target: &Value,
+) -> Option<Result<Value>> {
+    let init_scalar = singleton_scalar(init)?;
+    let (data, shape) = target.as_dense_tensor()?;
+    if shape.len() != 1 {
+        return None;
+    }
+    let line = qb.compiled_plan.lines.first()?;
+    let kernel = detect_fast_binary_fold_kernel(&line.source_tokens)?;
+    interp.runtime_metrics.quantized_block_use_count += data.len() as u64;
+    interp.runtime_metrics.vtu_bulk_kernel_use_count =
+        interp.runtime_metrics.vtu_bulk_kernel_use_count.saturating_add(1);
+    // Mirror the init shape: callers using `[ x ]` expect a Tensor[1] back,
+    // while a bare Scalar accumulator should stay Scalar.
+    let wrap_singleton = init.as_scalar().is_none();
+    Some(fold_fast_binary_over_data(kernel, init_scalar, data).map(|f| {
+        if wrap_singleton {
+            Value::from_tensor(vec![f], vec![1])
+        } else {
+            Value::from_number(f)
+        }
+    }))
+}
+
 fn detect_fast_unary_predicate_kernel(tokens: &[Token]) -> Option<FastUnaryPredicateKernel> {
     if tokens.len() == 1 {
         if let Token::Symbol(sym) = &tokens[0] {

--- a/rust/src/interpreter/higher_order/filter.rs
+++ b/rust/src/interpreter/higher_order/filter.rs
@@ -62,6 +62,38 @@ pub fn op_filter(interp: &mut Interpreter) -> Result<()> {
                 return Ok(());
             }
 
+            // VTU Phase III bulk fast path for 1-D dense Tensor + fast unary
+            // predicate kernel. Builds the surviving Fraction subset directly
+            // and returns either a Tensor (>=1 survivors) or NIL.
+            if let ExecutableCode::QuantizedBlock(qb) = &executable {
+                if !super::hedged::hedged_mode(interp.elastic_mode()) {
+                    if let Some(bulk) = super::fast_kernels::try_bulk_quantized_predicate(
+                        interp, qb, &target_val,
+                    ) {
+                        let (data, _shape) = target_val
+                            .as_dense_tensor()
+                            .expect("predicate bulk implies dense tensor");
+                        let mut kept: Vec<crate::types::fraction::Fraction> = Vec::new();
+                        for (i, keep) in bulk.flags.into_iter().enumerate() {
+                            if keep {
+                                kept.push(data[i].clone());
+                            }
+                        }
+                        let result = if kept.is_empty() {
+                            Value::nil()
+                        } else {
+                            let len = kept.len();
+                            Value::from_tensor(kept, vec![len])
+                        };
+                        if is_keep_mode {
+                            interp.stack.push(target_val);
+                        }
+                        interp.stack.push(result);
+                        return Ok(());
+                    }
+                }
+            }
+
             let mut results: Vec<Value> = Vec::with_capacity(n_elements);
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);

--- a/rust/src/interpreter/higher_order/hedged.rs
+++ b/rust/src/interpreter/higher_order/hedged.rs
@@ -12,7 +12,7 @@ use crate::interpreter::quantized_block::QuantizedBlock;
 use crate::interpreter::Interpreter;
 use crate::types::{DisplayHint, Token, Value};
 
-fn hedged_mode(mode: ElasticMode) -> bool {
+pub(super) fn hedged_mode(mode: ElasticMode) -> bool {
     matches!(mode, ElasticMode::HedgedSafe | ElasticMode::HedgedTrace)
 }
 

--- a/rust/src/interpreter/higher_order/map.rs
+++ b/rust/src/interpreter/higher_order/map.rs
@@ -59,6 +59,38 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
                 return Ok(());
             }
 
+            // VTU Phase III bulk fast path: when target is a 1-D dense Tensor
+            // and the kernel is a fast unary, iterate `Tensor.data` directly
+            // and emit a Tensor output, skipping per-element Value
+            // materialization. Disabled in hedged modes so the
+            // quantized/plain race still observes per-element kernel events.
+            if let ExecutableCode::QuantizedBlock(qb) = &executable {
+                if !super::hedged::hedged_mode(interp.elastic_mode()) {
+                if let Some(bulk) = super::fast_kernels::try_bulk_quantized_map(
+                    interp, qb, &target_val,
+                ) {
+                    match bulk {
+                        Ok(out) => {
+                            let result =
+                                Value::from_tensor(out.data, vec![n_elements]);
+                            if is_keep_mode {
+                                interp.stack.push(target_val);
+                            }
+                            interp.stack.push(result);
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            if !is_keep_mode {
+                                interp.stack.push(target_val);
+                            }
+                            interp.stack.push(code_val);
+                            return Err(e);
+                        }
+                    }
+                }
+                }
+            }
+
             let mut results: Vec<Value> = Vec::with_capacity(n_elements);
             let mut saved_stack: Vec<Value> = Vec::new();
             std::mem::swap(&mut interp.stack, &mut saved_stack);

--- a/rust/src/interpreter/higher_order/mod.rs
+++ b/rust/src/interpreter/higher_order/mod.rs
@@ -23,3 +23,37 @@ pub use any::op_any;
 pub use count::op_count;
 pub use filter::op_filter;
 pub use map::op_map;
+
+use crate::error::Result;
+use crate::interpreter::quantized_block::QuantizedBlock;
+use crate::interpreter::Interpreter;
+use crate::types::Value;
+
+/// Returns true when the interpreter is in a hedged execution mode where the
+/// HOF bulk fast paths should be skipped to keep race-validation events
+/// observable.
+#[inline]
+pub(crate) fn hedged_mode_active(interp: &Interpreter) -> bool {
+    hedged::hedged_mode(interp.elastic_mode())
+}
+
+/// Public-to-the-crate wrapper around the fast-kernel bulk fold so the
+/// `higher_order_fold` module (sibling, not child) can reach it.
+pub(crate) fn try_bulk_quantized_fold_pub(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    init: &Value,
+    target: &Value,
+) -> Option<Result<Value>> {
+    fast_kernels::try_bulk_quantized_fold(interp, qb, init, target)
+}
+
+/// Public-to-the-crate wrapper around the fast-kernel bulk predicate.
+pub(crate) fn try_bulk_quantized_predicate_pub(
+    interp: &mut Interpreter,
+    qb: &QuantizedBlock,
+    target: &Value,
+) -> Option<fast_kernels::BulkPredicateResult> {
+    fast_kernels::try_bulk_quantized_predicate(interp, qb, target)
+}
+

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -180,6 +180,10 @@ pub struct RuntimeMetrics {
     pub vtu_rejected_block_count: u64,
     /// QuantizedBlocks whose VtuHint marked them as fusion candidates.
     pub vtu_fusion_candidate_count: u64,
+    /// HOF invocations that took a Tensor-bulk fast path, iterating
+    /// `Tensor.data: &[Fraction]` directly without per-element Value
+    /// materialization. Phase III metric.
+    pub vtu_bulk_kernel_use_count: u64,
 }
 
 pub struct Interpreter {

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -833,3 +833,79 @@ fn vtu_unary_flat_increments_counter() {
     );
     assert!(m.vtu_allocated_elements >= 3);
 }
+
+// ---------------------------------------------------------------------------
+// VTU Phase III bulk fast path: 1-D dense Tensor inputs to MAP/FILTER/FOLD/
+// ANY/ALL/COUNT iterate the underlying `&[Fraction]` directly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vtu_phase_iii_map_bulk_kernel_fires_and_matches_per_element() {
+    let bulk = run_code("[ 1 2 3 4 ] { [ 2 ] * } MAP");
+    let plain = run_code("{ [ 2 ] * } 'DBL' DEF [ 1 2 3 4 ] 'DBL' MAP");
+    assert_eq!(bulk.get_stack(), plain.get_stack());
+    let m = bulk.runtime_metrics();
+    assert!(
+        m.vtu_bulk_kernel_use_count >= 1,
+        "MAP over dense Tensor + fast unary kernel should take the bulk path"
+    );
+}
+
+#[test]
+fn vtu_phase_iii_filter_bulk_kernel_matches_per_element() {
+    let bulk = run_code("[ 1 2 3 4 ] { [ 2 ] = } FILTER");
+    let plain = run_code("{ [ 2 ] = } 'EQ2' DEF [ 1 2 3 4 ] 'EQ2' FILTER");
+    assert_eq!(bulk.get_stack(), plain.get_stack());
+    assert!(bulk.runtime_metrics().vtu_bulk_kernel_use_count >= 1);
+}
+
+#[test]
+fn vtu_phase_iii_fold_bulk_kernel_matches_per_element() {
+    let bulk = run_code("[ 1 2 3 4 ] [ 0 ] { + } FOLD");
+    let plain = run_code("{ + } 'PLUS' DEF [ 1 2 3 4 ] [ 0 ] 'PLUS' FOLD");
+    assert_eq!(bulk.get_stack(), plain.get_stack());
+    assert!(bulk.runtime_metrics().vtu_bulk_kernel_use_count >= 1);
+}
+
+#[test]
+fn vtu_phase_iii_any_bulk_kernel_matches_per_element() {
+    let bulk = run_code("[ 1 2 3 ] { [ 2 ] = } ANY");
+    let plain = run_code("{ [ 2 ] = } 'EQ2' DEF [ 1 2 3 ] 'EQ2' ANY");
+    assert_eq!(bulk.get_stack(), plain.get_stack());
+    assert!(bulk.runtime_metrics().vtu_bulk_kernel_use_count >= 1);
+}
+
+#[test]
+fn vtu_phase_iii_all_bulk_kernel_matches_per_element() {
+    // Predicate `{ [ 0 ] = }` -> elements equal to 0; none in [1 2 3] so ALL=FALSE.
+    let bulk = run_code("[ 1 2 3 ] { [ 0 ] = } ALL");
+    let plain = run_code("{ [ 0 ] = } 'EQ0' DEF [ 1 2 3 ] 'EQ0' ALL");
+    assert_eq!(bulk.get_stack(), plain.get_stack());
+    assert!(bulk.runtime_metrics().vtu_bulk_kernel_use_count >= 1);
+}
+
+#[test]
+fn vtu_phase_iii_count_bulk_kernel_matches_per_element() {
+    let bulk = run_code("[ 1 2 3 4 ] { [ 2 ] = } COUNT");
+    let plain = run_code("{ [ 2 ] = } 'EQ2' DEF [ 1 2 3 4 ] 'EQ2' COUNT");
+    assert_eq!(bulk.get_stack(), plain.get_stack());
+    assert!(bulk.runtime_metrics().vtu_bulk_kernel_use_count >= 1);
+}
+
+#[test]
+fn vtu_phase_iii_map_bulk_division_by_zero_propagates() {
+    let result = run_code_result("[ 1 2 3 ] { [ 0 ] / } MAP");
+    assert!(result.is_err(), "division by zero should error out");
+}
+
+#[test]
+fn vtu_phase_iii_bulk_metric_zero_for_user_word_kernel() {
+    // User word does not match a fast unary kernel -> per-element path,
+    // bulk metric stays at 0.
+    let interp = run_code("{ [ 2 ] * } 'DBL' DEF [ 1 2 3 ] 'DBL' MAP");
+    assert_eq!(
+        interp.runtime_metrics().vtu_bulk_kernel_use_count,
+        0,
+        "user-word kernel should not take the bulk path"
+    );
+}

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -163,6 +163,18 @@ impl Value {
         matches!(self.data, ValueData::Tensor { .. })
     }
 
+    /// Borrow the dense numeric backing of a `Tensor` value as
+    /// `(data, shape)`. Returns `None` for any other representation.
+    /// Use this on hot HOF paths to iterate `Fraction`s directly without
+    /// materializing per-element `Value`s.
+    #[inline]
+    pub fn as_dense_tensor(&self) -> Option<(&[Fraction], &[usize])> {
+        match &self.data {
+            ValueData::Tensor { data, shape } => Some((data.as_slice(), shape.as_slice())),
+            _ => None,
+        }
+    }
+
     #[inline]
     pub fn is_uniquely_owned(&self) -> bool {
         match &self.data {


### PR DESCRIPTION
## Summary

Phase III follow-up to PR #874. When a HOF target is a 1-D dense
`Tensor` and the kernel is a fast unary op (or fast binary for FOLD),
iterate `Tensor.data: &[Fraction]` directly and emit a `Tensor` output,
skipping per-element `Value` materialization.

This was the user-selected starting point for Phase III ("HOF fast
path") from `docs/dev/vtu-phase-ii-handover.md`. Consumer-side
`CAST/JSON/SHAPE/RESHAPE/...` Tensor support and the
`ensure_hydrated()` boundary helpers are deferred to follow-up PRs.

## Mechanics

- `Value::as_dense_tensor() -> Option<(&[Fraction], &[usize])>` —
  zero-copy borrow of dense Tensor backing.
- `fast_kernels::try_bulk_quantized_{map,predicate,fold}` — drive the
  existing `FastUnaryMapKernel` / `FastUnaryPredicateKernel` /
  `FastBinaryFoldKernel` detectors against `&[Fraction]`.
- `op_map` / `op_filter` / `op_fold` / `op_any` / `op_all` / `op_count`
  call into the bulk path before entering the per-element loop.
- Bulk path is gated off in `HedgedSafe` / `HedgedTrace` so the
  quantized-vs-plain race still observes per-element events.
- New metric: `RuntimeMetrics::vtu_bulk_kernel_use_count`.

## Output shape parity

| HOF    | Per-element path output | Bulk path output |
|--------|-------------------------|------------------|
| MAP    | Tensor[n]               | Tensor[n]        |
| FILTER | Tensor[k] or NIL        | Tensor[k] or NIL |
| FOLD   | matches `init` shape    | matches `init` shape |
| ANY    | scalar boolean          | scalar boolean   |
| ALL    | scalar boolean          | scalar boolean   |
| COUNT  | `[ k ]`                 | `[ k ]`          |

## Tests

- 8 new parity tests in `quantized-block-tests.rs`: each asserts
  `bulk.get_stack() == plain.get_stack()` against a user-word kernel
  that intentionally falls off the fast path, and that the bulk metric
  is exercised.
- `vtu_phase_iii_bulk_metric_zero_for_user_word_kernel`: negative test
  confirming the metric stays 0 when no fast kernel matches.
- Division-by-zero parity test confirms the bulk path's error
  propagation.

## Test plan

- [x] `cargo test`: 832 lib + 57 integration pass
- [x] `cargo clippy --tests --no-deps`: 100 warnings (unchanged baseline)
- [ ] Bench impact recorded in `bench-baselines/` — deferred until the
      next Phase III PR adds plan-level benchmarks.

https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV)_