### PR TITLE
Use white for editor and search placeholders

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -176,7 +176,7 @@
 }
 
 #code-input::placeholder {
-    color: var(--gradient-purple-blue);
+    color: #ffffff;
 }
 
 
@@ -375,7 +375,7 @@
 }
 
 .vocabulary-search-input::placeholder {
-    color: var(--gradient-purple-blue);
+    color: #ffffff;
 }
 
 .vocabulary-search-clear-btn {


### PR DESCRIPTION
## 概要

青紫のプレースホルダーは背景にほぼ埋もれて見えなかったため、一旦プレースホルダー文字色を白に変更しました。

## 変更ファイル

- `src/styles/components.css`: `#code-input::placeholder` と `.vocabulary-search-input::placeholder` の色を白(`#ffffff`)に変更

## テスト

- [ ] エディタ・検索窓のプレースホルダーが白で表示されることを確認

https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNQqPrZnZyMszxdP7NRkMx)_