### PR TITLE
Refine interpreter quality: idiomatic refactors and dead-code removal

### DIFF
--- a/rust/src/interpreter/cast/cast_value_helpers.rs
+++ b/rust/src/interpreter/cast/cast_value_helpers.rs
@@ -43,7 +43,7 @@ pub(crate) fn is_string_value_with_hint(val: &Value, hint: DisplayHint) -> bool 
             return false
         }
     };
-    children.iter().all(|child| check_char_scalar(child))
+    children.iter().all(check_char_scalar)
 }
 
 fn check_char_scalar(child: &Value) -> bool {
@@ -58,7 +58,7 @@ fn check_char_scalar(child: &Value) -> bool {
         }
     };
     let n: i64 = match f.to_i64() {
-        Some(n) if n >= 0 && n <= 0x10FFFF => n,
+        Some(n) if (0..=0x10FFFF).contains(&n) => n,
         Some(_) => return false,
         None => return false,
     };
@@ -163,12 +163,13 @@ pub(crate) fn format_fraction_to_string(f: &Fraction) -> String {
 pub(crate) fn try_char_from_value(val: &Value) -> Option<char> {
     let f: &Fraction = val.as_scalar()?;
     let code: i64 = f.to_i64()?;
-    if code < 0 || code > 0x10FFFF {
+    if !(0..=0x10FFFF).contains(&code) {
         return None;
     }
     char::from_u32(code as u32)
 }
 
+#[cfg(test)]
 pub(crate) fn format_value_to_string_repr(value: &Value) -> String {
     format_value_to_string_repr_with_hint(value, DisplayHint::Auto)
 }

--- a/rust/src/interpreter/control_cond.rs
+++ b/rust/src/interpreter/control_cond.rs
@@ -96,7 +96,7 @@ fn collect_cond_pairs_from_stack(
         return Ok(pairs);
     }
 
-    if collected_blocks.len() % 2 != 0 {
+    if !collected_blocks.len().is_multiple_of(2) {
         return Err(AjisaiError::from(format!(
             "COND: expected even number of code blocks (guard/body pairs), got {}",
             collected_blocks.len()

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -13,7 +13,7 @@ fn extract_string_from_value(val: &Value) -> Result<String> {
             ValueData::Scalar(f) => f
                 .to_i64()
                 .and_then(|n| {
-                    if n >= 0 && n <= 0x10FFFF {
+                    if (0..=0x10FFFF).contains(&n) {
                         char::from_u32(n as u32)
                     } else {
                         None
@@ -24,7 +24,7 @@ fn extract_string_from_value(val: &Value) -> Result<String> {
             ValueData::Vector(children)
             | ValueData::Record {
                 pairs: children, ..
-            } => children.iter().flat_map(|c| collect_chars(c)).collect(),
+            } => children.iter().flat_map(collect_chars).collect(),
             ValueData::Tensor { data, .. } => data
                 .iter()
                 .filter_map(|f| {
@@ -59,11 +59,14 @@ fn is_string_like(val: &Value) -> bool {
     fn check_codepoints(val: &Value) -> bool {
         match &val.data {
             ValueData::Nil => false,
-            ValueData::Scalar(f) => f.to_i64().map(|n| n >= 0 && n <= 0x10FFFF).unwrap_or(false),
+            ValueData::Scalar(f) => f
+                .to_i64()
+                .map(|n| (0..=0x10FFFF).contains(&n))
+                .unwrap_or(false),
             ValueData::Vector(children)
             | ValueData::Record {
                 pairs: children, ..
-            } => children.iter().all(|c| check_codepoints(c)),
+            } => children.iter().all(check_codepoints),
             ValueData::Tensor { data, .. } => data
                 .iter()
                 .all(|f| f.to_i64().map(|n| (0..=0x10FFFF).contains(&n)).unwrap_or(false)),

--- a/rust/src/interpreter/higher_order/mod.rs
+++ b/rust/src/interpreter/higher_order/mod.rs
@@ -8,15 +8,10 @@ mod hedged;
 mod map;
 mod runners;
 
-pub(crate) use common::{
-    execute_executable_code, extract_executable_code, extract_predicate_boolean, ExecutableCode,
-};
-pub(crate) use hedged::{
-    execute_hedged_fold_kernel, execute_hedged_map_kernel, execute_hedged_predicate_kernel,
-};
-pub(crate) use runners::{
-    execute_quantized_fold_kernel, execute_quantized_map_kernel, execute_quantized_predicate_kernel,
-};
+pub(crate) use common::{execute_executable_code, extract_executable_code, ExecutableCode};
+pub(crate) use hedged::execute_hedged_fold_kernel;
+#[cfg(test)]
+pub(crate) use hedged::{execute_hedged_map_kernel, execute_hedged_predicate_kernel};
 
 pub use all::op_all;
 pub use any::op_any;

--- a/rust/src/interpreter/interpreter_mode_tests.rs
+++ b/rust/src/interpreter/interpreter_mode_tests.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+    use crate::interpreter::Interpreter;
 
     #[tokio::test]
     async fn test_keep_mode_basic() {

--- a/rust/src/interpreter/interval_ops.rs
+++ b/rust/src/interpreter/interval_ops.rs
@@ -167,7 +167,7 @@ pub(crate) fn op_sqrt_eps(interp: &mut Interpreter) -> Result<()> {
 
 fn sqrt_interval_with_eps(interval: Interval, eps: Fraction) -> Result<Interval> {
     if interval.hi.lt(&Fraction::from(0)) {
-        return Err(AjisaiError::from("sqrt of negative value"));
+        Err(AjisaiError::from("sqrt of negative value"))
     } else if interval.lo.lt(&Fraction::from(0)) {
         let hi = sqrt_value_to_interval(&interval.hi, &eps)?;
         Ok(Interval::new(Fraction::from(0), hi.hi)?)

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -74,7 +74,7 @@ pub fn op_not(interp: &mut Interpreter) -> Result<()> {
             Ok(())
         }
         OperationTargetMode::Stack => {
-            let source: Vec<Value> = interp.stack.iter().cloned().collect();
+            let source: Vec<Value> = interp.stack.to_vec();
             let mut results: Vec<Value> = Vec::with_capacity(source.len());
             for value in &source {
                 results.push(compute_inverted_value(value, Some(&mut interp.runtime_metrics))?);

--- a/rust/src/interpreter/random.rs
+++ b/rust/src/interpreter/random.rs
@@ -15,7 +15,7 @@ fn compute_uniform_random(denominator: &BigInt) -> Result<BigInt> {
 
     let denom_bits = denominator.bits() as usize;
     let total_bits = denom_bits + 64;
-    let bytes = (total_bits + 7) / 8;
+    let bytes = total_bits.div_ceil(8);
 
     let mut buf = vec![0u8; bytes];
     getrandom::getrandom(&mut buf).map_err(|e| {

--- a/rust/src/interpreter/value_extraction_helpers.rs
+++ b/rust/src/interpreter/value_extraction_helpers.rs
@@ -22,7 +22,7 @@ pub(crate) fn value_as_string(val: &Value) -> Option<String> {
             ValueData::Scalar(f) => f
                 .to_i64()
                 .and_then(|n| {
-                    if n >= 0 && n <= 0x10FFFF {
+                    if (0..=0x10FFFF).contains(&n) {
                         char::from_u32(n as u32)
                     } else {
                         None
@@ -33,7 +33,7 @@ pub(crate) fn value_as_string(val: &Value) -> Option<String> {
             ValueData::Vector(children)
             | ValueData::Record {
                 pairs: children, ..
-            } => children.iter().flat_map(|c| collect_chars(c)).collect(),
+            } => children.iter().flat_map(collect_chars).collect(),
             ValueData::Tensor { data, .. } => data
                 .iter()
                 .filter_map(|f| {

--- a/rust/src/interpreter/vector_ops/structure.rs
+++ b/rust/src/interpreter/vector_ops/structure.rs
@@ -72,7 +72,7 @@ fn parse_range_args(args_val: &Value) -> Result<(i64, i64, i64)> {
     }
 
     let n = args_val.len();
-    if n < 2 || n > 3 {
+    if !(2..=3).contains(&n) {
         return Err(AjisaiError::from(
             "RANGE requires [start end] or [start end step]",
         ));

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -380,10 +380,6 @@ fn parse_token_from_string_literal(chars: &[char]) -> QuoteParseResult {
     QuoteParseResult::Unclosed
 }
 
-fn is_delimiter(c: char) -> bool {
-    c.is_whitespace() || is_special_char(c)
-}
-
 fn is_string_close_delimiter(c: char) -> bool {
     c.is_whitespace() || (is_special_char(c) && c != '\'')
 }

--- a/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
@@ -14,25 +14,18 @@ pub(crate) struct UserWordData {
     pub(crate) description: Option<String>,
 }
 
-pub(crate) fn bracket_chars_for_depth(depth: usize) -> (char, char) {
-    let _ = depth;
-    ('[', ']')
-}
-
+#[cfg(test)]
 pub(crate) fn build_bracket_structure_from_shape(shape: &[usize]) -> String {
-    fn build_level(shape: &[usize], depth: usize) -> String {
-        let (open, close) = bracket_chars_for_depth(depth);
+    fn build_level(shape: &[usize]) -> String {
         if shape.len() == 1 {
-            let empty = format!("{} {}", open, close);
-            (0..shape[0])
-                .map(|_| empty.as_str())
+            let empty = "[ ]";
+            std::iter::repeat_n(empty, shape[0])
                 .collect::<Vec<_>>()
                 .join(" ")
         } else {
-            let inner = build_level(&shape[1..], depth + 1);
-            let one_element = format!("{} {} {}", open, inner, close);
-            (0..shape[0])
-                .map(|_| one_element.as_str())
+            let inner = build_level(&shape[1..]);
+            let one_element = format!("[ {} ]", inner);
+            std::iter::repeat_n(one_element.as_str(), shape[0])
                 .collect::<Vec<_>>()
                 .join(" ")
         }
@@ -40,11 +33,7 @@ pub(crate) fn build_bracket_structure_from_shape(shape: &[usize]) -> String {
     if shape.is_empty() {
         return "[ ]".to_string();
     }
-    build_level(shape, 0)
-}
-
-pub(crate) fn is_vector_value(val: &Value) -> bool {
-    val.is_vector()
+    build_level(shape)
 }
 
 fn fraction_display_source_from_js(num_obj: &js_sys::Object) -> Option<String> {


### PR DESCRIPTION
## Summary

First pass of the interpreter quality-improvement effort. This batch applies safe, idiomatic refactors and removes dead code across the `interpreter/` files, with no behavior change.

- Replace manual codepoint-range checks (`n >= 0 && n <= 0x10FFFF`) with `RangeInclusive::contains`, and adopt `is_multiple_of` / `div_ceil` / `to_vec` where clippy flagged manual reimplementations.
- Drop redundant closures in favor of direct function references; remove an unneeded `return`.
- Remove unused `pub(crate)` re-exports in `higher_order/mod.rs`, a dead `is_delimiter` tokenizer helper, and a dead duplicate `is_vector_value` in the wasm bindings.
- Gate test-only helpers (`format_value_to_string_repr`, `build_bracket_structure_from_shape`) behind `#[cfg(test)]` so they no longer trip dead-code warnings in release builds.

Lib clippy warnings dropped from 90 to 68; build warnings from 17 to 9 (remaining 9 are unwired infrastructure left intact).

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — all 1012 tests pass
- [x] `cargo clippy` re-run to confirm no new warnings

https://claude.ai/code/session_018eJbPmdrMSCRVTG6e5qykN

---
_Generated by [Claude Code](https://claude.ai/code/session_018eJbPmdrMSCRVTG6e5qykN)_