### PR TITLE
Preserve NIL metadata in comparison passthrough

### DIFF
--- a/rust/src/arithmetic-operation-tests.rs
+++ b/rust/src/arithmetic-operation-tests.rs
@@ -240,8 +240,10 @@ mod num_tests {
 
 #[cfg(test)]
 mod interval_tests {
+    use crate::error::NilReason;
     use crate::interpreter::interval_ops::value_to_interval;
     use crate::interpreter::Interpreter;
+    use crate::semantic::AbsenceOrigin;
     use crate::types::fraction::Fraction;
 
     #[tokio::test]
@@ -334,10 +336,15 @@ mod interval_tests {
         assert_eq!(format!("{}", interp.get_stack()[0]), "1");
 
         let mut interp_undetermined = Interpreter::new();
-        let result = interp_undetermined
+        interp_undetermined
             .execute("2 3 INTERVAL 3 4 INTERVAL <")
-            .await;
-        assert!(result.is_err());
+            .await
+            .unwrap();
+        let absence = interp_undetermined.get_stack()[0]
+            .absence_metadata()
+            .expect("overlapping interval comparison projects to NIL");
+        assert_eq!(absence.reason, Some(NilReason::Undecidable));
+        assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
 
         let mut interp_eq = Interpreter::new();
         interp_eq
@@ -465,7 +472,9 @@ mod ai_first_comparison_tests {
     //! that matches its intent directly rather than rewriting it as a
     //! negation or operand swap.
 
+    use crate::error::NilReason;
     use crate::interpreter::Interpreter;
+    use crate::semantic::AbsenceOrigin;
 
     async fn run(source: &str) -> Interpreter {
         let mut interp = Interpreter::new();
@@ -583,10 +592,17 @@ mod ai_first_comparison_tests {
     }
 
     #[tokio::test]
-    async fn gt_on_overlapping_intervals_is_undecidable() {
+    async fn gt_on_overlapping_intervals_projects_undecidable_nil() {
         let mut interp = Interpreter::new();
-        let result = interp.execute("2 3 INTERVAL 2 4 INTERVAL GT").await;
-        assert!(result.is_err(), "overlapping intervals must be undecidable");
+        interp
+            .execute("2 3 INTERVAL 2 4 INTERVAL GT")
+            .await
+            .unwrap();
+        let absence = interp.get_stack()[0]
+            .absence_metadata()
+            .expect("overlapping interval comparison projects to NIL");
+        assert_eq!(absence.reason, Some(NilReason::Undecidable));
+        assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
     }
 
     // ── NIL passthrough for the new ops (contract: nil_policy = Passthrough)

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -2,7 +2,7 @@ use crate::error::{AjisaiError, NilReason, Result};
 use crate::interpreter::interval_ops::value_to_interval;
 use crate::interpreter::tensor_ops::FlatTensor;
 use crate::interpreter::value_extraction_helpers::{
-    extract_integer_from_value, nil_passthrough_binary,
+    extract_integer_from_value, nil_passthrough_binary, nil_passthrough_value,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::continued_fraction::{ExactReal, DEFAULT_COMPARISON_BUDGET};
@@ -61,7 +61,9 @@ fn push_boolean_result(interp: &mut Interpreter, result: bool) {
 /// this on the stack instead of raising an error, so subsequent
 /// NIL-passthrough words can continue the pipeline.
 fn push_undecidable_nil(interp: &mut Interpreter) {
-    interp.stack.push(Value::nil_with_reason(NilReason::Undecidable));
+    interp
+        .stack
+        .push(Value::nil_with_reason(NilReason::Undecidable));
     let stack_len = interp.stack.len();
     interp.semantic_registry.normalize_to_stack_len(stack_len);
     interp
@@ -81,11 +83,7 @@ fn push_undecidable_nil(interp: &mut Interpreter) {
 /// routes through `ExactReal::cmp_with_budget` under the
 /// `DEFAULT_COMPARISON_BUDGET`; budget exhaustion surfaces as
 /// `Ok(None)` here.
-fn compare_scalar_pair(
-    a_val: &Value,
-    b_val: &Value,
-    kind: OrderingKind,
-) -> Result<Option<bool>> {
+fn compare_scalar_pair(a_val: &Value, b_val: &Value, kind: OrderingKind) -> Result<Option<bool>> {
     let a = extract_exact_real_for_comparison(a_val)?;
     let b = extract_exact_real_for_comparison(b_val)?;
     Ok(match (a.as_rational(), b.as_rational()) {
@@ -243,8 +241,8 @@ fn apply_binary_comparison(
                 interp.stack.drain(interp.stack.len() - count..).collect()
             };
 
-            if items.iter().any(|v| v.is_nil()) {
-                interp.stack.push(Value::nil());
+            if let Some(nil) = nil_passthrough_value(&items) {
+                interp.stack.push(nil);
                 return Ok(());
             }
 
@@ -305,9 +303,14 @@ where
             push_boolean_result(interp, v);
             Ok(())
         }
-        None => Err(AjisaiError::from(
-            "interval comparison is undecidable with current precision",
-        )),
+        None => {
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            push_undecidable_nil(interp);
+            Ok(())
+        }
     })
 }
 
@@ -318,7 +321,9 @@ pub fn op_lt(interp: &mut Interpreter) -> Result<()> {
         return Ok(());
     }
     if interp.operation_target_mode == OperationTargetMode::StackTop {
-        if let Some(res) = interval_relation(interp, |ai, bi| ai.hi.lt(&bi.lo), |ai, bi| ai.lo.ge(&bi.hi)) {
+        if let Some(res) =
+            interval_relation(interp, |ai, bi| ai.hi.lt(&bi.lo), |ai, bi| ai.lo.ge(&bi.hi))
+        {
             return res;
         }
     }
@@ -332,7 +337,9 @@ pub fn op_le(interp: &mut Interpreter) -> Result<()> {
         return Ok(());
     }
     if interp.operation_target_mode == OperationTargetMode::StackTop {
-        if let Some(res) = interval_relation(interp, |ai, bi| ai.hi.le(&bi.lo), |ai, bi| ai.lo.gt(&bi.hi)) {
+        if let Some(res) =
+            interval_relation(interp, |ai, bi| ai.hi.le(&bi.lo), |ai, bi| ai.lo.gt(&bi.hi))
+        {
             return res;
         }
     }
@@ -346,7 +353,9 @@ pub fn op_gt(interp: &mut Interpreter) -> Result<()> {
         return Ok(());
     }
     if interp.operation_target_mode == OperationTargetMode::StackTop {
-        if let Some(res) = interval_relation(interp, |ai, bi| ai.lo.gt(&bi.hi), |ai, bi| ai.hi.le(&bi.lo)) {
+        if let Some(res) =
+            interval_relation(interp, |ai, bi| ai.lo.gt(&bi.hi), |ai, bi| ai.hi.le(&bi.lo))
+        {
             return res;
         }
     }
@@ -360,7 +369,9 @@ pub fn op_gte(interp: &mut Interpreter) -> Result<()> {
         return Ok(());
     }
     if interp.operation_target_mode == OperationTargetMode::StackTop {
-        if let Some(res) = interval_relation(interp, |ai, bi| ai.lo.ge(&bi.hi), |ai, bi| ai.hi.lt(&bi.lo)) {
+        if let Some(res) =
+            interval_relation(interp, |ai, bi| ai.lo.ge(&bi.hi), |ai, bi| ai.hi.lt(&bi.lo))
+        {
             return res;
         }
     }
@@ -485,8 +496,8 @@ fn apply_equality(interp: &mut Interpreter, invert: bool) -> Result<()> {
                 interp.stack.drain(interp.stack.len() - count..).collect()
             };
 
-            if items.iter().any(|v| v.is_nil()) {
-                interp.stack.push(Value::nil());
+            if let Some(nil) = nil_passthrough_value(&items) {
+                interp.stack.push(nil);
                 return Ok(());
             }
 

--- a/rust/src/interpreter/nil-reason-tests.rs
+++ b/rust/src/interpreter/nil-reason-tests.rs
@@ -1,5 +1,7 @@
 use crate::error::{ErrorCategory, NilReason};
 use crate::interpreter::Interpreter;
+use crate::semantic::{AbsenceMetadata, AbsenceOrigin, Recoverability};
+use crate::types::Value;
 
 fn last_nil_reason(interp: &Interpreter) -> Option<NilReason> {
     interp
@@ -80,6 +82,66 @@ async fn nil_passthrough_preserves_reason_through_arithmetic_pipeline() {
     );
     let reason = last_nil_reason(&interp).expect("reason must propagate through passthrough");
     assert_eq!(reason, NilReason::DivisionByZero);
+}
+
+#[tokio::test]
+async fn nil_passthrough_preserves_full_absence_metadata() {
+    let mut interp = Interpreter::new();
+    let nil = Value::nil_with_absence(AbsenceMetadata::with_reason(
+        NilReason::ExecutionFailure,
+        AbsenceOrigin::HostEnvironment,
+        Recoverability::Retryable,
+    ));
+    interp.update_stack(vec![nil, Value::from_int(10)]);
+
+    interp.execute("+").await.unwrap();
+
+    let absence = interp.get_stack()[0]
+        .absence_metadata()
+        .expect("passthrough NIL keeps absence metadata");
+    assert_eq!(absence.reason, Some(NilReason::ExecutionFailure));
+    assert_eq!(absence.origin, AbsenceOrigin::HostEnvironment);
+    assert_eq!(absence.recoverability, Recoverability::Retryable);
+}
+
+#[tokio::test]
+async fn stak_comparison_nil_passthrough_preserves_full_absence_metadata() {
+    let mut interp = Interpreter::new();
+    let nil = Value::nil_with_absence(AbsenceMetadata::with_reason(
+        NilReason::InvalidEncoding,
+        AbsenceOrigin::HostEnvironment,
+        Recoverability::Retryable,
+    ));
+    interp.update_stack(vec![Value::from_int(1), nil, Value::from_int(3)]);
+
+    interp.execute("3 .. LT").await.unwrap();
+
+    let absence = interp.get_stack()[0]
+        .absence_metadata()
+        .expect("STAK NIL passthrough keeps absence metadata");
+    assert_eq!(absence.reason, Some(NilReason::InvalidEncoding));
+    assert_eq!(absence.origin, AbsenceOrigin::HostEnvironment);
+    assert_eq!(absence.recoverability, Recoverability::Retryable);
+}
+
+#[tokio::test]
+async fn stak_equality_nil_passthrough_preserves_full_absence_metadata() {
+    let mut interp = Interpreter::new();
+    let nil = Value::nil_with_absence(AbsenceMetadata::with_reason(
+        NilReason::MissingField,
+        AbsenceOrigin::HostEnvironment,
+        Recoverability::Retryable,
+    ));
+    interp.update_stack(vec![Value::from_int(1), nil, Value::from_int(1)]);
+
+    interp.execute("3 .. EQ").await.unwrap();
+
+    let absence = interp.get_stack()[0]
+        .absence_metadata()
+        .expect("STAK EQ NIL passthrough keeps absence metadata");
+    assert_eq!(absence.reason, Some(NilReason::MissingField));
+    assert_eq!(absence.origin, AbsenceOrigin::HostEnvironment);
+    assert_eq!(absence.recoverability, Recoverability::Retryable);
 }
 
 #[tokio::test]

--- a/rust/src/interpreter/value-extraction-helpers.rs
+++ b/rust/src/interpreter/value-extraction-helpers.rs
@@ -198,15 +198,21 @@ pub(crate) fn nil_passthrough_unary(interp: &mut Interpreter) -> bool {
     if !interp.stack[stack_len - 1].is_nil() {
         return false;
     }
-    let inherited = interp.stack[stack_len - 1].nil_reason().cloned();
+    let inherited = Value::nil_inheriting_absence_from(&interp.stack[stack_len - 1]);
     if interp.consumption_mode == ConsumptionMode::Consume {
         interp.stack.pop();
     }
-    interp.stack.push(match inherited {
-        Some(reason) => Value::nil_with_reason(reason),
-        None => Value::nil(),
-    });
+    interp.stack.push(inherited);
     true
+}
+
+pub(crate) fn nil_passthrough_value<'a>(
+    items: impl IntoIterator<Item = &'a Value>,
+) -> Option<Value> {
+    items
+        .into_iter()
+        .find(|v| v.is_nil())
+        .map(Value::nil_inheriting_absence_from)
 }
 
 pub(crate) fn nil_passthrough_binary(interp: &mut Interpreter) -> bool {
@@ -220,18 +226,15 @@ pub(crate) fn nil_passthrough_binary(interp: &mut Interpreter) -> bool {
         return false;
     }
     let inherited = if a_nil {
-        interp.stack[stack_len - 2].nil_reason().cloned()
+        Value::nil_inheriting_absence_from(&interp.stack[stack_len - 2])
     } else {
-        interp.stack[stack_len - 1].nil_reason().cloned()
+        Value::nil_inheriting_absence_from(&interp.stack[stack_len - 1])
     };
     if interp.consumption_mode == ConsumptionMode::Consume {
         interp.stack.pop();
         interp.stack.pop();
     }
-    interp.stack.push(match inherited {
-        Some(reason) => Value::nil_with_reason(reason),
-        None => Value::nil(),
-    });
+    interp.stack.push(inherited);
     true
 }
 

--- a/rust/src/types/value-operations.rs
+++ b/rust/src/types/value-operations.rs
@@ -60,6 +60,14 @@ impl Value {
     }
 
     #[inline]
+    pub fn nil_inheriting_absence_from(source: &Self) -> Self {
+        match source.normalized_absence_metadata() {
+            Some(absence) => Self::nil_with_absence(absence),
+            None => Self::nil(),
+        }
+    }
+
+    #[inline]
     pub fn nil_from_diagnosis(
         reason: NilReason,
         origin: AbsenceOrigin,


### PR DESCRIPTION
### Motivation
- Comparison and arithmetic NIL-passthrough paths were rebuilding NIL from only the `NilReason`, which discarded `AbsenceMetadata` fields like `origin` and `recoverability`; interval undecidability returned errors instead of projecting an Undecidable NIL.

### Description
- Add `Value::nil_inheriting_absence_from` and use it in nil-passthrough helpers so unary and binary passthrough preserve the full `AbsenceMetadata` instead of reconstructing from `reason` only.
- Introduce `nil_passthrough_value` helper and update Stack-mode handling for ordering (`LT/LTE/GT/GTE`) and equality (`EQ/NEQ`) to return the inherited NIL when any operand is NIL.
- Change interval undecidability (`interval_relation`) to project an Undecidable NIL (`NilReason::Undecidable`, origin `ComparisonBudget`) rather than returning an error, and wire `push_undecidable_nil` where appropriate.
- Add/adjust regression tests verifying interval undecidable → NIL projection and that NIL passthrough preserves full absence metadata in StackTop/STAK comparison and equality paths.

### Testing
- Ran `cargo test` (unit + integration test suite) and all tests passed successfully.
- Added targeted regression tests that exercise overlapping-interval undecidability and NIL-metadata propagation and they passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a052b27297c8326b7ce9579d41d80b1)