### PR TITLE
Preserve numeric literal spellings through runtime and UI with displaySource

### DIFF
--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -213,6 +213,9 @@ fn format_fraction(f: &Fraction) -> String {
     if f.is_nil() {
         return "NIL".to_string();
     }
+    if let Some(source) = f.display_source() {
+        return source.to_string();
+    }
     if f.is_integer() {
         f.numerator().to_string()
     } else {

--- a/rust/src/types/fraction-arithmetic.rs
+++ b/rust/src/types/fraction-arithmetic.rs
@@ -258,7 +258,7 @@ impl Fraction {
 
     pub fn floor(&self) -> Fraction {
         if self.is_integer() {
-            return self.clone();
+            return Fraction::from_repr(self.repr.clone());
         }
 
         match &self.repr {
@@ -283,7 +283,7 @@ impl Fraction {
 
     pub fn ceil(&self) -> Fraction {
         if self.is_integer() {
-            return self.clone();
+            return Fraction::from_repr(self.repr.clone());
         }
 
         match &self.repr {
@@ -309,7 +309,7 @@ impl Fraction {
 
     pub fn round(&self) -> Fraction {
         if self.is_integer() {
-            return self.clone();
+            return Fraction::from_repr(self.repr.clone());
         }
 
         if self.is_zero() {

--- a/rust/src/types/fraction.rs
+++ b/rust/src/types/fraction.rs
@@ -2,6 +2,7 @@ use num_bigint::BigInt;
 use num_traits::{Zero, One, ToPrimitive, Signed};
 use num_integer::Integer;
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[inline]
 pub(crate) fn compute_gcd_i64(mut a: i64, mut b: i64) -> i64 {
@@ -43,12 +44,24 @@ pub(crate) enum FractionRepr {
 #[derive(Debug, Clone)]
 pub struct Fraction {
     pub(crate) repr: FractionRepr,
+    pub(crate) display_source: Option<Arc<str>>,
 }
 
 impl Fraction {
     #[inline]
     pub(crate) fn from_repr(repr: FractionRepr) -> Self {
-        Fraction { repr }
+        Fraction { repr, display_source: None }
+    }
+
+    #[inline]
+    pub fn display_source(&self) -> Option<&str> {
+        self.display_source.as_deref()
+    }
+
+    #[inline]
+    pub fn with_display_source(mut self, source: &str) -> Self {
+        self.display_source = Some(Arc::from(source));
+        self
     }
 }
 
@@ -80,7 +93,7 @@ impl Eq for Fraction {}
 impl Fraction {
     #[inline]
     pub fn nil() -> Self {
-        Fraction { repr: FractionRepr::Small(0, 0) }
+        Fraction { repr: FractionRepr::Small(0, 0), display_source: None }
     }
 
     #[inline]
@@ -101,7 +114,7 @@ impl Fraction {
         if denominator.is_zero() { panic!("Division by zero"); }
 
         if numerator.is_zero() {
-            return Fraction { repr: FractionRepr::Small(0, 1) };
+            return Fraction { repr: FractionRepr::Small(0, 1), display_source: None };
         }
 
         if let (Some(n), Some(d)) = (numerator.to_i64(), denominator.to_i64()) {
@@ -112,7 +125,7 @@ impl Fraction {
                 num = -num;
                 den = -den;
             }
-            return Fraction { repr: FractionRepr::Small(num, den) };
+            return Fraction { repr: FractionRepr::Small(num, den), display_source: None };
         }
 
         let common: BigInt = numerator.gcd(&denominator);
@@ -148,9 +161,9 @@ impl Fraction {
     #[inline]
     pub(crate) fn from_bigint_pair(numerator: BigInt, denominator: BigInt) -> Self {
         if let (Some(n), Some(d)) = (numerator.to_i64(), denominator.to_i64()) {
-            return Fraction { repr: FractionRepr::Small(n, d) };
+            return Fraction { repr: FractionRepr::Small(n, d), display_source: None };
         }
-        Fraction { repr: FractionRepr::Big { numerator, denominator } }
+        Fraction { repr: FractionRepr::Big { numerator, denominator }, display_source: None }
     }
 
     #[inline]
@@ -266,13 +279,14 @@ impl Fraction {
         if n >= i64::MIN as i128 && n <= i64::MAX as i128
             && d >= 0 && d <= i64::MAX as i128
         {
-            return Fraction { repr: FractionRepr::Small(n as i64, d as i64) };
+            return Fraction { repr: FractionRepr::Small(n as i64, d as i64), display_source: None };
         }
         Fraction {
             repr: FractionRepr::Big {
                 numerator: create_bigint_from_i128(n),
                 denominator: create_bigint_from_i128(d),
             },
+            display_source: None,
         }
     }
 
@@ -312,9 +326,9 @@ impl Fraction {
             let num: BigInt = BigInt::from_str(s).map_err(|e| e.to_string())?;
 
             if let Some(n) = num.to_i64() {
-                return Ok(Fraction { repr: FractionRepr::Small(n, 1) });
+                return Ok(Fraction { repr: FractionRepr::Small(n, 1), display_source: None });
             }
-            Ok(Fraction { repr: FractionRepr::Big { numerator: num, denominator: BigInt::one() } })
+            Ok(Fraction { repr: FractionRepr::Big { numerator: num, denominator: BigInt::one() }, display_source: None })
         }
     }
 
@@ -323,16 +337,16 @@ impl Fraction {
         if s.is_empty() { return Err("Empty string".to_string()); }
 
         if s.contains(|c: char| c == 'e' || c == 'E') {
-            return Self::from_str(s);
+            return Self::from_str(s).map(|f| f.with_display_source(s));
         }
 
         if let Some(pos) = s.find('/') {
             let num: BigInt = BigInt::from_str(&s[..pos]).map_err(|e| e.to_string())?;
             let den: BigInt = BigInt::from_str(&s[pos+1..]).map_err(|e| e.to_string())?;
-            return Ok(Self::create_unreduced(num, den));
+            return Ok(Self::create_unreduced(num, den).with_display_source(s));
         }
 
-        Self::from_str(s)
+        Self::from_str(s).map(|f| f.with_display_source(s))
     }
 
     #[inline]
@@ -429,14 +443,14 @@ impl ToPrimitive for Fraction {
 impl From<i64> for Fraction {
     #[inline]
     fn from(n: i64) -> Self {
-        Fraction { repr: FractionRepr::Small(n, 1) }
+        Fraction { repr: FractionRepr::Small(n, 1), display_source: None }
     }
 }
 
 impl From<i32> for Fraction {
     #[inline]
     fn from(n: i32) -> Self {
-        Fraction { repr: FractionRepr::Small(n as i64, 1) }
+        Fraction { repr: FractionRepr::Small(n as i64, 1), display_source: None }
     }
 }
 
@@ -455,5 +469,28 @@ impl std::fmt::Display for Fraction {
                 }
             }
         }
+    }
+}
+
+
+#[cfg(test)]
+mod display_source_tests {
+    use super::Fraction;
+
+    #[test]
+    fn parsed_literal_display_source_preserves_surface_number_style() {
+        for source in ["1", "0.5", "2/1"] {
+            let fraction = Fraction::parse_unreduced_from_str(source).expect("literal parses");
+            assert_eq!(fraction.display_source(), Some(source));
+        }
+    }
+
+    #[test]
+    fn arithmetic_results_drop_literal_display_source() {
+        let left = Fraction::parse_unreduced_from_str("0.5").expect("literal parses");
+        let right = Fraction::parse_unreduced_from_str("0.5").expect("literal parses");
+        let sum = left.add(&right);
+        assert_eq!(sum.display_source(), None);
+        assert_eq!(sum.to_string(), "1");
     }
 }

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -19,13 +19,24 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct DenseTensor {
     pub numerators: Vec<i64>,
     pub denominators: Vec<i64>,
+    pub display_sources: Vec<Option<Arc<str>>>,
     pub valid_mask: Vec<u64>,
     pub shape: Vec<usize>,
     pub is_pure_integer: bool,
+}
+
+impl PartialEq for DenseTensor {
+    fn eq(&self, other: &Self) -> bool {
+        self.numerators == other.numerators
+            && self.denominators == other.denominators
+            && self.valid_mask == other.valid_mask
+            && self.shape == other.shape
+            && self.is_pure_integer == other.is_pure_integer
+    }
 }
 
 impl DenseTensor {
@@ -41,11 +52,14 @@ impl DenseTensor {
 
         let mut numerators = Vec::with_capacity(data.len());
         let mut denominators = Vec::with_capacity(data.len());
+        let mut display_sources = Vec::with_capacity(data.len());
         let mut is_pure_integer = true;
         for fraction in data {
+            let source = fraction.display_source.clone();
             let (numerator, denominator) = fraction.extract_i64_pair()?;
             numerators.push(numerator);
             denominators.push(denominator);
+            display_sources.push(source);
             is_pure_integer &= denominator == 1;
         }
 
@@ -61,6 +75,7 @@ impl DenseTensor {
         Some(Self {
             numerators,
             denominators,
+            display_sources,
             valid_mask,
             shape,
             is_pure_integer,
@@ -83,10 +98,12 @@ impl DenseTensor {
         if !self.is_valid(index) {
             return None;
         }
-        Some(Fraction::new(
+        let mut fraction = Fraction::new(
             self.numerators[index].into(),
             self.denominators[index].into(),
-        ))
+        );
+        fraction.display_source = self.display_sources.get(index).cloned().flatten();
+        Some(fraction)
     }
 
     pub fn fraction_or_nil(&self, index: usize) -> Fraction {
@@ -145,6 +162,7 @@ pub struct SparseTensor {
     pub indices: Vec<usize>,
     pub numerators: Vec<i64>,
     pub denominators: Vec<i64>,
+    pub display_sources: Vec<Option<Arc<str>>>,
     pub valid_mask: Vec<u64>,
     pub shape: Vec<usize>,
     pub len: usize,
@@ -169,12 +187,14 @@ impl SparseTensor {
         let mut indices = Vec::with_capacity(nonzero_count);
         let mut numerators = Vec::with_capacity(nonzero_count);
         let mut denominators = Vec::with_capacity(nonzero_count);
+        let mut display_sources = Vec::with_capacity(nonzero_count);
 
         for index in 0..dense.len() {
             if dense.numerators[index] != 0 {
                 indices.push(index);
                 numerators.push(dense.numerators[index]);
                 denominators.push(dense.denominators[index]);
+                display_sources.push(dense.display_sources.get(index).cloned().flatten());
             }
         }
 
@@ -191,6 +211,7 @@ impl SparseTensor {
             indices,
             numerators,
             denominators,
+            display_sources,
             valid_mask,
             shape: dense.shape.clone(),
             len: dense.len(),
@@ -201,15 +222,18 @@ impl SparseTensor {
     pub fn to_dense(&self) -> DenseTensor {
         let mut numerators = vec![0; self.len];
         let mut denominators = vec![1; self.len];
+        let mut display_sources = vec![None; self.len];
         for (entry, &index) in self.indices.iter().enumerate() {
             if index < self.len {
                 numerators[index] = self.numerators[entry];
                 denominators[index] = self.denominators[entry];
+                display_sources[index] = self.display_sources.get(entry).cloned().flatten();
             }
         }
         DenseTensor {
             numerators,
             denominators,
+            display_sources,
             valid_mask: self.valid_mask.clone(),
             shape: self.shape.clone(),
             is_pure_integer: self.is_pure_integer,
@@ -221,10 +245,12 @@ impl SparseTensor {
             return None;
         }
         let entry = self.indices.binary_search(&index).ok()?;
-        Some(Fraction::new(
+        let mut fraction = Fraction::new(
             self.numerators[entry].into(),
             self.denominators[entry].into(),
-        ))
+        );
+        fraction.display_source = self.display_sources.get(entry).cloned().flatten();
+        Some(fraction)
     }
 
     pub fn fraction_or_zero(&self, index: usize) -> Fraction {

--- a/rust/src/wasm-value-conversion.rs
+++ b/rust/src/wasm-value-conversion.rs
@@ -47,6 +47,20 @@ pub(crate) fn is_vector_value(val: &Value) -> bool {
     val.is_vector()
 }
 
+fn fraction_display_source_from_js(num_obj: &js_sys::Object) -> Option<String> {
+    js_sys::Reflect::get(num_obj, &"displaySource".into())
+        .ok()
+        .and_then(|value| value.as_string())
+        .filter(|source| !source.is_empty())
+}
+
+fn apply_fraction_display_source(mut fraction: Fraction, num_obj: &js_sys::Object) -> Fraction {
+    if let Some(source) = fraction_display_source_from_js(num_obj) {
+        fraction = fraction.with_display_source(&source);
+    }
+    fraction
+}
+
 pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
     let obj = js_sys::Object::from(js_val);
     let type_str = js_sys::Reflect::get(&obj, &"type".into())
@@ -67,9 +81,12 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
                 .map_err(|_| "No denominator".to_string())?
                 .as_string()
                 .ok_or("Denominator not string")?;
-            let fraction = Fraction::new(
-                BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
-                BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+            let fraction = apply_fraction_display_source(
+                Fraction::new(
+                    BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
+                    BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                ),
+                &num_obj,
             );
             Ok(Value::from_fraction(fraction))
         }
@@ -83,9 +100,12 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
                 .map_err(|_| "No denominator".to_string())?
                 .as_string()
                 .ok_or("Denominator not string")?;
-            let fraction = Fraction::new(
-                BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
-                BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+            let fraction = apply_fraction_display_source(
+                Fraction::new(
+                    BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
+                    BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                ),
+                &num_obj,
             );
             Ok(Value::from_datetime(fraction))
         }
@@ -126,9 +146,12 @@ pub(crate) fn js_value_to_value(js_val: JsValue) -> Result<Value, String> {
                     .map_err(|_| "No denominator in tensor data".to_string())?
                     .as_string()
                     .ok_or("Denominator not string")?;
-                let fraction = Fraction::new(
-                    BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
-                    BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                let fraction = apply_fraction_display_source(
+                    Fraction::new(
+                        BigInt::from_str(&num_str).map_err(|e| e.to_string())?,
+                        BigInt::from_str(&den_str).map_err(|e| e.to_string())?,
+                    ),
+                    &frac_obj,
                 );
                 fractions.push(fraction);
             }
@@ -238,6 +261,12 @@ fn value_semantics_to_js(value: &Value) -> JsValue {
     obj.into()
 }
 
+fn set_fraction_display_source_prop(obj: &js_sys::Object, fraction: &crate::types::fraction::Fraction) {
+    if let Some(source) = fraction.display_source() {
+        set_prop(obj, "displaySource", &source.into());
+    }
+}
+
 fn set_value_common_fields(obj: &js_sys::Object, value: &Value, hint: DisplayHint) {
     let hint_str: &str = match hint {
         DisplayHint::Auto => "auto",
@@ -284,6 +313,7 @@ pub(crate) fn value_to_js(value: &Value, external_hint_opt: Option<DisplayHint>)
                     let num_obj = js_sys::Object::new();
                     set_prop(&num_obj, "numerator", &f.numerator().to_string().into());
                     set_prop(&num_obj, "denominator", &f.denominator().to_string().into());
+                    set_fraction_display_source_prop(&num_obj, f);
                     set_prop(&obj, "value", &num_obj.into());
                 }
             }
@@ -373,6 +403,7 @@ fn tensor_data_to_js_array(
                 &f.denominator().to_string().into(),
             )
             .unwrap();
+            set_fraction_display_source_prop(&num_obj, f);
             let elem = js_sys::Object::new();
             js_sys::Reflect::set(&elem, &"type".into(), &"number".into()).unwrap();
             js_sys::Reflect::set(&elem, &"value".into(), &num_obj).unwrap();
@@ -463,6 +494,7 @@ pub(crate) fn arena_node_to_js(
                         &f.denominator().to_string().into(),
                     )
                     .unwrap();
+                    set_fraction_display_source_prop(&num_obj, f);
                     js_sys::Reflect::set(&obj, &"value".into(), &num_obj).unwrap();
                 }
             }

--- a/src/gui/display-source-annotator.test.ts
+++ b/src/gui/display-source-annotator.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { annotateStackDisplaySources } from './display-source-annotator';
+import type { Value } from '../wasm-interpreter-types';
+
+const num = (numerator: string, denominator: string = '1'): Value => ({
+    type: 'number',
+    value: { numerator, denominator }
+});
+
+const vec = (value: Value[]): Value => ({
+    type: 'vector',
+    value
+});
+
+describe('annotateStackDisplaySources', () => {
+    test('adds displaySource to literal-only numeric stack suffixes', () => {
+        const annotated = annotateStackDisplaySources([num('1', '2')], '0.5');
+        expect(annotated?.[0]?.value.displaySource).toBe('0.5');
+    });
+
+    test('preserves nested vector numeric literal spellings', () => {
+        const annotated = annotateStackDisplaySources(
+            [vec([num('1', '2'), vec([num('2', '1')])])],
+            '[ 0.5 [ 2/1 ] ]'
+        );
+
+        const root = annotated?.[0]?.value as Value[];
+        const inner = root[1]!.value as Value[];
+        expect(root[0]!.value.displaySource).toBe('0.5');
+        expect(inner[0]!.value.displaySource).toBe('2/1');
+    });
+
+    test('does not annotate explicit operation results', () => {
+        expect(annotateStackDisplaySources([num('1')], '0.5 0.5 ADD')).toBeNull();
+    });
+});

--- a/src/gui/display-source-annotator.ts
+++ b/src/gui/display-source-annotator.ts
@@ -1,0 +1,166 @@
+import type { Value } from '../wasm-interpreter-types';
+
+type LiteralNode =
+    | { readonly kind: 'number'; readonly source: string }
+    | { readonly kind: 'vector'; readonly children: readonly LiteralNode[] }
+    | { readonly kind: 'other' };
+
+const NUMERIC_LITERAL_RE = /^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:\/[+-]?\d+)?(?:[eE][+-]?\d+)?$/;
+
+const stripLineComment = (line: string): string => {
+    let inString = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (ch === "'") {
+            inString = !inString;
+            continue;
+        }
+        if (!inString && ch === '#') return line.slice(0, i);
+        if (!inString && ch === '/' && line[i + 1] === '/') return line.slice(0, i);
+    }
+    return line;
+};
+
+const tokenizeSource = (source: string): string[] => {
+    const code = source.split('\n').map(stripLineComment).join('\n');
+    const tokens: string[] = [];
+    let i = 0;
+
+    while (i < code.length) {
+        const ch = code[i]!;
+        if (/\s/.test(ch)) {
+            i++;
+            continue;
+        }
+        if (ch === '[' || ch === ']') {
+            tokens.push(ch);
+            i++;
+            continue;
+        }
+        if (ch === "'") {
+            let j = i + 1;
+            while (j < code.length && code[j] !== "'") j++;
+            if (j >= code.length) return [];
+            tokens.push(code.slice(i, j + 1));
+            i = j + 1;
+            continue;
+        }
+        let j = i;
+        while (j < code.length && !/\s/.test(code[j]!) && code[j] !== '[' && code[j] !== ']') {
+            j++;
+        }
+        tokens.push(code.slice(i, j));
+        i = j;
+    }
+
+    return tokens;
+};
+
+const parseLiteralAt = (tokens: readonly string[], start: number): { node: LiteralNode; next: number } | null => {
+    const token = tokens[start];
+    if (!token) return null;
+
+    if (token === '[') {
+        const children: LiteralNode[] = [];
+        let next = start + 1;
+        while (next < tokens.length && tokens[next] !== ']') {
+            const parsed = parseLiteralAt(tokens, next);
+            if (!parsed) return null;
+            children.push(parsed.node);
+            next = parsed.next;
+        }
+        if (tokens[next] !== ']') return null;
+        return { node: { kind: 'vector', children }, next: next + 1 };
+    }
+
+    if (token === ']') return null;
+    if (NUMERIC_LITERAL_RE.test(token)) return { node: { kind: 'number', source: token }, next: start + 1 };
+    if (/^'.*'$/.test(token)) return { node: { kind: 'other' }, next: start + 1 };
+    if (/^(?:TRUE|FALSE|NIL)$/i.test(token)) return { node: { kind: 'other' }, next: start + 1 };
+    return null;
+};
+
+const parseLiteralOnlySource = (source: string): LiteralNode[] | null => {
+    const tokens = tokenizeSource(source);
+    if (tokens.length === 0) return null;
+
+    const nodes: LiteralNode[] = [];
+    let next = 0;
+    while (next < tokens.length) {
+        const parsed = parseLiteralAt(tokens, next);
+        if (!parsed) return null;
+        nodes.push(parsed.node);
+        next = parsed.next;
+    }
+    return nodes;
+};
+
+const cloneValue = (value: Value): Value => ({
+    ...value,
+    value: Array.isArray(value.value)
+        ? value.value.map(cloneValue)
+        : value.value && typeof value.value === 'object'
+            ? { ...value.value }
+            : value.value
+});
+
+const collectNumericLiterals = (literal: LiteralNode, out: string[]): void => {
+    if (literal.kind === 'number') {
+        out.push(literal.source);
+        return;
+    }
+    if (literal.kind === 'vector') {
+        literal.children.forEach(child => collectNumericLiterals(child, out));
+    }
+};
+
+const annotateTensorLikeValue = (value: Value, literal: LiteralNode): Value => {
+    const numericLiterals: string[] = [];
+    collectNumericLiterals(literal, numericLiterals);
+    if (numericLiterals.length === 0 || !value.value || typeof value.value !== 'object') return value;
+
+    const tensor = value.value as { data?: unknown[] };
+    if (!Array.isArray(tensor.data)) return value;
+
+    let index = 0;
+    tensor.data = tensor.data.map(item => {
+        if (index >= numericLiterals.length || !item || typeof item !== 'object') return item;
+        const displaySource = numericLiterals[index++];
+        return { ...(item as Record<string, unknown>), displaySource };
+    });
+    return value;
+};
+
+const annotateValue = (value: Value, literal: LiteralNode): Value => {
+    const cloned = cloneValue(value);
+
+    if (literal.kind === 'number' && cloned.type === 'number' && cloned.value && typeof cloned.value === 'object') {
+        cloned.value = { ...(cloned.value as Record<string, unknown>), displaySource: literal.source };
+        return cloned;
+    }
+
+    if (literal.kind === 'vector') {
+        if (cloned.type === 'vector' && Array.isArray(cloned.value)) {
+            cloned.value = cloned.value.map((child, index) => {
+                const childLiteral = literal.children[index];
+                return childLiteral ? annotateValue(child, childLiteral) : child;
+            });
+        } else if (cloned.type === 'tensor') {
+            return annotateTensorLikeValue(cloned, literal);
+        }
+    }
+
+    return cloned;
+};
+
+export const annotateStackDisplaySources = (stack: readonly Value[], source: string): Value[] | null => {
+    const literals = parseLiteralOnlySource(source);
+    if (!literals || literals.length === 0 || literals.length > stack.length) return null;
+
+    const annotated = stack.map(cloneValue);
+    const start = annotated.length - literals.length;
+    literals.forEach((literal, index) => {
+        annotated[start + index] = annotateValue(annotated[start + index]!, literal);
+    });
+    return annotated;
+};

--- a/src/gui/execution-controller.ts
+++ b/src/gui/execution-controller.ts
@@ -10,6 +10,11 @@ import {
     resolveExecutionException
 } from './interpreter-execution-utils';
 import { createStepExecutor, StepExecutor } from './step-executor';
+import { annotateStackDisplaySources } from './display-source-annotator';
+import {
+    clearStackDisplayOverride,
+    setStackDisplayOverride
+} from './interpreter/interpreter-client';
 import type { ViewMode } from './mobile-view-switcher';
 
 export interface ExecutionCallbacks {
@@ -128,6 +133,10 @@ export const createExecutionController = (
 
             const currentState = createExecutionSnapshot(interpreter);
             const result = await WORKER_MANAGER.execute(code, currentState);
+            const annotatedStack = result.stack
+                ? annotateStackDisplaySources(result.stack, code)
+                : null;
+            setStackDisplayOverride(annotatedStack);
 
             try {
                 syncInterpreterState(interpreter, result);
@@ -139,6 +148,7 @@ export const createExecutionController = (
             applyExecutionResult(result, code);
 
         } catch (error) {
+            clearStackDisplayOverride();
             resolveExecutionException('ExecController', error, showInfo, showError);
         }
 
@@ -151,6 +161,7 @@ export const createExecutionController = (
             console.log('[ExecController] Executing full reset');
             stepExecutor.reset();
             await WORKER_MANAGER.resetAllWorkers();
+            clearStackDisplayOverride();
             const result = interpreter.reset();
 
             if (result.status === 'OK' && !result.error) {

--- a/src/gui/interpreter/interpreter-client.ts
+++ b/src/gui/interpreter/interpreter-client.ts
@@ -1,4 +1,4 @@
-import type { AjisaiInterpreter } from '../../wasm-interpreter-types';
+import type { AjisaiInterpreter, Value } from '../../wasm-interpreter-types';
 
 function getOptionalInterpreter(): AjisaiInterpreter | null {
     return window.ajisaiInterpreter ?? null;
@@ -11,6 +11,16 @@ function getRequiredInterpreter(): AjisaiInterpreter {
     }
     return interpreter;
 }
+
+let stackDisplayOverride: Value[] | null = null;
+
+export const setStackDisplayOverride = (stack: Value[] | null): void => {
+    stackDisplayOverride = stack;
+};
+
+export const clearStackDisplayOverride = (): void => {
+    stackDisplayOverride = null;
+};
 
 export type InterpreterClient = {
     readonly getOptional: () => AjisaiInterpreter | null;
@@ -32,6 +42,6 @@ export function createInterpreterClient(): InterpreterClient {
         collectImportedModules: () => getRequiredInterpreter().collect_imported_modules(),
         collectModuleWordsInfo: (moduleName: string) => getRequiredInterpreter().collect_module_words_info(moduleName),
         collectModuleSampleWordsInfo: (moduleName: string) => getRequiredInterpreter().collect_module_sample_words_info(moduleName),
-        collectStack: () => getRequiredInterpreter().collect_stack()
+        collectStack: () => stackDisplayOverride ?? getRequiredInterpreter().collect_stack()
     };
 }

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -73,12 +73,18 @@ const parseFractionToNumber = (fraction: Record<string, unknown>): number | null
 const formatNumber = (value: unknown): string => {
     const fraction = checkFractionObject(value);
     if (!fraction) return '?';
+    if (typeof fraction.displaySource === 'string' && fraction.displaySource.length > 0) {
+        return fraction.displaySource;
+    }
     return formatFractionScientific(String(fraction.numerator), String(fraction.denominator));
 };
 
 const formatFraction = (frac: unknown): string => {
     const fraction = checkFractionObject(frac);
     if (!fraction) return '?';
+    if (typeof fraction.displaySource === 'string' && fraction.displaySource.length > 0) {
+        return fraction.displaySource;
+    }
     return formatFractionScientific(String(fraction.numerator), String(fraction.denominator));
 };
 

--- a/src/gui/step-executor.ts
+++ b/src/gui/step-executor.ts
@@ -1,5 +1,7 @@
 
 import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import { annotateStackDisplaySources } from './display-source-annotator';
+import { setStackDisplayOverride } from './interpreter/interpreter-client';
 import type { AjisaiInterpreter, ExecuteResult } from '../wasm-interpreter-types';
 import {
     createExecutionSnapshot,
@@ -124,6 +126,10 @@ export const createStepExecutor = (
 
             const currentState = createExecutionSnapshot(interpreter);
             const result = await WORKER_MANAGER.execute(token, currentState);
+            const annotatedStack = result.stack
+                ? annotateStackDisplaySources(result.stack, token)
+                : null;
+            setStackDisplayOverride(annotatedStack);
 
             try {
                 syncInterpreterState(interpreter, result);
@@ -150,6 +156,7 @@ export const createStepExecutor = (
             }
 
         } catch (error) {
+            setStackDisplayOverride(null);
             resolveExecutionException('StepExecutor', error, showInfo, showError);
             reset();
         }

--- a/src/gui/value-formatter.test.ts
+++ b/src/gui/value-formatter.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'vitest';
 import {
     compareStack,
     compareValue,
+    formatFraction,
     formatFractionScientific,
 } from './value-formatter';
 import type { Fraction, Value } from '../wasm-interpreter-types';
@@ -243,5 +244,19 @@ describe('AQ-VER-004-D formatFractionScientific scientific-form conjunction', ()
         // bypasses the MC/DC table above.
         expect(formatFractionScientific('1234567890', '1')).toContain('e');
         expect(formatFractionScientific('5', '1')).toBe('5');
+    });
+});
+
+describe('formatFraction literal display source preservation', () => {
+    test.each([
+        ['1', frac(1, 1)],
+        ['0.5', frac(1, 2)],
+        ['2/1', frac(2, 1)],
+    ])('renders %s from displaySource instead of normalized fraction fields', (source, fraction) => {
+        expect(formatFraction({ ...fraction, displaySource: source })).toBe(source);
+    });
+
+    test('falls back to normalized numeric formatting when displaySource is absent', () => {
+        expect(formatFraction(frac(1, 2))).toBe('1/2');
     });
 });

--- a/src/gui/value-formatter.ts
+++ b/src/gui/value-formatter.ts
@@ -74,6 +74,9 @@ export function formatFractionScientific(numerStr: string, denomStr: string): st
 
 
 export function formatFraction(frac: Fraction): string {
+    if (frac.displaySource) {
+        return frac.displaySource;
+    }
     const denomStr = String(frac.denominator);
     const numerStr = String(frac.numerator);
     return formatFractionScientific(numerStr, denomStr);

--- a/src/wasm-interpreter-types.ts
+++ b/src/wasm-interpreter-types.ts
@@ -113,6 +113,7 @@ export interface ExecuteResult {
 export interface Fraction {
     numerator: string;
     denominator: string;
+    displaySource?: string;
 }
 
 export interface Value {


### PR DESCRIPTION
### Motivation

- Preserve the original source spelling of numeric literals (e.g. `0.5`, `2/1`, scientific forms) for presentation instead of always showing normalized fraction forms.
- Propagate and expose this surface-format information through fraction arithmetic, tensor conversions, WASM/JS interop and the GUI so UI renderers can display literal spellings when appropriate.

### Description

- Add a `display_source: Option<Arc<str>>` field to `Fraction` with accessors `display_source()` and `with_display_source()` and ensure parsing helpers (`parse_unreduced_from_str`, scientific parsing) attach the source where appropriate while arithmetic results drop the surface spelling.
- Extend `DenseTensor` and `SparseTensor` to carry per-element `display_sources` and restore `Fraction.display_source` when creating `Fraction` instances from tensor storage.
- Wire display-source through the WASM/JS layer by exporting/importing a `displaySource` property: implement `set_fraction_display_source_prop`, read `displaySource` in `js_value_to_value`, and include it when serializing values and tensor data to JS.
- Add a TypeScript `display-source-annotator` that parses a literal-only source suffix and annotates the interpreter stack/tensor entries with `displaySource` for literal-only results, and integrate it into `execution-controller` and `step-executor` using `setStackDisplayOverride`/`clearStackDisplayOverride` in `interpreter-client`.
- Update formatting code in `value-formatter` and GUI renderer to prefer `displaySource` when present; add unit tests for the behavior and small Rust tests validating `Fraction.display_source` preservation and clearing.

### Testing

- Ran Rust unit tests via `cargo test`, including new `display_source` tests in `fraction`, and they passed.
- Ran frontend unit tests with `vitest`, covering `display-source-annotator` and updated `value-formatter` tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ef55fe008326b715bfbae0ae4263)