### PR TITLE
VTU Phase III: tensor-aware COMPARE / LOGIC / CAST + audio fix

### DIFF
--- a/rust/src/interpreter/audio/execute-audio-commands.rs
+++ b/rust/src/interpreter/audio/execute-audio-commands.rs
@@ -4,7 +4,7 @@ use super::audio_types::{update_play_mode, PlayMode, WaveformType};
 use super::super::Interpreter;
 use crate::error::{AjisaiError, Result};
 use crate::types::fraction::Fraction;
-use crate::types::{Value, ValueData};
+use crate::types::Value;
 use num_traits::ToPrimitive;
 
 
@@ -21,11 +21,14 @@ pub fn op_sim(interp: &mut Interpreter) -> Result<()> {
 
 
 fn extract_scalar_from_value(val: &Value) -> Option<Fraction> {
-    match &val.data {
-        ValueData::Scalar(f) => Some(f.clone()),
-        ValueData::Vector(children) if children.len() == 1 => extract_scalar_from_value(&children[0]),
-        _ => None,
+    if let Some(f) = val.as_scalar() {
+        return Some(f.clone());
     }
+    if val.is_vector() && val.len() == 1 {
+        let child = val.child(0)?;
+        return extract_scalar_from_value(&child);
+    }
+    None
 }
 
 

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -997,3 +997,80 @@ fn vtu_phase_iii_sort_accepts_tensor_input() {
         .collect();
     assert_eq!(collected, vec![1, 2, 3]);
 }
+
+// ---------------------------------------------------------------------------
+// VTU Phase III consumer ops: COMPARE / LOGIC / CAST must accept a dense
+// Tensor input and behave identically to the nested-Vector input path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vtu_phase_iii_eq_dense_tensor_singleton_matches_scalar() {
+    // [ 5 ] becomes a Tensor[1] under Phase II producers. EQ between a
+    // scalar and a singleton tensor must collapse to TRUE / FALSE.
+    let true_case = run_code("[ 5 ] [ 5 ] =");
+    let false_case = run_code("[ 5 ] [ 6 ] =");
+    let t = stack_top(&true_case);
+    let f = stack_top(&false_case);
+    let truthy = |v: &Value| -> bool {
+        v.as_scalar()
+            .map(|f| !f.is_zero())
+            .or_else(|| v.child(0).and_then(|c| c.as_scalar().map(|f| !f.is_zero())))
+            .unwrap_or(false)
+    };
+    assert!(truthy(t), "5 = 5 should be truthy");
+    assert!(!truthy(f), "5 = 6 should be falsy");
+}
+
+#[test]
+fn vtu_phase_iii_lt_dense_tensor_against_scalar() {
+    let interp = run_code("[ 1 ] [ 2 ] <");
+    let t = stack_top(&interp);
+    let truthy = t
+        .as_scalar()
+        .map(|f| !f.is_zero())
+        .or_else(|| t.child(0).and_then(|c| c.as_scalar().map(|f| !f.is_zero())))
+        .unwrap_or(false);
+    assert!(truthy, "1 < 2 should be truthy");
+}
+
+#[test]
+fn vtu_phase_iii_not_over_dense_tensor() {
+    // NOT applied to [ 0 1 0 ] should produce [ 1 0 1 ] regardless of layout.
+    let interp = run_code("[ 0 1 0 ] NOT");
+    let top = stack_top(&interp);
+    assert_eq!(top.shape(), vec![3]);
+    let collected: Vec<i64> = (0..top.len())
+        .map(|i| top.child(i).unwrap().as_scalar().unwrap().to_i64().unwrap())
+        .collect();
+    assert_eq!(collected, vec![1, 0, 1]);
+}
+
+#[test]
+fn vtu_phase_iii_and_or_truthiness_on_dense_tensor() {
+    // AND/OR consume from the stack; the operands are Tensor[1] under Phase II.
+    // [ 1 ] AND [ 1 ] -> 1, [ 0 ] AND [ 1 ] -> 0, [ 0 ] OR [ 1 ] -> 1
+    let and_true = run_code("[ 1 ] [ 1 ] AND");
+    let and_false = run_code("[ 0 ] [ 1 ] AND");
+    let or_true = run_code("[ 0 ] [ 1 ] OR");
+    let truthy = |interp: &Interpreter| -> bool {
+        let t = stack_top(interp);
+        t.as_scalar()
+            .map(|f| !f.is_zero())
+            .or_else(|| t.child(0).and_then(|c| c.as_scalar().map(|f| !f.is_zero())))
+            .unwrap_or(false)
+    };
+    assert!(truthy(&and_true), "[1] AND [1] should be truthy");
+    assert!(!truthy(&and_false), "[0] AND [1] should be falsy");
+    assert!(truthy(&or_true), "[0] OR [1] should be truthy");
+}
+
+#[test]
+fn vtu_phase_iii_chars_decomposes_string_independent_of_target_layout() {
+    // CHARS expects a string and produces the code-point sequence. The string
+    // representation is preserved by Display::String hint, but verify the
+    // round-trip CHARS -> JOIN over the produced sequence matches the input
+    // even if intermediates pass through Tensor producers.
+    let interp = run_code("'ABC' CHARS JOIN");
+    let top = stack_top(&interp);
+    assert_eq!(format!("{}", top), "'ABC'");
+}


### PR DESCRIPTION
## Summary

Phase III follow-up sweep covering COMPARE / LOGIC / CAST. The survey
of comparison.rs / logic.rs / cast-value-helpers.rs / arithmetic.rs /
vector-execution-operations.rs / value-extraction-helpers.rs confirmed
that core paths already accept `ValueData::Tensor` end to end after
PRs #874–#877 (Scalar↔Tensor[1] equivalence in EQ, `FlatTensor::from_value`
branches in `compute_inverted_value` / `check_value_has_truthy`,
explicit Tensor arms in `extract_scalar_from_value`).

## Real gap fixed

- **`audio::execute_audio_commands::extract_scalar_from_value`** (used
  by SLOT and friends) was matching `ValueData::Vector(c)
  if c.len() == 1` only. After the Phase II producer switch `[ 0.05 ]`
  becomes `Tensor[1]`, so SLOT and any other audio op funneling
  through this helper would silently fail with "requires a single
  number". Switched to `is_vector()` / `len()` / `child(0)` so a
  Tensor[1] singleton is unwrapped just like a Vector[1].

## Parity tests

Five new `vtu_phase_iii_*` tests in `quantized-block-tests.rs` lock in
Tensor-input behavior across the consumer ops:

- `vtu_phase_iii_eq_dense_tensor_singleton_matches_scalar`
- `vtu_phase_iii_lt_dense_tensor_against_scalar`
- `vtu_phase_iii_not_over_dense_tensor`
- `vtu_phase_iii_and_or_truthiness_on_dense_tensor`
- `vtu_phase_iii_chars_decomposes_string_independent_of_target_layout`

## Test plan

- [x] `cargo test`: 848 lib + 57 integration pass
- [x] `cargo clippy --tests --no-deps`: 99 warnings (-1 vs 100
      baseline — `audio/execute-audio-commands.rs` no longer imports
      the unused `ValueData`)

## Out of scope

- Plan-level fusion / in-place mutation / cache (Phase IV+).
- Examples-output CI verification (separate PR).

https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhMbPnMK5S1bdSWGwfPheV)_