### PR TITLE
Use 45-degree diagonal accent in text editor corner

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -217,20 +217,13 @@
 #input-panel::after {
     content: "";
     position: absolute;
-    top: 0;
-    right: 0;
-    width: 4.5rem;
-    height: 4.5rem;
+    inset: 0;
     pointer-events: none;
     z-index: 1;
-    background: radial-gradient(circle at top right in oklch,
+    background: linear-gradient(225deg in oklch,
         var(--editor-accent) 0%,
-        var(--editor-accent-fade) 70%);
-    transition: opacity 0.15s ease;
-}
-
-#input-panel:has(#code-input:placeholder-shown)::after {
-    opacity: 0;
+        var(--editor-accent) 22%,
+        var(--editor-accent-fade) 32%);
 }
 
 


### PR DESCRIPTION
## 概要

前回マージ済みの差し色(放射状グラデーション)が円状になっていたため、斜め45度の直線グラデーションに変更しました。

- `radial-gradient` を `linear-gradient(225deg ...)` に変更し、右上角から斜め45度の直線で差し色を区切る形に
- 差し色がテキストエディタの約30%を覆うようグラデーション停止位置を調整(22%〜32%でフェード)
- 差し色は常時表示(空のときに消す連動を削除)
- oklch補間・同一色相の透明フェードはそのまま維持し、濁りのない色変化を継続

## 変更ファイル

- `src/styles/components.css`: `#input-panel::after` のグラデーションを45度直線に変更

## テスト

- [ ] テキストエディタ右上に斜め45度の差し色が常時表示されることを確認
- [ ] `×`(Clear)ボタンが差し色の上に重なって視認できることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_