### PR TITLE
Update README to reflect continued-fraction internal model

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 # Ajisai
 
-Ajisai is an AI-first, vector-oriented, fractional-dataflow language.
+Ajisai is an AI-first, vector-oriented, continued-fraction-dataflow language.
 
-It is designed around one strict promise: **value integrity first**. Every numeric value stays exact, structure is explicit, and behavior is mechanically testable through clear contracts.
+It is designed around one strict promise: **value integrity first**. Every numeric value is an exact real backed by a finite or lazy continued fraction, structure is explicit, and behavior is mechanically testable through clear contracts.
 
 The name *Ajisai* comes from hydrangea, whose scientific meaning is often interpreted as a “water vessel.” This project uses water as its core metaphor for how values move through code.
 
@@ -20,13 +20,15 @@ The name *Ajisai* comes from hydrangea, whose scientific meaning is often interp
 
 ## Why Ajisai (as a water system)
 
-### 1) Exact fractions: water that never evaporates
+### 1) Continued fractions: water with an exact flow history
 
-In Ajisai, all numeric values are treated as exact rationals internally. No hidden floating-point drift, no silent rounding loss.
+Ajisai no longer models its numeric world as “everything is internally a fraction.” Every numeric value is now an **exact real represented internally as a continued fraction**. Finite continued fractions cover the rational values Ajisai has always handled exactly; lazy infinite continued fractions let the runtime represent admitted irrationals such as `MATH@SQRT` results without collapsing them into approximate floats.
 
-Like water that keeps the same volume no matter which channel it passes through, Ajisai values preserve exactness across operations.
+Surface numeric literals still look familiar — integers, fractions, decimals, and scientific notation — but they are convenience forms for the same continued-fraction representation. The canonical AI-readable serialization is the nested continued-fraction display form, not a source literal.
 
-Spec links: [§4.2 Scalar: exact rational arithmetic](SPECIFICATION.md#42-scalar-exact-rational-arithmetic), [§3.2 Numeric literal formats](SPECIFICATION.md#32-numeric-literal-formats)
+Like water that keeps both its volume and its channel history, Ajisai values preserve exactness while exposing a representation that can keep flowing beyond the rational sub-domain. Arithmetic operates on partial quotients directly, so operations do not detour through hidden floating-point approximations or truncated rationals.
+
+Spec links: [§4.2 Scalar: exact-real continued-fraction arithmetic](SPECIFICATION.md#42-scalar-exact-real-continued-fraction-arithmetic), [§3.2 Numeric literal formats](SPECIFICATION.md#32-numeric-literal-formats), [§12.2 Display hints](SPECIFICATION.md#122-display-hints)
 
 ### 2) Bubble/NIL: bubbles that keep the flow inspectable
 


### PR DESCRIPTION
### Motivation
- The README described Ajisai as a "fractional-dataflow" language and implied an internal rational-only model, which needed to be updated to reflect the runtime's continued-fraction (finite or lazy) representation and its implications for exactness and arithmetic.

### Description
- Change the top-level identity string to describe Ajisai as a "continued-fraction-dataflow" language and clarify that every numeric value is an exact real backed by a finite or lazy continued fraction.
- Replace the "Exact fractions" section with a new "Continued fractions" subsection that explains finite continued fractions for rationals, lazy infinite continued fractions for admitted irrationals (e.g. `MATH@SQRT`), the canonical nested continued-fraction display form, and that arithmetic operates on partial quotients rather than floating-point approximations.
- Update specification cross-links to point at the continued-fraction semantics and the `ContinuedFraction` display hint (Section 4.2 and 12.2) and tweak a few related wording instances about sorting/comparison semantics.
- The change is limited to `README.md` only.

### Testing
- Ran `git diff --check` to validate the tree state and formatting, which succeeded.
- Ran `rg -n "fractional-dataflow|Exact fractions|exact rational|exact rationals|continued-fraction|continued fraction|MATH@SQRT" README.md` to confirm the intended replacements, which returned the updated occurrences.
- Inspected the top of `README.md` with `nl -ba README.md | sed -n '1,45p'` to verify the new header and continued-fraction section text, which showed the updated content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0747f188508326b92e3cdd93beccaa)