### PR TITLE
interpreter: Phase 7 — EQ/NEQ Undecidable-NIL via ExactReal::eq_with_budget

### DIFF
--- a/rust/src/arithmetic-operation-tests.rs
+++ b/rust/src/arithmetic-operation-tests.rs
@@ -771,3 +771,189 @@ mod comparison_budget_infrastructure_tests {
         assert!(interp.get_stack()[0].is_nil());
     }
 }
+
+/// Phase 7 — EQ / NEQ Undecidable-NIL plumbing.
+///
+/// Phase 6 (PR #904) wired the `Undecidable` / `ComparisonBudget`
+/// projection through the ordering path (`LT` / `LTE` / `GT` /
+/// `GTE`) and explicitly left `EQ` / `NEQ` for Phase 7. This module
+/// pins the new dispatch shape:
+///
+/// 1. `pairwise_eq` is three-valued (`Option<bool>`): rational
+///    operands always decide; non-Rational `ExactReal` operands run
+///    through `ExactReal::eq_with_budget` and may surface `None`.
+/// 2. `apply_equality` projects `None` to the §7.4.1 Undecidable
+///    NIL via the existing `push_undecidable_nil` helper.
+/// 3. STAK-mode `EQ` / `NEQ` short-circuit on the first
+///    NIL-producing pair (SPEC §7.4).
+///
+/// We can't yet construct a non-Rational `ExactReal` scalar value
+/// from Ajisai source — `ValueData::Scalar` is still `Fraction`-
+/// backed — so these tests:
+///
+/// * regress the rational-operand fast path through EQ / NEQ for
+///   value equality, reduced-form equality, and structural fallback;
+/// * pin the dispatch helpers (`ExactReal::eq_with_budget`) so the
+///   non-Rational branch is exercised at the type-level boundary
+///   that `apply_equality` will route through once subsequent phases
+///   replace the scalar storage.
+#[cfg(test)]
+mod phase_seven_eq_budget_tests {
+    use crate::error::NilReason;
+    use crate::interpreter::Interpreter;
+    use crate::semantic::AbsenceOrigin;
+    use crate::types::continued_fraction::{ExactReal, DEFAULT_COMPARISON_BUDGET};
+    use crate::types::fraction::Fraction;
+    use num_bigint::BigInt;
+
+    async fn run(source: &str) -> Interpreter {
+        let mut interp = Interpreter::new();
+        interp.execute(source).await.unwrap();
+        interp
+    }
+
+    fn bool_of(interp: &Interpreter) -> bool {
+        let v = &interp.get_stack()[0];
+        let s = format!("{}", v);
+        match s.as_str() {
+            "1" => true,
+            "0" => false,
+            other => panic!("expected boolean (0 or 1), got {}", other),
+        }
+    }
+
+    // ── Regression: EQ / NEQ still decide on rationals ───────────────────
+
+    #[tokio::test]
+    async fn eq_decides_value_equal_reduced_rationals() {
+        let interp = run("2/4 1/2 EQ").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn eq_decides_unequal_rationals() {
+        let interp = run("1/2 2/3 EQ").await;
+        assert!(!bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn neq_decides_unequal_rationals() {
+        let interp = run("1/2 2/3 NEQ").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn neq_decides_equal_reduced_rationals() {
+        let interp = run("2/4 1/2 NEQ").await;
+        assert!(!bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn eq_decides_large_rationals() {
+        let interp = run("355/113 355/113 EQ").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn eq_decides_negative_vs_positive() {
+        let interp = run("-1/2 1/2 EQ").await;
+        assert!(!bool_of(&interp));
+    }
+
+    // ── STAK-mode regression ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn stak_eq_all_equal_is_true() {
+        let interp = run("2/4 1/2 4/8 3 .. EQ").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn stak_eq_with_one_distinct_is_false() {
+        let interp = run("1/2 1/2 2/3 3 .. EQ").await;
+        assert!(!bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn stak_neq_all_adjacent_unequal_is_true() {
+        let interp = run("1 2 3 4 4 .. NEQ").await;
+        assert!(bool_of(&interp));
+    }
+
+    #[tokio::test]
+    async fn stak_neq_with_adjacent_duplicate_is_false() {
+        let interp = run("1 2 2 3 4 .. NEQ").await;
+        assert!(!bool_of(&interp));
+    }
+
+    // ── NIL passthrough is unchanged ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn eq_with_left_nil_passes_nil_through() {
+        let interp = run("NIL 1 EQ").await;
+        assert!(interp.get_stack()[0].is_nil());
+    }
+
+    #[tokio::test]
+    async fn neq_with_right_nil_passes_nil_through() {
+        let interp = run("1 NIL NEQ").await;
+        assert!(interp.get_stack()[0].is_nil());
+    }
+
+    // ── ExactReal-level dispatch boundary (Phase 7 hook) ─────────────────
+    //
+    // These cover the budgeted CF path that `pairwise_eq` /
+    // `scalar_pair_eq` routes through whenever at least one operand
+    // is non-Rational. `eq_with_budget` is exercised here so the
+    // dispatch boundary is pinned even before a runtime path can
+    // place such a value on the stack.
+
+    fn rational(n: i64, d: i64) -> ExactReal {
+        ExactReal::Rational(Fraction::new(BigInt::from(n), BigInt::from(d)))
+    }
+
+    #[test]
+    fn exact_real_eq_with_budget_decides_equal_rationals() {
+        assert_eq!(
+            rational(2, 4).eq_with_budget(&rational(1, 2), DEFAULT_COMPARISON_BUDGET),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn exact_real_eq_with_budget_decides_unequal_rationals() {
+        assert_eq!(
+            rational(1, 2).eq_with_budget(&rational(2, 3), DEFAULT_COMPARISON_BUDGET),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn exact_real_eq_with_budget_decides_rational_vs_algebraic_sqrt() {
+        // √2 is irrational; it can never equal 7/5 (or any rational).
+        // The CF streams diverge in fewer than `DEFAULT_COMPARISON_BUDGET`
+        // steps, so the result is decidable.
+        let sqrt_two =
+            ExactReal::from_sqrt_rational(Fraction::new(BigInt::from(2), BigInt::from(1)))
+                .expect("sqrt(2) constructible");
+        assert_eq!(
+            sqrt_two.eq_with_budget(&rational(7, 5), DEFAULT_COMPARISON_BUDGET),
+            Some(false)
+        );
+    }
+
+    // ── Undecidable-NIL helper still has the §7.4.1 origin ───────────────
+    //
+    // `apply_equality` projects the `None` branch through
+    // `push_undecidable_nil` — the same helper the ordering path
+    // already uses. The contract is identical, so any future EQ /
+    // NEQ Undecidable NIL surfaces the §7.4.1 metadata.
+
+    #[tokio::test]
+    async fn eq_undecidable_nil_carries_comparison_budget_origin() {
+        let v = crate::types::Value::nil_with_reason(NilReason::Undecidable);
+        let absence = v.absence_metadata().expect("nil carries absence");
+        assert_eq!(absence.reason, Some(NilReason::Undecidable));
+        assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
+    }
+}

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -5,13 +5,15 @@ use crate::interpreter::value_extraction_helpers::{
     extract_integer_from_value, nil_passthrough_binary,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::types::continued_fraction::{ExactReal, DEFAULT_COMPARISON_BUDGET};
 use crate::types::fraction::Fraction;
 use crate::types::{DisplayHint, Value, ValueData};
 
 /// One of the four ordering comparisons. Carries the dispatch
 /// decision through the SCALAR-comparison helper so the helper can
-/// keep the Fraction fast path for the common case while leaving a
-/// hook for Phase 7's ExactReal `cmp_with_budget` path.
+/// keep the Fraction fast path for both-Rational operands while
+/// routing any non-Rational ExactReal pair through
+/// `ExactReal::cmp_with_budget` (SPEC §7.4.1).
 #[derive(Debug, Clone, Copy)]
 enum OrderingKind {
     Lt,
@@ -28,6 +30,20 @@ impl OrderingKind {
             OrderingKind::Gt => a.gt(b),
             OrderingKind::Ge => a.ge(b),
         }
+    }
+
+    /// Apply the relation to a budgeted `ExactReal` three-way
+    /// comparison result. `None` propagates the budget-exhaustion
+    /// case unchanged so callers project it to the §7.4.1
+    /// Undecidable NIL.
+    fn apply_to_ordering(self, ord: Option<std::cmp::Ordering>) -> Option<bool> {
+        use std::cmp::Ordering;
+        ord.map(|o| match self {
+            OrderingKind::Lt => o == Ordering::Less,
+            OrderingKind::Le => o != Ordering::Greater,
+            OrderingKind::Gt => o == Ordering::Greater,
+            OrderingKind::Ge => o != Ordering::Less,
+        })
     }
 }
 
@@ -58,19 +74,38 @@ fn push_undecidable_nil(interp: &mut Interpreter) {
 /// exhausts (SPEC §7.4.1) — the caller projects `None` to an Undecidable
 /// NIL. Returns `Err(_)` for structurally-non-comparable operands.
 ///
-/// Phase 6 implementation keeps the existing Fraction fast path
-/// because `ValueData::Scalar` is still `Fraction`-backed; the dispatch
-/// shape is in place so Phase 7 can route the non-Rational ExactReal
-/// case through `ExactReal::cmp_with_budget` without touching the
-/// caller-side code paths or the STAK-mode short-circuit.
+/// Both-Rational operands take the Fraction fast path (always
+/// decidable per SPEC §7.4.1: "the budget value itself is not part
+/// of observable semantics; it must be high enough that distinct
+/// rationals always decide"). Any non-Rational ExactReal operand
+/// routes through `ExactReal::cmp_with_budget` under the
+/// `DEFAULT_COMPARISON_BUDGET`; budget exhaustion surfaces as
+/// `Ok(None)` here.
 fn compare_scalar_pair(
     a_val: &Value,
     b_val: &Value,
     kind: OrderingKind,
 ) -> Result<Option<bool>> {
-    let af = extract_scalar_for_comparison(a_val)?;
-    let bf = extract_scalar_for_comparison(b_val)?;
-    Ok(Some(kind.apply_to_fraction(&af, &bf)))
+    let a = extract_exact_real_for_comparison(a_val)?;
+    let b = extract_exact_real_for_comparison(b_val)?;
+    Ok(match (a.as_rational(), b.as_rational()) {
+        (Some(af), Some(bf)) => Some(kind.apply_to_fraction(af, bf)),
+        _ => kind.apply_to_ordering(a.cmp_with_budget(&b, DEFAULT_COMPARISON_BUDGET)),
+    })
+}
+
+/// Extract an `ExactReal` view of a value's scalar content for
+/// comparison. Scalar (`Fraction`-backed) values lift to
+/// `ExactReal::Rational`; singleton Vector / Tensor values also
+/// project to their sole scalar. Non-scalar shapes and non-numeric
+/// kinds error. When a future migration replaces
+/// `ValueData::Scalar(Fraction)` with an `ExactReal`-backed
+/// representation, this helper is the single point that needs to
+/// surface the new variant, and `compare_scalar_pair` / `pairwise_eq`
+/// will route it through the budgeted CF path automatically.
+fn extract_exact_real_for_comparison(val: &Value) -> Result<ExactReal> {
+    let f = extract_scalar_for_comparison(val)?;
+    Ok(ExactReal::from_fraction(f))
 }
 
 fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
@@ -127,8 +162,26 @@ fn check_all_adjacent_pairs(items: &[Value], kind: OrderingKind) -> Result<Optio
     Ok(Some(true))
 }
 
-fn check_all_adjacent_equal(items: &[Value]) -> bool {
-    items.windows(2).all(|pair| pair[0].data == pair[1].data)
+/// Same three-valued discipline as `check_all_adjacent_pairs` for
+/// the EQ relation: `Some(true)` iff every adjacent pair decides
+/// equal, `Some(false)` on the first decidedly-unequal pair, `None`
+/// on the first §7.4.1 budget-exhausted pair (short-circuit per
+/// SPEC §7.4 STAK-mode short-circuit rule). `invert` flips the
+/// per-pair predicate to drive `NEQ`'s "all adjacent pairs unequal"
+/// semantics.
+fn check_all_adjacent_eq(items: &[Value], invert: bool) -> Option<bool> {
+    for pair in items.windows(2) {
+        match pairwise_eq(&pair[0], &pair[1]) {
+            Some(eq) => {
+                let pair_ok = if invert { !eq } else { eq };
+                if !pair_ok {
+                    return Some(false);
+                }
+            }
+            None => return None,
+        }
+    }
+    Some(true)
 }
 
 fn apply_binary_comparison(
@@ -322,32 +375,59 @@ pub fn op_neq(interp: &mut Interpreter) -> Result<()> {
     apply_equality(interp, true)
 }
 
-fn pairwise_eq(a_val: &Value, b_val: &Value) -> bool {
+/// Three-valued pairwise equality matching the SPEC §7.4.1
+/// discipline: `Some(true)` / `Some(false)` for decidable pairs,
+/// `None` when budget exhaustion makes the comparison undecidable.
+/// `None` is only reachable for scalar pairs where at least one
+/// operand is a non-Rational `ExactReal`; the structural Vector /
+/// Tensor / Record paths and the singleton-projection paths always
+/// decide.
+fn pairwise_eq(a_val: &Value, b_val: &Value) -> Option<bool> {
     if a_val.data == b_val.data {
-        return true;
+        return Some(true);
     }
     if let (Some(ai), Some(bi)) = (value_to_interval(a_val), value_to_interval(b_val)) {
         if ai.is_exact() && bi.is_exact() {
-            return ai.lo == bi.lo;
+            return Some(ai.lo == bi.lo);
         }
-        return false;
+        return Some(false);
     }
     match (&a_val.data, &b_val.data) {
+        (ValueData::Scalar(_), ValueData::Scalar(_)) => scalar_pair_eq(a_val, b_val),
         (ValueData::Scalar(_), ValueData::Vector(children)) if children.len() == 1 => {
-            a_val.data == children[0].data
+            Some(a_val.data == children[0].data)
         }
         (ValueData::Vector(children), ValueData::Scalar(_)) if children.len() == 1 => {
-            children[0].data == b_val.data
+            Some(children[0].data == b_val.data)
         }
-        (ValueData::Scalar(_), ValueData::Tensor { .. }) if b_val.len() == 1 => b_val
-            .child(0)
-            .map(|c| a_val.data == c.data)
-            .unwrap_or(false),
-        (ValueData::Tensor { .. }, ValueData::Scalar(_)) if a_val.len() == 1 => a_val
-            .child(0)
-            .map(|c| c.data == b_val.data)
-            .unwrap_or(false),
-        _ => false,
+        (ValueData::Scalar(_), ValueData::Tensor { .. }) if b_val.len() == 1 => Some(
+            b_val
+                .child(0)
+                .map(|c| a_val.data == c.data)
+                .unwrap_or(false),
+        ),
+        (ValueData::Tensor { .. }, ValueData::Scalar(_)) if a_val.len() == 1 => Some(
+            a_val
+                .child(0)
+                .map(|c| c.data == b_val.data)
+                .unwrap_or(false),
+        ),
+        _ => Some(false),
+    }
+}
+
+/// Scalar–scalar equality routed through `ExactReal::eq_with_budget`
+/// (SPEC §7.4.1). Both-Rational operands decide via `Fraction`
+/// `PartialEq` — value equality on canonical reduced rationals.
+/// Anything mixing in a non-Rational `ExactReal` runs the budgeted
+/// CF expansion; budget exhaustion returns `None` and the caller
+/// projects it to the Undecidable NIL.
+fn scalar_pair_eq(a_val: &Value, b_val: &Value) -> Option<bool> {
+    let a = extract_exact_real_for_comparison(a_val).ok()?;
+    let b = extract_exact_real_for_comparison(b_val).ok()?;
+    match (a.as_rational(), b.as_rational()) {
+        (Some(af), Some(bf)) => Some(af == bf),
+        _ => a.eq_with_budget(&b, DEFAULT_COMPARISON_BUDGET),
     }
 }
 
@@ -377,8 +457,10 @@ fn apply_equality(interp: &mut Interpreter, invert: bool) -> Result<()> {
                 (a_val, b_val)
             };
 
-            let eq: bool = pairwise_eq(&a_val, &b_val);
-            push_boolean_result(interp, if invert { !eq } else { eq });
+            match pairwise_eq(&a_val, &b_val) {
+                Some(eq) => push_boolean_result(interp, if invert { !eq } else { eq }),
+                None => push_undecidable_nil(interp),
+            }
             Ok(())
         }
 
@@ -408,12 +490,10 @@ fn apply_equality(interp: &mut Interpreter, invert: bool) -> Result<()> {
                 return Ok(());
             }
 
-            let property: bool = if invert {
-                items.windows(2).all(|pair| !pairwise_eq(&pair[0], &pair[1]))
-            } else {
-                check_all_adjacent_equal(&items)
-            };
-            push_boolean_result(interp, property);
+            match check_all_adjacent_eq(&items, invert) {
+                Some(decided) => push_boolean_result(interp, decided),
+                None => push_undecidable_nil(interp),
+            }
             Ok(())
         }
     }


### PR DESCRIPTION
Completes the SPEC §7.4.1 comparison-budget plumbing for the equality relations. Phase 6 (PR #904) wired `Undecidable` / `ComparisonBudget` through the ordering path (`LT` / `LTE` / `GT` / `GTE`) and explicitly left `EQ` / `NEQ` for Phase 7. This change makes every §7.4 relation route through the `ExactReal` budgeted-CF dispatch and surface NIL with the same metadata when the partial-quotient budget exhausts.

## `comparison.rs`

- `compare_scalar_pair` now extracts operands as `ExactReal`. Both-Rational pairs take the existing `Fraction` fast path (always decidable per §7.4.1: "the budget itself is not part of observable semantics; it must be high enough that distinct rationals always decide"). Any non-Rational `ExactReal` operand routes through `cmp_with_budget` under `DEFAULT_COMPARISON_BUDGET` and projects budget exhaustion to `Ok(None)` — the caller maps `None` to `push_undecidable_nil` exactly as the Phase 6 ordering path already does.
- New `extract_exact_real_for_comparison` helper is the single boundary that lifts `ValueData::Scalar(Fraction)` into an `ExactReal::Rational` view. When a later phase replaces the scalar storage with an ExactReal-backed representation, the new variant surfaces here and the budgeted dispatch in `compare_scalar_pair` / `scalar_pair_eq` picks it up without further changes at the call sites or in the STAK-mode loops.
- `OrderingKind` gains `apply_to_ordering`, which lifts a three-way `ExactReal::cmp_with_budget` result into the LT/LTE/GT/GTE truth value while preserving the `None` branch unchanged.
- `pairwise_eq` is now `Option<bool>`. Structural Vector/Tensor/Record paths still always decide; the scalar–scalar arm delegates to a new `scalar_pair_eq` helper that mirrors `compare_scalar_pair`'s Rational fast-path / `cmp_with_budget` dispatch but consults `ExactReal::eq_with_budget`.
- `apply_equality` (`op_eq` / `op_neq`) gains the `Some`/`None` split: decidable pairs push the boolean; the `None` branch projects through the existing `push_undecidable_nil` helper, so EQ/NEQ NILs carry `NilReason::Undecidable` + `AbsenceOrigin::ComparisonBudget` with the same wire shape as LT/LTE/GT/GTE.
- New `check_all_adjacent_eq` replaces the inline loops for STAK-mode EQ/NEQ and short-circuits on the first `None` pair (SPEC §7.4: "STAK-mode ordering comparisons short-circuit on the first NIL-producing pair … regardless of how many subsequent pairs would have decided" — the rule applies equally to EQ/NEQ per §7.4.1's enumeration).

## Tests

16 new tests in `phase_seven_eq_budget_tests`:

- EQ / NEQ regression on rationals (reduced-form equal, distinct, large rationals, negative vs positive)
- STAK-mode EQ "all equal" / EQ with one distinct, NEQ "all adjacent unequal" / NEQ with adjacent duplicate
- NIL-passthrough for EQ and NEQ on either operand
- `ExactReal::eq_with_budget` dispatch boundary at the type level: rationals (equal / unequal) and `AlgebraicSqrt(2)` vs `7/5` to exercise the non-Rational arm that `scalar_pair_eq` routes through
- Undecidable NIL helper still maps `NilReason::Undecidable` to `AbsenceOrigin::ComparisonBudget` for the EQ/NEQ projection path

**1003 / 1003 lib tests pass (was 987, +16). No regressions.**

The new EQ/NEQ Undecidable-NIL branch is currently unreachable from Ajisai source because `ValueData::Scalar` is still `Fraction`-backed — the dispatch shape, the `cmp_with_budget` / `eq_with_budget` routing, and the STAK-mode short-circuit are all in place so the subsequent phase that places non-Rational `ExactReal` scalars on the stack will see the §7.4.1 metadata surface automatically.

## Summary

- Route `EQ` / `NEQ` through `ExactReal::eq_with_budget` and project budget exhaustion to the §7.4.1 Undecidable NIL.
- Unify the §7.4 dispatch shape: every comparison primitive now uses the three-valued `Some(true)` / `Some(false)` / `None` discipline, with `None` projected to NIL via the shared `push_undecidable_nil` helper.
- Add STAK-mode short-circuit for `EQ` / `NEQ` on the first NIL-producing pair, matching the ordering path.

## Quality Classification

- Highest impacted level: 

## Traceability

- Requirement(s): SPEC §7.4, §7.4.1, §11.2
- Verification evidence: `phase_seven_eq_budget_tests` (rust/src/arithmetic-operation-tests.rs)

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — no new warnings
- [x] `cargo test --all-targets --verbose` (in `rust/`) — 1003/1003 lib tests pass
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

https://claude.ai/code/session_01BHxFFsdofSz2k9Vn96fnRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHxFFsdofSz2k9Vn96fnRK)_