### PR TITLE
Update header/footer gradients and rename gradient tokens

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -84,7 +84,7 @@ select:focus-visible {
 
 
 header {
-    background: linear-gradient(in oklch to right, var(--gradient-header) 70%, var(--gradient-header-right) 100%);
+    background: linear-gradient(in oklch to right, var(--gradient-purple-red) 0%, var(--gradient-purple-blue) 50%, var(--gradient-purple-red) 100%);
     padding: 1rem 2rem;
     display: flex;
     flex-direction: column;
@@ -175,7 +175,7 @@ header h1 a {
 
 
 footer {
-    background: linear-gradient(in oklch to right, var(--gradient-header) 70%, var(--gradient-header-right) 100%);
+    background: linear-gradient(in oklch to right, var(--gradient-purple-blue) 0%, var(--gradient-purple-red) 50%, var(--gradient-purple-blue) 100%);
     padding: 0.75rem 2rem;
     display: flex;
     align-items: center;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -14,8 +14,8 @@
     --color-primary: #6b5b95;
 
 
-    --gradient-header: #6b5b95;
-    --gradient-header-right: #b5688c;
+    --gradient-purple-blue: #6b5b95;
+    --gradient-purple-red: #b5688c;
     --gradient-background: #f6f5f9;
     --gradient-parent: #e4e1ec;
     --gradient-child: #edebf2;


### PR DESCRIPTION
### Motivation
- Refresh the app chrome by changing the header and footer gradient ordering to improve visual balance.
- Make the two purple variants explicit in the token names to avoid ambiguity in future styling changes.

### Description
- Renamed gradient tokens in `src/styles/tokens.css` from `--gradient-header` / `--gradient-header-right` to `--gradient-purple-blue` and `--gradient-purple-red`.
- Updated the header background in `src/styles/base.css` to `linear-gradient(..., var(--gradient-purple-red) 0%, var(--gradient-purple-blue) 50%, var(--gradient-purple-red) 100%)` to produce red-purple → blue-purple → red-purple.
- Updated the footer background in `src/styles/base.css` to `linear-gradient(..., var(--gradient-purple-blue) 0%, var(--gradient-purple-red) 50%, var(--gradient-purple-blue) 100%)` to produce blue-purple → red-purple → blue-purple.
- Changes touch `src/styles/tokens.css` and `src/styles/base.css` only.

### Testing
- Ran `git diff --check` with no issues detected, and it passed.
- Ran `npm run check` (`tsc --noEmit`) and it completed successfully.
- Ran `npm run build:web` (Vite production build) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0936052788832683218debb90add72)