### PR TITLE
VTU: add internal SparseTensor candidate observation, metrics and cautious multiply fast paths

### DIFF
--- a/docs/dev/virtual-tensor-unit-design.md
+++ b/docs/dev/virtual-tensor-unit-design.md
@@ -137,3 +137,9 @@ parser and `apply_*_with_metrics` outputs over to `Tensor`, at which point
 >
 > Ajisai is a debuggable, exact-by-default, virtual-accelerator-aware
 > language.
+
+## Sparse tensor candidates
+
+Ajisai's VTU layer may classify dense Tensor values with many zero lanes as sparse candidates. This is an internal optimization hint and does not change Ajisai's observable value semantics. Sparse candidates are used only to reduce unnecessary data movement and element-wise work.
+
+AjisaiのVTU層は、ゼロ要素の多いTensorをSparse候補として分類する場合があります。これは内部最適化のためのヒントであり、Ajisaiプログラムから観測できる値の意味論は変わりません。Sparse候補は、不要なデータ移動と要素ごとの処理を減らすためにのみ利用されます。

--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -8,7 +8,7 @@ use crate::interpreter::value_extraction_helpers::{
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::semantic::{AbsenceOrigin, Recoverability};
 use crate::types::fraction::Fraction;
-use crate::types::{DisplayHint, Value, ValueData};
+use crate::types::{DisplayHint, SparseTensor, Value, ValueData};
 
 fn extract_scalar_from_value(val: &Value) -> Option<Fraction> {
     match &val.data {
@@ -29,6 +29,65 @@ fn extract_scalar_from_value(val: &Value) -> Option<Fraction> {
 
 fn is_scalar_value(val: &Value) -> bool {
     extract_scalar_from_value(val).is_some()
+}
+
+fn sparse_mul_candidate(a: &Value, b: &Value) -> Option<Value> {
+    if let Some(result) = sparse_tensor_scalar_mul(a, b) {
+        return Some(result);
+    }
+    if let Some(result) = sparse_tensor_scalar_mul(b, a) {
+        return Some(result);
+    }
+    sparse_same_shape_tensor_mul(a, b)
+}
+
+fn sparse_tensor_scalar_mul(tensor_value: &Value, scalar_value: &Value) -> Option<Value> {
+    let (dense, shape) = tensor_value.as_dense_tensor()?;
+    if !dense.is_sparse_candidate() {
+        return None;
+    }
+    let scalar = extract_scalar_from_value(scalar_value)?;
+    let sparse = SparseTensor::from_dense(dense)?;
+    let mut result = vec![Fraction::from(0_i64); sparse.len];
+    for (&index, entry) in sparse.indices.iter().zip(0..) {
+        result[index] = Fraction::new(
+            sparse.numerators[entry].into(),
+            sparse.denominators[entry].into(),
+        )
+        .mul(&scalar);
+    }
+    Some(Value::from_tensor(result, shape.to_vec()))
+}
+
+fn sparse_same_shape_tensor_mul(a: &Value, b: &Value) -> Option<Value> {
+    let (a_dense, a_shape) = a.as_dense_tensor()?;
+    let (b_dense, b_shape) = b.as_dense_tensor()?;
+    if a_shape != b_shape || a_dense.len() != b_dense.len() {
+        return None;
+    }
+
+    let use_a_sparse = a_dense.is_sparse_candidate();
+    let use_b_sparse = b_dense.is_sparse_candidate();
+    if !use_a_sparse && !use_b_sparse {
+        return None;
+    }
+
+    let (sparse, other) = if use_a_sparse {
+        (SparseTensor::from_dense(a_dense)?, b_dense)
+    } else {
+        (SparseTensor::from_dense(b_dense)?, a_dense)
+    };
+
+    let mut result = vec![Fraction::from(0_i64); sparse.len];
+    for (&index, entry) in sparse.indices.iter().zip(0..) {
+        let lhs = Fraction::new(
+            sparse.numerators[entry].into(),
+            sparse.denominators[entry].into(),
+        );
+        let rhs = other.get_small_fraction(index)?;
+        result[index] = lhs.mul(&rhs);
+    }
+    Some(Value::from_tensor(result, a_shape.to_vec()))
 }
 
 fn apply_binary_arithmetic<F>(interp: &mut Interpreter, op: F) -> Result<()>
@@ -257,6 +316,15 @@ pub fn op_mul(interp: &mut Interpreter) -> Result<()> {
                 .runtime_metrics
                 .vtu_simd_kernel_use_count
                 .saturating_add(1);
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            interp.stack.push(result);
+            return Ok(());
+        }
+
+        if let Some(result) = sparse_mul_candidate(a, b) {
             if interp.consumption_mode != ConsumptionMode::Keep {
                 interp.stack.pop();
                 interp.stack.pop();

--- a/rust/src/interpreter/interpreter-core.rs
+++ b/rust/src/interpreter/interpreter-core.rs
@@ -173,6 +173,14 @@ pub struct RuntimeMetrics {
     pub vtu_projected_broadcast_count: u64,
     /// SIMD fast paths actually taken (target-arch dependent).
     pub vtu_simd_kernel_use_count: u64,
+    /// Dense Tensor values classified as sparse optimization candidates.
+    pub vtu_sparse_candidate_count: u64,
+    /// Total dense lanes in sparse candidate Tensor values.
+    pub vtu_sparse_candidate_elements: u64,
+    /// Non-zero dense lanes in sparse candidate Tensor values.
+    pub vtu_sparse_candidate_nonzero_elements: u64,
+    /// Zero dense lanes that sparse handling may skip moving or scanning.
+    pub vtu_sparse_skippable_zero_elements: u64,
     /// QuantizedBlocks classified as VTU candidates (Strong or Weak).
     pub vtu_candidate_block_count: u64,
     /// QuantizedBlocks rejected as not suitable for VTU.

--- a/rust/src/interpreter/quantized-block-tests.rs
+++ b/rust/src/interpreter/quantized-block-tests.rs
@@ -1,8 +1,12 @@
 use crate::interpreter::quantized_block::{
     is_quantizable_block, quantize_code_block, KernelKind, QuantizedArity, QuantizedPurity,
-    VtuSuitability,
+    VtuBackendCandidate, VtuSuitability,
 };
-use crate::interpreter::Interpreter;
+use crate::interpreter::tensor_ops::{
+    apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics,
+};
+use crate::interpreter::{Interpreter, RuntimeMetrics};
+use crate::types::fraction::Fraction;
 use crate::types::{Token, Value};
 
 // ---------------------------------------------------------------------------
@@ -456,7 +460,12 @@ fn scan_produces_prefix_sums() {
         panic!("SCAN element is not a numeric scalar or single-element vector");
     };
     let vals: Vec<i64> = (0..3)
-        .map(|i| extract(top.child(i).expect("len==3 implies child(i) exists for i<3")))
+        .map(|i| {
+            extract(
+                top.child(i)
+                    .expect("len==3 implies child(i) exists for i<3"),
+            )
+        })
         .collect();
     assert_eq!(vals, vec![1, 3, 6]);
 }
@@ -719,12 +728,7 @@ fn arity_fully_known_still_fixed() {
 fn vtu_hint_map_unary_is_strong_candidate() {
     // `[ 1 ] +` is the const-vector pattern detected as MapUnaryPure.
     let mut interp = make_interp();
-    let tokens = vec![
-        Token::VectorStart,
-        num("1"),
-        Token::VectorEnd,
-        sym("+"),
-    ];
+    let tokens = vec![Token::VectorStart, num("1"), Token::VectorEnd, sym("+")];
     let qb = quantize_code_block(&tokens, &mut interp).unwrap();
     assert_eq!(qb.kernel_kind, KernelKind::MapUnaryPure);
     assert_eq!(qb.vtu_hint.suitability, VtuSuitability::StrongCandidate);
@@ -764,6 +768,62 @@ fn vtu_hint_generic_pure_is_weak_candidate() {
 }
 
 #[test]
+fn vtu_hint_map_unary_includes_sparse_tensor_loop_without_guard_effect() {
+    let mut interp = make_interp();
+    let tokens = vec![Token::VectorStart, num("1"), Token::VectorEnd, sym("+")];
+    let qb = quantize_code_block(&tokens, &mut interp).unwrap();
+    assert!(qb
+        .vtu_hint
+        .backend_candidates
+        .contains(&VtuBackendCandidate::SparseTensorLoop));
+    assert_eq!(qb.guard_signature.kernel_kind, KernelKind::MapUnaryPure);
+}
+
+#[test]
+fn vtu_sparse_candidate_metrics_increment_for_dense_tensor_unary() {
+    let mut metrics = RuntimeMetrics::default();
+    let mut data = vec![Fraction::from(0_i64); 64];
+    data[7] = Fraction::from(5_i64);
+    let value = Value::from_tensor(data, vec![64]);
+
+    let _ = apply_unary_flat_with_metrics(&value, |f| f.clone(), Some(&mut metrics))
+        .expect("unary tensor operation should succeed");
+
+    assert_eq!(metrics.vtu_sparse_candidate_count, 1);
+    assert_eq!(metrics.vtu_sparse_candidate_elements, 64);
+    assert_eq!(metrics.vtu_sparse_candidate_nonzero_elements, 1);
+    assert_eq!(metrics.vtu_sparse_skippable_zero_elements, 63);
+}
+
+#[test]
+fn vtu_sparse_candidate_metrics_skip_shape_mismatch_and_nil_rejection() {
+    let mut sparse_data = vec![Fraction::from(0_i64); 64];
+    sparse_data[3] = Fraction::from(2_i64);
+    let sparse = Value::from_tensor(sparse_data, vec![8, 8]);
+    let mismatched = Value::from_tensor(vec![Fraction::from(1_i64); 9], vec![3, 3]);
+
+    let mut shape_metrics = RuntimeMetrics::default();
+    assert!(apply_binary_broadcast_with_metrics(
+        &sparse,
+        &mismatched,
+        |a, b| Ok(a.add(b)),
+        Some(&mut shape_metrics),
+    )
+    .is_err());
+    assert_eq!(shape_metrics.vtu_sparse_candidate_count, 0);
+
+    let mut nil_metrics = RuntimeMetrics::default();
+    assert!(apply_binary_broadcast_with_metrics(
+        &Value::nil(),
+        &sparse,
+        |a, b| Ok(a.add(b)),
+        Some(&mut nil_metrics),
+    )
+    .is_err());
+    assert_eq!(nil_metrics.vtu_sparse_candidate_count, 0);
+}
+
+#[test]
 fn vtu_metrics_increment_on_quantize() {
     let mut interp = make_interp();
     let baseline = interp.runtime_metrics().vtu_candidate_block_count;
@@ -787,6 +847,10 @@ fn vtu_default_metrics_are_zero() {
     assert_eq!(m.vtu_same_shape_elementwise_count, 0);
     assert_eq!(m.vtu_projected_broadcast_count, 0);
     assert_eq!(m.vtu_simd_kernel_use_count, 0);
+    assert_eq!(m.vtu_sparse_candidate_count, 0);
+    assert_eq!(m.vtu_sparse_candidate_elements, 0);
+    assert_eq!(m.vtu_sparse_candidate_nonzero_elements, 0);
+    assert_eq!(m.vtu_sparse_skippable_zero_elements, 0);
     assert_eq!(m.vtu_candidate_block_count, 0);
     assert_eq!(m.vtu_rejected_block_count, 0);
     assert_eq!(m.vtu_fusion_candidate_count, 0);
@@ -936,10 +1000,10 @@ fn vtu_phase_iii_shape_accepts_tensor_input() {
 fn vtu_phase_iii_rank_accepts_tensor_input() {
     let interp = run_code("[ 1 2 3 ] RANK");
     let top = stack_top(&interp);
-    let rank = top
-        .as_scalar()
-        .and_then(|f| f.to_i64())
-        .or_else(|| top.child(0).and_then(|c| c.as_scalar().and_then(|f| f.to_i64())));
+    let rank = top.as_scalar().and_then(|f| f.to_i64()).or_else(|| {
+        top.child(0)
+            .and_then(|c| c.as_scalar().and_then(|f| f.to_i64()))
+    });
     assert_eq!(rank, Some(1));
 }
 

--- a/rust/src/interpreter/quantized-block.rs
+++ b/rust/src/interpreter/quantized-block.rs
@@ -33,12 +33,14 @@ pub enum QuantizedPurity {
 //     `GuardSignature` would cause spurious guard invalidations on what is
 //     fundamentally an explanation field, so it is intentionally kept out.
 //   - All variants are forward-looking; only `CpuScalar`, `WasmSimd`, and
-//     `DenseTensorLoop` map to surfaces Ajisai actually executes today.
+//     `DenseTensorLoop` and `SparseTensorLoop` map to surfaces Ajisai can
+//     exercise internally today.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VtuBackendCandidate {
     CpuScalar,
     WasmSimd,
     DenseTensorLoop,
+    SparseTensorLoop,
     #[allow(dead_code)]
     NpuCandidate,
     #[allow(dead_code)]
@@ -498,6 +500,7 @@ fn infer_vtu_hint(kernel_kind: KernelKind, purity: QuantizedPurity) -> VtuHint {
                 CpuScalar,
                 WasmSimd,
                 DenseTensorLoop,
+                SparseTensorLoop,
                 NpuCandidate,
                 GpuCandidate,
             ],
@@ -506,20 +509,20 @@ fn infer_vtu_hint(kernel_kind: KernelKind, purity: QuantizedPurity) -> VtuHint {
         },
         KernelKind::PredicateUnaryPure => VtuHint {
             suitability: StrongCandidate,
-            backend_candidates: vec![CpuScalar, WasmSimd, DenseTensorLoop],
+            backend_candidates: vec![CpuScalar, WasmSimd, DenseTensorLoop, SparseTensorLoop],
             data_movement: Low,
             reason: "elementwise pure predicate",
         },
         KernelKind::FoldBinaryPure => VtuHint {
             suitability: WeakCandidate,
-            backend_candidates: vec![CpuScalar, DenseTensorLoop],
+            backend_candidates: vec![CpuScalar, DenseTensorLoop, SparseTensorLoop],
             data_movement: Medium,
             reason: "reduction may depend on order/associativity; \
                      parallelization requires Approx boundary",
         },
         KernelKind::ScanBinaryPure => VtuHint {
             suitability: WeakCandidate,
-            backend_candidates: vec![CpuScalar, DenseTensorLoop],
+            backend_candidates: vec![CpuScalar, DenseTensorLoop, SparseTensorLoop],
             data_movement: Medium,
             reason: "scan carries an accumulator; not embarrassingly parallel",
         },

--- a/rust/src/interpreter/tensor-shape-operations.rs
+++ b/rust/src/interpreter/tensor-shape-operations.rs
@@ -14,6 +14,29 @@ fn record_flatten(metrics: &mut Option<&mut RuntimeMetrics>, elements: usize) {
     }
 }
 
+fn record_sparse_candidate_value(metrics: &mut Option<&mut RuntimeMetrics>, value: &Value) {
+    let ValueData::Tensor { data, .. } = &value.data else {
+        return;
+    };
+    if !data.is_sparse_candidate() {
+        return;
+    }
+
+    if let Some(m) = metrics.as_deref_mut() {
+        let nonzero = data.nonzero_count() as u64;
+        let zero = data.zero_count() as u64;
+        m.vtu_sparse_candidate_count = m.vtu_sparse_candidate_count.saturating_add(1);
+        m.vtu_sparse_candidate_elements = m
+            .vtu_sparse_candidate_elements
+            .saturating_add(data.len() as u64);
+        m.vtu_sparse_candidate_nonzero_elements = m
+            .vtu_sparse_candidate_nonzero_elements
+            .saturating_add(nonzero);
+        m.vtu_sparse_skippable_zero_elements =
+            m.vtu_sparse_skippable_zero_elements.saturating_add(zero);
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct FlatTensor {
     pub(crate) data: Vec<Fraction>,
@@ -239,6 +262,8 @@ where
     record_flatten(&mut metrics, tensor_b.data.len());
 
     let out_shape = broadcast_shape(&tensor_a.shape, &tensor_b.shape)?;
+    record_sparse_candidate_value(&mut metrics, a);
+    record_sparse_candidate_value(&mut metrics, b);
     let out_size: usize = if out_shape.is_empty() {
         1
     } else {
@@ -299,6 +324,7 @@ where
     let tensor = FlatTensor::from_value(val)?;
     let element_count = tensor.data.len();
     record_flatten(&mut metrics, element_count);
+    record_sparse_candidate_value(&mut metrics, val);
 
     if let Some(m) = metrics {
         m.vtu_unary_flat_count = m.vtu_unary_flat_count.saturating_add(1);

--- a/rust/src/tensor-operation-tests.rs
+++ b/rust/src/tensor-operation-tests.rs
@@ -154,16 +154,21 @@ mod tensor_ops_integration_tests {
         assert_eq!(result, "[ [ 101 102 103 ] [ 204 205 206 ] ]");
     }
 
-
     #[tokio::test]
     async fn test_percent_alias_matches_mod_basic() {
         let mut mod_interp = Interpreter::new();
-        mod_interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        mod_interp
+            .execute("'json' IMPORT 'io' IMPORT")
+            .await
+            .unwrap();
         mod_interp.execute("[ 7 ] [ 3 ] MOD").await.unwrap();
         let mod_result = format!("{}", mod_interp.get_stack().last().unwrap());
 
         let mut alias_interp = Interpreter::new();
-        alias_interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        alias_interp
+            .execute("'json' IMPORT 'io' IMPORT")
+            .await
+            .unwrap();
         alias_interp.execute("[ 7 ] [ 3 ] %").await.unwrap();
         let alias_result = format!("{}", alias_interp.get_stack().last().unwrap());
 
@@ -174,19 +179,19 @@ mod tensor_ops_integration_tests {
     #[tokio::test]
     async fn test_percent_alias_matches_mod_broadcast() {
         let mut mod_interp = Interpreter::new();
-        mod_interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
         mod_interp
-            .execute("[ 1 2 3 4 5 ] [ 2 ] MOD")
+            .execute("'json' IMPORT 'io' IMPORT")
             .await
             .unwrap();
+        mod_interp.execute("[ 1 2 3 4 5 ] [ 2 ] MOD").await.unwrap();
         let mod_result = format!("{}", mod_interp.get_stack().last().unwrap());
 
         let mut alias_interp = Interpreter::new();
-        alias_interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
         alias_interp
-            .execute("[ 1 2 3 4 5 ] [ 2 ] %")
+            .execute("'json' IMPORT 'io' IMPORT")
             .await
             .unwrap();
+        alias_interp.execute("[ 1 2 3 4 5 ] [ 2 ] %").await.unwrap();
         let alias_result = format!("{}", alias_interp.get_stack().last().unwrap());
 
         assert_eq!(alias_result, mod_result);
@@ -291,5 +296,52 @@ mod unicode_tests {
         assert_eq!(stack.len(), 1);
         let result = format!("{}", stack[0]);
         assert_eq!(result, "'hello'");
+    }
+}
+
+#[cfg(test)]
+mod sparse_tensor_fast_path_integration_tests {
+    use crate::interpreter::Interpreter;
+
+    fn sparse_fraction_vector_literal() -> String {
+        let mut lanes = vec!["0".to_string(); 64];
+        lanes[5] = "3/2".to_string();
+        lanes[40] = "-5/3".to_string();
+        format!("[ {} ]", lanes.join(" "))
+    }
+
+    #[tokio::test]
+    async fn sparse_candidate_tensor_scalar_mul_matches_dense_semantics() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute(&format!("{} 2 *", sparse_fraction_vector_literal()))
+            .await
+            .unwrap();
+        let result = interp.get_stack().last().unwrap();
+        assert_eq!(format!("{}", result.child(5).unwrap()), "3");
+        assert_eq!(format!("{}", result.child(40).unwrap()), "-10/3");
+        for index in 0..64 {
+            if index != 5 && index != 40 {
+                assert_eq!(format!("{}", result.child(index).unwrap()), "0");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn sparse_candidate_same_shape_mul_matches_dense_semantics() {
+        let mut interp = Interpreter::new();
+        let rhs = "[ ".to_string() + &vec!["2"; 64].join(" ") + " ]";
+        interp
+            .execute(&format!("{} {} *", sparse_fraction_vector_literal(), rhs))
+            .await
+            .unwrap();
+        let result = interp.get_stack().last().unwrap();
+        assert_eq!(format!("{}", result.child(5).unwrap()), "3");
+        assert_eq!(format!("{}", result.child(40).unwrap()), "-10/3");
+        for index in 0..64 {
+            if index != 5 && index != 40 {
+                assert_eq!(format!("{}", result.child(index).unwrap()), "0");
+            }
+        }
     }
 }

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -111,6 +111,146 @@ impl DenseTensor {
         };
         ((word >> (index % 64)) & 1) == 1
     }
+
+    pub fn zero_count(&self) -> usize {
+        (0..self.len())
+            .filter(|&index| self.is_valid(index) && self.numerators[index] == 0)
+            .count()
+    }
+
+    pub fn nonzero_count(&self) -> usize {
+        (0..self.len())
+            .filter(|&index| self.is_valid(index) && self.numerators[index] != 0)
+            .count()
+    }
+
+    pub fn density(&self) -> f64 {
+        if self.is_empty() {
+            return 0.0;
+        }
+        self.nonzero_count() as f64 / self.len() as f64
+    }
+
+    pub fn is_sparse_candidate(&self) -> bool {
+        const MIN_LEN: usize = 64;
+        const MAX_DENSITY: f64 = 0.25;
+
+        self.len() >= MIN_LEN && self.density() <= MAX_DENSITY
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SparseTensor {
+    pub indices: Vec<usize>,
+    pub numerators: Vec<i64>,
+    pub denominators: Vec<i64>,
+    pub valid_mask: Vec<u64>,
+    pub shape: Vec<usize>,
+    pub len: usize,
+    pub is_pure_integer: bool,
+}
+
+impl SparseTensor {
+    pub fn from_dense(dense: &DenseTensor) -> Option<Self> {
+        let expected_len = if dense.shape.is_empty() {
+            dense.len()
+        } else {
+            dense.shape.iter().product()
+        };
+        if expected_len != dense.len() {
+            return None;
+        }
+        if (0..dense.len()).any(|index| !dense.is_valid(index)) {
+            return None;
+        }
+
+        let nonzero_count = dense.nonzero_count();
+        let mut indices = Vec::with_capacity(nonzero_count);
+        let mut numerators = Vec::with_capacity(nonzero_count);
+        let mut denominators = Vec::with_capacity(nonzero_count);
+
+        for index in 0..dense.len() {
+            if dense.numerators[index] != 0 {
+                indices.push(index);
+                numerators.push(dense.numerators[index]);
+                denominators.push(dense.denominators[index]);
+            }
+        }
+
+        let valid_mask_len = dense.len().div_ceil(64);
+        let mut valid_mask = vec![u64::MAX; valid_mask_len];
+        if let Some(last) = valid_mask.last_mut() {
+            let live_bits = dense.len() % 64;
+            if live_bits != 0 {
+                *last = (1u64 << live_bits) - 1;
+            }
+        }
+
+        Some(Self {
+            indices,
+            numerators,
+            denominators,
+            valid_mask,
+            shape: dense.shape.clone(),
+            len: dense.len(),
+            is_pure_integer: dense.is_pure_integer,
+        })
+    }
+
+    pub fn to_dense(&self) -> DenseTensor {
+        let mut numerators = vec![0; self.len];
+        let mut denominators = vec![1; self.len];
+        for (entry, &index) in self.indices.iter().enumerate() {
+            if index < self.len {
+                numerators[index] = self.numerators[entry];
+                denominators[index] = self.denominators[entry];
+            }
+        }
+        DenseTensor {
+            numerators,
+            denominators,
+            valid_mask: self.valid_mask.clone(),
+            shape: self.shape.clone(),
+            is_pure_integer: self.is_pure_integer,
+        }
+    }
+
+    pub fn get_small_fraction(&self, index: usize) -> Option<Fraction> {
+        if index >= self.len || !self.is_valid(index) {
+            return None;
+        }
+        let entry = self.indices.binary_search(&index).ok()?;
+        Some(Fraction::new(
+            self.numerators[entry].into(),
+            self.denominators[entry].into(),
+        ))
+    }
+
+    pub fn fraction_or_zero(&self, index: usize) -> Fraction {
+        self.get_small_fraction(index)
+            .unwrap_or_else(|| Fraction::new(0.into(), 1.into()))
+    }
+
+    pub fn nonzero_count(&self) -> usize {
+        self.indices.len()
+    }
+
+    pub fn density(&self) -> f64 {
+        if self.len == 0 {
+            return 0.0;
+        }
+        self.nonzero_count() as f64 / self.len as f64
+    }
+
+    pub fn is_valid(&self, index: usize) -> bool {
+        if index >= self.len {
+            return false;
+        }
+        let Some(word) = self.valid_mask.get(index / 64) else {
+            return false;
+        };
+        ((word >> (index % 64)) & 1) == 1
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -460,3 +600,72 @@ pub struct WordDefinition {
 }
 
 pub type Stack = Vec<Value>;
+
+#[cfg(test)]
+mod sparse_tensor_tests {
+    use super::{DenseTensor, SparseTensor};
+    use crate::types::fraction::Fraction;
+
+    fn dense_from_i64(values: &[i64], shape: Vec<usize>) -> DenseTensor {
+        DenseTensor::from_fractions(values.iter().copied().map(Fraction::from).collect(), shape)
+            .expect("small dense tensor should build")
+    }
+
+    #[test]
+    fn dense_tensor_sparse_density_counts_zero_and_nonzero_lanes() {
+        let all_zero = dense_from_i64(&vec![0; 64], vec![64]);
+        assert_eq!(all_zero.zero_count(), 64);
+        assert_eq!(all_zero.nonzero_count(), 0);
+        assert_eq!(all_zero.density(), 0.0);
+        assert!(all_zero.is_sparse_candidate());
+
+        let all_nonzero = dense_from_i64(&vec![1; 64], vec![64]);
+        assert_eq!(all_nonzero.zero_count(), 0);
+        assert_eq!(all_nonzero.nonzero_count(), 64);
+        assert_eq!(all_nonzero.density(), 1.0);
+        assert!(!all_nonzero.is_sparse_candidate());
+
+        let mixed = dense_from_i64(&[0, 7, 0, -3], vec![4]);
+        assert_eq!(mixed.zero_count(), 2);
+        assert_eq!(mixed.nonzero_count(), 2);
+        assert_eq!(mixed.density(), 0.5);
+        assert!(!mixed.is_sparse_candidate());
+    }
+
+    #[test]
+    fn dense_tensor_sparse_density_does_not_count_invalid_lanes_as_zero() {
+        let mut dense = dense_from_i64(&[0, 5, 0, 9], vec![4]);
+        dense.clear_valid(0);
+        dense.clear_valid(1);
+        assert_eq!(dense.zero_count(), 1);
+        assert_eq!(dense.nonzero_count(), 1);
+        assert_eq!(dense.density(), 0.25);
+        assert!(SparseTensor::from_dense(&dense).is_none());
+    }
+
+    #[test]
+    fn sparse_tensor_round_trips_dense_values_and_shape() {
+        let dense = dense_from_i64(&[0, 0, 3, 0, -4, 0], vec![2, 3]);
+        let sparse =
+            SparseTensor::from_dense(&dense).expect("all-valid dense tensor is sparseable");
+        assert_eq!(sparse.shape, vec![2, 3]);
+        assert_eq!(sparse.len, 6);
+        assert_eq!(sparse.indices, vec![2, 4]);
+        assert_eq!(sparse.nonzero_count(), 2);
+        assert!(sparse.indices.windows(2).all(|w| w[0] < w[1]));
+        assert_eq!(sparse.fraction_or_zero(0), Fraction::from(0_i64));
+        assert_eq!(sparse.get_small_fraction(2), Some(Fraction::from(3_i64)));
+        assert_eq!(sparse.to_dense(), dense);
+    }
+
+    #[test]
+    fn sparse_tensor_accepts_all_zero_dense_tensor() {
+        let dense = dense_from_i64(&vec![0; 64], vec![8, 8]);
+        let sparse =
+            SparseTensor::from_dense(&dense).expect("all-zero all-valid tensor is sparseable");
+        assert!(sparse.indices.is_empty());
+        assert_eq!(sparse.nonzero_count(), 0);
+        assert_eq!(sparse.density(), 0.0);
+        assert_eq!(sparse.to_dense(), dense);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce an internal, non-observable sparse representation and VTU observations to reduce unnecessary data movement while preserving Ajisai semantics. 
- Start with a minimal COO-like internal `SparseTensor` for small `i64`/`i64` fractions and avoid adding any new Core words or `ValueData` variants. 
- Record observational VTU metrics and add safe, limited fast paths (only zero-preserving multiplication) while always falling back to existing dense execution on failure. 

### Description
- Added dense-tensor helper APIs on `DenseTensor`: `zero_count`, `nonzero_count`, `density`, and `is_sparse_candidate`, which ignore invalid/NIL lanes when counting. 
- Introduced an internal `SparseTensor` (COO-like linear index) with `from_dense`, `to_dense`, `get_small_fraction`, `fraction_or_zero`, `nonzero_count`, `density`, and validity rules that require all lanes valid (so unsafe conversions return `None`). 
- Extended `RuntimeMetrics` with sparse candidate counters (`vtu_sparse_candidate_count`, `vtu_sparse_candidate_elements`, `vtu_sparse_candidate_nonzero_elements`, `vtu_sparse_skippable_zero_elements`) and record them in `apply_binary_broadcast_with_metrics` and `apply_unary_flat_with_metrics` only after NIL/shape rejections are ruled out. 
- Added `VtuBackendCandidate::SparseTensorLoop` and included it in `VtuHint` backend candidate lists (explanatory only, not part of `GuardSignature`), and implemented a cautious sparse fast path for `Tensor × Scalar`, `Scalar × Tensor`, and same-shape `Tensor × Tensor` multiplications that converts to `SparseTensor` when safe and otherwise falls back to existing dense paths. 
- Kept all user-observable behavior unchanged by never exposing `SparseTensor` as `ValueData` and by returning results through the existing `Value::from_tensor` / dense routes. 
- Documentation: added a short note to VTU design docs stating sparse candidates are internal optimization hints and do not change observable semantics. 

### Testing
- Ran the focused sparse tests and integration checks via `cargo test sparse -- --nocapture`, and those targeted tests passed (all added sparse-related unit/integration tests succeeded). 
- Ran the full test suite with `cargo test`, and the entire suite completed successfully (`861` tests passed, `0` failed). 
- Added unit tests covering `DenseTensor` helper behavior, `SparseTensor` round-trip and properties, VTU metric increments and NIL/shape rejection safety, and sparse multiply fast-path parity tests; all new tests passed as part of the runs above. 
- Formatting (`cargo fmt`) was applied and the repository compiles and tests cleanly with the new changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0043284a088326a6e806a7f892a2e6)