### PR TITLE
Preserve numeric literal display style on stack

### DIFF
--- a/rust/src/interpreter/compiled-plan.rs
+++ b/rust/src/interpreter/compiled-plan.rs
@@ -109,10 +109,12 @@ pub fn compile_word_definition(word_def: &WordDefinition, interp: &Interpreter) 
         while i < tokens.len() {
             let token = &tokens[i];
             let op = match token {
-                Token::Number(n) => match crate::types::fraction::Fraction::from_str(n) {
-                    Ok(frac) => CompiledOp::PushLiteral(Value::from_number(frac)),
-                    Err(_) => CompiledOp::FallbackToken(token.clone()),
-                },
+                Token::Number(n) => {
+                    match crate::types::fraction::Fraction::parse_unreduced_from_str(n) {
+                        Ok(frac) => CompiledOp::PushLiteral(Value::from_number(frac)),
+                        Err(_) => CompiledOp::FallbackToken(token.clone()),
+                    }
+                }
                 Token::String(s) => CompiledOp::PushLiteral(Value::from_string(s)),
                 Token::BlockStart => {
                     if let Some((block, next_i)) = collect_code_block(&tokens, i) {

--- a/rust/src/interpreter/execution-loop.rs
+++ b/rust/src/interpreter/execution-loop.rs
@@ -261,7 +261,8 @@ impl Interpreter {
         while i < execute_tokens.len() {
             match &execute_tokens[i] {
                 Token::Number(n) => {
-                    let frac = Fraction::from_str(n).map_err(AjisaiError::from)?;
+                    let frac =
+                        Fraction::parse_unreduced_from_str(n).map_err(AjisaiError::from)?;
                     self.stack.push(create_number_value(frac));
                     self.semantic_registry.push_hint(DisplayHint::Number);
                 }

--- a/rust/src/interpreter/interpreter-execution-tests.rs
+++ b/rust/src/interpreter/interpreter-execution-tests.rs
@@ -198,6 +198,26 @@ ADDTEST
 }
 
 #[tokio::test]
+async fn top_level_numeric_literals_preserve_surface_style_on_stack() {
+    use crate::types::ValueData;
+    let cases = [("1", "1"), ("0.5", "0.5"), ("2/1", "2/1")];
+    for (program, expected) in cases {
+        let mut interp = crate::interpreter::Interpreter::new();
+        interp.execute(program).await.unwrap();
+        assert_eq!(interp.stack.len(), 1, "program: {program}");
+        let scalar = match &interp.stack[0].data {
+            ValueData::Scalar(f) => f,
+            other => panic!("expected scalar for {program}, got {:?}", other),
+        };
+        assert_eq!(
+            scalar.display_source(),
+            Some(expected),
+            "Surface literal style for `{program}` must be preserved as `{expected}`",
+        );
+    }
+}
+
+#[tokio::test]
 async fn comparison_words_return_scalar_booleans() {
     let cases = [("1 2 LT", true), ("2 2 LTE", true), ("2 1 LT", false), ("1 1 EQ", true), ("1 2 EQ", false)];
     for (program, expected) in cases {


### PR DESCRIPTION
## Summary

エディタから入力した数値リテラルが Stack エリアで形が崩れる問題を修正しました。

- 入力 `1` → `1` ✓
- 入力 `0.5` → これまで `1/2` と表示 → 修正後 `0.5`
- 入力 `2/1` → これまで `2` と表示 → 修正後 `2/1`
- 入力 `'TEST'` → `'TEST'` ✓

## 原因

`execute_section_core` および `compiled-plan.rs` のリテラルコンパイル経路でトップレベルの数値リテラルが `Fraction::from_str` で解析されており、約分・10進形式の喪失が起こって `display_source` が付与されていませんでした。一方、Vector 内部のリテラル経路は既に `parse_unreduced_from_str` を使用しており、ネストされた Vector でのリテラル形は保持されていました。

そのため、トップレベルと Vector 内部で表示挙動が一致しないという問題が生じていました。

## 修正

- `rust/src/interpreter/execution-loop.rs` および `rust/src/interpreter/compiled-plan.rs` で `Fraction::parse_unreduced_from_str` を採用。
- これにより全ての数値リテラル経路で `display_source` が一貫して保持され、Stack 表示は明示的な変換命令がない限り入力スタイルと一致します。
- ネストされた Vector 内部の表示伝播 (`from_vector_promoted_with_hint`) は既に正しく動作しており、変更不要であることを確認しました。

## Test plan

- [x] `cargo test --lib` (1009 passed)
- [x] 追加した `top_level_numeric_literals_preserve_surface_style_on_stack` で `1` / `0.5` / `2/1` がそれぞれ `display_source` として保持されることを確認

https://claude.ai/code/session_01NzFHHQ3Fuwd5cjak9mgcXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzFHHQ3Fuwd5cjak9mgcXK)_