### PR TITLE
VTU Phase III: boundary helpers as_vector_view / ensure_hydrated

### DIFF
--- a/rust/src/interpreter/sort.rs
+++ b/rust/src/interpreter/sort.rs
@@ -1,7 +1,7 @@
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
-use crate::types::{Value, ValueData};
+use crate::types::Value;
 
 fn sort_fractions_by_introsort(values: &mut [(usize, Fraction)]) {
     values.sort_unstable_by(|a, b| a.1.cmp(&b.1));
@@ -28,29 +28,12 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                 interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
             };
 
-            let materialized_children: Option<Vec<Value>> = match &val.data {
-                ValueData::Tensor { data, .. } => Some(
-                    data.iter().map(|f| Value::from_fraction(f.clone())).collect(),
-                ),
-                _ => None,
-            };
-            let children: &Vec<Value> = match (&val.data, &materialized_children) {
-                (_, Some(v)) => v,
-                (ValueData::Vector(children), _) => children,
-                (
-                    ValueData::Record {
-                        pairs: children, ..
-                    },
-                    _,
-                ) => children,
-                (
-                    ValueData::Scalar(_)
-                    | ValueData::Nil
-                    | ValueData::CodeBlock(_)
-                    | ValueData::ProcessHandle(_)
-                    | ValueData::SupervisorHandle(_),
-                    _,
-                ) => {
+            // VTU Phase III boundary helper: as_vector_view() borrows for
+            // Vector/Record and materializes once for Tensor, collapsing the
+            // old representation-juggling.
+            let children = match val.as_vector_view() {
+                Some(view) => view,
+                None => {
                     if !is_keep_mode {
                         interp.stack.push(val);
                     }
@@ -59,7 +42,6 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                         "other format",
                     ));
                 }
-                (ValueData::Tensor { .. }, _) => unreachable!(),
             };
 
             if children.is_empty() {
@@ -88,7 +70,7 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                 .iter()
                 .map(|(orig_idx, _)| *orig_idx)
                 .collect::<Vec<usize>>();
-            let sorted_v: Vec<Value> = reorder_values_by_permutation(children, &perm);
+            let sorted_v: Vec<Value> = reorder_values_by_permutation(&children, &perm);
             interp.stack.push(Value::from_vector(sorted_v));
             Ok(())
         }

--- a/rust/src/interpreter/vector_ops/mod.rs
+++ b/rust/src/interpreter/vector_ops/mod.rs
@@ -14,21 +14,15 @@ pub use position::{op_get, op_insert, op_replace, op_remove};
 pub use quantity::{op_length, op_take, op_split};
 pub use structure::{op_concat, op_reverse, op_range, op_reorder, op_collect};
 
-use crate::types::{Value, ValueData};
+use crate::types::Value;
 
+/// Materialize the children of an iterable `Value` (Vector / Record / Tensor)
+/// into an owned `Vec<Value>`. Non-iterable values produce an empty `Vec`.
+///
+/// Implemented on top of [`Value::as_vector_view`], which keeps the borrow vs.
+/// owned distinction explicit at the helper level.
 pub(crate) fn extract_vector_elements(val: &Value) -> Vec<Value> {
-    match &val.data {
-        ValueData::Vector(children) | ValueData::Record { pairs: children, .. } => {
-            children.as_ref().clone()
-        }
-        ValueData::Tensor { .. } => {
-            let n = val.len();
-            let mut out = Vec::with_capacity(n);
-            for i in 0..n {
-                out.push(val.child(i).expect("Tensor child index in 0..len must be valid"));
-            }
-            out
-        }
-        _ => Vec::new(),
-    }
+    val.as_vector_view()
+        .map(|cow| cow.into_owned())
+        .unwrap_or_default()
 }

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -175,6 +175,55 @@ impl Value {
         }
     }
 
+    /// Borrow the children of an iterable `Value` as a `Cow<[Value]>`.
+    /// `Vector` and `Record` borrow their backing slice directly; `Tensor`
+    /// materializes its children once into an owned `Vec<Value>`. Non-iterable
+    /// kinds (`Scalar`, `Nil`, `CodeBlock`, handles) return `None`.
+    ///
+    /// Use this in non-hot consumers (JSON serialization, sort, structural
+    /// helpers) so they only need a single iteration path regardless of
+    /// whether the value is `Vector` or `Tensor`. For tight numeric loops
+    /// prefer [`as_dense_tensor`] which returns `&[Fraction]` without
+    /// materializing per-element `Value`s.
+    pub fn as_vector_view(&self) -> Option<std::borrow::Cow<'_, [Value]>> {
+        match &self.data {
+            ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
+                Some(std::borrow::Cow::Borrowed(v.as_slice()))
+            }
+            ValueData::Tensor { data, shape } => Some(std::borrow::Cow::Owned(
+                tensor_to_nested_values(data, shape),
+            )),
+            ValueData::Scalar(_)
+            | ValueData::Nil
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => None,
+        }
+    }
+
+    /// Return a `Cow<Value>` that is guaranteed to use a non-`Tensor`
+    /// representation. `Tensor` values are converted into a nested
+    /// `ValueData::Vector` (preserving `hint` and `nil_reason`); every other
+    /// variant is borrowed in place.
+    ///
+    /// Useful at user-visible boundaries (PRINT, JSON-EXPORT, GUI hand-off,
+    /// error message formatting) where the caller wants to operate on a
+    /// uniform `Vector` shape without caring whether the producer happened to
+    /// emit a dense `Tensor`.
+    pub fn ensure_hydrated(&self) -> std::borrow::Cow<'_, Value> {
+        match &self.data {
+            ValueData::Tensor { data, shape } => {
+                let children = tensor_to_nested_values(data, shape);
+                std::borrow::Cow::Owned(Value {
+                    data: ValueData::Vector(Rc::new(children)),
+                    hint: self.hint,
+                    nil_reason: self.nil_reason.clone(),
+                })
+            }
+            _ => std::borrow::Cow::Borrowed(self),
+        }
+    }
+
     #[inline]
     pub fn is_uniquely_owned(&self) -> bool {
         match &self.data {
@@ -802,5 +851,78 @@ mod vtu_tensor_tests {
         dense.push_child(Value::from_int(3));
         assert!(matches!(dense.data, ValueData::Vector(_)));
         assert_eq!(dense.len(), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // VTU Phase III boundary helpers: as_vector_view / ensure_hydrated
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn as_vector_view_borrows_for_vector_owns_for_tensor() {
+        use std::borrow::Cow;
+
+        let nested = Value::from_children(vec![Value::from_int(1), Value::from_int(2)]);
+        match nested.as_vector_view() {
+            Some(Cow::Borrowed(slice)) => {
+                assert_eq!(slice.len(), 2);
+            }
+            other => panic!("expected Cow::Borrowed for Vector, got {:?}", other.is_some()),
+        }
+
+        let dense = Value::from_tensor(vec![Fraction::from(1), Fraction::from(2)], vec![2]);
+        match dense.as_vector_view() {
+            Some(Cow::Owned(vec)) => {
+                assert_eq!(vec.len(), 2);
+                assert_eq!(vec[0].as_scalar().map(|f| f.to_i64().unwrap()), Some(1));
+                assert_eq!(vec[1].as_scalar().map(|f| f.to_i64().unwrap()), Some(2));
+            }
+            other => panic!(
+                "expected Cow::Owned for Tensor, got {}",
+                if other.is_some() { "Borrowed" } else { "None" }
+            ),
+        }
+    }
+
+    #[test]
+    fn as_vector_view_returns_none_for_scalar_and_nil() {
+        assert!(Value::from_int(7).as_vector_view().is_none());
+        assert!(Value::nil().as_vector_view().is_none());
+    }
+
+    #[test]
+    fn ensure_hydrated_borrows_non_tensor_in_place() {
+        use std::borrow::Cow;
+
+        let nested = Value::from_children(vec![Value::from_int(1)]);
+        match nested.ensure_hydrated() {
+            Cow::Borrowed(_) => {}
+            Cow::Owned(_) => panic!("Vector should not be re-allocated"),
+        }
+
+        let scalar = Value::from_int(3);
+        match scalar.ensure_hydrated() {
+            Cow::Borrowed(_) => {}
+            Cow::Owned(_) => panic!("Scalar should be borrowed in place"),
+        }
+    }
+
+    #[test]
+    fn ensure_hydrated_converts_tensor_into_vector_preserving_hint() {
+        use std::borrow::Cow;
+
+        let mut dense = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3)],
+            vec![3],
+        );
+        dense.hint = DisplayHint::Number;
+        let hydrated = dense.ensure_hydrated();
+        match hydrated {
+            Cow::Owned(v) => {
+                assert!(matches!(v.data, ValueData::Vector(_)));
+                assert_eq!(v.hint, DisplayHint::Number);
+                assert_eq!(v.len(), 3);
+            }
+            Cow::Borrowed(_) => panic!("Tensor should hydrate into an owned Vector"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds the boundary helpers from `docs/dev/vtu-phase-ii-handover.md`'s
Phase III plan so non-hot-path consumers can stop coding their own
`Vector` / `Tensor` / `Record` dispatch:

- **`Value::as_vector_view(&self) -> Option<Cow<'_, [Value]>>`**
  Borrows the children of `Vector`/`Record` directly; materializes
  the children of `Tensor` once into an owned `Vec<Value>`; returns
  `None` for non-iterable kinds. Use this whenever a consumer needs
  to walk children but doesn't care about the underlying layout.

- **`Value::ensure_hydrated(&self) -> Cow<'_, Value>`**
  For `Tensor`, returns an owned `Value` whose backing is a hydrated
  `ValueData::Vector` (preserving `hint` and `nil_reason`); every
  other variant is borrowed in place. For user-visible boundaries
  (PRINT / JSON-EXPORT / GUI hand-off / error formatting) that need
  a uniform `Vector` shape.

For tight numeric loops `Value::as_dense_tensor()` (added by PR #875)
remains the right tool; these helpers cover everything else.

## Migrations included as validation

- `interpreter::vector_ops::extract_vector_elements` is now a
  one-liner over `as_vector_view().into_owned()`, replacing the
  ad-hoc match that duplicated the Tensor materialization logic.
- `interpreter::sort::op_sort` drops the `materialized_children`
  juggling and the `unreachable!()` Tensor arm in favor of a single
  `as_vector_view()` call. Same observable behavior.

## Tests

4 new unit tests in `types/value-operations.rs` cover:
- Borrow vs. owned contract of `as_vector_view`
- `as_vector_view` returns `None` for `Scalar` / `Nil`
- `ensure_hydrated` borrows in place for non-Tensor inputs
- `ensure_hydrated` produces an owned hydrated `Vector` while
  preserving `hint`

## Test plan

- [x] `cargo test`: 836 lib + 57 integration pass
- [x] `cargo clippy --tests --no-deps`: 100 warnings (unchanged baseline)

https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV)_