### PR TITLE
Preserve numeric display source hints

### DIFF
--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -213,6 +213,9 @@ fn format_fraction(f: &Fraction) -> String {
     if f.is_nil() {
         return "NIL".to_string();
     }
+    if let Some(source) = f.display_source() {
+        return source.to_string();
+    }
     if f.is_integer() {
         f.numerator().to_string()
     } else {

--- a/rust/src/types/fraction-arithmetic.rs
+++ b/rust/src/types/fraction-arithmetic.rs
@@ -258,7 +258,7 @@ impl Fraction {
 
     pub fn floor(&self) -> Fraction {
         if self.is_integer() {
-            return self.clone();
+            return Fraction::from_repr(self.repr.clone());
         }
 
         match &self.repr {
@@ -283,7 +283,7 @@ impl Fraction {
 
     pub fn ceil(&self) -> Fraction {
         if self.is_integer() {
-            return self.clone();
+            return Fraction::from_repr(self.repr.clone());
         }
 
         match &self.repr {
@@ -309,7 +309,7 @@ impl Fraction {
 
     pub fn round(&self) -> Fraction {
         if self.is_integer() {
-            return self.clone();
+            return Fraction::from_repr(self.repr.clone());
         }
 
         if self.is_zero() {

--- a/rust/src/types/fraction.rs
+++ b/rust/src/types/fraction.rs
@@ -2,6 +2,7 @@ use num_bigint::BigInt;
 use num_traits::{Zero, One, ToPrimitive, Signed};
 use num_integer::Integer;
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[inline]
 pub(crate) fn compute_gcd_i64(mut a: i64, mut b: i64) -> i64 {
@@ -43,12 +44,24 @@ pub(crate) enum FractionRepr {
 #[derive(Debug, Clone)]
 pub struct Fraction {
     pub(crate) repr: FractionRepr,
+    pub(crate) display_source: Option<Arc<str>>,
 }
 
 impl Fraction {
     #[inline]
     pub(crate) fn from_repr(repr: FractionRepr) -> Self {
-        Fraction { repr }
+        Fraction { repr, display_source: None }
+    }
+
+    #[inline]
+    pub fn display_source(&self) -> Option<&str> {
+        self.display_source.as_deref()
+    }
+
+    #[inline]
+    pub fn with_display_source(mut self, source: &str) -> Self {
+        self.display_source = Some(Arc::from(source));
+        self
     }
 }
 
@@ -80,7 +93,7 @@ impl Eq for Fraction {}
 impl Fraction {
     #[inline]
     pub fn nil() -> Self {
-        Fraction { repr: FractionRepr::Small(0, 0) }
+        Fraction { repr: FractionRepr::Small(0, 0), display_source: None }
     }
 
     #[inline]
@@ -101,7 +114,7 @@ impl Fraction {
         if denominator.is_zero() { panic!("Division by zero"); }
 
         if numerator.is_zero() {
-            return Fraction { repr: FractionRepr::Small(0, 1) };
+            return Fraction { repr: FractionRepr::Small(0, 1), display_source: None };
         }
 
         if let (Some(n), Some(d)) = (numerator.to_i64(), denominator.to_i64()) {
@@ -112,7 +125,7 @@ impl Fraction {
                 num = -num;
                 den = -den;
             }
-            return Fraction { repr: FractionRepr::Small(num, den) };
+            return Fraction { repr: FractionRepr::Small(num, den), display_source: None };
         }
 
         let common: BigInt = numerator.gcd(&denominator);
@@ -148,9 +161,9 @@ impl Fraction {
     #[inline]
     pub(crate) fn from_bigint_pair(numerator: BigInt, denominator: BigInt) -> Self {
         if let (Some(n), Some(d)) = (numerator.to_i64(), denominator.to_i64()) {
-            return Fraction { repr: FractionRepr::Small(n, d) };
+            return Fraction { repr: FractionRepr::Small(n, d), display_source: None };
         }
-        Fraction { repr: FractionRepr::Big { numerator, denominator } }
+        Fraction { repr: FractionRepr::Big { numerator, denominator }, display_source: None }
     }
 
     #[inline]
@@ -266,13 +279,14 @@ impl Fraction {
         if n >= i64::MIN as i128 && n <= i64::MAX as i128
             && d >= 0 && d <= i64::MAX as i128
         {
-            return Fraction { repr: FractionRepr::Small(n as i64, d as i64) };
+            return Fraction { repr: FractionRepr::Small(n as i64, d as i64), display_source: None };
         }
         Fraction {
             repr: FractionRepr::Big {
                 numerator: create_bigint_from_i128(n),
                 denominator: create_bigint_from_i128(d),
             },
+            display_source: None,
         }
     }
 
@@ -312,9 +326,9 @@ impl Fraction {
             let num: BigInt = BigInt::from_str(s).map_err(|e| e.to_string())?;
 
             if let Some(n) = num.to_i64() {
-                return Ok(Fraction { repr: FractionRepr::Small(n, 1) });
+                return Ok(Fraction { repr: FractionRepr::Small(n, 1), display_source: None });
             }
-            Ok(Fraction { repr: FractionRepr::Big { numerator: num, denominator: BigInt::one() } })
+            Ok(Fraction { repr: FractionRepr::Big { numerator: num, denominator: BigInt::one() }, display_source: None })
         }
     }
 
@@ -323,16 +337,16 @@ impl Fraction {
         if s.is_empty() { return Err("Empty string".to_string()); }
 
         if s.contains(|c: char| c == 'e' || c == 'E') {
-            return Self::from_str(s);
+            return Self::from_str(s).map(|f| f.with_display_source(s));
         }
 
         if let Some(pos) = s.find('/') {
             let num: BigInt = BigInt::from_str(&s[..pos]).map_err(|e| e.to_string())?;
             let den: BigInt = BigInt::from_str(&s[pos+1..]).map_err(|e| e.to_string())?;
-            return Ok(Self::create_unreduced(num, den));
+            return Ok(Self::create_unreduced(num, den).with_display_source(s));
         }
 
-        Self::from_str(s)
+        Self::from_str(s).map(|f| f.with_display_source(s))
     }
 
     #[inline]
@@ -429,14 +443,14 @@ impl ToPrimitive for Fraction {
 impl From<i64> for Fraction {
     #[inline]
     fn from(n: i64) -> Self {
-        Fraction { repr: FractionRepr::Small(n, 1) }
+        Fraction { repr: FractionRepr::Small(n, 1), display_source: None }
     }
 }
 
 impl From<i32> for Fraction {
     #[inline]
     fn from(n: i32) -> Self {
-        Fraction { repr: FractionRepr::Small(n as i64, 1) }
+        Fraction { repr: FractionRepr::Small(n as i64, 1), display_source: None }
     }
 }
 
@@ -455,5 +469,28 @@ impl std::fmt::Display for Fraction {
                 }
             }
         }
+    }
+}
+
+
+#[cfg(test)]
+mod display_source_tests {
+    use super::Fraction;
+
+    #[test]
+    fn parsed_literal_display_source_preserves_surface_number_style() {
+        for source in ["1", "0.5", "2/1"] {
+            let fraction = Fraction::parse_unreduced_from_str(source).expect("literal parses");
+            assert_eq!(fraction.display_source(), Some(source));
+        }
+    }
+
+    #[test]
+    fn arithmetic_results_drop_literal_display_source() {
+        let left = Fraction::parse_unreduced_from_str("0.5").expect("literal parses");
+        let right = Fraction::parse_unreduced_from_str("0.5").expect("literal parses");
+        let sum = left.add(&right);
+        assert_eq!(sum.display_source(), None);
+        assert_eq!(sum.to_string(), "1");
     }
 }

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -19,13 +19,24 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct DenseTensor {
     pub numerators: Vec<i64>,
     pub denominators: Vec<i64>,
+    pub display_sources: Vec<Option<Arc<str>>>,
     pub valid_mask: Vec<u64>,
     pub shape: Vec<usize>,
     pub is_pure_integer: bool,
+}
+
+impl PartialEq for DenseTensor {
+    fn eq(&self, other: &Self) -> bool {
+        self.numerators == other.numerators
+            && self.denominators == other.denominators
+            && self.valid_mask == other.valid_mask
+            && self.shape == other.shape
+            && self.is_pure_integer == other.is_pure_integer
+    }
 }
 
 impl DenseTensor {
@@ -41,11 +52,14 @@ impl DenseTensor {
 
         let mut numerators = Vec::with_capacity(data.len());
         let mut denominators = Vec::with_capacity(data.len());
+        let mut display_sources = Vec::with_capacity(data.len());
         let mut is_pure_integer = true;
         for fraction in data {
+            let source = fraction.display_source.clone();
             let (numerator, denominator) = fraction.extract_i64_pair()?;
             numerators.push(numerator);
             denominators.push(denominator);
+            display_sources.push(source);
             is_pure_integer &= denominator == 1;
         }
 
@@ -61,6 +75,7 @@ impl DenseTensor {
         Some(Self {
             numerators,
             denominators,
+            display_sources,
             valid_mask,
             shape,
             is_pure_integer,
@@ -83,10 +98,12 @@ impl DenseTensor {
         if !self.is_valid(index) {
             return None;
         }
-        Some(Fraction::new(
+        let mut fraction = Fraction::new(
             self.numerators[index].into(),
             self.denominators[index].into(),
-        ))
+        );
+        fraction.display_source = self.display_sources.get(index).cloned().flatten();
+        Some(fraction)
     }
 
     pub fn fraction_or_nil(&self, index: usize) -> Fraction {
@@ -145,6 +162,7 @@ pub struct SparseTensor {
     pub indices: Vec<usize>,
     pub numerators: Vec<i64>,
     pub denominators: Vec<i64>,
+    pub display_sources: Vec<Option<Arc<str>>>,
     pub valid_mask: Vec<u64>,
     pub shape: Vec<usize>,
     pub len: usize,
@@ -169,12 +187,14 @@ impl SparseTensor {
         let mut indices = Vec::with_capacity(nonzero_count);
         let mut numerators = Vec::with_capacity(nonzero_count);
         let mut denominators = Vec::with_capacity(nonzero_count);
+        let mut display_sources = Vec::with_capacity(nonzero_count);
 
         for index in 0..dense.len() {
             if dense.numerators[index] != 0 {
                 indices.push(index);
                 numerators.push(dense.numerators[index]);
                 denominators.push(dense.denominators[index]);
+                display_sources.push(dense.display_sources.get(index).cloned().flatten());
             }
         }
 
@@ -191,6 +211,7 @@ impl SparseTensor {
             indices,
             numerators,
             denominators,
+            display_sources,
             valid_mask,
             shape: dense.shape.clone(),
             len: dense.len(),
@@ -201,15 +222,18 @@ impl SparseTensor {
     pub fn to_dense(&self) -> DenseTensor {
         let mut numerators = vec![0; self.len];
         let mut denominators = vec![1; self.len];
+        let mut display_sources = vec![None; self.len];
         for (entry, &index) in self.indices.iter().enumerate() {
             if index < self.len {
                 numerators[index] = self.numerators[entry];
                 denominators[index] = self.denominators[entry];
+                display_sources[index] = self.display_sources.get(entry).cloned().flatten();
             }
         }
         DenseTensor {
             numerators,
             denominators,
+            display_sources,
             valid_mask: self.valid_mask.clone(),
             shape: self.shape.clone(),
             is_pure_integer: self.is_pure_integer,
@@ -221,10 +245,12 @@ impl SparseTensor {
             return None;
         }
         let entry = self.indices.binary_search(&index).ok()?;
-        Some(Fraction::new(
+        let mut fraction = Fraction::new(
             self.numerators[entry].into(),
             self.denominators[entry].into(),
-        ))
+        );
+        fraction.display_source = self.display_sources.get(entry).cloned().flatten();
+        Some(fraction)
     }
 
     pub fn fraction_or_zero(&self, index: usize) -> Fraction {

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -47,6 +47,20 @@ pub(crate) fn is_vector_value(val: &Value) -> bool {
     val.is_vector()
 }
 
+fn fraction_display_source_from_js(num_obj: &js_sys::Object) -> Option<String> {
+    js_sys::Reflect::get(num_obj, &"displaySource".into())
+        .ok()
+        .and_then(|value| value.as_string())
+        .filter(|source| !source.is_empty())
+}
+
+fn apply_fraction_display_source(mut fraction: Fraction, num_obj: &js_sys::Object) -> Fraction {
+    if let Some(source) = fraction_display_source_from_js(num_obj) {
+        fraction = fraction.with_display_source(&source);
+    }
+    fraction
+}
+
 pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
     let obj = js_sys::Object::from(js_val);
     let type_str = js_sys::Reflect::get(&obj, &"type".into())
@@ -67,9 +81,12 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
                 .map_err(|_| "No denominator".to_string())?
                 .as_string()
                 .ok_or("Denominator not string")?;
-            let fraction = Fraction::new(
-                BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
-                BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+            let fraction = apply_fraction_display_source(
+                Fraction::new(
+                    BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
+                    BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                ),
+                &num_obj,
             );
             Ok(Value::from_fraction(fraction))
         }
@@ -83,9 +100,12 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
                 .map_err(|_| "No denominator".to_string())?
                 .as_string()
                 .ok_or("Denominator not string")?;
-            let fraction = Fraction::new(
-                BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
-                BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+            let fraction = apply_fraction_display_source(
+                Fraction::new(
+                    BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
+                    BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                ),
+                &num_obj,
             );
             Ok(Value::from_datetime(fraction))
         }
@@ -126,9 +146,12 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
                     .map_err(|_| "No denominator in tensor data".to_string())?
                     .as_string()
                     .ok_or("Denominator not string")?;
-                let fraction = Fraction::new(
-                    BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
-                    BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                let fraction = apply_fraction_display_source(
+                    Fraction::new(
+                        BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
+                        BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                    ),
+                    &frac_obj,
                 );
                 fractions.push(fraction);
             }
@@ -238,6 +261,12 @@ fn value_semantics_to_js(value: &Value) -> JsValue {
     obj.into()
 }
 
+fn set_fraction_display_source_prop(obj: &js_sys::Object, fraction: &crate::types::fraction::Fraction) {
+    if let Some(source) = fraction.display_source() {
+        set_prop(obj, "displaySource", &source.into());
+    }
+}
+
 fn set_value_common_fields(obj: &js_sys::Object, value: &Value, hint: DisplayHint) {
     let hint_str: &str = match hint {
         DisplayHint::Auto => "auto",
@@ -284,6 +313,7 @@ pub(crate) fn value_to_js(value: &Value, external_hint_opt: Option<DisplayHint>)
                     let num_obj = js_sys::Object::new();
                     set_prop(&num_obj, "numerator", &f.numerator().to_string().into());
                     set_prop(&num_obj, "denominator", &f.denominator().to_string().into());
+                    set_fraction_display_source_prop(&num_obj, f);
                     set_prop(&obj, "value", &num_obj.into());
                 }
             }
@@ -373,6 +403,7 @@ fn tensor_data_to_js_array(
                 &f.denominator().to_string().into(),
             )
             .unwrap();
+            set_fraction_display_source_prop(&num_obj, f);
             let elem = js_sys::Object::new();
             js_sys::Reflect::set(&elem, &"type".into(), &"number".into()).unwrap();
             js_sys::Reflect::set(&elem, &"value".into(), &num_obj).unwrap();
@@ -463,6 +494,7 @@ pub(crate) fn arena_node_to_js(
                         &f.denominator().to_string().into(),
                     )
                     .unwrap();
+                    set_fraction_display_source_prop(&num_obj, f);
                     js_sys::Reflect::set(&obj, &"value".into(), &num_obj).unwrap();
                 }
             }

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -73,12 +73,18 @@ const parseFractionToNumber = (fraction: Record<string, unknown>): number | null
 const formatNumber = (value: unknown): string => {
     const fraction = checkFractionObject(value);
     if (!fraction) return '?';
+    if (typeof fraction.displaySource === 'string' && fraction.displaySource.length > 0) {
+        return fraction.displaySource;
+    }
     return formatFractionScientific(String(fraction.numerator), String(fraction.denominator));
 };
 
 const formatFraction = (frac: unknown): string => {
     const fraction = checkFractionObject(frac);
     if (!fraction) return '?';
+    if (typeof fraction.displaySource === 'string' && fraction.displaySource.length > 0) {
+        return fraction.displaySource;
+    }
     return formatFractionScientific(String(fraction.numerator), String(fraction.denominator));
 };
 

--- a/src/gui/value-formatter.test.ts
+++ b/src/gui/value-formatter.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'vitest';
 import {
     compareStack,
     compareValue,
+    formatFraction,
     formatFractionScientific,
 } from './value-formatter';
 import type { Fraction, Value } from '../wasm-interpreter-types';
@@ -243,5 +244,19 @@ describe('AQ-VER-004-D formatFractionScientific scientific-form conjunction', ()
         // bypasses the MC/DC table above.
         expect(formatFractionScientific('1234567890', '1')).toContain('e');
         expect(formatFractionScientific('5', '1')).toBe('5');
+    });
+});
+
+describe('formatFraction literal display source preservation', () => {
+    test.each([
+        ['1', frac(1, 1)],
+        ['0.5', frac(1, 2)],
+        ['2/1', frac(2, 1)],
+    ])('renders %s from displaySource instead of normalized fraction fields', (source, fraction) => {
+        expect(formatFraction({ ...fraction, displaySource: source })).toBe(source);
+    });
+
+    test('falls back to normalized numeric formatting when displaySource is absent', () => {
+        expect(formatFraction(frac(1, 2))).toBe('1/2');
     });
 });

--- a/src/gui/value-formatter.ts
+++ b/src/gui/value-formatter.ts
@@ -74,6 +74,9 @@ export function formatFractionScientific(numerStr: string, denomStr: string): st
 
 
 export function formatFraction(frac: Fraction): string {
+    if (frac.displaySource) {
+        return frac.displaySource;
+    }
     const denomStr = String(frac.denominator);
     const numerStr = String(frac.numerator);
     return formatFractionScientific(numerStr, denomStr);

--- a/src/wasm-interpreter-types.ts
+++ b/src/wasm-interpreter-types.ts
@@ -113,6 +113,7 @@ export interface ExecuteResult {
 export interface Fraction {
     numerator: string;
     denominator: string;
+    displaySource?: string;
 }
 
 export interface Value {


### PR DESCRIPTION
### Motivation
- Stack display must preserve the original textual form of numeric literals (e.g. `1`, `0.5`, `2/1`) so editor-provided styles and Stack-area rendering remain consistent unless an operation produces a new value. 
- The DisplayHint flow must respect explicit hints across nested Vectors/Tensors and through the WASM/JSON boundary so nesting does not cause implicit normalization or stringification. 
- This change implements a lightweight metadata path to carry the literal surface text through value creation, arena/tensor promotion, and JS <-> WASM roundtrips.

### Description
- Add `display_source` to the Rust `Fraction` type and provide `display_source()/with_display_source()` helpers and set it when parsing numeric literals (`parse_unreduced_from_str` / `from_str`).
- Propagate the display source through dense/sparse tensor conversions by adding per-lane `display_sources` storage in `DenseTensor`/`SparseTensor` and restoring `Fraction.display_source` when reconstructing scalar lanes.
- Export/import `displaySource` in the WASM/JS protocol by reading `displaySource` from incoming numeric objects and setting `displaySource` on outgoing objects; the GUI/TS protocol type (`Fraction`) is extended with `displaySource?: string`.
- Make formatters prefer the preserved textual source: Rust `format_fraction` and TS `formatFraction`/`formatNumber`/`output-display-renderer` check `displaySource` first; add unit tests in Rust and Vitest for the formatter behavior and roundtrip expectations.

### Testing
- Ran `cargo check` on the Rust workspace and it completed successfully.
- Ran `cargo test display_source_tests` (new Rust tests) and both tests passed.
- Ran `npm run check` (`tsc --noEmit`) and it succeeded.
- Ran `npm run test -- src/gui/value-formatter.test.ts` (Vitest) and the test file passed (all tests green).
- Note: `npm run build:wasm` was not performed because `wasm-pack` is not installed in the environment and `cargo install wasm-pack` failed due to crates.io network/proxy errors; this prevented regenerating committed wasm artifacts but all unit/TS tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ef55fe008326b715bfbae0ae4263)