### PR TITLE
Fix HTML semantics in static and dynamic markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 <body data-active-area="input">
     <a href="#code-input" class="skip-link">Skip to main content</a>
     <div class="container">
-        <header role="banner">
+        <header>
             <div class="app-header-top">
                 <div class="app-brand-meta">
                     <a href="https://masamoto1982.github.io/Ajisai/" class="app-brand-block" aria-label="Ajisai">
@@ -34,7 +34,7 @@
                 </div>
             </div>
             <div class="header-actions">
-                <a href="docs/index.html" class="btn-secondary" target="_blank">
+                <a href="docs/index.html" class="btn-secondary" target="_blank" rel="noopener noreferrer">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                         <path d="M9 9h6v6M15 9l-6 6M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z"/>
                     </svg>
@@ -82,12 +82,12 @@
                         <option value="output">Output</option>
                     </select>
                 </div>
-                <section id="output-panel" class="output-area" role="region" aria-label="Output" tabindex="0" hidden>
+                <section id="output-panel" class="output-area" aria-label="Output" tabindex="0" hidden>
                     <h2 class="visually-hidden">Output</h2>
                     <div id="output-display" class="display-area" aria-live="polite" aria-atomic="false"></div>
                     <button id="copy-output-btn" class="btn-primary" type="button" aria-label="Copy output to clipboard">Copy</button>
                 </section>
-                <section id="input-panel" class="input-area" role="region" aria-label="Input" tabindex="0">
+                <section id="input-panel" class="input-area" aria-label="Input" tabindex="0">
                     <h2 class="visually-hidden">Input</h2>
                     <textarea id="code-input" aria-label="Ajisai code input" placeholder="Enter code here"></textarea>
                     <button id="clear-btn" type="button" class="inline-clear-btn" aria-label="Clear input">&times;</button>
@@ -108,12 +108,12 @@
                         <button id="dictionary-search-clear-btn" type="button" class="inline-clear-btn vocabulary-search-clear-btn" aria-label="Clear search">&times;</button>
                     </div>
                 </div>
-                <section id="stack-panel" class="stack-area" role="region" aria-label="Stack" tabindex="0">
+                <section id="stack-panel" class="stack-area" aria-label="Stack" tabindex="0">
                     <h2 class="visually-hidden">Stack</h2>
                     <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
                 </section>
 
-                <section id="dictionary-panel" class="dictionary-area" role="region" aria-label="Dictionary" tabindex="0" hidden>
+                <section id="dictionary-panel" class="dictionary-area" aria-label="Dictionary" tabindex="0" hidden>
                     <h2 class="visually-hidden">Dictionary</h2>
                     <label for="dictionary-sheet-select" class="visually-hidden">Select dictionary</label>
                     <select id="dictionary-sheet-select" class="dictionary-sheet-select">

--- a/src/entry/entry-common.ts
+++ b/src/entry/entry-common.ts
@@ -53,11 +53,12 @@ export async function initializeApplication(): Promise<void> {
         console.error('[Main] Application startup failed:', error);
         const outputDisplay = document.getElementById('output-display');
         if (outputDisplay) {
-            outputDisplay.innerHTML = `
-                <span style="color: #dc3545; font-weight: bold;">
-                    Application startup failed: ${(error as Error).message}
-                </span>
-            `;
+            outputDisplay.innerHTML = '';
+            const errorSpan = document.createElement('span');
+            errorSpan.style.color = '#dc3545';
+            errorSpan.style.fontWeight = 'bold';
+            errorSpan.textContent = `Application startup failed: ${(error as Error).message}`;
+            outputDisplay.appendChild(errorSpan);
         }
     }
 }

--- a/src/gui/dictionary-element-builders.ts
+++ b/src/gui/dictionary-element-builders.ts
@@ -88,6 +88,7 @@ export const createWordButtonElement = (
     onContextMenu?: (event: MouseEvent) => void
 ): HTMLButtonElement => {
     const button = document.createElement('button');
+    button.type = 'button';
     button.textContent = text;
     button.className = className;
     button.title = title;


### PR DESCRIPTION
## Summary

HTML semantics review and fixes for both `index.html` and dynamically generated DOM.

### `index.html`
- Removed redundant ARIA roles: `role="banner"` on `<header>` and `role="region"` on the four `<section>` panels — these are already implied by the native elements (and the sections carry an `aria-label`).
- Added `rel="noopener noreferrer"` to the external Reference link (`target="_blank"`), consistent with the footer link.

### Dynamically generated HTML
- `entry-common.ts`: the startup-error message was interpolated into `innerHTML`. Rebuilt it with `document.createElement` + `textContent` to avoid markup breakage / injection from error message content.
- `dictionary-element-builders.ts`: `createWordButtonElement` created `<button>` without a `type`, defaulting to `submit`. Added `type="button"` for consistency with other dynamically created buttons.

## Notes / not changed
- The skip link still targets the `#code-input` textarea (works; conventionally a landmark is preferred).
- Sections retain both `aria-label` and a `visually-hidden <h2>` — consolidating via `aria-labelledby` was noted but left as-is.
- The editor suggestions panel could be enhanced with `role="listbox"`/`role="option"` + `aria-activedescendant`; flagged as a possible follow-up.

## Test plan
- [ ] `npm run check` (pre-existing vitest module errors are unrelated to these changes)
- [ ] Verify header, panels, and Reference link render and behave unchanged
- [ ] Confirm dictionary word buttons and startup-error display still work

https://claude.ai/code/session_012ptMFQmNzi5asaDYakGGNs

---
_Generated by [Claude Code](https://claude.ai/code/session_012ptMFQmNzi5asaDYakGGNs)_