### PR TITLE
Drop redundant tooltips from +/− affordance buttons

### DIFF
--- a/src/gui/dictionary-element-builders.ts
+++ b/src/gui/dictionary-element-builders.ts
@@ -113,7 +113,6 @@ export const createWordButtonElement = (
     removeBtn.className = 'word-button-remove';
     removeBtn.textContent = '−';
     removeBtn.setAttribute('aria-label', onRemove.label);
-    removeBtn.title = onRemove.label;
     if (onHover) removeBtn.addEventListener('mouseenter', onHover);
     if (onLeave) removeBtn.addEventListener('mouseleave', onLeave);
     removeBtn.addEventListener('click', (e) => {

--- a/src/gui/dictionary-sheet-picker.ts
+++ b/src/gui/dictionary-sheet-picker.ts
@@ -102,7 +102,6 @@ export const createDictionarySheetPicker = (
             ? `Import this module (${moduleName})`
             : `Unimport this module (${moduleName})`;
         button.setAttribute('aria-label', label);
-        button.title = label;
         button.addEventListener('click', (event) => {
             event.stopPropagation();
             hideList();


### PR DESCRIPTION
## Summary

- ピッカー行の `+`/`−` ボタンとワードボタンの `−` 削除ボタンに付けていた `title` 属性(ブラウザのホバーツールチップ)を削除しました。
- 記号自体が動作を示しており説明が冗長なため、ホバーツールチップは不要との指摘を反映。
- スクリーンリーダー向けの `aria-label` は引き続き残し、アクセシビリティは維持します。

## Test plan

- [x] `npm run check` 通過
- [ ] ピッカー展開時に `+`/`−` にホバーしても説明吹き出しが出ないことを実機で確認
- [ ] ユーザワードの `−` にホバーしても "Delete <name>" が表示されないことを確認

https://claude.ai/code/session_015z5Gki4XnsJfj264dfYQhe

---
_Generated by [Claude Code](https://claude.ai/code/session_015z5Gki4XnsJfj264dfYQhe)_