### PR TITLE
Introduce DenseTensor SoA + validity-mask and update spec to Static Mass Conservation

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -147,11 +147,13 @@ An ordered, indexable sequence of values. Vectors may be nested (tensor-like). I
 A Vector value is internally represented in one of two classes:
 
 - **nested** — a tree of `Value` elements (`Vec<Value>`). Any element type may appear, including mixed types (Scalars, Vectors, Strings, NIL, etc.).
-- **dense** — a flat buffer of Fractions plus a `shape` (`Vec<Fraction>` + `Vec<usize>`). Every leaf is a Fraction; the shape encodes a (possibly multi-dimensional) rectangular structure.
+- **dense** — a SIMD-oriented `DenseTensor` with Structure-of-Arrays numerator and denominator buffers, a `shape` (`Vec<usize>`), and a validity mask (`Vec<u64>`). Every valid lane is an exact Fraction; an invalid lane represents NIL occupancy without changing the dense representation class.
 
 The class is chosen at construction time. Observable semantics — `Display`, ordering, equality, NIL-ness, `SHAPE`, `LENGTH`, indexing, iteration order — are identical between the two classes. Operations are free to take a fast path when the input is dense.
 
-Equality across classes: a dense Vector and a nested Vector compare equal when (1) flattening the nested Vector into its leaf Fractions yields the same sequence as the dense buffer, and (2) the shape inferred from the nested Vector matches the dense Vector's shape. No language-visible word distinguishes the two classes; they are interchangeable from the user's perspective.
+**No-Rebuild Principle:** a dense Vector never degrades to a nested Vector solely because a lane becomes NIL. NIL occupancy is represented by clearing the corresponding validity-mask bit. Internal diagnostic reasons for invalid lanes are stored outside the dense payload in an execution-context sparse registry keyed by lane/index; they are not embedded in `DenseTensor`.
+
+Equality across classes: a dense Vector and a nested Vector compare equal when (1) flattening the nested Vector into its leaf Fractions/NIL lanes yields the same lane sequence and validity as the dense buffer, and (2) the shape inferred from the nested Vector matches the dense Vector's shape. No language-visible word distinguishes the two classes; they are interchangeable from the user's perspective.
 
 This dual representation exists for the Virtual Tensor Unit (VTU) data-movement optimizations (see `docs/dev/virtual-tensor-unit-design.md`). It does not introduce approximate numeric types: all numeric leaves remain exact Fractions.
 
@@ -632,22 +634,11 @@ Accepts a ProcessHandle. Terminates the child runtime immediately.
 | `CondExhausted` | COND expression has no matching clause |
 | `Custom` | Explicit error raised by user code |
 
-### 11.2 Internal flow-level error categories
-
-The following errors are raised by the internal flow conservation mechanism. They are not user-level language constructs and are not observable in normal execution.
-
-| Error | Trigger condition |
-|-------|-------------------|
-| `OverConsumption` | More flow mass consumed than available |
-| `UnconsumedLeak` | Flow mass not fully consumed at an operation boundary |
-| `FlowBreak` | Flow conservation invariant violated |
-| `BifurcationViolation` | Sum of child flow masses does not equal parent flow mass |
-
-### 11.3 Equal-value output
+### 11.2 Equal-value output
 
 Operations that produce a value equal to their input are successful. Equal-value output is not an error.
 
-### 11.4 Safe mode behavior
+### 11.3 Safe mode behavior
 
 `~` (`SAFE`) is the explicit projection operator that turns a partial operation into a total one by mapping any error to a NIL with reason. The projected NIL carries `NilReason::SafeCaught` and preserves a structured reference to the original error category (e.g. `DivisionByZero`, `StackUnderflow`, `IndexOutOfBounds`). The error itself does not propagate.
 
@@ -683,20 +674,15 @@ Display hints are applied only at explicit semantic boundaries: rendering, `PRIN
 
 ## 13. Fractional-Dataflow Internal Invariants
 
-### 13.1 Flow tokens
+### 13.1 Static Mass Conservation
 
-The runtime optionally tracks flow mass via internal FlowToken objects. Each FlowToken holds:
-- A unique runtime-assigned ID
-- Total mass and remaining mass
-- Value shape information
-- Parent and child flow relationships
-- Mass ratio for bifurcations
+Ajisai treats flow mass conservation as a compile/JIT-time property. A Coreword Contract declares the arity, consumption, production, bifurcation, and NIL-projection behavior needed to prove that a flow preserves mass before it is admitted to an optimized execution path.
 
-FlowToken state is an **internal runtime invariant**. It is not a user-visible language construct and must not appear as default runtime output.
+The runtime does not maintain per-value FlowToken objects for ordinary execution and does not perform step-by-step mass accounting. Dynamic categories formerly associated with runtime flow accounting — over-consumption, unconsumed leaks, flow breaks, and bifurcation-ratio violations — are contract-validation failures. They must be rejected by the compiler/JIT, loader, or developer diagnostics before execution of the optimized path.
 
 ### 13.2 Bifurcation
 
-The `,,` (keep/bifurcation) modifier retains source context while also pushing the result. Mass ratio and branch conservation details are internal. Optional diagnostics may surface FlowToken information, but only when diagnostic visibility is explicitly enabled.
+The `,,` (keep/bifurcation) modifier retains source context while also pushing the result. Its mass relationship is specified by the relevant Coreword Contract and is statically checked with the surrounding flow. Runtime execution only performs the value-level stack effects that the contract has already proven.
 
 ---
 
@@ -757,5 +743,5 @@ A change is conformant only if all of the following hold:
 6. It improves or preserves AI-first structural clarity.
 7. Every built-in word (Core or module) introduced or renamed has an English-word-based canonical name; any symbolic form is registered as syntactic sugar that maps to that canonical name.
 8. Every introduced or modified Coreword has a contract entry covering `partiality`, `nil_policy`, and `safety_level` (Section 7.14).
-9. Every NIL-producing path attaches the appropriate `NilReason` (Section 4.5.0); `SAFE` projection preserves the original error category (Section 11.4).
+9. Every NIL-producing path attaches the appropriate `NilReason` (Section 4.5.0); `SAFE` projection preserves the original error category (Section 11.3).
 10. Per-Coreword contract tests, NIL reason tests, MC/DC-style tests, and stack-discipline tests exist as required by Section 15.

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -14,7 +14,6 @@ fn record_flatten(metrics: &mut Option<&mut RuntimeMetrics>, elements: usize) {
     }
 }
 
-
 #[derive(Debug, Clone)]
 pub(crate) struct FlatTensor {
     pub(crate) data: Vec<Fraction>,
@@ -49,12 +48,14 @@ impl FlatTensor {
                 let shape_vec: Vec<usize> = (**shape).clone();
                 let strides: Vec<usize> = compute_strides(&shape_vec);
                 Ok(Self {
-                    data: (**data).clone(),
+                    data: data.to_fractions(),
                     shape: shape_vec,
                     strides,
                 })
             }
-            ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => Err(AjisaiError::from(
+            ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => Err(AjisaiError::from(
                 "Tensor conversion requires scalar or vector",
             )),
         }

--- a/rust/src/types/arena.rs
+++ b/rust/src/types/arena.rs
@@ -1,5 +1,5 @@
 use super::fraction::Fraction;
-use super::{DisplayHint, Token, Value, ValueData};
+use super::{DenseTensor, DisplayHint, Token, Value, ValueData};
 use num_traits::ToPrimitive;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -125,11 +125,9 @@ pub fn value_to_arena(root: &Value) -> (ValueArena, NodeId) {
                     .collect();
                 arena.alloc_vector(child_ids, value.hint)
             }
-            ValueData::Tensor { data, shape } => arena.alloc_tensor(
-                (**data).clone(),
-                (**shape).clone(),
-                value.hint,
-            ),
+            ValueData::Tensor { data, shape } => {
+                arena.alloc_tensor(data.to_fractions(), (**shape).clone(), value.hint)
+            }
             ValueData::Record { pairs, index } => {
                 let pair_ids = pairs
                     .iter()
@@ -183,7 +181,10 @@ pub fn arena_to_value(arena: &ValueArena, root: NodeId) -> Value {
             }
             NodeKind::Tensor { data, shape } => Value {
                 data: ValueData::Tensor {
-                    data: Rc::new(data.clone()),
+                    data: Rc::new(
+                        DenseTensor::from_fractions(data.clone(), shape.clone())
+                            .expect("arena tensor nodes preserve shape-compatible dense data"),
+                    ),
                     shape: Rc::new(shape.clone()),
                 },
                 hint: arena.hint(id),
@@ -312,9 +313,7 @@ pub fn arena_node_to_json(arena: &ValueArena, root: NodeId) -> JsonValue {
                 .collect();
             JsonValue::Array(arr)
         }
-        NodeKind::Tensor { data, shape } => {
-            tensor_to_json(arena.hint(root), data, shape)
-        }
+        NodeKind::Tensor { data, shape } => tensor_to_json(arena.hint(root), data, shape),
         NodeKind::Record { pairs, .. } => {
             let mut map = serde_json::Map::new();
             for pair_id in pairs {
@@ -496,11 +495,15 @@ mod tests {
         let (arena, _root) = value_to_arena(&value);
         for id in 0..arena.nodes.len() as u32 {
             if let NodeKind::Vector { children } = arena.kind(id) {
-                let all_plain_ints = children.iter().all(|c| {
-                    matches!(arena.kind(*c), NodeKind::Scalar(f) if f.is_integer())
-                });
+                let all_plain_ints = children
+                    .iter()
+                    .all(|c| matches!(arena.kind(*c), NodeKind::Scalar(f) if f.is_integer()));
                 if all_plain_ints && !children.is_empty() {
-                    assert_ne!(arena.hint(id), DisplayHint::String, "node {id} incorrectly string");
+                    assert_ne!(
+                        arena.hint(id),
+                        DisplayHint::String,
+                        "node {id} incorrectly string"
+                    );
                 }
             }
         }
@@ -518,7 +521,12 @@ mod tests {
         use crate::types::Value;
 
         let value = Value::from_tensor(
-            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![
+                Fraction::from(1),
+                Fraction::from(2),
+                Fraction::from(3),
+                Fraction::from(4),
+            ],
             vec![2, 2],
         );
         let (arena, root) = value_to_arena(&value);
@@ -533,7 +541,12 @@ mod tests {
         use crate::types::Value;
 
         let value = Value::from_tensor(
-            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![
+                Fraction::from(1),
+                Fraction::from(2),
+                Fraction::from(3),
+                Fraction::from(4),
+            ],
             vec![2, 2],
         );
         let (arena, root) = value_to_arena(&value);

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -21,6 +21,103 @@ use std::sync::Arc;
 
 pub use flow_token::{FlowResult, FlowToken};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DenseTensor {
+    pub numerators: Vec<i64>,
+    pub denominators: Vec<i64>,
+    pub valid_mask: Vec<u64>,
+    pub shape: Vec<usize>,
+    pub is_pure_integer: bool,
+    fractions: Vec<Fraction>,
+}
+
+impl DenseTensor {
+    pub fn from_fractions(data: Vec<Fraction>, shape: Vec<usize>) -> Option<Self> {
+        let expected_len = if shape.is_empty() {
+            0
+        } else {
+            shape.iter().product()
+        };
+        if expected_len != data.len() {
+            return None;
+        }
+
+        let mut numerators = Vec::with_capacity(data.len());
+        let mut denominators = Vec::with_capacity(data.len());
+        let mut is_pure_integer = true;
+        for fraction in &data {
+            let (numerator, denominator) = fraction.extract_i64_pair()?;
+            numerators.push(numerator);
+            denominators.push(denominator);
+            is_pure_integer &= denominator == 1;
+        }
+
+        let valid_mask_len = data.len().div_ceil(64);
+        let mut valid_mask = vec![u64::MAX; valid_mask_len];
+        if let Some(last) = valid_mask.last_mut() {
+            let live_bits = data.len() % 64;
+            if live_bits != 0 {
+                *last = (1u64 << live_bits) - 1;
+            }
+        }
+
+        Some(Self {
+            numerators,
+            denominators,
+            valid_mask,
+            shape,
+            is_pure_integer,
+            fractions: data,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.numerators.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.numerators.is_empty()
+    }
+
+    pub fn as_slice(&self) -> &[Fraction] {
+        &self.fractions
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Fraction> {
+        self.fractions.iter()
+    }
+
+    pub fn get(&self, index: usize) -> Option<&Fraction> {
+        if self.is_valid(index) {
+            self.fractions.get(index)
+        } else {
+            None
+        }
+    }
+
+    pub fn to_fractions(&self) -> Vec<Fraction> {
+        self.fractions.clone()
+    }
+
+    pub fn is_valid(&self, index: usize) -> bool {
+        if index >= self.len() {
+            return false;
+        }
+        let word = self.valid_mask[index / 64];
+        ((word >> (index % 64)) & 1) == 1
+    }
+}
+
+impl std::ops::Deref for DenseTensor {
+    type Target = [Fraction];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+pub type NilReasonRegistry = HashMap<usize, NilReason>;
+
 pub trait ValueExt: std::fmt::Debug + 'static {
     fn clone_box(&self) -> Box<dyn ValueExt>;
     fn as_any(&self) -> &dyn Any;
@@ -50,7 +147,7 @@ pub enum ValueData {
     Scalar(Fraction),
     Vector(Rc<Vec<Value>>),
     Tensor {
-        data: Rc<Vec<self::fraction::Fraction>>,
+        data: Rc<DenseTensor>,
         shape: Rc<Vec<usize>>,
     },
     Record {
@@ -69,20 +166,28 @@ impl PartialEq for ValueData {
             (ValueData::Scalar(a), ValueData::Scalar(b)) => a == b,
             (ValueData::Vector(a), ValueData::Vector(b)) => a == b,
             (
-                ValueData::Tensor { data: a_data, shape: a_shape },
-                ValueData::Tensor { data: b_data, shape: b_shape },
+                ValueData::Tensor {
+                    data: a_data,
+                    shape: a_shape,
+                },
+                ValueData::Tensor {
+                    data: b_data,
+                    shape: b_shape,
+                },
             ) => a_data == b_data && a_shape == b_shape,
+            (ValueData::Vector(v), ValueData::Tensor { data, shape })
+            | (ValueData::Tensor { data, shape }, ValueData::Vector(v)) => {
+                tensor_eq_vector(data.as_slice(), shape, v)
+            }
             (
-                ValueData::Vector(v),
-                ValueData::Tensor { data, shape },
-            )
-            | (
-                ValueData::Tensor { data, shape },
-                ValueData::Vector(v),
-            ) => tensor_eq_vector(data, shape, v),
-            (
-                ValueData::Record { pairs: ap, index: ai },
-                ValueData::Record { pairs: bp, index: bi },
+                ValueData::Record {
+                    pairs: ap,
+                    index: ai,
+                },
+                ValueData::Record {
+                    pairs: bp,
+                    index: bi,
+                },
             ) => ap == bp && ai == bi,
             (ValueData::Nil, ValueData::Nil) => true,
             (ValueData::CodeBlock(a), ValueData::CodeBlock(b)) => a == b,
@@ -93,11 +198,7 @@ impl PartialEq for ValueData {
     }
 }
 
-fn tensor_eq_vector(
-    data: &[self::fraction::Fraction],
-    shape: &[usize],
-    v: &[Value],
-) -> bool {
+fn tensor_eq_vector(data: &[self::fraction::Fraction], shape: &[usize], v: &[Value]) -> bool {
     let nested_shape = nested_vector_shape(v);
     if nested_shape != shape {
         return false;
@@ -121,11 +222,7 @@ fn nested_vector_shape(v: &[Value]) -> Vec<usize> {
     }
 }
 
-fn nested_flatten_matches(
-    v: &[Value],
-    data: &[self::fraction::Fraction],
-    idx: &mut usize,
-) -> bool {
+fn nested_flatten_matches(v: &[Value], data: &[self::fraction::Fraction], idx: &mut usize) -> bool {
     for child in v {
         match &child.data {
             ValueData::Scalar(f) => {
@@ -139,7 +236,9 @@ fn nested_flatten_matches(
                     return false;
                 }
             }
-            ValueData::Tensor { data: inner_data, .. } => {
+            ValueData::Tensor {
+                data: inner_data, ..
+            } => {
                 for f in inner_data.iter() {
                     if *idx >= data.len() || data[*idx] != *f {
                         return false;
@@ -299,7 +398,9 @@ impl Capabilities {
     pub const SPAWN: Self = Self { bits: 0b0010_0000 };
     pub const EVAL: Self = Self { bits: 0b0100_0000 };
     pub const MUTATES_DICT: Self = Self { bits: 0b1000_0000 };
-    pub const INPUT_HELPER: Self = Self { bits: 0b0001_0000_0000 };
+    pub const INPUT_HELPER: Self = Self {
+        bits: 0b0001_0000_0000,
+    };
 
     pub const fn empty() -> Self {
         Self { bits: 0 }

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -1,6 +1,6 @@
 use super::fraction::Fraction;
 use super::interval::Interval;
-use super::{DisplayHint, Token, Value, ValueData};
+use super::{DenseTensor, DisplayHint, Token, Value, ValueData};
 use crate::error::NilReason;
 use std::rc::Rc;
 
@@ -654,9 +654,15 @@ impl Value {
         } else {
             shape
         };
+        let Some(tensor) = DenseTensor::from_fractions(data.clone(), resolved_shape.clone()) else {
+            return Self::from_vector_with_hint(
+                tensor_to_nested_values(&data, &resolved_shape),
+                DisplayHint::Auto,
+            );
+        };
         Self {
             data: ValueData::Tensor {
-                data: Rc::new(data),
+                data: Rc::new(tensor),
                 shape: Rc::new(resolved_shape),
             },
             hint: DisplayHint::Auto,
@@ -682,14 +688,16 @@ impl Value {
             };
         }
         if let Some((data, shape)) = try_collect_dense(&values) {
-            return Self {
-                data: ValueData::Tensor {
-                    data: Rc::new(data),
-                    shape: Rc::new(shape),
-                },
-                hint,
-                nil_reason: None,
-            };
+            if let Some(tensor) = DenseTensor::from_fractions(data, shape.clone()) {
+                return Self {
+                    data: ValueData::Tensor {
+                        data: Rc::new(tensor),
+                        shape: Rc::new(shape),
+                    },
+                    hint,
+                    nil_reason: None,
+                };
+            }
         }
         Self {
             data: ValueData::Vector(Rc::new(values)),
@@ -731,11 +739,7 @@ fn try_collect_dense(values: &[Value]) -> Option<(Vec<Fraction>, Vec<usize>)> {
 /// Materialize the i-th child of a dense Tensor as an owned `Value`. For 1-D
 /// shape `[n]` the child is a Scalar; for higher rank the child is itself a
 /// dense Tensor with the trailing dimensions.
-fn tensor_child(
-    data: &[Fraction],
-    shape: &[usize],
-    index: usize,
-) -> Option<Value> {
+fn tensor_child(data: &[Fraction], shape: &[usize], index: usize) -> Option<Value> {
     if shape.is_empty() {
         return None;
     }
@@ -758,7 +762,7 @@ fn try_dense_value(v: &Value) -> Option<(Vec<Fraction>, Vec<usize>)> {
     }
     match &v.data {
         ValueData::Scalar(f) => Some((vec![f.clone()], Vec::new())),
-        ValueData::Tensor { data, shape } => Some(((**data).clone(), (**shape).clone())),
+        ValueData::Tensor { data, shape } => Some((data.to_fractions(), (**shape).clone())),
         ValueData::Vector(children) => try_collect_dense(children),
         ValueData::Nil
         | ValueData::Record { .. }
@@ -771,15 +775,18 @@ fn try_dense_value(v: &Value) -> Option<(Vec<Fraction>, Vec<usize>)> {
 /// Materialize a dense Tensor (`data` + `shape`) as a tree of nested `Value`s.
 /// Used by mutating helpers that need a uniform `Vec<Value>` representation,
 /// and by display fallbacks.
-pub(super) fn tensor_to_nested_values(
-    data: &[Fraction],
-    shape: &[usize],
-) -> Vec<Value> {
+pub(super) fn tensor_to_nested_values(data: &[Fraction], shape: &[usize]) -> Vec<Value> {
     if shape.is_empty() {
-        return data.iter().map(|f| Value::from_fraction(f.clone())).collect();
+        return data
+            .iter()
+            .map(|f| Value::from_fraction(f.clone()))
+            .collect();
     }
     if shape.len() == 1 {
-        return data.iter().map(|f| Value::from_fraction(f.clone())).collect();
+        return data
+            .iter()
+            .map(|f| Value::from_fraction(f.clone()))
+            .collect();
     }
     let outer = shape[0];
     let rest = &shape[1..];
@@ -800,7 +807,12 @@ mod vtu_tensor_tests {
     #[test]
     fn tensor_and_nested_vector_compare_equal_when_flatten_matches() {
         let dense = Value::from_tensor(
-            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![
+                Fraction::from(1),
+                Fraction::from(2),
+                Fraction::from(3),
+                Fraction::from(4),
+            ],
             vec![2, 2],
         );
         let nested = Value::from_children(vec![
@@ -814,7 +826,12 @@ mod vtu_tensor_tests {
     #[test]
     fn tensor_shape_matches_nested_shape() {
         let dense = Value::from_tensor(
-            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![
+                Fraction::from(1),
+                Fraction::from(2),
+                Fraction::from(3),
+                Fraction::from(4),
+            ],
             vec![2, 2],
         );
         assert_eq!(dense.shape(), vec![2, 2]);
@@ -825,7 +842,12 @@ mod vtu_tensor_tests {
     #[test]
     fn tensor_with_different_shape_compares_unequal_to_nested() {
         let dense = Value::from_tensor(
-            vec![Fraction::from(1), Fraction::from(2), Fraction::from(3), Fraction::from(4)],
+            vec![
+                Fraction::from(1),
+                Fraction::from(2),
+                Fraction::from(3),
+                Fraction::from(4),
+            ],
             vec![4],
         );
         let nested = Value::from_children(vec![
@@ -844,13 +866,37 @@ mod vtu_tensor_tests {
 
     #[test]
     fn tensor_hydrates_to_vector_on_push_child() {
-        let mut dense = Value::from_tensor(
-            vec![Fraction::from(1), Fraction::from(2)],
-            vec![2],
-        );
+        let mut dense = Value::from_tensor(vec![Fraction::from(1), Fraction::from(2)], vec![2]);
         dense.push_child(Value::from_int(3));
         assert!(matches!(dense.data, ValueData::Vector(_)));
         assert_eq!(dense.len(), 3);
+    }
+
+    #[test]
+    fn dense_tensor_uses_soa_buffers_and_full_valid_mask() {
+        let dense = Value::from_tensor(
+            vec![Fraction::from(1), Fraction::new(3.into(), 2.into())],
+            vec![2],
+        );
+        let ValueData::Tensor { data, shape } = dense.data else {
+            panic!("expected DenseTensor representation");
+        };
+        assert_eq!(&*shape, &[2]);
+        assert_eq!(data.numerators, vec![1, 3]);
+        assert_eq!(data.denominators, vec![1, 2]);
+        assert_eq!(data.valid_mask, vec![0b11]);
+        assert!(!data.is_pure_integer);
+    }
+
+    #[test]
+    fn big_fraction_tensor_falls_back_without_losing_shape() {
+        use num_bigint::BigInt;
+
+        let big = Fraction::new(BigInt::from(i128::from(i64::MAX) + 1), 1.into());
+        let value = Value::from_tensor(vec![big.clone()], vec![1]);
+        assert!(matches!(value.data, ValueData::Vector(_)));
+        assert_eq!(value.shape(), vec![1]);
+        assert_eq!(value.collect_fractions_flat(), vec![big]);
     }
 
     // -----------------------------------------------------------------------
@@ -866,7 +912,10 @@ mod vtu_tensor_tests {
             Some(Cow::Borrowed(slice)) => {
                 assert_eq!(slice.len(), 2);
             }
-            other => panic!("expected Cow::Borrowed for Vector, got {:?}", other.is_some()),
+            other => panic!(
+                "expected Cow::Borrowed for Vector, got {:?}",
+                other.is_some()
+            ),
         }
 
         let dense = Value::from_tensor(vec![Fraction::from(1), Fraction::from(2)], vec![2]);


### PR DESCRIPTION
### Motivation
- Replace runtime FlowToken mass-tracking with a static, contract-driven mass-conservation model to simplify runtime and enable a No-Rebuild dense-tensor design. 
- Represent dense numeric tensors as SIMD-friendly SoA buffers with an explicit validity mask so NIL occupancy can be represented without degrading to nested vectors. 
- Keep exact Fraction semantics and BigInt fallbacks intact while changing the internal dense representation to improve VTU pipeline clarity. 

### Description
- Update `SPECIFICATION.md` to define `Static Mass Conservation` (Coreword Contract proofs at compile/JIT time), remove the runtime internal flow-level error catalog, add the `No-Rebuild Principle`, and document the `DenseTensor` validity-mask model. 
- Add a `DenseTensor` SoA type with `numerators`, `denominators`, `valid_mask`, `shape`, `is_pure_integer` and preserved `Fraction` backing in `rust/src/types/mod.rs`. 
- Change `ValueData::Tensor` to hold `Rc<DenseTensor>` and update `Value::from_tensor` / `from_vector_promoted` to build `DenseTensor` when possible and fall back to nested `Vec<Value>` when exact BigInt fractions prevent SoA packing. 
- Wire conversion boundaries: update arena serialization/deserialization (`rust/src/types/arena.rs`) and tensor-shape helpers (`rust/src/interpreter/tensor-shape-operations.rs`) to interoperate with `DenseTensor` via `to_fractions()` / `from_fractions()` paths. 
- Update dense-related helpers (`try_dense_value`, `tensor_child`, `tensor_to_nested_values`) and add VTU tests validating SoA buffers, validity masks, and BigInt fallback preservation in `rust/src/types/value-operations.rs`. 

### Testing
- Ran `cargo check` and the workspace successfully type-checked with only non-blocking warnings. (passed) 
- Ran the VTU tensor unit tests with `cargo test vtu_tensor_tests` and all VTU tensor tests passed (11 passed, 0 failed). (passed) 
- Ran `cargo fmt` as part of the workflow to keep formatting consistent. (ran)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe17ec8fec832688ea50d3fee7698a)