### PR TITLE
types: ExactReal scaffold with Rational variant (Phase 3)

### DIFF
--- a/rust/src/types/continued_fraction.rs
+++ b/rust/src/types/continued_fraction.rs
@@ -1,0 +1,276 @@
+use crate::types::fraction::Fraction;
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::{One, Signed, Zero};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExactReal {
+    Rational(Fraction),
+}
+
+impl ExactReal {
+    #[inline]
+    pub fn from_fraction(f: Fraction) -> Self {
+        Self::Rational(f)
+    }
+
+    #[inline]
+    pub fn from_integer(n: i64) -> Self {
+        Self::Rational(Fraction::new(BigInt::from(n), BigInt::one()))
+    }
+
+    #[inline]
+    pub fn from_bigint(n: BigInt) -> Self {
+        Self::Rational(Fraction::new(n, BigInt::one()))
+    }
+
+    #[inline]
+    pub fn as_rational(&self) -> Option<&Fraction> {
+        match self {
+            Self::Rational(f) => Some(f),
+        }
+    }
+
+    #[inline]
+    pub fn to_fraction(&self) -> Option<Fraction> {
+        match self {
+            Self::Rational(f) => Some(f.clone()),
+        }
+    }
+
+    #[inline]
+    pub fn is_rational(&self) -> bool {
+        matches!(self, Self::Rational(_))
+    }
+
+    #[inline]
+    pub fn is_nil(&self) -> bool {
+        match self {
+            Self::Rational(f) => f.is_nil(),
+        }
+    }
+
+    #[inline]
+    pub fn is_integer(&self) -> bool {
+        match self {
+            Self::Rational(f) => f.is_integer(),
+        }
+    }
+
+    pub fn partial_quotients(&self) -> Option<Vec<BigInt>> {
+        match self {
+            Self::Rational(f) => {
+                if f.is_nil() {
+                    return None;
+                }
+                Some(rational_partial_quotients(f.numerator(), f.denominator()))
+            }
+        }
+    }
+
+    pub fn from_partial_quotients(terms: &[BigInt]) -> Option<Self> {
+        if terms.is_empty() {
+            return None;
+        }
+        for term in terms.iter().skip(1) {
+            if !term.is_positive() {
+                return None;
+            }
+        }
+
+        let mut iter = terms.iter().rev();
+        let last = iter.next().expect("non-empty by length check above");
+        let mut num: BigInt = last.clone();
+        let mut den: BigInt = BigInt::one();
+        for a in iter {
+            let new_num = a * &num + &den;
+            let new_den = num;
+            num = new_num;
+            den = new_den;
+        }
+        Some(Self::Rational(Fraction::new(num, den)))
+    }
+}
+
+fn rational_partial_quotients(mut num: BigInt, mut den: BigInt) -> Vec<BigInt> {
+    debug_assert!(!den.is_zero());
+
+    if den.is_negative() {
+        num = -num;
+        den = -den;
+    }
+
+    let mut terms: Vec<BigInt> = Vec::new();
+
+    loop {
+        let (q, r) = num.div_mod_floor(&den);
+        terms.push(q);
+        if r.is_zero() {
+            break;
+        }
+        num = den;
+        den = r;
+    }
+
+    if terms.len() >= 2 && terms.last().expect("non-empty").is_one() {
+        let popped = terms.pop().expect("just checked length >= 2");
+        *terms.last_mut().expect("length >= 1 after pop") += popped;
+    }
+
+    terms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bi(n: i64) -> BigInt {
+        BigInt::from(n)
+    }
+
+    fn terms(seq: &[i64]) -> Vec<BigInt> {
+        seq.iter().map(|&n| BigInt::from(n)).collect()
+    }
+
+    fn rational(num: i64, den: i64) -> ExactReal {
+        ExactReal::Rational(Fraction::new(bi(num), bi(den)))
+    }
+
+    #[test]
+    fn integer_three_expands_to_single_term() {
+        assert_eq!(rational(3, 1).partial_quotients(), Some(terms(&[3])));
+    }
+
+    #[test]
+    fn three_halves_expands_to_one_two() {
+        assert_eq!(rational(3, 2).partial_quotients(), Some(terms(&[1, 2])));
+    }
+
+    #[test]
+    fn one_half_expands_to_zero_two() {
+        assert_eq!(rational(1, 2).partial_quotients(), Some(terms(&[0, 2])));
+    }
+
+    #[test]
+    fn negative_three_halves_expands_via_floor_division() {
+        assert_eq!(rational(-3, 2).partial_quotients(), Some(terms(&[-2, 2])));
+    }
+
+    #[test]
+    fn negative_one_half_expands_via_floor_division() {
+        assert_eq!(rational(-1, 2).partial_quotients(), Some(terms(&[-1, 2])));
+    }
+
+    #[test]
+    fn three_seven_sixteen_expands_for_355_113() {
+        assert_eq!(
+            rational(355, 113).partial_quotients(),
+            Some(terms(&[3, 7, 16]))
+        );
+    }
+
+    #[test]
+    fn zero_expands_to_single_zero() {
+        assert_eq!(rational(0, 1).partial_quotients(), Some(terms(&[0])));
+    }
+
+    #[test]
+    fn negative_integer_expands_to_single_term() {
+        assert_eq!(rational(-5, 1).partial_quotients(), Some(terms(&[-5])));
+    }
+
+    #[test]
+    fn negative_denominator_is_normalized_before_expansion() {
+        assert_eq!(rational(3, -2).partial_quotients(), Some(terms(&[-2, 2])));
+    }
+
+    #[test]
+    fn trailing_one_is_folded_into_previous_term() {
+        let f = ExactReal::Rational(Fraction::new(bi(2), bi(1)));
+        assert_eq!(f.partial_quotients(), Some(terms(&[2])));
+    }
+
+    #[test]
+    fn from_partial_quotients_evaluates_canonical_sequence() {
+        let reconstructed = ExactReal::from_partial_quotients(&terms(&[3, 7, 16]));
+        assert_eq!(reconstructed, Some(rational(355, 113)));
+    }
+
+    #[test]
+    fn from_partial_quotients_evaluates_single_term() {
+        assert_eq!(
+            ExactReal::from_partial_quotients(&terms(&[3])),
+            Some(rational(3, 1))
+        );
+    }
+
+    #[test]
+    fn from_partial_quotients_evaluates_negative_leading_term() {
+        assert_eq!(
+            ExactReal::from_partial_quotients(&terms(&[-2, 2])),
+            Some(rational(-3, 2))
+        );
+    }
+
+    #[test]
+    fn from_partial_quotients_accepts_non_canonical_trailing_one() {
+        assert_eq!(
+            ExactReal::from_partial_quotients(&terms(&[1, 1])),
+            Some(rational(2, 1))
+        );
+    }
+
+    #[test]
+    fn from_partial_quotients_rejects_empty_input() {
+        assert_eq!(ExactReal::from_partial_quotients(&[]), None);
+    }
+
+    #[test]
+    fn from_partial_quotients_rejects_non_positive_after_first() {
+        assert_eq!(
+            ExactReal::from_partial_quotients(&terms(&[1, 0])),
+            None
+        );
+        assert_eq!(
+            ExactReal::from_partial_quotients(&terms(&[1, -2])),
+            None
+        );
+    }
+
+    #[test]
+    fn round_trip_canonical_sequence_is_idempotent() {
+        let value = rational(355, 113);
+        let canonical = value.partial_quotients().expect("rational");
+        let reconstructed =
+            ExactReal::from_partial_quotients(&canonical).expect("valid sequence");
+        let canonical_again = reconstructed.partial_quotients().expect("rational");
+        assert_eq!(canonical, canonical_again);
+    }
+
+    #[test]
+    fn round_trip_negative_value_is_idempotent() {
+        let value = rational(-22, 7);
+        let canonical = value.partial_quotients().expect("rational");
+        let reconstructed =
+            ExactReal::from_partial_quotients(&canonical).expect("valid sequence");
+        let canonical_again = reconstructed.partial_quotients().expect("rational");
+        assert_eq!(canonical, canonical_again);
+    }
+
+    #[test]
+    fn nil_fraction_has_no_partial_quotients() {
+        let nil = ExactReal::Rational(Fraction::nil());
+        assert!(nil.is_nil());
+        assert_eq!(nil.partial_quotients(), None);
+    }
+
+    #[test]
+    fn from_integer_round_trips_through_fraction() {
+        let value = ExactReal::from_integer(42);
+        assert!(value.is_integer());
+        assert!(!value.is_nil());
+        let f = value.to_fraction().expect("rational");
+        assert_eq!(f.numerator(), bi(42));
+        assert_eq!(f.denominator(), bi(1));
+    }
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -6,6 +6,7 @@ mod fraction_arithmetic;
 #[cfg(test)]
 #[path = "fraction-mcdc-tests.rs"]
 mod fraction_mcdc_tests;
+pub mod continued_fraction;
 pub mod interval;
 #[path = "value-operations.rs"]
 mod value_operations;


### PR DESCRIPTION
## Summary

Phase 3 of the continued-fraction migration. Purely additive: introduces the `ExactReal` type that subsequent phases will extend with lazy-CF representations. **No existing callsite is changed** — `ValueData::Scalar` still holds `Fraction` directly. The new type compiles, has 20 unit tests, and is wired into `types/mod.rs` so it is importable as `crate::types::continued_fraction::ExactReal`.

### What this PR adds

**New file: `rust/src/types/continued_fraction.rs` (277 lines incl. tests)**

```rust
pub enum ExactReal {
    Rational(Fraction),
}
```

Single variant for Phase 3. Doc/comment placeholders for the future `AlgebraicSqrt`, `Gosper`, `LazyCf` variants (SPEC §4.2.2) are intentionally omitted from the enum body to avoid dead-warning churn; they will be added in Phases 4–5 alongside their implementations.

**API surface**

| Function | Purpose |
|---|---|
| `from_fraction(Fraction)` | Wrap an existing `Fraction` (zero-copy ergonomics) |
| `from_integer(i64)` / `from_bigint(BigInt)` | Convenience constructors |
| `as_rational(&self) -> Option<&Fraction>` | Borrowing accessor (`None` reserved for future non-rational variants) |
| `to_fraction(&self) -> Option<Fraction>` | Owning accessor |
| `is_rational` / `is_nil` / `is_integer` | Predicates mirroring `Fraction` |
| `partial_quotients(&self) -> Option<Vec<BigInt>>` | Canonical floor-division Euclidean expansion per SPEC §4.2.1 |
| `from_partial_quotients(&[BigInt]) -> Option<Self>` | Permissive inverse |

**Canonical form (SPEC §4.2.1)** is enforced by `partial_quotients`:

- `a0` any integer, `a_i > 0` for `i ≥ 1`.
- If the sequence has length ≥ 2 and the last term equals `1`, it is folded into the previous term so the result ends in a term `> 1`.
- The denominator is pre-normalized to positive before expansion (defensive — `Fraction::new` already does this, but `from_bigint_pair` callers might bypass it).

**Worked examples covered by tests**:

| Value | Canonical sequence |
|---|---|
| `3` | `[3]` |
| `3/2` | `[1, 2]` |
| `1/2` | `[0, 2]` |
| `-3/2` | `[-2, 2]` (floor-div, not truncation) |
| `-1/2` | `[-1, 2]` |
| `355/113` | `[3, 7, 16]` |
| `0` | `[0]` |
| `-5` | `[-5]` |

**Round-trip idempotence**: `partial_quotients(from_partial_quotients(canonical)) == canonical` for canonical input. Non-canonical input (e.g. `[1, 1]`) is accepted by `from_partial_quotients` and evaluates to the same rational as its canonical form (`[2]`), so round-tripping it through `partial_quotients` produces the canonical form.

**Input validation in `from_partial_quotients`**:
- Empty slice → `None`.
- Any `a_i ≤ 0` for `i ≥ 1` → `None` (`[1, 0]`, `[1, -2]`).
- `a_0` may be any sign or zero.

### Test plan

- [x] `cargo test --lib continued_fraction` — 20 / 20 pass
- [x] `cargo test --lib` — 909 / 909 pass (889 pre-existing + 20 new, no regressions)
- [ ] Reviewer: confirm the `partial_quotients` canonical-form rules match SPEC §4.2.1 reading
- [ ] Reviewer: confirm permissive `from_partial_quotients` (accepts non-canonical trailing 1) is acceptable, vs. a strict variant that rejects

### Handover note for Phase 4

The next session will pick up Phase 4: Gosper bihomographic arithmetic + `AlgebraicSqrt`, retiring the interval-based `MATH@SQRT`. Starting points:

1. **SPEC §4.2.2 and §7.3** define the target semantics.
2. **`rust/src/types/continued_fraction.rs`** is the home for the new variants. Add them to the `ExactReal` enum and extend the `match` arms in each method (the compiler will flag every site).
3. **Floor / Ceil / Round / DIV / MOD** in `rust/src/types/fraction-arithmetic.rs` are the current authority for rational arithmetic; Phase 4 should leave that intact and route new ExactReal ops through bihomographic transforms only when at least one operand is non-rational. For pure-rational inputs, the existing `Fraction` kernel stays the fast path.
4. **`Möbius` coefficients are always BigInt** (SPEC §4.2.2 final paragraph). Do not introduce `i64` coefficient storage.
5. The interval-based `MATH@SQRT` retirement is a separate concern — search for `SQRT` usages and stage the swap behind a feature gate or do it in a follow-up commit within Phase 4.

https://claude.ai/code/session_01N7yzNQDmkEY1XHHQPVpf1u

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7yzNQDmkEY1XHHQPVpf1u)_