### PR TITLE
Use header red-purple for editor and search placeholders

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -176,7 +176,7 @@
 }
 
 #code-input::placeholder {
-    color: var(--code-comment);
+    color: var(--gradient-purple-red);
 }
 
 
@@ -375,7 +375,7 @@
 }
 
 .vocabulary-search-input::placeholder {
-    color: var(--code-comment);
+    color: var(--gradient-purple-red);
 }
 
 .vocabulary-search-clear-btn {


### PR DESCRIPTION
## 概要

テキストエディタおよびDictionary検索窓のプレースホルダー文字色を、ヘッダー/フッターの背景に使われている赤紫(`--gradient-purple-red`)に変更しました。

- 従来の `--code-comment` は背景色との相性が良くなかったため変更
- 可読性は高くないが、プレースホルダーは存在感が希薄な方が望ましいという意図に沿った配色

## 変更ファイル

- `src/styles/components.css`: `#code-input::placeholder` と `.vocabulary-search-input::placeholder` の色を `--gradient-purple-red` に変更

## テスト

- [ ] エディタ・検索窓のプレースホルダーが赤紫で表示されることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_