### PR TITLE
Use header red/blue purple for text editor accent gradient

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -220,10 +220,11 @@
     inset: 0;
     pointer-events: none;
     z-index: 1;
+    opacity: 0.4;
     background: linear-gradient(225deg in oklch,
-        var(--editor-accent) 0%,
-        var(--editor-accent) 22%,
-        var(--editor-accent-fade) 32%);
+        var(--editor-accent-red) 0%,
+        40%,
+        var(--editor-accent-blue) 100%);
 }
 
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -52,8 +52,8 @@
     --code-inline-bg: rgba(107, 91, 149, 0.1);
 
 
-    --editor-accent: oklch(0.58 0.11 300);
-    --editor-accent-fade: oklch(0.58 0.11 300 / 0);
+    --editor-accent-red: var(--gradient-purple-red);
+    --editor-accent-blue: var(--gradient-purple-blue);
 
 
     --color-core: #E65100;


### PR DESCRIPTION
## 概要

テキストエディタの差し色を、ヘッダー/フッターで使われている赤紫(`--gradient-purple-red`)と青紫(`--gradient-purple-blue`)に変更しました。

- エディタ全面に対角グラデーション(225度方向)を適用
- 右上角=赤紫、左下角=青紫
- グラデーション補間ヒントを40%に置き、赤紫4:青紫6の比率に調整
- コードテキストの視認性を保つため `opacity: 0.4` の半透明オーバーレイに
- oklch補間を維持し、ヘッダー/フッターと同様に濁りのない色変化

## 変更ファイル

- `src/styles/tokens.css`: アクセントトークンをヘッダー配色(`--editor-accent-red` / `--editor-accent-blue`)に変更
- `src/styles/components.css`: `#input-panel::after` を二色の対角グラデーションに変更

## テスト

- [ ] エディタ右上が赤紫、左下が青紫の対角グラデーションになっていることを確認
- [ ] コードテキストがオーバーレイ越しに読めることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_