### PR TITLE
Optimize frontend hot paths in GUI rendering

### DIFF
--- a/src/gui/code-input-editor.ts
+++ b/src/gui/code-input-editor.ts
@@ -142,8 +142,9 @@ export const createEditor = (
     };
 
     const computeCursorCoords = (el: HTMLTextAreaElement): { top: number; left: number } => {
-        const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
-        const paddingTop = parseFloat(getComputedStyle(el).paddingTop) || 0;
+        const style = getComputedStyle(el);
+        const lineHeight = parseFloat(style.lineHeight) || 20;
+        const paddingTop = parseFloat(style.paddingTop) || 0;
         const text = el.value.substring(0, el.selectionStart);
         const lines = text.split('\n');
         const lineIndex = lines.length - 1;

--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -54,7 +54,18 @@ export interface GUI {
     readonly extractExecutionController: () => ExecutionController;
 }
 
+// The full word list only changes when the vocabulary changes (after an
+// execution). Without this cache the whole set — including several WASM
+// round-trips per imported module — was rebuilt on every keystroke.
+let autocompleteWordsCache: string[] | null = null;
+
+const invalidateAutocompleteCache = (): void => {
+    autocompleteWordsCache = null;
+};
+
 const collectAutocompleteWords = (): string[] => {
+    if (autocompleteWordsCache) return autocompleteWordsCache;
+
     const interpreter = INTERPRETER_CLIENT.getOptional();
     if (!interpreter) return [];
 
@@ -88,7 +99,8 @@ const collectAutocompleteWords = (): string[] => {
     } catch {  }
 
     const allWords: Set<string> = new Set([...coreWords, ...userWords, ...moduleWords]);
-    return Array.from(allWords).sort((a: string, b: string) => a.localeCompare(b));
+    autocompleteWordsCache = Array.from(allWords).sort((a: string, b: string) => a.localeCompare(b));
+    return autocompleteWordsCache;
 };
 
 export const createGUI = (): GUI => {
@@ -129,6 +141,8 @@ export const createGUI = (): GUI => {
 
     const updateAllDisplays = (): void => {
         if (!INTERPRETER_CLIENT.getOptional()) return;
+
+        invalidateAutocompleteCache();
 
         try {
             display.renderStack(INTERPRETER_CLIENT.collectStack());

--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -215,6 +215,7 @@ export const createModuleTabManager = (
             const matched = sorted.filter(wd => checkWordMatchesFilter(wd[0], searchFilter));
             const prefix = `${moduleSheet.moduleName}@`;
 
+            const fragment = document.createDocumentFragment();
             matched.forEach(wordData => {
                 const name = wordData[0];
                 const shortName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
@@ -242,8 +243,9 @@ Right-click to unimport this word.`;
                     }])
                 );
 
-                wordsDisplay.appendChild(button);
+                fragment.appendChild(button);
             });
+            wordsDisplay.appendChild(fragment);
 
             if (searchFilter && matched.length === 0) {
                 wordsDisplay.classList.add('is-empty');

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -1,7 +1,6 @@
 import type { Value, ExecuteResult } from '../wasm-interpreter-types';
 import { AUDIO_ENGINE } from '../audio/audio-engine';
 import { formatFractionScientific } from './value-formatter';
-import { pipe } from './functional-result-helpers';
 
 export interface DisplayElements {
     outputDisplay: HTMLElement;
@@ -291,42 +290,34 @@ const formatValue = (item: Value, depth: number): string => {
 };
 
 
-const extractAudioCommands = (output: string): string[] =>
-    output.split('\n')
-        .filter(line => line.startsWith('AUDIO:'))
-        .map(line => line.substring(6));
+interface ParsedOutput {
+    readonly audio: readonly string[];
+    readonly config: readonly string[];
+    readonly effect: readonly string[];
+    readonly jsonExport: readonly string[];
+    /** Output lines with all special command lines removed, joined by newlines. */
+    readonly program: string;
+}
 
-const extractConfigCommands = (output: string): string[] =>
-    output.split('\n')
-        .filter(line => line.startsWith('CONFIG:'))
-        .map(line => line.substring(7));
+// Single pass over the output: previously each command category re-split the
+// same string, costing 5-6 full scans per render.
+const parseOutputCommands = (output: string): ParsedOutput => {
+    const audio: string[] = [];
+    const config: string[] = [];
+    const effect: string[] = [];
+    const jsonExport: string[] = [];
+    const programLines: string[] = [];
 
-const extractEffectCommands = (output: string): string[] =>
-    output.split('\n')
-        .filter(line => line.startsWith('EFFECT:'))
-        .map(line => line.substring(7));
+    for (const line of output.split('\n')) {
+        if (line.startsWith('AUDIO:')) audio.push(line.substring(6));
+        else if (line.startsWith('CONFIG:')) config.push(line.substring(7));
+        else if (line.startsWith('EFFECT:')) effect.push(line.substring(7));
+        else if (line.startsWith('JSONEXPORT:')) jsonExport.push(line.substring(11));
+        else programLines.push(line);
+    }
 
-const extractJsonExportCommands = (output: string): string[] =>
-    output.split('\n')
-        .filter(line => line.startsWith('JSONEXPORT:'))
-        .map(line => line.substring(11));
-
-const checkIsSpecialCommand = (line: string): boolean =>
-    line.startsWith('AUDIO:') || line.startsWith('CONFIG:') ||
-    line.startsWith('EFFECT:') || line.startsWith('JSONEXPORT:');
-
-const removeSpecialCommandLines = (output: string): string =>
-    output.split('\n')
-        .filter(line => !checkIsSpecialCommand(line))
-        .join('\n');
-
-const formatExecutionOutput = (result: ExecuteResult): { debug: string; program: string } => ({
-    debug: (result.debugOutput || '').trim(),
-    program: pipe(
-        (result.output || '').trim(),
-        removeSpecialCommandLines
-    )
-});
+    return { audio, config, effect, jsonExport, program: programLines.join('\n') };
+};
 
 const formatErrorMessage = (error: Error | { message?: string } | string): string =>
     typeof error === 'string'
@@ -348,8 +339,8 @@ const appendToElement = (parent: HTMLElement, child: HTMLElement): void => {
     parent.appendChild(child);
 };
 
-const applyEffectCommands = (output: string): void => {
-    extractEffectCommands(output).forEach(commandStr => {
+const applyEffectCommands = (commands: readonly string[]): void => {
+    commands.forEach(commandStr => {
         try {
             const effect = JSON.parse(commandStr);
             if (effect.gain !== undefined) {
@@ -364,8 +355,8 @@ const applyEffectCommands = (output: string): void => {
     });
 };
 
-const applyConfigCommands = (output: string): void => {
-    extractConfigCommands(output).forEach(commandStr => {
+const applyConfigCommands = (commands: readonly string[]): void => {
+    commands.forEach(commandStr => {
         try {
             const config = JSON.parse(commandStr);
             if (config.slot_duration !== undefined) {
@@ -378,11 +369,11 @@ const applyConfigCommands = (output: string): void => {
     });
 };
 
-const executeAudioCommands = (output: string): void => {
-    applyEffectCommands(output);
-    applyConfigCommands(output);
+const executeAudioCommands = (parsed: ParsedOutput): void => {
+    applyEffectCommands(parsed.effect);
+    applyConfigCommands(parsed.config);
 
-    extractAudioCommands(output).forEach(commandStr => {
+    parsed.audio.forEach(commandStr => {
         try {
             const audioCommand = JSON.parse(commandStr);
             AUDIO_ENGINE.playAudioCommand(audioCommand).catch(console.error);
@@ -414,8 +405,8 @@ const createJsonDownloadLinkElement = (jsonCompact: string): HTMLAnchorElement =
     return a;
 };
 
-const renderJsonExportLinks = (output: string, outputDisplay: HTMLElement): void => {
-    extractJsonExportCommands(output).forEach(jsonCompact => {
+const renderJsonExportLinks = (jsonExportCommands: readonly string[], outputDisplay: HTMLElement): void => {
+    jsonExportCommands.forEach(jsonCompact => {
         const link = createJsonDownloadLinkElement(jsonCompact);
         appendToElement(outputDisplay, document.createElement('br'));
         appendToElement(outputDisplay, link);
@@ -437,9 +428,11 @@ export const createDisplay = (elements: DisplayElements): Display => {
     };
 
     const renderExecutionResult = (result: ExecuteResult): void => {
-        const { debug, program } = formatExecutionOutput(result);
-        const rawOutput = result.output || '';
-        executeAudioCommands(rawOutput);
+        const parsed = parseOutputCommands(result.output || '');
+        executeAudioCommands(parsed);
+
+        const debug = (result.debugOutput || '').trim();
+        const program = parsed.program.trim();
 
         mainOutput = `${debug}\n${program}`;
         clearElement(elements.outputDisplay);
@@ -456,17 +449,17 @@ export const createDisplay = (elements: DisplayElements): Display => {
             appendSpan(program, '#4DC4FF');
         }
 
-        renderJsonExportLinks(rawOutput, elements.outputDisplay);
+        renderJsonExportLinks(parsed.jsonExport, elements.outputDisplay);
 
-        if (!debug && !program && !extractJsonExportCommands(rawOutput).length && result.status === 'OK') {
+        if (!debug && !program && parsed.jsonExport.length === 0 && result.status === 'OK') {
             appendSpan('OK', '#333');
         }
     };
 
     const appendExecutionResult = (result: ExecuteResult): void => {
-        const programOutput = (result.output || '').trim();
-        executeAudioCommands(programOutput);
-        const filteredOutput = removeSpecialCommandLines(programOutput);
+        const parsed = parseOutputCommands(result.output || '');
+        executeAudioCommands(parsed);
+        const filteredOutput = parsed.program.trim();
 
         if (filteredOutput) {
             appendSpan(filteredOutput, '#4DC4FF');
@@ -474,12 +467,12 @@ export const createDisplay = (elements: DisplayElements): Display => {
     };
 
     const renderOutput = (text: string): void => {
-        executeAudioCommands(text);
-        const filteredText = removeSpecialCommandLines(text);
+        const parsed = parseOutputCommands(text);
+        executeAudioCommands(parsed);
 
-        mainOutput = filteredText;
+        mainOutput = parsed.program;
         clearElement(elements.outputDisplay);
-        appendSpan(filteredText, '#4DC4FF');
+        appendSpan(parsed.program, '#4DC4FF');
     };
 
     const renderError = (error: Error | { message?: string } | string): void => {

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -184,6 +184,36 @@ export const createVocabularyManager = (
     let searchFilter = '';
     let cachedUserWords: Array<[string, string, string | null, boolean]> = [];
     let selectedDictionary = 'DEMO';
+    // Core words are fixed once WASM is loaded; fetching + canonical-filtering +
+    // sorting them on every search keystroke was pure waste.
+    let sortedCoreWordsCache: unknown[][] | null = null;
+
+    const getSortedCoreWords = (): unknown[][] => {
+        if (sortedCoreWordsCache) return sortedCoreWordsCache;
+
+        const coreWords = window.ajisaiInterpreter.collect_core_listed_words_info();
+        const filtered = coreWords.filter(
+            wd =>
+                Array.isArray(wd)
+                && typeof wd[0] === 'string'
+                && isCanonicalCoreWordName(wd[0])
+        );
+
+        const droppedCount = coreWords.length - filtered.length;
+        if (droppedCount > 0) {
+            console.info(`[Vocabulary] Filtered out ${droppedCount} non-canonical core word entries from WASM payload.`);
+        }
+
+        sortedCoreWordsCache = [...filtered].sort((a, b) =>
+            compareWordName(a[0] as string, b[0] as string)
+        );
+        return sortedCoreWordsCache;
+    };
+
+    const selectDictionaryWords = (): WordInfo[] =>
+        cachedUserWords
+            .map(createWordInfoFromTuple)
+            .filter(word => word.dictionary === selectedDictionary);
 
     const deleteWord = async (wordName: string, forceDelete: boolean): Promise<boolean> => {
         const deleteCode = forceDelete
@@ -224,35 +254,16 @@ export const createVocabularyManager = (
     };
 
     const renderBuiltInWordsSorted = (
-        container: HTMLElement,
-        coreWords: unknown[][]
+        container: HTMLElement
     ): void => {
         clearElement(container);
         container.classList.remove('is-empty');
 
-
-        const filtered = coreWords.filter(
-            (wd): wd is unknown[] =>
-                Array.isArray(wd)
-                && typeof wd[0] === 'string'
-                && isCanonicalCoreWordName(wd[0])
-        );
-
-        const droppedCount = coreWords.length - filtered.length;
-        if (droppedCount > 0) {
-            console.info(`[Vocabulary] Filtered out ${droppedCount} non-canonical core word entries from WASM payload.`);
-        }
-
-        const sorted = [...filtered].sort((a, b) =>
-            compareWordName(a[0] as string, b[0] as string)
-        );
-
-
-        const matched = sorted.filter(wd =>
+        const matched = getSortedCoreWords().filter(wd =>
             checkWordMatchesFilter(wd[0] as string, searchFilter)
         );
 
-
+        const fragment = document.createDocumentFragment();
         matched.forEach(wordData => {
             const name = wordData[0] as string;
             const description = (wordData[1] as string) || name;
@@ -266,8 +277,9 @@ export const createVocabularyManager = (
                 () => { resetWordInfoDisplay(elements.builtInWordInfo); }
             );
 
-            container.appendChild(button);
+            fragment.appendChild(button);
         });
+        container.appendChild(fragment);
 
         if (searchFilter && matched.length === 0) {
             container.classList.add('is-empty');
@@ -292,6 +304,7 @@ export const createVocabularyManager = (
             compareWordName(a.name, b.name)
         );
 
+        const fragment = document.createDocumentFragment();
         sortedFiltered.forEach(wordInfo => {
             const className = wordInfo.protected
                 ? 'word-button dependency'
@@ -315,8 +328,9 @@ export const createVocabularyManager = (
                 (event) => renderDeleteContextMenu(event, `${wordInfo.dictionary}@${wordInfo.name}`)
             );
 
-            container.appendChild(button);
+            fragment.appendChild(button);
         });
+        container.appendChild(fragment);
 
 
         if (searchFilter && words.length > 0 && filteredWords.length === 0) {
@@ -338,8 +352,7 @@ export const createVocabularyManager = (
         if (!window.ajisaiInterpreter) return;
 
         try {
-            const coreWords = window.ajisaiInterpreter.collect_core_listed_words_info();
-            renderBuiltInWordsSorted(elements.builtInWordsDisplay, coreWords);
+            renderBuiltInWordsSorted(elements.builtInWordsDisplay);
         } catch (error) {
             console.error('Failed to render core words:', error);
         }
@@ -362,16 +375,14 @@ export const createVocabularyManager = (
             selectedDictionary = dictionaries.includes('DEMO') ? 'DEMO' : (dictionaries[0] || 'DEMO');
         }
         elements.userDictionarySelect.value = selectedDictionary;
-        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
-        renderUserWordButtons(elements.userWordsDisplay, words);
+        renderUserWordButtons(elements.userWordsDisplay, selectDictionaryWords());
     };
 
     const updateSearchFilter = (filter: string): void => {
         searchFilter = filter.trim();
 
         renderBuiltInWords();
-        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
-        renderUserWordButtons(elements.userWordsDisplay, words);
+        renderUserWordButtons(elements.userWordsDisplay, selectDictionaryWords());
     };
 
     const setSelectedDictionary = (dictionary: string): void => {
@@ -380,14 +391,12 @@ export const createVocabularyManager = (
         if (!optionExists) return;
         selectedDictionary = dictionary;
         elements.userDictionarySelect.value = dictionary;
-        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
-        renderUserWordButtons(elements.userWordsDisplay, words);
+        renderUserWordButtons(elements.userWordsDisplay, selectDictionaryWords());
     };
 
     elements.userDictionarySelect.addEventListener('change', () => {
         selectedDictionary = elements.userDictionarySelect.value;
-        const words = cachedUserWords.map(createWordInfoFromTuple).filter(word => word.dictionary === selectedDictionary);
-        renderUserWordButtons(elements.userWordsDisplay, words);
+        renderUserWordButtons(elements.userWordsDisplay, selectDictionaryWords());
         void onSaveState?.();
     });
 


### PR DESCRIPTION
## Summary

Frontend performance had not previously been a focus. This PR removes redundant work in per-keystroke and per-render code paths in the GUI layer. All changes are behavior-preserving.

- **Autocomplete word list caching** (`gui-application.ts`): `collectAutocompleteWords` was rebuilt on every keystroke, issuing multiple WASM round-trips (core words, user words, imported modules, plus per-module word/sample lookups) and a full sort. It is now cached and invalidated only when the vocabulary changes (`updateAllDisplays`).
- **Core word list caching** (`vocabulary-state-controller.ts`): dictionary search re-fetched `collect_core_listed_words_info()` from WASM and re-applied the canonical filter + sort on every keystroke. The core vocabulary is static after WASM load, so the sorted list is now cached.
- **Single-pass output parsing** (`output-display-renderer.ts`): execution output was split by newline 5-6 times per render (once per command category plus `removeSpecialCommandLines`). Replaced with one `parseOutputCommands` pass that partitions lines into audio/config/effect/jsonExport/program.
- **Batched DOM insertion** (`vocabulary-state-controller.ts`, `module-selector-sheets.ts`): word buttons were appended one-by-one to live containers, causing reflow per button. Now built into a `DocumentFragment` and appended once.
- **Single `getComputedStyle` call** (`code-input-editor.ts`): cursor-coordinate calculation read computed styles twice.

## Test plan

- [x] `npm run check` (tsc) passes
- [x] `npm test` (vitest) passes — 29 tests
- [ ] Manual: verify autocomplete suggestions still update as the vocabulary changes after executing code
- [ ] Manual: verify dictionary search filtering still works for core / user / module words
- [ ] Manual: verify audio/config/effect/JSON-export output commands still apply

https://claude.ai/code/session_012rm72MQQH6t6JbNeDKqMxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012rm72MQQH6t6JbNeDKqMxJ)_