### PR TITLE
Unify word-button and dictionary-picker right-click affordances

### DIFF
--- a/src/gui/dictionary-element-builders.ts
+++ b/src/gui/dictionary-element-builders.ts
@@ -78,6 +78,11 @@ export const registerBackgroundClickListeners = (
     }
 };
 
+export interface WordButtonRemoveOption {
+    readonly label: string;
+    readonly onClick: () => void;
+}
+
 export const createWordButtonElement = (
     text: string,
     title: string,
@@ -85,8 +90,8 @@ export const createWordButtonElement = (
     onClick: () => void,
     onHover?: () => void,
     onLeave?: () => void,
-    onContextMenu?: (event: MouseEvent) => void
-): HTMLButtonElement => {
+    onRemove?: WordButtonRemoveOption
+): HTMLElement => {
     const button = document.createElement('button');
     button.type = 'button';
     button.textContent = text;
@@ -96,12 +101,26 @@ export const createWordButtonElement = (
 
     if (onHover) button.addEventListener('mouseenter', onHover);
     if (onLeave) button.addEventListener('mouseleave', onLeave);
-    if (onContextMenu) {
-        button.addEventListener('contextmenu', (e) => {
-            e.preventDefault();
-            onContextMenu(e);
-        });
-    }
 
-    return button;
+    if (!onRemove) return button;
+
+    const wrapper = document.createElement('span');
+    wrapper.className = 'word-button-cell';
+    wrapper.appendChild(button);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'word-button-remove';
+    removeBtn.textContent = '−';
+    removeBtn.setAttribute('aria-label', onRemove.label);
+    removeBtn.title = onRemove.label;
+    if (onHover) removeBtn.addEventListener('mouseenter', onHover);
+    if (onLeave) removeBtn.addEventListener('mouseleave', onLeave);
+    removeBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        onRemove.onClick();
+    });
+    wrapper.appendChild(removeBtn);
+
+    return wrapper;
 };

--- a/src/gui/dictionary-sheet-picker.ts
+++ b/src/gui/dictionary-sheet-picker.ts
@@ -1,8 +1,3 @@
-type ContextMenuAction = {
-    readonly label: string;
-    readonly onClick: () => void;
-};
-
 export interface DictionarySheetPickerOptions {
     readonly selectEl: HTMLSelectElement;
     readonly onSelectSheet: (sheetId: string) => void;
@@ -15,60 +10,14 @@ export interface DictionarySheetPicker {
     readonly syncSelection: () => void;
 }
 
-const createContextMenuElement = (): HTMLDivElement => {
-    const menu = document.createElement('div');
-    menu.hidden = true;
-    menu.className = 'context-menu module-context-menu dictionary-picker-context-menu';
-    document.body.appendChild(menu);
-    return menu;
-};
+type ModuleAffordance = 'import' | 'unimport' | null;
 
-const renderContextMenu = (
-    menu: HTMLDivElement,
-    event: MouseEvent,
-    actions: readonly ContextMenuAction[]
-): void => {
-    menu.innerHTML = '';
-    for (const action of actions) {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.textContent = action.label;
-        button.addEventListener('click', (clickEvent) => {
-            clickEvent.stopPropagation();
-            menu.hidden = true;
-            action.onClick();
-        });
-        menu.appendChild(button);
+const moduleAffordanceForOption = (option: HTMLOptionElement): ModuleAffordance => {
+    switch (option.dataset.moduleState) {
+        case 'available': return 'import';
+        case 'imported': return 'unimport';
+        default: return null;
     }
-    menu.hidden = false;
-    menu.style.left = `${event.clientX}px`;
-    menu.style.top = `${event.clientY}px`;
-};
-
-const moduleActionsForOption = (
-    option: HTMLOptionElement,
-    onImportModule: (moduleName: string) => void,
-    onUnimportModule: (moduleName: string) => void
-): readonly ContextMenuAction[] => {
-    const moduleName = option.dataset.moduleName;
-    const moduleState = option.dataset.moduleState;
-    if (!moduleName || !moduleState) return [];
-
-    if (moduleState === 'available') {
-        return [{
-            label: `Import this module (${moduleName})`,
-            onClick: () => onImportModule(moduleName),
-        }];
-    }
-
-    if (moduleState === 'imported') {
-        return [{
-            label: `Unimport this module (${moduleName})`,
-            onClick: () => onUnimportModule(moduleName),
-        }];
-    }
-
-    return [];
 };
 
 export const createDictionarySheetPicker = (
@@ -93,8 +42,6 @@ export const createDictionarySheetPicker = (
     list.setAttribute('role', 'listbox');
     wrapper.appendChild(list);
 
-    const contextMenu = createContextMenuElement();
-
     selectEl.classList.add('dictionary-sheet-native-select');
     selectEl.after(wrapper);
 
@@ -116,10 +63,6 @@ export const createDictionarySheetPicker = (
         }
     };
 
-    const hideContextMenu = (): void => {
-        contextMenu.hidden = true;
-    };
-
     const syncSelection = (): void => {
         const selected = selectEl.selectedOptions[0] ?? selectEl.options[0];
         const label = selected?.textContent?.trim() || 'Select dictionary';
@@ -128,7 +71,7 @@ export const createDictionarySheetPicker = (
         trigger.dataset.moduleState = state;
         trigger.title = selected?.title || label;
 
-        for (const item of list.querySelectorAll<HTMLButtonElement>('.dictionary-sheet-picker-item')) {
+        for (const item of list.querySelectorAll<HTMLElement>('.dictionary-sheet-picker-item')) {
             const isSelected = item.dataset.sheetId === selectEl.value;
             item.classList.toggle('is-selected', isSelected);
             item.setAttribute('aria-selected', isSelected ? 'true' : 'false');
@@ -146,27 +89,47 @@ export const createDictionarySheetPicker = (
         syncSelection();
     };
 
-    const openModuleContextMenu = (event: MouseEvent, option: HTMLOptionElement | undefined): void => {
-        if (!option) return;
-        const actions = moduleActionsForOption(option, onImportModule, onUnimportModule);
-        if (actions.length === 0) return;
-        event.preventDefault();
-        event.stopPropagation();
-        hideList();
-        renderContextMenu(contextMenu, event, actions);
+    const buildActionButton = (
+        moduleName: string,
+        affordance: Exclude<ModuleAffordance, null>
+    ): HTMLButtonElement => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        const isImport = affordance === 'import';
+        button.textContent = isImport ? '+' : '−';
+        button.className = `dictionary-sheet-picker-item-action ${isImport ? 'is-import' : 'is-unimport'}`;
+        const label = isImport
+            ? `Import this module (${moduleName})`
+            : `Unimport this module (${moduleName})`;
+        button.setAttribute('aria-label', label);
+        button.title = label;
+        button.addEventListener('click', (event) => {
+            event.stopPropagation();
+            hideList();
+            if (isImport) {
+                onImportModule(moduleName);
+            } else {
+                onUnimportModule(moduleName);
+            }
+        });
+        return button;
     };
 
     const refresh = (): void => {
         list.innerHTML = '';
         for (const option of Array.from(selectEl.options)) {
-            const item = document.createElement('button');
-            item.type = 'button';
+            const item = document.createElement('div');
             item.className = 'dictionary-sheet-picker-item';
             item.dataset.sheetId = option.value;
             item.dataset.moduleState = option.dataset.moduleState ?? 'base';
-            item.textContent = option.textContent;
             item.title = option.title || option.textContent || '';
             item.setAttribute('role', 'option');
+            item.tabIndex = 0;
+
+            const label = document.createElement('span');
+            label.className = 'dictionary-sheet-picker-item-label';
+            label.textContent = option.textContent;
+            item.appendChild(label);
 
             const state = option.dataset.moduleState;
             if (state === 'available') {
@@ -177,11 +140,23 @@ export const createDictionarySheetPicker = (
                 item.classList.add('is-base');
             }
 
-            item.addEventListener('click', () => {
+            const affordance = moduleAffordanceForOption(option);
+            const moduleName = option.dataset.moduleName;
+            if (affordance && moduleName) {
+                item.appendChild(buildActionButton(moduleName, affordance));
+            }
+
+            const activate = (): void => {
                 selectSheet(option.value);
                 hideList();
+            };
+            item.addEventListener('click', activate);
+            item.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    activate();
+                }
             });
-            item.addEventListener('contextmenu', (event) => openModuleContextMenu(event, option));
             list.appendChild(item);
         }
         syncSelection();
@@ -189,13 +164,7 @@ export const createDictionarySheetPicker = (
 
     trigger.addEventListener('click', (event) => {
         event.stopPropagation();
-        hideContextMenu();
         toggleList();
-    });
-
-    trigger.addEventListener('contextmenu', (event) => {
-        const selected = selectEl.selectedOptions[0];
-        openModuleContextMenu(event, selected);
     });
 
     selectEl.addEventListener('change', () => {
@@ -204,11 +173,9 @@ export const createDictionarySheetPicker = (
 
     document.addEventListener('click', (event) => {
         if (!wrapper.contains(event.target as Node)) hideList();
-        hideContextMenu();
     });
     window.addEventListener('blur', () => {
         hideList();
-        hideContextMenu();
     });
 
     refresh();

--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -49,43 +49,6 @@ export interface ModuleActionConfig {
 }
 
 
-type ContextMenuAction = {
-    readonly label: string;
-    readonly onClick: () => void;
-    readonly disabled?: boolean;
-};
-
-const createContextMenuElement = (): HTMLDivElement => {
-    const menu = document.createElement('div');
-    menu.hidden = true;
-    menu.className = 'context-menu module-context-menu';
-    document.body.appendChild(menu);
-    return menu;
-};
-
-const renderContextMenu = (
-    menu: HTMLDivElement,
-    event: MouseEvent,
-    actions: readonly ContextMenuAction[]
-): void => {
-    menu.innerHTML = '';
-    for (const action of actions) {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.textContent = action.label;
-        button.disabled = Boolean(action.disabled);
-        button.addEventListener('click', (clickEvent) => {
-            clickEvent.stopPropagation();
-            menu.hidden = true;
-            if (!action.disabled) action.onClick();
-        });
-        menu.appendChild(button);
-    }
-    menu.hidden = false;
-    menu.style.left = `${event.clientX}px`;
-    menu.style.top = `${event.clientY}px`;
-};
-
 const quoteAjisaiString = (value: string): string => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
 export interface ModuleTabManagerOptions {
@@ -118,15 +81,7 @@ export const createModuleTabManager = (
 
     const sheets: ModuleSheet[] = [];
     let searchFilter = '';
-    const contextMenu = createContextMenuElement();
     let dictionarySheetPicker: DictionarySheetPicker | null = null;
-
-    const hideContextMenu = (): void => {
-        contextMenu.hidden = true;
-    };
-
-    document.addEventListener('click', hideContextMenu);
-    window.addEventListener('blur', hideContextMenu);
 
     const runModuleMutationCode = async (
         code: string,
@@ -199,10 +154,10 @@ export const createModuleTabManager = (
         option.dataset.moduleState = state;
         if (state === 'available') {
             option.className = 'module-option available-module-option';
-            option.title = `${moduleName} is available. Right-click this entry to import.`;
+            option.title = `${moduleName} is available. Use the + button in the dictionary picker to import.`;
         } else {
             option.className = 'module-option imported-module-option';
-            option.title = `${moduleName} is imported. Right-click this entry to unimport.`;
+            option.title = `${moduleName} is imported. Use the − button in the dictionary picker to unimport.`;
         }
         return option;
     };
@@ -213,7 +168,7 @@ export const createModuleTabManager = (
         sheet.id = `dictionary-sheet-${sheetId}`;
         sheet.hidden = true;
         sheet.appendChild(createEmptyWordsElement(
-            `${moduleName} is available but not imported. Right-click the ${moduleName} entry in the dictionary picker to import it.`
+            `${moduleName} is available but not imported. Use the + button beside the ${moduleName} entry in the dictionary picker to import it.`
         ));
         return sheet;
     };
@@ -233,14 +188,6 @@ export const createModuleTabManager = (
         wordsDisplay.className = 'words-display module-words-display';
         sheet.appendChild(wordsDisplay);
         registerBackgroundClickListeners(wordsDisplay, onBackgroundClick, onBackgroundDoubleClick);
-        wordsDisplay.addEventListener('contextmenu', (event) => {
-            if ((event.target as HTMLElement).closest('.word-button')) return;
-            event.preventDefault();
-            renderContextMenu(contextMenu, event, [{
-                label: `Unimport this module (${moduleName})`,
-                onClick: () => unimportModule(moduleName),
-            }]);
-        });
 
         const actions = options.moduleActions?.[moduleName];
         if (actions) {
@@ -293,8 +240,8 @@ export const createModuleTabManager = (
                 const name = wordData[0];
                 const shortName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
                 const description = wordData[1] || name;
-                const moduleTitle = `${shortName}\nBuilt-in word from module ${moduleSheet.moduleName}.\nRight-click to unimport this word.`;
-                const moduleInfo = `${description}\n\nBuilt-in word from module ${moduleSheet.moduleName}.\nRight-click to unimport this word.`;
+                const moduleTitle = `${shortName}\nBuilt-in word from module ${moduleSheet.moduleName}.\nClick − to unimport this word.`;
+                const moduleInfo = `${description}\n\nBuilt-in word from module ${moduleSheet.moduleName}.\nClick − to unimport this word.`;
                 const button = createWordButtonElement(
                     shortName,
                     moduleTitle,
@@ -302,13 +249,10 @@ export const createModuleTabManager = (
                     () => onWordClick(shortName),
                     () => { renderWordInfo(wordInfo as HTMLElement, moduleInfo); },
                     () => { resetWordInfoDisplay(wordInfo as HTMLElement); },
-                    (event) => renderContextMenu(contextMenu, event, [{
+                    {
                         label: `Unimport ${moduleSheet.moduleName}@${shortName}`,
                         onClick: () => unimportModuleWord(moduleSheet.moduleName, shortName),
-                    }, {
-                        label: `Unimport this module (${moduleSheet.moduleName})`,
-                        onClick: () => unimportModule(moduleSheet.moduleName),
-                    }])
+                    }
                 );
 
                 fragment.appendChild(button);

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -91,88 +91,11 @@ const isCanonicalCoreWordName = (name: string): boolean => /^[A-Z][A-Z0-9-]*$/.t
 
 const DEPENDENCY_DELETE_ERROR = 'Cannot delete';
 
-const createDeleteContextMenuElement = (
-    onDelete: () => void
-): HTMLDivElement => {
-    const menu = document.createElement('div');
-    menu.hidden = true;
-    Object.assign(menu.style, {
-        position: 'fixed',
-        zIndex: '1000',
-        minWidth: '7rem',
-        padding: '0.125rem',
-        backgroundColor: '#ffffff',
-        border: '1px solid #c0c0c0',
-        boxShadow: '0 2px 6px rgba(0, 0, 0, 0.15)'
-    } satisfies Partial<CSSStyleDeclaration>);
-
-    const deleteButton = document.createElement('button');
-    deleteButton.type = 'button';
-    deleteButton.textContent = 'Delete';
-    Object.assign(deleteButton.style, {
-        display: 'block',
-        width: '100%',
-        padding: '0.375rem 0.75rem',
-        backgroundColor: 'transparent',
-        color: '#000000',
-        border: 'none',
-        textAlign: 'left',
-        cursor: 'pointer'
-    } satisfies Partial<CSSStyleDeclaration>);
-    deleteButton.addEventListener('mouseenter', () => {
-        deleteButton.style.backgroundColor = '#e8e8e8';
-    });
-    deleteButton.addEventListener('mouseleave', () => {
-        deleteButton.style.backgroundColor = 'transparent';
-    });
-    deleteButton.addEventListener('click', (event) => {
-        event.stopPropagation();
-        onDelete();
-    });
-
-    menu.appendChild(deleteButton);
-    document.body.appendChild(menu);
-
-    return menu;
-};
-
 export const createVocabularyManager = (
     elements: VocabularyElements,
     callbacks: VocabularyCallbacks
 ): VocabularyManager => {
     const { onWordClick, onBackgroundClick, onBackgroundDoubleClick, onUpdateDisplays, onSaveState, showInfo } = callbacks;
-    const deleteContextMenu = createDeleteContextMenuElement(() => {
-        if (!activeContextWordName) {
-            return;
-        }
-
-        const selectedWordName = activeContextWordName;
-        hideDeleteContextMenu();
-        void confirmAndDeleteWord(selectedWordName);
-    });
-    let activeContextWordName: string | null = null;
-
-    const hideDeleteContextMenu = (): void => {
-        deleteContextMenu.hidden = true;
-        activeContextWordName = null;
-    };
-
-    const renderDeleteContextMenu = (event: MouseEvent, wordName: string): void => {
-        activeContextWordName = wordName;
-        deleteContextMenu.hidden = false;
-        deleteContextMenu.style.left = `${event.clientX}px`;
-        deleteContextMenu.style.top = `${event.clientY}px`;
-    };
-
-    document.addEventListener('click', () => {
-        hideDeleteContextMenu();
-    });
-    document.addEventListener('contextmenu', (event) => {
-        if (!(event.target instanceof HTMLElement) || !event.target.closest('.word-button')) {
-            hideDeleteContextMenu();
-        }
-    });
-    window.addEventListener('blur', hideDeleteContextMenu);
 
     [elements.builtInWordsDisplay, elements.userWordsDisplay].forEach(container => {
         registerBackgroundClickListeners(container, onBackgroundClick, onBackgroundDoubleClick);
@@ -325,7 +248,10 @@ export const createVocabularyManager = (
                     );
                 },
                 () => { resetWordInfoDisplay(elements.userWordInfo); },
-                (event) => renderDeleteContextMenu(event, `${wordInfo.dictionary}@${wordInfo.name}`)
+                {
+                    label: `Delete ${wordInfo.name}`,
+                    onClick: () => { void confirmAndDeleteWord(`${wordInfo.dictionary}@${wordInfo.name}`); },
+                }
             );
 
             fragment.appendChild(button);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -392,36 +392,6 @@
 
 
 
-.context-menu {
-    position: fixed;
-    z-index: 1000;
-    min-width: 12rem;
-    padding: 0.125rem;
-    background: #fff;
-    border: var(--border-main);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-}
-
-.context-menu button {
-    display: block;
-    width: 100%;
-    padding: 0.375rem 0.75rem;
-    background: transparent;
-    color: var(--color-text);
-    border: none;
-    text-align: left;
-    cursor: pointer;
-}
-
-.context-menu button:hover:not(:disabled) {
-    background: var(--color-light);
-}
-
-.context-menu button:disabled {
-    color: var(--color-text-light);
-    cursor: not-allowed;
-}
-
 .no-results-message {
     width: 100%;
     color: var(--color-text-light);
@@ -612,6 +582,41 @@
 }
 
 
+.word-button-cell {
+    display: inline-flex;
+    align-items: stretch;
+    margin: 2px;
+    vertical-align: middle;
+}
+
+.word-button-cell .word-button {
+    margin: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+}
+
+.word-button-remove {
+    padding: 0.2rem 0.4rem;
+    background: #fff;
+    color: var(--color-text-light, #777);
+    border: var(--border-main);
+    border-left: 1px solid var(--color-medium, #ccc);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    font-family: var(--font-stack-mono);
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.word-button-remove:hover {
+    background: var(--color-light);
+    color: var(--color-dependency, #c0392b);
+}
 
 .stack-item {
     font-family: var(--font-stack-mono);
@@ -868,6 +873,9 @@
 }
 
 .dictionary-sheet-picker-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
     width: 100%;
     padding: 0.35rem 0.5rem;
     border: none;
@@ -888,11 +896,41 @@
     background: var(--gradient-parent, #e4e1ec);
 }
 
-.dictionary-sheet-picker-item.is-available {
+.dictionary-sheet-picker-item.is-available .dictionary-sheet-picker-item-label {
     opacity: 0.58;
 }
 
-.dictionary-sheet-picker-item.is-imported,
-.dictionary-sheet-picker-item.is-base {
-    opacity: 1;
+.dictionary-sheet-picker-item-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dictionary-sheet-picker-item-action {
+    flex: 0 0 auto;
+    min-width: 1.4rem;
+    padding: 0.05rem 0.4rem;
+    border: 1px solid var(--color-border-strong, #999);
+    border-radius: 3px;
+    background: #fff;
+    color: var(--color-text);
+    font-family: var(--font-stack-mono);
+    font-size: 0.9rem;
+    font-weight: 700;
+    line-height: 1.1;
+    cursor: pointer;
+}
+
+.dictionary-sheet-picker-item-action.is-import {
+    color: var(--color-non-dependency, #2c7a4f);
+}
+
+.dictionary-sheet-picker-item-action.is-unimport {
+    color: var(--color-dependency, #c0392b);
+}
+
+.dictionary-sheet-picker-item-action:hover {
+    background: var(--color-light, #f0eef5);
 }


### PR DESCRIPTION
## Summary

- ワードボタンとモジュール辞書セレクタの右クリック挙動の不統一を解消するため、隠された右クリックコンテキストメニューを廃止し、各エントリに「+」「−」の明示的なアフォーダンスを直接添える形に変更しました。
- ワードボタンには末尾に「−」ボタンが付き、ユーザワードでは削除、モジュールワードでは個別アンインポートを行います。
- 辞書ピッカーの各行には available モジュールに「+」、imported モジュールに「−」が付き、ドロップダウン項目選択(=シート切替)と分離されたアクションとして実行できます。
- これにより「セレクタを左クリック → ドロップダウン展開 → 項目を右クリック」という二段操作と、コンテキストメニューがセレクタから離れた位置に現れる問題が解消されます。

## Changes

- `dictionary-element-builders.ts`: `createWordButtonElement` の `onContextMenu` を `onRemove`(label + onClick)に置換。`onRemove` 指定時は word-button と「−」ボタンを横並びにした `.word-button-cell` ラッパを返します。
- `vocabulary-state-controller.ts`: 自前で作っていた delete 用フローティングメニュー、document/window のクリック・コンテキストメニューリスナを撤去。`onRemove` に `confirmAndDeleteWord` を直接渡します。
- `dictionary-sheet-picker.ts`: 各 list item を `<button>` から `<div role="option">` + 子要素(ラベル span + アクション button)に再構成。トリガーおよび項目の `contextmenu` ハンドラと共有コンテキストメニュー要素を削除しました。`+`/`−` 子ボタンが `stopPropagation` でシート選択と独立して動作します。
- `module-selector-sheets.ts`: モジュールワードボタンの右クリックハンドラを `onRemove` に置換、シート背景の右クリックハンドラとコンテキストメニュー基盤を削除。
- `components.css`: `.word-button-cell` / `.word-button-remove` と `.dictionary-sheet-picker-item` の flex 化 + `.dictionary-sheet-picker-item-action` を追加。未使用となった `.context-menu` 系スタイルを削除しました。

## Test plan

- [x] `npm run check`(TS 型検査)に新規エラーが出ないことを確認
- [x] `npm test`(vitest, 29 tests)が全てパス
- [x] dev server を起動し Playwright + Chromium で手動駆動:
  - [x] 辞書ピッカー展開時、`MUSIC`/`JSON`/`IO`/`TIME`/`CRYPTO`/`ALGO`/`MATH` の各行に緑の `+` ボタンが表示される
  - [x] `Core word`/`User word` の base 行にはアフォーダンスが表示されない
  - [x] `+` をクリックして MUSIC をインポートすると state が `available`→`imported` に遷移し、ボタンが `+` から赤系 `−` (is-unimport) に切り替わる
  - [x] User word シートで `GREET`/`SAY-HELLO` 等の各ユーザワードに `−` ボタンが付き、aria-label が `Delete <name>` になる
  - [x] `−` ボタンのクリックは word-button 本体のクリックや背景クリックを発火させない(stopPropagation)

https://claude.ai/code/session_015z5Gki4XnsJfj264dfYQhe

---
_Generated by [Claude Code](https://claude.ai/code/session_015z5Gki4XnsJfj264dfYQhe)_