### PR TITLE
interpreter: comparison-budget NIL projection scaffolding (SPEC §7.4.1)

### DIFF
--- a/rust/src/arithmetic-operation-tests.rs
+++ b/rust/src/arithmetic-operation-tests.rs
@@ -661,3 +661,113 @@ mod ai_first_comparison_tests {
         assert!(interp.get_stack().last().unwrap().is_nil());
     }
 }
+
+#[cfg(test)]
+mod comparison_budget_infrastructure_tests {
+    //! Phase 6 infrastructure for SPEC §7.4.1's partial-quotient
+    //! budget. Every Ajisai scalar currently on the stack is still
+    //! a `Fraction`, so the ordering ops always decide and never
+    //! project Undecidable. These tests pin the *current* behavior
+    //! against regression as the refactor lands, and assert that the
+    //! Undecidable / ComparisonBudget plumbing (NilReason +
+    //! AbsenceOrigin) is wired correctly so Phase 7's non-Rational
+    //! ExactReals will surface NIL with the right metadata when they
+    //! exhaust the budget.
+    use crate::error::NilReason;
+    use crate::interpreter::Interpreter;
+    use crate::semantic::AbsenceOrigin;
+    use crate::types::Value;
+
+    async fn run(source: &str) -> Interpreter {
+        let mut interp = Interpreter::new();
+        interp.execute(source).await.unwrap();
+        interp
+    }
+
+    fn bool_of(interp: &Interpreter) -> bool {
+        let v = &interp.get_stack()[0];
+        let s = format!("{}", v);
+        match s.as_str() {
+            "1" => true,
+            "0" => false,
+            other => panic!("expected boolean (0 or 1), got {}", other),
+        }
+    }
+
+    // ── Regression: every ordering decides on rational operands ──────────
+
+    #[tokio::test]
+    async fn lt_decides_on_rational_pair() {
+        let interp = run("1/2 2/3 LT").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn lte_decides_on_equal_reduced_rationals() {
+        let interp = run("2/4 1/2 LTE").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn gt_decides_on_negative_left() {
+        let interp = run("-3/2 1/2 GT").await;
+        assert!(!bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn gte_decides_on_large_rationals() {
+        let interp = run("355/113 22/7 GTE").await;
+        // 355/113 ≈ 3.14159292 < 22/7 ≈ 3.14285714 ⇒ GTE is false.
+        assert!(!bool_of(&interp));
+    }
+
+    // ── Regression: STAK-mode property checks still produce a single bool
+
+    #[tokio::test]
+    async fn stak_lt_monotonic_sequence_is_true() {
+        let interp = run("1 2 3 5 8 5 .. LT").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn stak_lt_non_monotonic_sequence_is_false() {
+        let interp = run("1 3 2 4 4 .. LT").await;
+        assert!(!bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn stak_gte_non_increasing_sequence_is_true() {
+        let interp = run("5 5 3 1 0 5 .. GTE").await;
+        assert!(bool_of(&interp));
+    }
+
+    // ── NIL projection contract for the Undecidable case ─────────────────
+
+    #[tokio::test]
+    async fn undecidable_nil_carries_comparison_budget_origin() {
+        // We can't yet drive the comparison path into the Undecidable
+        // branch via runtime source (no non-Rational ExactReal scalar
+        // is constructable yet — Phase 7 introduces that), so this
+        // test pins the helper that the comparison.rs refactor calls:
+        // building NIL with reason `Undecidable` must yield the
+        // §7.4.1 origin `ComparisonBudget`.
+        let v = Value::nil_with_reason(NilReason::Undecidable);
+        let absence = v.absence_metadata().expect("nil carries absence");
+        assert_eq!(absence.reason, Some(NilReason::Undecidable));
+        assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
+    }
+
+    // ── NIL passthrough is unchanged ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn lt_with_left_nil_passes_nil_through() {
+        let interp = run("NIL 1 LT").await;
+        assert!(interp.get_stack()[0].is_nil());
+    }
+
+    #[tokio::test]
+    async fn lt_with_right_nil_passes_nil_through() {
+        let interp = run("1 NIL LT").await;
+        assert!(interp.get_stack()[0].is_nil());
+    }
+}

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -13,6 +13,13 @@ pub enum NilReason {
     IndexOutOfBounds,
     UnknownWord,
     ExecutionFailure,
+    /// Comparison-budget exhaustion per SPEC §7.4.1: two lazy CFs
+    /// agreed on every emitted partial quotient up to the budget
+    /// without diverging, or one of the operands' CF streams reported
+    /// `CfStep::Exhausted`. The Bubble Rule projects this to NIL with
+    /// `absence.origin = comparisonBudget` rather than a SAFE-caught
+    /// error.
+    Undecidable,
     SafeCaught(Box<ErrorCategory>),
 }
 
@@ -80,6 +87,7 @@ impl NilReason {
             NilReason::IndexOutOfBounds => "indexOutOfBounds",
             NilReason::UnknownWord => "unknownWord",
             NilReason::ExecutionFailure => "executionFailure",
+            NilReason::Undecidable => "undecidable",
             NilReason::SafeCaught(_) => "safeCaught",
         }
     }

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -1,4 +1,4 @@
-use crate::error::{AjisaiError, Result};
+use crate::error::{AjisaiError, NilReason, Result};
 use crate::interpreter::interval_ops::value_to_interval;
 use crate::interpreter::tensor_ops::FlatTensor;
 use crate::interpreter::value_extraction_helpers::{
@@ -8,6 +8,29 @@ use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, Value, ValueData};
 
+/// One of the four ordering comparisons. Carries the dispatch
+/// decision through the SCALAR-comparison helper so the helper can
+/// keep the Fraction fast path for the common case while leaving a
+/// hook for Phase 7's ExactReal `cmp_with_budget` path.
+#[derive(Debug, Clone, Copy)]
+enum OrderingKind {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+impl OrderingKind {
+    fn apply_to_fraction(self, a: &Fraction, b: &Fraction) -> bool {
+        match self {
+            OrderingKind::Lt => a.lt(b),
+            OrderingKind::Le => a.le(b),
+            OrderingKind::Gt => a.gt(b),
+            OrderingKind::Ge => a.ge(b),
+        }
+    }
+}
+
 fn push_boolean_result(interp: &mut Interpreter, result: bool) {
     interp.stack.push(Value::from_bool(result));
     let stack_len = interp.stack.len();
@@ -15,6 +38,39 @@ fn push_boolean_result(interp: &mut Interpreter, result: bool) {
     interp
         .semantic_registry
         .update_hint_at(stack_len - 1, DisplayHint::Boolean);
+}
+
+/// Push the SPEC §7.4.1 undecidable-NIL: reason = `Undecidable`,
+/// origin = `ComparisonBudget`. The Bubble Rule (SPEC §11.2) places
+/// this on the stack instead of raising an error, so subsequent
+/// NIL-passthrough words can continue the pipeline.
+fn push_undecidable_nil(interp: &mut Interpreter) {
+    interp.stack.push(Value::nil_with_reason(NilReason::Undecidable));
+    let stack_len = interp.stack.len();
+    interp.semantic_registry.normalize_to_stack_len(stack_len);
+    interp
+        .semantic_registry
+        .update_hint_at(stack_len - 1, DisplayHint::Nil);
+}
+
+/// Compare two scalar values under an ordering kind. Returns `Ok(Some(bool))`
+/// when the comparison decides, `Ok(None)` when the comparison budget
+/// exhausts (SPEC §7.4.1) — the caller projects `None` to an Undecidable
+/// NIL. Returns `Err(_)` for structurally-non-comparable operands.
+///
+/// Phase 6 implementation keeps the existing Fraction fast path
+/// because `ValueData::Scalar` is still `Fraction`-backed; the dispatch
+/// shape is in place so Phase 7 can route the non-Rational ExactReal
+/// case through `ExactReal::cmp_with_budget` without touching the
+/// caller-side code paths or the STAK-mode short-circuit.
+fn compare_scalar_pair(
+    a_val: &Value,
+    b_val: &Value,
+    kind: OrderingKind,
+) -> Result<Option<bool>> {
+    let af = extract_scalar_for_comparison(a_val)?;
+    let bf = extract_scalar_for_comparison(b_val)?;
+    Ok(Some(kind.apply_to_fraction(&af, &bf)))
 }
 
 fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
@@ -54,28 +110,32 @@ fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
     }
 }
 
-fn check_all_adjacent_pairs<F>(items: &[Value], op: F) -> Result<bool>
-where
-    F: Fn(&Fraction, &Fraction) -> bool,
-{
+/// Check whether every adjacent pair in `items` satisfies `kind`.
+/// Returns `Ok(Some(bool))` when the property is decidable for every
+/// pair, `Ok(None)` when some pair triggers SPEC §7.4.1's comparison
+/// budget short-circuit. SPEC §7.4 requires the entire STAK-mode
+/// result to be NIL on the first NIL-producing pair regardless of
+/// later pairs.
+fn check_all_adjacent_pairs(items: &[Value], kind: OrderingKind) -> Result<Option<bool>> {
     for pair in items.windows(2) {
-        let a_scalar: Fraction = extract_scalar_for_comparison(&pair[0])?;
-        let b_scalar: Fraction = extract_scalar_for_comparison(&pair[1])?;
-        if !op(&a_scalar, &b_scalar) {
-            return Ok(false);
+        match compare_scalar_pair(&pair[0], &pair[1], kind)? {
+            Some(true) => continue,
+            Some(false) => return Ok(Some(false)),
+            None => return Ok(None),
         }
     }
-    Ok(true)
+    Ok(Some(true))
 }
 
 fn check_all_adjacent_equal(items: &[Value]) -> bool {
     items.windows(2).all(|pair| pair[0].data == pair[1].data)
 }
 
-fn apply_binary_comparison<F>(interp: &mut Interpreter, op: F, _op_name: &str) -> Result<()>
-where
-    F: Fn(&Fraction, &Fraction) -> bool,
-{
+fn apply_binary_comparison(
+    interp: &mut Interpreter,
+    kind: OrderingKind,
+    _op_name: &str,
+) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
     match interp.operation_target_mode {
@@ -95,8 +155,9 @@ where
                 (a_val, b_val)
             };
 
-            let a_scalar: Fraction = match extract_scalar_for_comparison(&a_val) {
-                Ok(f) => f,
+            match compare_scalar_pair(&a_val, &b_val, kind) {
+                Ok(Some(b)) => push_boolean_result(interp, b),
+                Ok(None) => push_undecidable_nil(interp),
                 Err(e) => {
                     if !is_keep_mode {
                         interp.stack.push(a_val);
@@ -104,20 +165,7 @@ where
                     }
                     return Err(e);
                 }
-            };
-            let b_scalar: Fraction = match extract_scalar_for_comparison(&b_val) {
-                Ok(f) => f,
-                Err(e) => {
-                    if !is_keep_mode {
-                        interp.stack.push(a_val);
-                        interp.stack.push(b_val);
-                    }
-                    return Err(e);
-                }
-            };
-
-            let result: bool = op(&a_scalar, &b_scalar);
-            push_boolean_result(interp, result);
+            }
             Ok(())
         }
 
@@ -147,8 +195,9 @@ where
                 return Ok(());
             }
 
-            let all_true: bool = match check_all_adjacent_pairs(&items, op) {
-                Ok(v) => v,
+            match check_all_adjacent_pairs(&items, kind) {
+                Ok(Some(decided)) => push_boolean_result(interp, decided),
+                Ok(None) => push_undecidable_nil(interp),
                 Err(e) => {
                     if !is_keep_mode {
                         interp.stack.extend(items);
@@ -156,9 +205,7 @@ where
                     interp.stack.push(count_val);
                     return Err(e);
                 }
-            };
-
-            push_boolean_result(interp, all_true);
+            }
             Ok(())
         }
     }
@@ -222,7 +269,7 @@ pub fn op_lt(interp: &mut Interpreter) -> Result<()> {
             return res;
         }
     }
-    apply_binary_comparison(interp, |a, b| a.lt(b), "<")
+    apply_binary_comparison(interp, OrderingKind::Lt, "<")
 }
 
 pub fn op_le(interp: &mut Interpreter) -> Result<()> {
@@ -236,7 +283,7 @@ pub fn op_le(interp: &mut Interpreter) -> Result<()> {
             return res;
         }
     }
-    apply_binary_comparison(interp, |a, b| a.le(b), "<=")
+    apply_binary_comparison(interp, OrderingKind::Le, "<=")
 }
 
 pub fn op_gt(interp: &mut Interpreter) -> Result<()> {
@@ -250,7 +297,7 @@ pub fn op_gt(interp: &mut Interpreter) -> Result<()> {
             return res;
         }
     }
-    apply_binary_comparison(interp, |a, b| a.gt(b), ">")
+    apply_binary_comparison(interp, OrderingKind::Gt, ">")
 }
 
 pub fn op_gte(interp: &mut Interpreter) -> Result<()> {
@@ -264,7 +311,7 @@ pub fn op_gte(interp: &mut Interpreter) -> Result<()> {
             return res;
         }
     }
-    apply_binary_comparison(interp, |a, b| a.ge(b), ">=")
+    apply_binary_comparison(interp, OrderingKind::Ge, ">=")
 }
 
 pub fn op_eq(interp: &mut Interpreter) -> Result<()> {

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -51,7 +51,8 @@ fn error_category_for_nil_reason(reason: &NilReason) -> Option<ErrorCategory> {
         | NilReason::MissingField
         | NilReason::InvalidEncoding
         | NilReason::InvalidLens
-        | NilReason::ExecutionFailure => Some(ErrorCategory::Custom),
+        | NilReason::ExecutionFailure
+        | NilReason::Undecidable => Some(ErrorCategory::Custom),
     }
 }
 

--- a/rust/src/semantic/absence.rs
+++ b/rust/src/semantic/absence.rs
@@ -14,6 +14,10 @@ pub enum AbsenceOrigin {
     IndexOutOfBounds,
     UnknownWord,
     ExecutionFailure,
+    /// Continued-fraction comparison exhausted its partial-quotient
+    /// budget without resolving the order of the two operands per
+    /// SPEC §7.4.1. Used together with `NilReason::Undecidable`.
+    ComparisonBudget,
     HostEnvironment,
     Unknown,
 }

--- a/rust/src/semantic/protocol.rs
+++ b/rust/src/semantic/protocol.rs
@@ -83,6 +83,7 @@ impl AbsenceOrigin {
             AbsenceOrigin::IndexOutOfBounds => "indexOutOfBounds",
             AbsenceOrigin::UnknownWord => "unknownWord",
             AbsenceOrigin::ExecutionFailure => "executionFailure",
+            AbsenceOrigin::ComparisonBudget => "comparisonBudget",
             AbsenceOrigin::HostEnvironment => "hostEnvironment",
             AbsenceOrigin::Unknown => "unknown",
         }

--- a/rust/src/semantic/protocol_string_tests.rs
+++ b/rust/src/semantic/protocol_string_tests.rs
@@ -39,3 +39,29 @@ fn absence_and_diagnosis_protocol_strings_do_not_use_debug_names() {
         "typoOrUnknownName"
     );
 }
+
+#[test]
+fn comparison_budget_undecidable_protocol_strings() {
+    // SPEC §7.4.1 requires the comparison-budget NIL to be tagged
+    // with `reason = "undecidable"` and `origin =
+    // "comparisonBudget"`. The runtime constructs this via
+    // `Value::nil_with_reason(NilReason::Undecidable)` and the
+    // origin is derived through `absence_origin_for_reason`.
+    assert_eq!(NilReason::Undecidable.as_protocol_str(), "undecidable");
+    assert_eq!(
+        AbsenceOrigin::ComparisonBudget.as_protocol_str(),
+        "comparisonBudget"
+    );
+}
+
+#[test]
+fn nil_with_reason_undecidable_routes_to_comparison_budget_origin() {
+    // `nil_with_reason` is the runtime's primary entry point for
+    // building reasoned NIL values. Verify the §7.4.1 reason/origin
+    // pairing is preserved end-to-end.
+    use crate::types::Value;
+    let v = Value::nil_with_reason(NilReason::Undecidable);
+    let absence = v.absence_metadata().expect("nil carries absence");
+    assert_eq!(absence.reason, Some(NilReason::Undecidable));
+    assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
+}

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -19,6 +19,7 @@ fn absence_origin_for_reason(reason: &NilReason) -> AbsenceOrigin {
         NilReason::IndexOutOfBounds => AbsenceOrigin::IndexOutOfBounds,
         NilReason::UnknownWord => AbsenceOrigin::UnknownWord,
         NilReason::ExecutionFailure => AbsenceOrigin::ExecutionFailure,
+        NilReason::Undecidable => AbsenceOrigin::ComparisonBudget,
         NilReason::SafeCaught(_) => AbsenceOrigin::SafeProjection,
         NilReason::DivisionByZero => AbsenceOrigin::SafeProjection,
     }


### PR DESCRIPTION
Wires the SPEC §7.4.1 undecidable-NIL outcome through the runtime comparison path so Phase 7's non-Rational ExactReal scalars surface the right metadata when the partial-quotient budget exhausts. Pure infrastructure for Phase 6: every scalar on the stack is still a Fraction, so the new NIL branch is currently unreachable from source — but the dispatch shape, the NilReason / AbsenceOrigin variants, and the STAK-mode short-circuit are all in place.

New variants:
  - NilReason::Undecidable, protocol_str "undecidable"
  - AbsenceOrigin::ComparisonBudget, protocol_str "comparisonBudget"
  - absence_origin_for_reason maps Undecidable → ComparisonBudget
  - execution-loop's error_category_for_nil_reason groups Undecidable with the other Custom-classified non-error reasons

comparison.rs refactor:
  - new OrderingKind { Lt, Le, Gt, Ge } discriminator replaces the Fn(&Fraction, &Fraction) -> bool closure threaded through apply_binary_comparison; each variant carries its apply_to_fraction projection
  - new compare_scalar_pair helper returns Result<Option<bool>>: Some(true|false) for decidable, None for the §7.4.1 Undecidable case (currently never returned because Fraction comparison always terminates; Phase 7 will route the non-Rational ExactReal case through cmp_with_budget here)
  - new push_undecidable_nil helper constructs the NilReason::Undecidable + ComparisonBudget NIL with the Boolean→Nil display-hint update
  - apply_binary_comparison now matches three arms: Some(b) → push_boolean_result, None → push_undecidable_nil, Err → restore stack and propagate (unchanged structurally)
  - check_all_adjacent_pairs returns Option<bool> and SHORT-CIRCUITS on the first None per SPEC §7.4 ("STAK-mode ordering comparisons short-circuit on the first NIL-producing pair: the entire stack-mode result is NIL with the propagated reason, regardless of how many subsequent pairs would have decided")
  - op_lt / op_le / op_gt / op_gte call sites pass OrderingKind::{Lt,Le,Gt,Ge} instead of closures

EQ / NEQ are intentionally not touched in this PR: their existing pairwise_eq path is correct for the only currently-reachable case (Scalar(Fraction) → Fraction PartialEq is value equality on rationals). Phase 7 will refactor pairwise_eq when ExactReal scalars can appear on the stack.

12 new tests:
  - protocol_string_tests x2: "undecidable" / "comparisonBudget" protocol strings; Value::nil_with_reason(Undecidable) routes through absence_origin_for_reason to ComparisonBudget origin
  - comparison_budget_infrastructure_tests x10: ordering regression on rationals (LT / LTE / GT / GTE for positive, negative, reduced-equal, and large rationals); STAK-mode property checks (monotonic / non-monotonic / non-increasing); the Undecidable-NIL helper directly; NIL-passthrough on either operand for LT

987/987 lib tests pass (was 975 before, +12 new). No regression.

https://claude.ai/code/session_01963qUbZ4mLzyB1DfSxYQKg

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
