### PR TITLE
Fix darkened accent gradient and apply to dictionary search box

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -214,13 +214,14 @@
     display: none;
 }
 
-#input-panel::after {
+#input-panel::after,
+.search-wrapper::after {
     content: "";
     position: absolute;
     inset: 0;
     pointer-events: none;
+    mix-blend-mode: lighten;
     z-index: 1;
-    opacity: 0.4;
     background: linear-gradient(225deg in oklch,
         var(--editor-accent-red) 0%,
         40%,
@@ -381,6 +382,8 @@
     right: 0.25rem;
     top: 50%;
     transform: translateY(-50%);
+    z-index: 2;
+    color: var(--code-text);
 }
 
 .vocabulary-search-input:placeholder-shown ~ .vocabulary-search-clear-btn {


### PR DESCRIPTION
## 概要

差し色がヘッダー/フッターの赤紫・青紫より黒ずんで見える問題を修正し、同じグラデーションをDictionaryエリアの検索窓にも適用しました。

### 黒ずみの原因と修正

半透明オーバーレイ(`opacity: 0.4`)は、暗いエディタ背景色 `--code-bg`(`#393544`)の上でアルファ合成されるため、両方の紫が黒方向に引っ張られていました。

`mix-blend-mode: lighten` をフル強度で使用するよう変更:
- 暗い背景の上ではヘッダー/フッターと同一の赤紫・青紫の純色が表示される
- 明るいコードテキストはそのまま残り、視認性を維持

### 検索窓への適用

Dictionaryエリアのワード絞り込み検索窓(`.search-wrapper` / `.vocabulary-search-input`)にも同じ対角グラデーションを適用。`×` クリアボタンを前面に配置。

## 変更ファイル

- `src/styles/components.css`: `#input-panel::after` と `.search-wrapper::after` を共通化し `mix-blend-mode: lighten` に変更。`.vocabulary-search-clear-btn` を前面に配置

## テスト

- [ ] エディタの赤紫・青紫がヘッダー/フッターと同じ鮮やかさで表示されることを確認
- [ ] Dictionary検索窓にも対角グラデーションが適用されることを確認
- [ ] エディタ・検索窓ともにテキストが読めることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_