### PR TITLE
tokenizer: reject '(' and ')' as Ajisai source characters (Phase 2)

### DIFF
--- a/examples/nested-vector-brackets-test.ajisai
+++ b/examples/nested-vector-brackets-test.ajisai
@@ -1,43 +1,38 @@
 // Test: Nested Vector Bracket Normalization
-// Purpose: Verify that input bracket types are normalized and display shows depth-based brackets
-// Expected behavior:
-// - All input brackets ([], {}, ()) are treated the same internally
-// - Display shows brackets based on nesting depth:
-//   - Depth 0: [ ]
-//   - Depth 1: { }
-//   - Depth 2: ( )
-//   - Depth 3+: cycles back ([ ], { }, ( ), ...)
+// Purpose: Verify that vector input bracket types are normalized and display always uses [ ].
+// Notes (post SPECIFICATION.md 2026-05-13):
+// - The only valid vector bracket pair in Ajisai source is [ ].
+// - { } delimits a code block (Section 3.4).
+// - ( ) is not valid in Ajisai source (Section 3.4); it is reserved for the
+//   nested continued-fraction display form (Section 4.2.3).
+// - Display always renders vectors with [ ] regardless of nesting depth
+//   (see examples/nested-vector-brackets-sample-test.ajisai for the
+//   current display behavior).
 
-// Test 1: Different input brackets should be treated identically
+// Test 1: Vector with square brackets
 [ 1 2 3 ]
-{ 1 2 3 }
-( 1 2 3 )
-// All three vectors above should be internally identical
+// Expected display: [ 1 2 3 ]
 
-// Test 2: Nested vectors with square brackets
+// Test 2: Nested vectors
 [[ 1 2 ] [ 3 4 ]]
-// Expected display: [ { 1 2 } { 3 4 } ]
+// Expected display: [ [ 1 2 ] [ 3 4 ] ]
 
-// Test 3: Nested vectors with mixed brackets (all should normalize)
-[{ 1 2 } ( 3 4 )]
-// Expected display: [ { 1 2 } { 3 4 } ] (same as Test 2)
-
-// Test 4: Triple nesting
+// Test 3: Triple nesting
 [[[ 1 2 ]]]
-// Expected display: [ { ( 1 2 ) } ]
+// Expected display: [ [ [ 1 2 ] ] ]
 
-// Test 5: Quad nesting (should cycle back to square brackets)
+// Test 4: Quad nesting
 [[[[ 1 ]]]]
-// Expected display: [ { ( [ 1 ] ) } ]
+// Expected display: [ [ [ [ 1 ] ] ] ]
 
-// Test 6: Complex nested structure
+// Test 5: Complex nested structure
 [[ 1 [ 2 3 ] 4 ] [ 5 [ 6 7 ] 8 ]]
-// Expected display: [ { 1 ( 2 3 ) 4 } { 5 ( 6 7 ) 8 } ]
+// Expected display: [ [ 1 [ 2 3 ] 4 ] [ 5 [ 6 7 ] 8 ] ]
 
-// Test 7: Operations on nested vectors should preserve depth-based display
+// Test 6: Operations on nested vectors should preserve [ ] display
 [ 1 2 ] [ 3 4 ] 2 CONCAT
 // Expected display after CONCAT: [ 1 2 3 4 ]
 
-// Test 8: Deeply nested vectors created by operations
+// Test 7: Deeply nested vectors created by operations
 [ [ 1 ] ] [ [ 2 ] ] 2 CONCAT
-// Expected display after CONCAT: [ { 1 } { 2 } ]
+// Expected display after CONCAT: [ [ 1 ] [ 2 ] ]

--- a/rust/src/tokenizer-regression-tests-2.rs
+++ b/rust/src/tokenizer-regression-tests-2.rs
@@ -408,19 +408,23 @@ mod tokenizer_regression_tests_2 {
 
 
     #[test]
-    fn test_mismatched_brace_paren() {
+    fn test_close_paren_rejected_after_brace() {
 
         let result = tokenize("{ [ 2 ] * )");
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Mismatched brackets"));
+        assert!(result
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]
-    fn test_mismatched_paren_brace() {
+    fn test_open_paren_rejected_before_brace_close() {
 
         let result = tokenize("( [ 2 ] * }");
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Mismatched brackets"));
+        assert!(result
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]
@@ -432,11 +436,13 @@ mod tokenizer_regression_tests_2 {
     }
 
     #[test]
-    fn test_mismatched_bracket_paren() {
+    fn test_close_paren_rejected_after_bracket() {
 
         let result = tokenize("[ 1 2 3 )");
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Mismatched brackets"));
+        assert!(result
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]
@@ -455,23 +461,29 @@ mod tokenizer_regression_tests_2 {
     }
 
     #[test]
-    fn test_matched_parens_ok() {
+    fn test_paren_rejected_at_top_level() {
 
         let result = tokenize("( [ 2 ] * )");
-        assert!(result.is_ok());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]
-    fn test_nested_mixed_brackets_ok() {
+    fn test_paren_rejected_in_nested_position() {
 
         let result = tokenize("{ ( [ 1 ] + ) }");
-        assert!(result.is_ok());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]
     fn test_mismatched_nested_brackets() {
 
-        let result = tokenize("{ ( [ 1 ] + } )");
+        let result = tokenize("{ [ 1 ] + ]");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Mismatched brackets"));
     }

--- a/rust/src/tokenizer-regression-tests.rs
+++ b/rust/src/tokenizer-regression-tests.rs
@@ -313,49 +313,26 @@ mod tokenizer_regression_tests {
             ]
         );
 
-        let result3 = tokenize("( x y z )").unwrap();
-        assert_eq!(
-            result3,
-            vec![
-                Token::BlockStart,
-                Token::Symbol("x".into()),
-                Token::Symbol("y".into()),
-                Token::Symbol("z".into()),
-                Token::BlockEnd,
-            ]
-        );
+        let result3 = tokenize("( x y z )");
+        assert!(result3.is_err());
+        assert!(result3
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]
-    fn test_mixed_bracket_styles() {
-        let result = tokenize("{ ( [ 1 ] ) }").unwrap();
-        assert_eq!(
-            result,
-            vec![
-                Token::BlockStart,
-                Token::BlockStart,
-                Token::VectorStart,
-                Token::Number("1".into()),
-                Token::VectorEnd,
-                Token::BlockEnd,
-                Token::BlockEnd,
-            ]
-        );
+    fn test_paren_rejected_in_block_position() {
+        let result = tokenize("{ ( [ 1 ] ) }");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
 
-        let result2 = tokenize("{ ( X ) ( Y ) }").unwrap();
-        assert_eq!(
-            result2,
-            vec![
-                Token::BlockStart,
-                Token::BlockStart,
-                Token::Symbol("X".into()),
-                Token::BlockEnd,
-                Token::BlockStart,
-                Token::Symbol("Y".into()),
-                Token::BlockEnd,
-                Token::BlockEnd,
-            ]
-        );
+        let result2 = tokenize("{ ( X ) ( Y ) }");
+        assert!(result2.is_err());
+        assert!(result2
+            .unwrap_err()
+            .contains("not a valid Ajisai source character"));
     }
 
     #[test]

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -33,7 +33,13 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
         }
 
         if chars[i] == ':' {
-            return Err("':' (code block start) has been removed. Use '{' and '}' or '(' and ')' for code blocks.".to_string());
+            return Err("':' (code block start) has been removed. Use '{' and '}' for code blocks.".to_string());
+        }
+        if chars[i] == '(' || chars[i] == ')' {
+            return Err(format!(
+                "'{}' is not a valid Ajisai source character (Section 3.4). The nested continued-fraction form is a display/serialization artifact only; use '{{' and '}}' for code blocks.",
+                chars[i]
+            ));
         }
         if chars[i] == ';' {
             if i + 1 < chars.len() && chars[i + 1] == ';' {
@@ -186,8 +192,8 @@ fn parse_token_from_single_char(c: char) -> Option<(Token, usize)> {
     match c {
         '[' => Some((Token::VectorStart, 1)),
         ']' => Some((Token::VectorEnd, 1)),
-        '{' | '(' => Some((Token::BlockStart, 1)),
-        '}' | ')' => Some((Token::BlockEnd, 1)),
+        '{' => Some((Token::BlockStart, 1)),
+        '}' => Some((Token::BlockEnd, 1)),
 
         '$' => Some((Token::CondClauseSep, 1)),
         '~' => Some((Token::SafeMode, 1)),
@@ -242,7 +248,7 @@ fn check_bracket_matching(input: &str) -> Result<(), String> {
         }
 
         match c {
-            '[' | '{' | '(' => stack.push(c),
+            '[' | '{' => stack.push(c),
             ']' => match stack.pop() {
                 Some('[') => {}
                 Some(open) => {
@@ -269,19 +275,6 @@ fn check_bracket_matching(input: &str) -> Result<(), String> {
                     return Err("Unexpected '}' without matching '{'".to_string());
                 }
             },
-            ')' => match stack.pop() {
-                Some('(') => {}
-                Some(open) => {
-                    return Err(format!(
-                        "Mismatched brackets: '{}' is closed by ')', expected '{}'",
-                        open,
-                        closing_bracket(open)
-                    ));
-                }
-                None => {
-                    return Err("Unexpected ')' without matching '('".to_string());
-                }
-            },
             _ => {}
         }
         i += 1;
@@ -302,7 +295,6 @@ fn closing_bracket(open: char) -> char {
     match open {
         '[' => ']',
         '{' => '}',
-        '(' => ')',
         _ => '?',
     }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the continued-fraction migration. Implements the lexical-level decision made in Phase 1 ([#898](https://github.com/masamoto1982/Ajisai/pull/898), SPEC §3.4 / §3.7): `(` and `)` are no longer valid characters in Ajisai source. They are reserved at the lexical level so the nested continued-fraction display form (`( a0 ( a1 ( a2 )))`, SPEC §4.2.3) is unambiguous when it appears in renderer/serialization output.

### Tokenizer changes (`rust/src/tokenizer.rs`)

- New top-of-loop check that returns a clear error referencing Section 3.4 whenever `(` or `)` is encountered outside of a string literal or `#` comment.
- `parse_token_from_single_char` no longer maps `(` → `BlockStart` or `)` → `BlockEnd`.
- `check_bracket_matching` no longer tracks `(` / `)` (now unreachable in well-formed input).
- `closing_bracket` simplified.
- `is_special_char` still includes `(` and `)` so a stray paren breaks symbol tokenization cleanly into the rejection branch instead of being silently absorbed into an adjacent symbol.
- The error from `:` (already removed) updates its hint from "use `{}` or `()`" to just "use `{}`".

### Tests

- **`tokenizer-regression-tests.rs`**: `test_block_parsing` now expects `( x y z )` to error; `test_mixed_bracket_styles` is replaced by `test_paren_rejected_in_block_position` covering `{ ( [ 1 ] ) }` and `{ ( X ) ( Y ) }`.
- **`tokenizer-regression-tests-2.rs`**: four `test_mismatched_*_paren*` tests are reframed as rejection tests (`test_close_paren_rejected_after_brace`, `test_open_paren_rejected_before_brace_close`, `test_close_paren_rejected_after_bracket`); `test_matched_parens_ok` and `test_nested_mixed_brackets_ok` become `test_paren_rejected_at_top_level` and `test_paren_rejected_in_nested_position`; the surviving `test_mismatched_nested_brackets` is trimmed to a no-paren case. `test_brackets_in_string_ignored` and `test_brackets_in_comment_ignored` are kept unchanged to lock down the in-string / in-comment safe paths.

Result: **889 / 889 lib tests pass** (tokenizer module: 97 / 97).

### Example migration

`examples/nested-vector-brackets-test.ajisai`: dropped the two source-level `(...)` occurrences (`( 1 2 3 )` and `( 3 4 )` inside a mixed-bracket vector). Updated the "Expected display" comments, which described a depth-cycling bracket scheme (`[ ]` → `{ }` → `( )`) that the current renderer doesn't actually implement — `format_value_recursive` always emits `[ ]` regardless of depth. The newer `nested-vector-brackets-sample-test.ajisai` already covers actual behavior; the older file is kept as a smaller test of nested `[...]` and `{...}` inputs.

A grep across `examples/` and `docs/` confirmed no other `.ajisai` file uses `(...)` outside of `#` comments. Module / built-in word source is in Rust strings, none of which contains `(...)` as code.

## Test plan

- [x] `cargo test --lib` — 889 passing, 0 failing
- [x] `cargo test --lib tokenizer` — 97 / 97
- [ ] Reviewer: run the Quality Gate / Rust Tests / TypeScript Check workflows on this PR
- [ ] Reviewer: spot-check that nothing in `docs/dev/*.md` instructs writing `(...)` as Ajisai source that someone will paste into the REPL
- [ ] Reviewer: confirm the tokenizer error message wording is acceptable

### Next phase

Phase 3: introduce the `ExactReal` type with a `Rational` representation behind the existing `Fraction` kernel (no behavior change yet — purely an internal abstraction layer that Phases 4–6 will extend).

https://claude.ai/code/session_01N7yzNQDmkEY1XHHQPVpf1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7yzNQDmkEY1XHHQPVpf1u)_