### PR TITLE
Add CF-native comparison shortcuts and rounding to ExactReal

### DIFF
--- a/rust/src/types/continued_fraction.rs
+++ b/rust/src/types/continued_fraction.rs
@@ -392,6 +392,23 @@ impl ExactReal {
 /// Gosper transforms) from running unboundedly.
 pub const DEFAULT_COMPARISON_BUDGET: usize = 256;
 
+/// Three-way comparison of √`radicand` against the rational `q`,
+/// yielding the ordering of √`radicand` relative to `q`.
+///
+/// `radicand` is the positive, non-perfect-square rational stored by
+/// an `AlgebraicSqrt`, so √`radicand` is a positive irrational and is
+/// never equal to the rational `q`. The result is exact and computed
+/// in O(1): a non-positive `q` is below the positive root, and for a
+/// positive `q` the order follows from `radicand` vs `q²` because
+/// squaring is increasing on the non-negative reals.
+fn cmp_sqrt_vs_rational(radicand: &Fraction, q: &Fraction) -> std::cmp::Ordering {
+    if !q.numerator().is_positive() {
+        // q <= 0 < √radicand.
+        return std::cmp::Ordering::Greater;
+    }
+    radicand.cmp(&q.mul(q))
+}
+
 impl ExactReal {
     /// Three-way comparison of CF values under a partial-quotient
     /// budget.
@@ -421,6 +438,27 @@ impl ExactReal {
         }
         if budget == 0 {
             return None;
+        }
+        // Algebraic short-circuits (SPEC §4.2.4): a comparison whose
+        // operands are only `Rational` and `AlgebraicSqrt` is decided
+        // exactly in O(1) from the operands' algebraic structure,
+        // without streaming partial quotients. This avoids the
+        // budget-length CF expansion and, crucially, lets two equal
+        // irrational square roots decide `Equal` instead of running
+        // their never-diverging CF streams to budget exhaustion.
+        match (self, other) {
+            (Self::AlgebraicSqrt { radicand: r }, Self::AlgebraicSqrt { radicand: s }) => {
+                // √ is strictly increasing on the non-negative
+                // rationals, so √r vs √s is decided by r vs s.
+                return Some(r.cmp(s));
+            }
+            (Self::AlgebraicSqrt { radicand: r }, Self::Rational(q)) => {
+                return Some(cmp_sqrt_vs_rational(r, q));
+            }
+            (Self::Rational(q), Self::AlgebraicSqrt { radicand: r }) => {
+                return Some(cmp_sqrt_vs_rational(r, q).reverse());
+            }
+            _ => {}
         }
         let mut a = CfIter::from_exact_real(self);
         let mut b = CfIter::from_exact_real(other);
@@ -496,6 +534,151 @@ impl ExactReal {
     pub fn ge_with_budget(&self, other: &Self, budget: usize) -> Option<bool> {
         self.cmp_with_budget(other, budget)
             .map(|o| o != std::cmp::Ordering::Less)
+    }
+}
+
+// =========================================================================
+// CF-native rounding and rational approximation
+// =========================================================================
+
+impl ExactReal {
+    /// Floor: the greatest integer not exceeding the value.
+    ///
+    /// For a canonical continued fraction `[a0; a1, a2, …]` the floor
+    /// is exactly the first partial quotient `a0`: when the CF has a
+    /// tail the fractional part `1/[a1; a2, …]` lies strictly in
+    /// `(0, 1)`, and when it does not the value already equals `a0`.
+    /// This holds for every representation — `Rational`,
+    /// `AlgebraicSqrt`, and `Gosper` — so the floor even of an
+    /// irrational costs a single partial-quotient pull.
+    ///
+    /// Returns `None` when the value is nil, or when a lazy CF stream
+    /// exhausts its internal safety budget before `a0` is fixed
+    /// (SPEC §7.4.1 `undecidable`).
+    pub fn floor(&self) -> Option<ExactReal> {
+        if self.is_nil() {
+            return None;
+        }
+        let mut iter = CfIter::from_exact_real(self);
+        match iter.next_step() {
+            CfStep::Quotient(a0) => Some(ExactReal::from_bigint(a0)),
+            CfStep::Ended | CfStep::Exhausted => None,
+        }
+    }
+
+    /// Ceiling: the least integer not below the value.
+    ///
+    /// Equal to `a0` when the value is an integer (the CF is the
+    /// single term `[a0]`) and to `a0 + 1` otherwise, since a present
+    /// CF tail forces the fractional part into `(0, 1)`.
+    ///
+    /// Returns `None` on nil or safety-budget exhaustion, like `floor`.
+    pub fn ceil(&self) -> Option<ExactReal> {
+        if self.is_nil() {
+            return None;
+        }
+        let mut iter = CfIter::from_exact_real(self);
+        let a0 = match iter.next_step() {
+            CfStep::Quotient(q) => q,
+            CfStep::Ended | CfStep::Exhausted => return None,
+        };
+        match iter.next_step() {
+            CfStep::Ended => Some(ExactReal::from_bigint(a0)),
+            CfStep::Quotient(_) => Some(ExactReal::from_bigint(a0 + BigInt::one())),
+            CfStep::Exhausted => None,
+        }
+    }
+
+    /// Round to the nearest integer, ties away from zero (matching
+    /// `Fraction::round`).
+    ///
+    /// With `[a0; a1, …]` the fractional part is `f = 1/r` where
+    /// `r = [a1; a2, …]`. Then `f < 1/2 ⇔ r > 2`, `f = 1/2 ⇔ r = 2`
+    /// (the CF is exactly `[a0; 2]`), and `f > 1/2 ⇔ r < 2 ⇔ a1 = 1`.
+    /// At a tie the value is the half-integer `a0 + 1/2`; rounding
+    /// away from zero picks `a0 + 1` when `a0 >= 0` and `a0` when
+    /// `a0 < 0`. At most three partial quotients are pulled.
+    ///
+    /// Returns `None` on nil or safety-budget exhaustion.
+    pub fn round(&self) -> Option<ExactReal> {
+        if self.is_nil() {
+            return None;
+        }
+        let mut iter = CfIter::from_exact_real(self);
+        let a0 = match iter.next_step() {
+            CfStep::Quotient(q) => q,
+            CfStep::Ended | CfStep::Exhausted => return None,
+        };
+        let a1 = match iter.next_step() {
+            CfStep::Ended => return Some(ExactReal::from_bigint(a0)),
+            CfStep::Quotient(q) => q,
+            CfStep::Exhausted => return None,
+        };
+        let rounded = match a1.cmp(&BigInt::from(2)) {
+            // a1 = 1 ⇒ r < 2 ⇒ f > 1/2.
+            std::cmp::Ordering::Less => a0 + BigInt::one(),
+            // a1 >= 3 ⇒ r > 2 ⇒ f < 1/2.
+            std::cmp::Ordering::Greater => a0,
+            // a1 = 2 ⇒ r > 2 if the CF continues, r = 2 (a tie) if it
+            // ends here.
+            std::cmp::Ordering::Equal => match iter.next_step() {
+                CfStep::Quotient(_) => a0,
+                CfStep::Ended => {
+                    if a0.is_negative() {
+                        a0
+                    } else {
+                        a0 + BigInt::one()
+                    }
+                }
+                CfStep::Exhausted => return None,
+            },
+        };
+        Some(ExactReal::from_bigint(rounded))
+    }
+
+    /// Best rational approximation within a denominator bound.
+    ///
+    /// Streams the canonical partial quotients and returns the
+    /// principal convergent whose denominator is the largest not
+    /// exceeding `max_denominator`. Every principal convergent is a
+    /// best rational approximation in the strong sense — no rational
+    /// with an equal or smaller denominator is strictly closer to the
+    /// value — so the result is the closest such convergent the bound
+    /// admits. For a `Rational` value whose own denominator already
+    /// fits the bound the result is the value itself.
+    ///
+    /// Returns `None` when `max_denominator < 1`, when the value is
+    /// nil, or when a lazy CF stream exhausts before any convergent
+    /// is produced.
+    pub fn best_rational_approximation(
+        &self,
+        max_denominator: &BigInt,
+    ) -> Option<Fraction> {
+        if max_denominator < &BigInt::one() {
+            return None;
+        }
+        if self.is_nil() {
+            return None;
+        }
+        let mut iter = CfIter::from_exact_real(self);
+        // Convergent recurrence with the standard seed
+        // h_{-1}/k_{-1} = 1/0 and h_{-2}/k_{-2} = 0/1.
+        let mut h_prev2 = BigInt::zero();
+        let mut h_prev1 = BigInt::one();
+        let mut k_prev2 = BigInt::one();
+        let mut k_prev1 = BigInt::zero();
+        let mut best: Option<(BigInt, BigInt)> = None;
+        while let CfStep::Quotient(a) = iter.next_step() {
+            let h = &a * &h_prev1 + &h_prev2;
+            let k = &a * &k_prev1 + &k_prev2;
+            if &k > max_denominator {
+                break;
+            }
+            h_prev2 = std::mem::replace(&mut h_prev1, h.clone());
+            k_prev2 = std::mem::replace(&mut k_prev1, k.clone());
+            best = Some((h, k));
+        }
+        best.map(|(h, k)| Fraction::new(h, k))
     }
 }
 
@@ -1987,15 +2170,66 @@ mod tests {
     }
 
     #[test]
-    fn cmp_equal_sqrt_two_is_undecidable_within_budget() {
-        // SPEC §7.4.1: "two equal irrationals never differ — the
-        // procedure does not terminate by itself." Two distinct
-        // AlgebraicSqrt values built from the same radicand expand
-        // identically forever; the comparison budget exhausts.
+    fn cmp_equal_sqrt_two_decides_equal() {
+        // Two AlgebraicSqrt values built from the same radicand are
+        // equal. The algebraic short-circuit decides this in O(1)
+        // from the radicands rather than streaming the never-
+        // diverging CFs to budget exhaustion. It needs no budget
+        // headroom beyond the budget-0 guard.
         let a = sqrt_of(2, 1);
         let b = sqrt_of(2, 1);
-        assert_eq!(a.cmp_with_budget(&b, 32), None);
-        assert_eq!(a.cmp_with_budget(&b, BUDGET), None);
+        assert_eq!(a.cmp_with_budget(&b, 1), Some(Ordering::Equal));
+        assert_eq!(a.cmp_with_budget(&b, BUDGET), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn cmp_distinct_sqrts_decide_from_radicands() {
+        // √(2/3) < √2 < √8, each decided in O(1) from the radicands.
+        assert_eq!(
+            sqrt_of(2, 3).cmp_with_budget(&sqrt_of(2, 1), BUDGET),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            sqrt_of(8, 1).cmp_with_budget(&sqrt_of(2, 1), BUDGET),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            sqrt_of(7, 1).cmp_with_budget(&sqrt_of(7, 1), 1),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn cmp_sqrt_against_non_positive_rationals() {
+        let s = sqrt_of(2, 1);
+        assert_eq!(
+            s.cmp_with_budget(&rational(0, 1), BUDGET),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            s.cmp_with_budget(&rational(-5, 1), BUDGET),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            rational(-5, 1).cmp_with_budget(&s, BUDGET),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn eq_equal_sqrts_resolves_decidably() {
+        assert_eq!(
+            sqrt_of(2, 1).eq_with_budget(&sqrt_of(2, 1), BUDGET),
+            Some(true)
+        );
+        assert_eq!(
+            sqrt_of(2, 1).ne_with_budget(&sqrt_of(2, 1), BUDGET),
+            Some(false)
+        );
+        assert_eq!(
+            sqrt_of(2, 1).eq_with_budget(&sqrt_of(3, 1), BUDGET),
+            Some(false)
+        );
     }
 
     // -- gosper vs everything --
@@ -2123,8 +2357,12 @@ mod tests {
 
     #[test]
     fn boolean_wrappers_propagate_undecidable_as_none() {
-        let a = sqrt_of(2, 1);
-        let b = sqrt_of(2, 1);
+        // A lazy Gosper zero (√2 − √2) compared against true zero
+        // cannot be resolved within the budget — no algebraic
+        // short-circuit applies to a Gosper operand — so every
+        // boolean wrapper surfaces `None`.
+        let a = sqrt_of(2, 1).sub(&sqrt_of(2, 1));
+        let b = rational(0, 1);
         assert_eq!(a.eq_with_budget(&b, BUDGET), None);
         assert_eq!(a.lt_with_budget(&b, BUDGET), None);
         assert_eq!(a.le_with_budget(&b, BUDGET), None);
@@ -2156,9 +2394,9 @@ mod tests {
     fn cmp_reflexive_for_finite_rationals() {
         // Reflexivity holds for finite (rational) CFs: both streams
         // emit the same canonical sequence then end, and the
-        // (Ended, Ended) branch returns Equal. Lazy values do NOT
-        // satisfy reflexivity through `cmp_with_budget` — see
-        // `cmp_equal_sqrt_two_is_undecidable_within_budget`.
+        // (Ended, Ended) branch returns Equal. Equal `AlgebraicSqrt`
+        // values are likewise reflexive via the algebraic
+        // short-circuit — see `cmp_equal_sqrt_two_decides_equal`.
         for r in &[
             rational(0, 1),
             rational(1, 1),
@@ -2173,5 +2411,106 @@ mod tests {
                 r
             );
         }
+    }
+
+    // === Phase 6: CF-native rounding and rational approximation ===
+
+    fn frac(num: i64, den: i64) -> Fraction {
+        Fraction::new(bi(num), bi(den))
+    }
+
+    #[test]
+    fn floor_of_rationals_is_first_partial_quotient() {
+        assert_eq!(rational(7, 2).floor(), Some(rational(3, 1)));
+        assert_eq!(rational(-7, 2).floor(), Some(rational(-4, 1)));
+        assert_eq!(rational(5, 1).floor(), Some(rational(5, 1)));
+        assert_eq!(rational(0, 1).floor(), Some(rational(0, 1)));
+    }
+
+    #[test]
+    fn ceil_of_rationals() {
+        assert_eq!(rational(7, 2).ceil(), Some(rational(4, 1)));
+        assert_eq!(rational(-7, 2).ceil(), Some(rational(-3, 1)));
+        assert_eq!(rational(5, 1).ceil(), Some(rational(5, 1)));
+        assert_eq!(rational(0, 1).ceil(), Some(rational(0, 1)));
+    }
+
+    #[test]
+    fn round_of_rationals_ties_away_from_zero() {
+        // Ties (half-integers): away from zero.
+        assert_eq!(rational(1, 2).round(), Some(rational(1, 1)));
+        assert_eq!(rational(-1, 2).round(), Some(rational(-1, 1)));
+        assert_eq!(rational(5, 2).round(), Some(rational(3, 1)));
+        assert_eq!(rational(-5, 2).round(), Some(rational(-3, 1)));
+        // Non-ties.
+        assert_eq!(rational(7, 3).round(), Some(rational(2, 1))); // 2.33…
+        assert_eq!(rational(8, 3).round(), Some(rational(3, 1))); // 2.66…
+        assert_eq!(rational(4, 1).round(), Some(rational(4, 1)));
+    }
+
+    #[test]
+    fn floor_ceil_round_of_algebraic_sqrt() {
+        // √2 ≈ 1.41421.
+        let s2 = sqrt_of(2, 1);
+        assert_eq!(s2.floor(), Some(rational(1, 1)));
+        assert_eq!(s2.ceil(), Some(rational(2, 1)));
+        assert_eq!(s2.round(), Some(rational(1, 1)));
+        // √7 ≈ 2.64575.
+        let s7 = sqrt_of(7, 1);
+        assert_eq!(s7.floor(), Some(rational(2, 1)));
+        assert_eq!(s7.ceil(), Some(rational(3, 1)));
+        assert_eq!(s7.round(), Some(rational(3, 1)));
+    }
+
+    #[test]
+    fn floor_ceil_round_of_gosper_value() {
+        // √2 + 1 ≈ 2.41421, held as a lazy Möbius Gosper.
+        let v = sqrt_of(2, 1).add(&rational(1, 1));
+        assert_eq!(v.floor(), Some(rational(2, 1)));
+        assert_eq!(v.ceil(), Some(rational(3, 1)));
+        assert_eq!(v.round(), Some(rational(2, 1)));
+    }
+
+    #[test]
+    fn rounding_of_nil_returns_none() {
+        let nil = ExactReal::Rational(Fraction::nil());
+        assert_eq!(nil.floor(), None);
+        assert_eq!(nil.ceil(), None);
+        assert_eq!(nil.round(), None);
+    }
+
+    #[test]
+    fn best_rational_approximation_of_rational() {
+        // 355/113 = [3; 7, 16]; principal convergents are 3, 22/7,
+        // 355/113.
+        let v = rational(355, 113);
+        assert_eq!(v.best_rational_approximation(&bi(6)), Some(frac(3, 1)));
+        assert_eq!(v.best_rational_approximation(&bi(50)), Some(frac(22, 7)));
+        assert_eq!(
+            v.best_rational_approximation(&bi(200)),
+            Some(frac(355, 113))
+        );
+    }
+
+    #[test]
+    fn best_rational_approximation_of_sqrt_two() {
+        // √2 = [1; 2, 2, 2, …]; convergent denominators 1, 2, 5, 12,
+        // 29, 70, 169, …
+        let s = sqrt_of(2, 1);
+        assert_eq!(s.best_rational_approximation(&bi(1)), Some(frac(1, 1)));
+        assert_eq!(s.best_rational_approximation(&bi(10)), Some(frac(7, 5)));
+        assert_eq!(s.best_rational_approximation(&bi(100)), Some(frac(99, 70)));
+        assert_eq!(s.best_rational_approximation(&bi(168)), Some(frac(99, 70)));
+        assert_eq!(
+            s.best_rational_approximation(&bi(169)),
+            Some(frac(239, 169))
+        );
+    }
+
+    #[test]
+    fn best_rational_approximation_rejects_bad_bound_and_nil() {
+        assert_eq!(rational(1, 2).best_rational_approximation(&bi(0)), None);
+        let nil = ExactReal::Rational(Fraction::nil());
+        assert_eq!(nil.best_rational_approximation(&bi(10)), None);
     }
 }


### PR DESCRIPTION
## Summary

連分数表現を前提とした最適化のうち A-1〜A-3 を `ExactReal` に実装しました。

- **A-1 — 比較の代数ショートカット**: `cmp_with_budget` に `AlgebraicSqrt`/`Rational` の組をパターンマッチし、partial quotient を逐次展開せず O(1) で厳密に順序を決定。√は非負有理数上で単調なので `√r ⋚ √s ⟺ r ⋚ s`、`√r` vs 有理数 `q` は `radicand` vs `q²` で決まります。最大256項の展開を回避するだけでなく、**等しい無理平方根同士の比較が「永遠に分岐しない CF ストリーム」を budget まで使い切って `undecidable` NIL を返していた正当性バグも解消**します（例: `SQRT@2 SQRT@2 EQ` が `true` に）。Gosper オペランドを含む比較は従来どおりストリーミング。

- **A-2 — CF ネイティブな floor/ceil/round**: 先頭の partial quotient から整数部を直接読み取ります（FLOOR は本質的に `a0`）。`Rational`・`AlgebraicSqrt`・`Gosper` のすべての表現で厳密に動作し、コストは 1〜3 項のプル。`round` は `Fraction::round` と同じ「タイは0から遠い方へ」規則。

- **A-3 — best_rational_approximation**: 分母上限内で最も近い主収束分数を CF 切り詰めで返します。主収束分数は強い意味での最良有理近似なので、上限が許す最良近似になります。

## 留意点

`ExactReal` は現状ランタイム値システム（`Fraction` ベース）にはまだ本接続されておらず、これらは CF 値システム移行に向けた厳密な基盤プリミティブです。ただし A-1 の比較ロジックは比較経路のバグ修正でもあります。

旧（バグのある）挙動を前提にしていたテストを更新し、ショートカット・丸め・近似の新規テストを追加しました。

## Test plan

- [x] `cargo test --lib continued_fraction` — 98 passed
- [x] `cargo test --lib` — 1007 passed
- [x] `cargo clippy --lib` — 新規コードに警告なし

https://claude.ai/code/session_0169hUcpG3QoBwdYhv5HkSs8

---
_Generated by [Claude Code](https://claude.ai/code/session_0169hUcpG3QoBwdYhv5HkSs8)_