### PR TITLE
docs: refresh VTU handover status and add vtu_bulk metric check

### DIFF
--- a/CLAUDECODE_HANDOVER.md
+++ b/CLAUDECODE_HANDOVER.md
@@ -1,6 +1,6 @@
 # Ajisai 半コンパイル実行系化 — ClaudeCode 引き継ぎ書
 
-最終更新: 2026-04-13
+最終更新: 2026-05-08
 
 ---
 
@@ -12,9 +12,9 @@
 
 - **第1段階（Temporal Epoch Stack）**: ほぼ導入済み
 - **第2段階（CompiledPlan キャッシュ）**: 基本導入済み
-- **第3段階（QuantizedBlock）**: 骨組み実装のみ
-- **第4段階（高階関数最適化）**: MAP中心の部分対応
-- **第5段階（計測・安全化）**: メトリクス・trace flagは追加済み、ベンチはまだ簡易テスト相当
+- **第3段階（QuantizedBlock / VTU分類）**: arity・purity・dependency推論とVTU hint/metricsまで導入済み
+- **第4段階（高階関数最適化）**: MAP/FILTER/ANY/ALL/COUNT/FOLD の quantized + Tensor bulk kernel を導入済み
+- **第5段階（計測・安全化）**: メトリクス・trace flag・VTU countersは追加済み、ベンチはまだ簡易テスト相当
 
 ---
 
@@ -32,14 +32,22 @@
 - `WordDefinition.compiled_plan` を追加してキャッシュ保持
 - `execute_word_core` でキャッシュ hit/miss と再コンパイル分岐
 
-### QuantizedBlock（現状は最小限）
+### QuantizedBlock / VTU（現状）
 - `rust/src/interpreter/quantized-block.rs` 追加
 - `QuantizedBlock` 型と `quantize_code_block` / `is_quantizable_block`
+- arity推論（典型的な 1→1 / 2→1）、purity推論、dependency_words収集を導入済み
+- `VtuHint` / `VtuSuitability` / `VtuBackendCandidate` を追加し、実行意味論には影響しない観測用分類として保持
 - 高階関数側 `ExecutableCode` に `QuantizedBlock` を追加
-- `MAP` 経路で quantized 実行を一部利用
+- `MAP` / `FILTER` / `ANY` / `ALL` / `COUNT` / `FOLD` で quantized 経路を利用
+
+### VTU Phase II / III（ClaudeCode後続で進展済み）
+- Vector生成を dense `Tensor` producer に寄せ、consumer側は `as_vector_view` / `ensure_hydrated` 境界ヘルパで既存意味論を維持
+- MAP/FILTER/FOLD/ANY/ALL/COUNT は 1-D dense Tensor + fast kernel の場合、`Tensor.data` を直接走査する bulk fast path を持つ
+- SHAPE/RANK/RESHAPE/TRANSPOSE/FILL/JOIN/SORT/COMPARE/LOGIC/CAST/CHARS は dense Tensor 入力互換の parity test を追加済み
+- VTU counters: flatten/rebuild/broadcast/unary/simd/candidate/rejected/fusion/bulk を `RuntimeMetrics` に追加済み
 
 ### 計測 / trace
-- `RuntimeMetrics` 追加（plan build/hit/miss, quantized build/use）
+- `RuntimeMetrics` 追加（plan build/hit/miss, quantized build/use, VTU counters）
 - Cargo features 追加:
   - `trace-compile`
   - `trace-epoch`
@@ -51,20 +59,23 @@
 
 以下は **仕様書の完了条件に対して未充足** です。
 
-1. **QuantizedBlock の静的解析不足**
-   - `input_arity` / `output_arity` がほぼ `Variable`
-   - `purity` が `Unknown` 中心
-   - `dependency_words` 未活用
+1. **SCAN のVTU/quantized fold parityが未完**
+   - `FOLD` は quantized/bulk kernel 済みだが、`SCAN` は fold と同じ binary op を使う設計に留まる
+   - accumulator履歴を保持するため、bulk化時の出力形状・エラー復元の parity test がまだ不足
 
-2. **高階関数の最適化不足**
-   - MAP 以外（`FILTER`, `ANY`, `ALL`, `COUNT`, `FOLD`, `SCAN`）の専用 kernel が未整備
-   - エラー時のスタック復元ポリシーを quantized 経路で統一検証できていない
+2. **QuantizedBlock 静的解析の精度向上余地**
+   - 典型的な builtin arity / purity / dependency_words は入るようになった
+   - ただし unknown op を含む複合ブロック、qualified user word、ネストした control-flow の arity は保守的に `Variable` へ落ちる
 
 3. **perf-regression-tests が“ベンチ”として弱い**
    - 現在は `#[test]` ベースのスモーク寄り
    - 所要時間・利用率などの計測レポート未整備
 
-4. **CompiledPlan の最適化粒度**
+4. **VTU bulk path の網羅性**
+   - Phase III は 1-D dense Tensor + fast unary/binary kernel に限定
+   - 2-D以上、user word kernel、SCAN、複合predicateのbulk化は未対応
+
+5. **CompiledPlan の最適化粒度**
    - fallback token を含む行は行全体を従来実行へ戻す保守的設計
    - 効果は安全だが性能上の伸び代あり
 
@@ -72,20 +83,20 @@
 
 ## 4. ClaudeCode で優先して進める実装順
 
-### 優先A（第4段階の実質完了）
-1. `FILTER` / `ANY` / `ALL` / `COUNT` に quantized predicate kernel を導入
-2. `FOLD` / `SCAN` に quantized fold kernel を導入
-3. quantized経路と従来経路の一致テスト（結果・エラー動作）を拡充
+### 優先A（VTU Phase IIIの仕上げ）
+1. `SCAN` に quantized fold kernel / bulk parity test を追加
+2. MAP/FILTER/FOLD/ANY/ALL/COUNT の bulk fast path について、エラー時のスタック復元 parity test を増やす
+3. user word kernel・複合predicateが安全に fallback することを metric込みで維持
 
 ### 優先B（第3段階の質向上）
-1. `quantize_code_block` で arity 推論（最低でも典型1→1, 2→1）
-2. purity 推論（副作用語検出）
-3. dependency_words の収集
+1. `quantize_code_block` の unknown op 周辺の arity 推論をもう一段だけ精密化
+2. nested control-flow / qualified word の purity・dependency propagation を拡充
+3. `VtuHint` は引き続き guard signature から除外し、意味論に影響しない観測情報として扱う
 
 ### 優先C（第5段階の完了）
 1. `perf-regression-tests.rs` を bench/計測出力付きに再構成
 2. metrics 出力（feature flag有効時）を統一
-3. 実行時間・hit率・quantized利用率を定量可視化
+3. 実行時間・hit率・quantized利用率・VTU bulk利用率を定量可視化
 
 ---
 
@@ -98,6 +109,12 @@
 - `compiled_plan_cache_miss_count`
 - `quantized_block_build_count`
 - `quantized_block_use_count`
+- `vtu_tensor_flatten_count` / `vtu_tensor_flattened_elements`
+- `vtu_tensor_rebuild_count` / `vtu_tensor_rebuilt_elements`
+- `vtu_broadcast_count` / `vtu_unary_flat_count` / `vtu_allocated_elements`
+- `vtu_same_shape_elementwise_count` / `vtu_projected_broadcast_count`
+- `vtu_simd_kernel_use_count` / `vtu_bulk_kernel_use_count`
+- `vtu_candidate_block_count` / `vtu_rejected_block_count` / `vtu_fusion_candidate_count`
 
 ---
 
@@ -109,6 +126,7 @@ cargo test -q
 cargo test -q compiled_plan_tests
 cargo test -q quantized_block_tests
 cargo test -q perf_regression_tests
+cargo test -q vtu_phase_iii
 cargo test perf_regression_tests -- --nocapture
 ```
 

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -790,6 +790,7 @@ fn vtu_default_metrics_are_zero() {
     assert_eq!(m.vtu_candidate_block_count, 0);
     assert_eq!(m.vtu_rejected_block_count, 0);
     assert_eq!(m.vtu_fusion_candidate_count, 0);
+    assert_eq!(m.vtu_bulk_kernel_use_count, 0);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Bring the ClaudeCode handover document up to date with the current VTU/QuantizedBlock implementation and Phase II/III progress. 
- Make the handover actionable for follow-up work (SCAN parity, bulk path coverage, arity/purity propagation). 
- Ensure the VTU bulk-use metric is covered by regression tests to avoid silent regressions.

### Description

- Update `CLAUDECODE_HANDOVER.md` to reflect that `QuantizedBlock` now includes arity/purity/dependency inference, `VtuHint` classification, VTU counters, and that `MAP`/`FILTER`/`ANY`/`ALL`/`COUNT`/`FOLD` have quantized + Tensor bulk kernels; add VTU Phase II/III notes, revised open items, and adjusted prioritization. 
- Extend the `RuntimeMetrics` list and recommended test commands in the handover, adding `vtu_bulk_kernel_use_count` and a `vtu_phase_iii` test entry. 
- Add an assertion in `rust/src/interpreter/quantized-block-tests.rs` (`vtu_default_metrics_are_zero`) to check that `vtu_bulk_kernel_use_count` defaults to zero. 
- Commit message: `docs: refresh VTU handover status` (two files changed: `CLAUDECODE_HANDOVER.md` and `rust/src/interpreter/quantized-block-tests.rs`).

### Testing

- Ran `git diff --check` with no whitespace errors. (passed)
- Ran `cd rust && cargo test -q quantized_block_tests` which executed the suite including the modified test; `87` tests passed and `0` failed. (passed)
- Ran the targeted `cd rust && cargo test -q vtu_default_metrics_are_zero` which passed. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0cfc3bec8326b50d4c5062ebec32)