### PR TITLE
Add accent color to text editor top-right corner

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -206,10 +206,31 @@
 #clear-btn {
     top: 0.5rem;
     right: 0.5rem;
+    z-index: 2;
+    color: var(--code-text);
 }
 
 #code-input:placeholder-shown ~ #clear-btn {
     display: none;
+}
+
+#input-panel::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 4.5rem;
+    height: 4.5rem;
+    pointer-events: none;
+    z-index: 1;
+    background: radial-gradient(circle at top right in oklch,
+        var(--editor-accent) 0%,
+        var(--editor-accent-fade) 70%);
+    transition: opacity 0.15s ease;
+}
+
+#input-panel:has(#code-input:placeholder-shown)::after {
+    opacity: 0;
 }
 
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -52,6 +52,10 @@
     --code-inline-bg: rgba(107, 91, 149, 0.1);
 
 
+    --editor-accent: oklch(0.58 0.11 300);
+    --editor-accent-fade: oklch(0.58 0.11 300 / 0);
+
+
     --color-core: #E65100;
     --color-dependency: #E69500;
     --color-non-dependency: #009B68;


### PR DESCRIPTION
## 概要

ヘッダー/フッターの赤紫の差し色がタイトル・ボタン・著作権表示を視覚的に浮き立たせている発想を、テキストエディタにも応用しました。

- テキストエディタ(`#input-panel`)の右上角に、放射状グラデーションの差し色を追加
- これにより、入力内容を消去する `×`(Clear)ボタンの視認性を向上
- 差し色はエディタ背景色(`--code-bg: #393544`)を基に、明度・彩度を高めた `oklch(0.58 0.11 300)` を使用
- グラデーションはヘッダー/フッターと同じく oklch 補間を採用し、濁りのない色変化に。フェード先も同一色相の透明値を指定して黒へのにじみを回避
- エディタが空のとき(プレースホルダ表示=`×`ボタン非表示時)は差し色も連動して消える

## 変更ファイル

- `src/styles/tokens.css`: 差し色トークン `--editor-accent` / `--editor-accent-fade` を追加
- `src/styles/components.css`: `#input-panel::after` で角の差し色を描画、`#clear-btn` を前面に配置

## テスト

- [ ] エディタにコードを入力し、右上角に差し色と `×` ボタンが表示されることを確認
- [ ] エディタを空にすると差し色と `×` ボタンが消えることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_