### PR TITLE
Drop remaining selector-side hover tooltips

### DIFF
--- a/src/gui/dictionary-sheet-picker.ts
+++ b/src/gui/dictionary-sheet-picker.ts
@@ -69,7 +69,6 @@ export const createDictionarySheetPicker = (
         const state = selected?.dataset.moduleState ?? 'base';
         trigger.textContent = label;
         trigger.dataset.moduleState = state;
-        trigger.title = selected?.title || label;
 
         for (const item of list.querySelectorAll<HTMLElement>('.dictionary-sheet-picker-item')) {
             const isSelected = item.dataset.sheetId === selectEl.value;
@@ -121,7 +120,6 @@ export const createDictionarySheetPicker = (
             item.className = 'dictionary-sheet-picker-item';
             item.dataset.sheetId = option.value;
             item.dataset.moduleState = option.dataset.moduleState ?? 'base';
-            item.title = option.title || option.textContent || '';
             item.setAttribute('role', 'option');
             item.tabIndex = 0;
 

--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -152,13 +152,9 @@ export const createModuleTabManager = (
         option.textContent = formatDictionaryTabName(moduleName);
         option.dataset.moduleName = moduleName;
         option.dataset.moduleState = state;
-        if (state === 'available') {
-            option.className = 'module-option available-module-option';
-            option.title = `${moduleName} is available. Use the + button in the dictionary picker to import.`;
-        } else {
-            option.className = 'module-option imported-module-option';
-            option.title = `${moduleName} is imported. Use the − button in the dictionary picker to unimport.`;
-        }
+        option.className = state === 'available'
+            ? 'module-option available-module-option'
+            : 'module-option imported-module-option';
         return option;
     };
 


### PR DESCRIPTION
## Summary

- 前回 PR (#938) では `+`/`−` ボタン自身の `title` 属性しか除去できておらず、ピッカーのトリガー・各行・上流の `<option>` に右クリック時代の説明ツールチップが残っていました。
- アフォーダンスがインライン表示される現状ではこれらも冗長なので、`trigger.title` / `item.title` / `option.title` の代入を全て撤去しました。
- ワードボタン本体の `title`(ワードの説明そのもの)はアフォーダンスではなく実用情報なので維持しています。

## Test plan

- [x] `npm run check`
- [x] `npm test` (29 passed)
- [ ] 実機で辞書セレクタのトリガー・ドロップダウン項目にホバーしても説明吹き出しが出ないことを確認

https://claude.ai/code/session_015z5Gki4XnsJfj264dfYQhe

---
_Generated by [Claude Code](https://claude.ai/code/session_015z5Gki4XnsJfj264dfYQhe)_