### PR TITLE
Use header blue-purple for editor and search placeholders

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -176,7 +176,7 @@
 }
 
 #code-input::placeholder {
-    color: var(--gradient-purple-red);
+    color: var(--gradient-purple-blue);
 }
 
 
@@ -375,7 +375,7 @@
 }
 
 .vocabulary-search-input::placeholder {
-    color: var(--gradient-purple-red);
+    color: var(--gradient-purple-blue);
 }
 
 .vocabulary-search-clear-btn {


### PR DESCRIPTION
## 概要

プレースホルダー文字色を赤紫から青紫(`--gradient-purple-blue`)に変更しました。赤紫では可読性が低すぎたため、青紫で可読性を改善します。

## 変更ファイル

- `src/styles/components.css`: `#code-input::placeholder` と `.vocabulary-search-input::placeholder` の色を `--gradient-purple-blue` に変更

## テスト

- [ ] エディタ・検索窓のプレースホルダーが青紫で表示されることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_