### PR TITLE
VTU Phase III: tensor-aware JSON / JOIN consumers + parity tests

### DIFF
--- a/rust/src/interpreter/cast-chars-join.rs
+++ b/rust/src/interpreter/cast-chars-join.rs
@@ -4,7 +4,7 @@ use crate::interpreter::cast::cast_value_helpers::{
 };
 use crate::interpreter::value_extraction_helpers::value_as_string;
 use crate::interpreter::{Interpreter, OperationTargetMode};
-use crate::types::{Value, ValueData};
+use crate::types::Value;
 
 pub fn op_chars(interp: &mut Interpreter) -> Result<()> {
     match interp.operation_target_mode {
@@ -117,7 +117,7 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
                 return Err(AjisaiError::from("JOIN: expected Vector, got Nil"));
             }
 
-            if let ValueData::Vector(children) = &val.data {
+            if let Some(children) = val.as_vector_view() {
                 if children.is_empty() {
                     interp.stack.push(val);
                     return Err(AjisaiError::from(
@@ -201,7 +201,7 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
                 }
 
 
-                if let ValueData::Vector(children) = &elem.data {
+                if let Some(children) = elem.as_vector_view() {
                     if children.is_empty() {
                         interp.stack = results;
                         interp.stack.push(elem);

--- a/rust/src/interpreter/json.rs
+++ b/rust/src/interpreter/json.rs
@@ -300,14 +300,14 @@ pub fn op_json_export(interp: &mut Interpreter) -> Result<()> {
 }
 
 fn extract_string_content_from_value(val: &Value) -> String {
-    if let ValueData::Vector(chars) = &val.data {
-        if chars.iter().all(|c| matches!(c.data, ValueData::Scalar(_))) {
-            return chars
+    if let Some(view) = val.as_vector_view() {
+        if view.iter().all(|c| matches!(c.data, ValueData::Scalar(_))) {
+            return view
                 .iter()
                 .filter_map(|c| {
                     if let ValueData::Scalar(f) = &c.data {
                         f.to_i64().and_then(|n| {
-                            if n >= 0 && n <= 0x10FFFF {
+                            if (0..=0x10FFFF).contains(&n) {
                                 char::from_u32(n as u32)
                             } else {
                                 None

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -909,3 +909,91 @@ fn vtu_phase_iii_bulk_metric_zero_for_user_word_kernel() {
         "user-word kernel should not take the bulk path"
     );
 }
+
+// ---------------------------------------------------------------------------
+// VTU Phase III consumer ops: SHAPE / RANK / RESHAPE / TRANSPOSE / FILL /
+// JSON-STRINGIFY / JOIN / SORT must all accept a dense Tensor input and
+// produce the same observable result they produced for nested Vector inputs
+// before the producer switch.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vtu_phase_iii_shape_accepts_tensor_input() {
+    // [ 1 2 3 ] is now a dense Tensor under Phase II. SHAPE must still
+    // return [ 3 ].
+    let interp = run_code("[ 1 2 3 ] SHAPE");
+    let top = stack_top(&interp);
+    assert!(top.is_vector(), "SHAPE result should be a vector");
+    assert_eq!(top.len(), 1);
+    let dim = top
+        .child(0)
+        .and_then(|c| c.as_scalar().and_then(|f| f.to_i64()));
+    assert_eq!(dim, Some(3));
+}
+
+#[test]
+fn vtu_phase_iii_rank_accepts_tensor_input() {
+    let interp = run_code("[ 1 2 3 ] RANK");
+    let top = stack_top(&interp);
+    let rank = top
+        .as_scalar()
+        .and_then(|f| f.to_i64())
+        .or_else(|| top.child(0).and_then(|c| c.as_scalar().and_then(|f| f.to_i64())));
+    assert_eq!(rank, Some(1));
+}
+
+#[test]
+fn vtu_phase_iii_reshape_dense_to_2d_matches_nested() {
+    let dense = run_code("[ 1 2 3 4 ] [ 2 2 ] RESHAPE");
+    // SHAPE of the result should be [ 2 2 ].
+    let mut sh = run_code("[ 1 2 3 4 ] [ 2 2 ] RESHAPE SHAPE");
+    let shape_top = sh.stack.pop().unwrap();
+    assert!(shape_top.is_vector());
+    assert_eq!(shape_top.len(), 2);
+    // The reshaped value should round-trip through TRANSPOSE -> TRANSPOSE
+    // back to itself.
+    let twice = run_code("[ 1 2 3 4 ] [ 2 2 ] RESHAPE TRANSPOSE TRANSPOSE");
+    assert_eq!(dense.get_stack(), twice.get_stack());
+}
+
+#[test]
+fn vtu_phase_iii_transpose_accepts_tensor_2d() {
+    // Transposing [[1 2 3] [4 5 6]] should yield [[1 4] [2 5] [3 6]].
+    let interp = run_code("[ [ 1 2 3 ] [ 4 5 6 ] ] TRANSPOSE");
+    let top = stack_top(&interp);
+    assert!(top.is_vector());
+    assert_eq!(top.shape(), vec![3, 2]);
+}
+
+#[test]
+fn vtu_phase_iii_fill_produces_dense_tensor() {
+    let interp = run_code("[ 3 0 ] FILL");
+    let top = stack_top(&interp);
+    assert_eq!(top.shape(), vec![3]);
+    for i in 0..3 {
+        let elem = top.child(i).unwrap();
+        assert_eq!(elem.as_scalar().and_then(|f| f.to_i64()), Some(0));
+    }
+}
+
+#[test]
+fn vtu_phase_iii_join_accepts_tensor_of_codepoints() {
+    // [ 65 66 67 ] is a dense Tensor. JOIN must still treat its elements as
+    // Unicode code points and produce 'ABC'.
+    let interp = run_code("[ 65 66 67 ] JOIN");
+    let top = stack_top(&interp);
+    assert_eq!(format!("{}", top), "'ABC'");
+}
+
+#[test]
+fn vtu_phase_iii_sort_accepts_tensor_input() {
+    // [ 3 1 2 ] is a dense Tensor under Phase II producers. SORT must
+    // accept it via the new boundary-helper code path.
+    let interp = run_code("[ 3 1 2 ] SORT");
+    let top = stack_top(&interp);
+    assert_eq!(top.shape(), vec![3]);
+    let collected: Vec<i64> = (0..top.len())
+        .map(|i| top.child(i).unwrap().as_scalar().unwrap().to_i64().unwrap())
+        .collect();
+    assert_eq!(collected, vec![1, 2, 3]);
+}

--- a/rust/src/interpreter/random.rs
+++ b/rust/src/interpreter/random.rs
@@ -152,7 +152,6 @@ fn parse_csprng_args(interp: &mut Interpreter) -> Result<(BigInt, usize)> {
 #[cfg(test)]
 mod tests {
     use crate::interpreter::Interpreter;
-    use crate::types::ValueData;
 
     #[tokio::test]
     async fn test_csprng_rejects_stack_mode() {
@@ -175,11 +174,8 @@ mod tests {
         assert_eq!(interp.stack.len(), 1);
 
         let val = &interp.stack[0];
-        if let ValueData::Vector(children) = &val.data {
-            assert_eq!(children.len(), 1);
-        } else {
-            panic!("Expected Vector");
-        }
+        assert!(val.is_vector(), "Expected vector-like value");
+        assert_eq!(val.len(), 1);
     }
 
     #[tokio::test]
@@ -194,11 +190,8 @@ mod tests {
         assert_eq!(interp.stack.len(), 1);
 
         let val = &interp.stack[0];
-        if let ValueData::Vector(children) = &val.data {
-            assert_eq!(children.len(), 5);
-        } else {
-            panic!("Expected Vector");
-        }
+        assert!(val.is_vector(), "Expected vector-like value");
+        assert_eq!(val.len(), 5);
     }
 
     #[tokio::test]
@@ -214,11 +207,8 @@ mod tests {
         assert_eq!(interp.stack.len(), 1);
 
         let val = &interp.stack[0];
-        if let ValueData::Vector(children) = &val.data {
-            assert_eq!(children.len(), 3);
-        } else {
-            panic!("Expected Vector");
-        }
+        assert!(val.is_vector(), "Expected vector-like value");
+        assert_eq!(val.len(), 3);
     }
 
     #[tokio::test]
@@ -254,10 +244,7 @@ mod tests {
         assert!(result.is_ok());
 
         let val = &interp.stack[0];
-        if let ValueData::Vector(children) = &val.data {
-            assert_eq!(children.len(), 50);
-        } else {
-            panic!("Expected Vector");
-        }
+        assert!(val.is_vector(), "Expected vector-like value");
+        assert_eq!(val.len(), 50);
     }
 }


### PR DESCRIPTION
## Summary

Phase III consumer-op pass focused on the JSON / SHAPE family. After
the survey, most of those ops already accepted `ValueData::Tensor`
end-to-end (PRs #874–#876 wired `Value::shape`, `child(i)`,
`FlatTensor::from_value`, and `arena_node_to_json` for it). This PR
covers the remaining gaps and locks the contract down with parity
tests so the Phase II producer switch can't silently regress them.

## Changes

### Bug fixes (silent regressions from Phase II promotion)

- **`json::extract_string_content_from_value`** — was matching
  `ValueData::Vector` only and falling through to
  `format!("{}", val)` for Tensor. Under Phase II, formatting a
  string-like Tensor adds surrounding quotes (`'ABC'` not `ABC`),
  which would break JSON_GET / JSON_SET key matching. Migrated to
  `as_vector_view()` so Vector and Tensor share the same code-point
  extraction path.
- **`cast_chars_join::op_join`** (both StackTop and Stack modes) hard-
  rejected Tensor with "expected Vector". A literal
  `[ 65 66 67 ] JOIN` regressed to that error after the producer
  switch. Migrated to `as_vector_view()` so JOIN treats dense numeric
  tensors as code-point sequences just like nested vectors.

### Test cleanup

- **`interpreter::random::tests`** were pattern-matching
  `ValueData::Vector` on CSPRNG outputs, which now arrive as Tensor.
  Switched to `is_vector()` / `len()` so the assertions are
  representation-agnostic.

### Parity coverage

7 new Phase-III consumer parity tests in
`interpreter::quantized-block-tests`:

- `vtu_phase_iii_shape_accepts_tensor_input`
- `vtu_phase_iii_rank_accepts_tensor_input`
- `vtu_phase_iii_reshape_dense_to_2d_matches_nested`
- `vtu_phase_iii_transpose_accepts_tensor_2d`
- `vtu_phase_iii_fill_produces_dense_tensor`
- `vtu_phase_iii_join_accepts_tensor_of_codepoints`
- `vtu_phase_iii_sort_accepts_tensor_input`

## Test plan

- [x] `cargo test`: 843 lib + 57 integration pass
- [x] `cargo clippy --tests --no-deps`: 99 warnings (-1 vs 100
      baseline — `cast-chars-join.rs` no longer imports the unused
      `ValueData`)

## Out of scope (deferred)

- `JSON_GET` / `JSON_SET` / `JSON_KEYS` over Tensor: keyed lookup on a
  numeric Tensor is conceptually NIL anyway, current behavior is
  preserved.
- COMPARE / LOGIC / CAST consumer pass — separate PR.
- Plan-level fusion (Phase IV+).

https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV)_