### PR TITLE
Parallelize hedged execution and debounce state persistence

### DIFF
--- a/src/gui/interpreter-state-persistence.ts
+++ b/src/gui/interpreter-state-persistence.ts
@@ -136,7 +136,12 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
         showError?.(new Error('Failed to initialize database. Changes will not be saved.'));
     };
 
-    const saveCurrentState = async (): Promise<void> => {
+    const SAVE_DEBOUNCE_MS = 400;
+    let saveTimer: ReturnType<typeof setTimeout> | null = null;
+    let pendingSave: Promise<void> | null = null;
+    let resolvePendingSave: (() => void) | null = null;
+
+    const performSave = async (): Promise<void> => {
         if (!window.ajisaiInterpreter) return;
         if (!dbInitialized) {
             console.warn('Database not initialized, skipping state save.');
@@ -151,6 +156,38 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
             console.error('Failed to auto-save state:', error);
         }
     };
+
+    // Auto-save fires after every execution, word edit and dictionary switch.
+    // Debouncing coalesces bursts of those operations into a single snapshot
+    // + IndexedDB write. The snapshot is taken when the timer fires, so the
+    // most recent interpreter state is always the one persisted.
+    const flushPendingSave = (): void => {
+        if (!saveTimer) return;
+        clearTimeout(saveTimer);
+        saveTimer = null;
+        const resolve = resolvePendingSave;
+        pendingSave = null;
+        resolvePendingSave = null;
+        void performSave().finally(() => resolve?.());
+    };
+
+    const saveCurrentState = (): Promise<void> => {
+        if (!pendingSave) {
+            pendingSave = new Promise<void>(resolve => { resolvePendingSave = resolve; });
+        }
+        if (saveTimer) clearTimeout(saveTimer);
+        saveTimer = setTimeout(flushPendingSave, SAVE_DEBOUNCE_MS);
+        return pendingSave;
+    };
+
+    // A debounced save would otherwise be lost if the tab is hidden or closed
+    // within the debounce window, so flush it immediately on those events.
+    if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') flushPendingSave();
+        });
+        window.addEventListener('pagehide', flushPendingSave);
+    }
 
     const loadDemoWords = async (): Promise<void> => {
         try {

--- a/src/workers/execution-worker-manager.ts
+++ b/src/workers/execution-worker-manager.ts
@@ -212,9 +212,13 @@ export class WorkerManager {
     }
 
     private processQueue(): void {
-        const availableWorker = this.workers.find(w => !w.busy);
-        const nextTask = this.taskQueue.shift();
-        if (availableWorker && nextTask) {
+        // Drain as many queued tasks as there are idle workers. Assigning only
+        // one task per call serialized hedged execution: the two strategies
+        // were queued together but ran one after another instead of racing.
+        while (this.taskQueue.length > 0) {
+            const availableWorker = this.workers.find(w => !w.busy);
+            if (!availableWorker) break;
+            const nextTask = this.taskQueue.shift()!;
             this.assignTaskToWorker(availableWorker, nextTask);
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #918, optimizing the IndexedDB and Web Worker layers. (There is no Service Worker in the codebase, so that area is out of scope.)

- **Parallelize hedged execution** (`execution-worker-manager.ts`): `processQueue` assigned only one task per call. Hedged execution enqueues two racing strategies (`hedged-safe` + `plain-greedy`) together but `execute()` calls `processQueue` once — so the two strategies ran **sequentially** instead of in parallel, negating the speedup even when idle workers were available. `processQueue` now drains the queue across every idle worker.
- **Debounce IndexedDB auto-save** (`interpreter-state-persistence.ts`): auto-save fired a full WASM snapshot (a `lookup_word_definition` call per user word) plus a whole-state IndexedDB write after *every* execution, word edit and dictionary switch. Saves are now debounced (400ms) so bursts collapse into a single write. The snapshot is captured when the timer fires, so the most recent state is always persisted, and pending saves are flushed on `visibilitychange` (hidden) / `pagehide` so the last change is not lost if the tab closes within the debounce window.

## Test plan

- [x] `npm run check` (tsc) passes
- [x] `npm test` (vitest) passes — 29 tests
- [ ] Manual: run code in hedged-trace mode and confirm both strategies execute concurrently (`[HEDGED-WINNER]` reported)
- [ ] Manual: perform rapid edits, then reload the page and confirm the latest state is restored
- [ ] Manual: edit, immediately switch tab away, return and reload — confirm the change persisted

https://claude.ai/code/session_012rm72MQQH6t6JbNeDKqMxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012rm72MQQH6t6JbNeDKqMxJ)_