### PR TITLE
Simplify theme: replace gradients with flat backgrounds and remove decorative effects

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -14,7 +14,7 @@ body {
 
 body {
     font-family: var(--font-stack-primary);
-    background: var(--gradient-background);
+    background: #fff;
     color: var(--color-text);
     line-height: 1.6;
 }
@@ -22,7 +22,6 @@ body {
 a {
     color: var(--color-primary);
     text-decoration: none;
-    transition: color 0.3s;
 }
 
 a:hover {
@@ -34,14 +33,11 @@ a:hover {
     position: absolute;
     top: -40px;
     left: 0;
-    background: var(--color-primary);
+    background: #000;
     color: #fff;
     padding: 8px 16px;
     z-index: 1000;
     text-decoration: none;
-    font-weight: 500;
-    border-radius: 0 0 var(--radius-main) 0;
-    transition: top 0.2s;
 }
 
 .skip-link:focus {
@@ -72,7 +68,6 @@ textarea:focus-visible,
 select:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 
@@ -84,7 +79,7 @@ select:focus-visible {
 
 
 header {
-    background: linear-gradient(in oklch to right, var(--gradient-purple-red) 0%, var(--gradient-purple-blue) 50%, var(--gradient-purple-red) 100%);
+    background: #fff;
     padding: 1rem 2rem;
     display: flex;
     flex-direction: column;
@@ -165,35 +160,35 @@ header h1 {
 }
 
 header h1 a {
-    color: var(--header-text);
+    color: var(--color-text);
 }
 
 .version {
     font-size: 0.875rem;
-    color: var(--header-text-secondary);
+    color: var(--color-text-light);
 }
 
 
 footer {
-    background: linear-gradient(in oklch to right, var(--gradient-purple-blue) 0%, var(--gradient-purple-red) 50%, var(--gradient-purple-blue) 100%);
+    background: #fff;
     padding: 0.75rem 2rem;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 2rem;
     flex-shrink: 0;
-    color: var(--header-text);
+    color: var(--color-text);
     font-size: 0.875rem;
     text-align: center;
 }
 
 footer a {
-    color: var(--header-text-secondary);
+    color: var(--color-text-light);
     text-decoration: none;
 }
 
 footer a:hover {
-    color: var(--header-text);
+    color: var(--color-text);
 }
 
 
@@ -215,7 +210,7 @@ footer a:hover {
 
 .btn-primary {
     font-weight: 500;
-    background: var(--color-primary);
+    background: #000;
     color: #fff;
     border: var(--border-main);
     transition: background-color 0.2s ease;
@@ -260,9 +255,11 @@ footer a:hover {
 }
 
 .display-area,
-.state-display {
+.state-display,
+.words-display {
     background-color: rgba(255, 255, 255, 0.5);
     padding: 0.75rem;
+    border: var(--border-main);
 }
 
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -15,7 +15,7 @@
     padding: 0;
     min-height: 0;
     border: 1px solid var(--color-border-strong, #999);
-    background: var(--gradient-child, #fff);
+    background: #fff;
 }
 
 
@@ -30,23 +30,10 @@
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;
     border: 1px solid var(--color-border-strong, #999);
-    border-radius: 3px;
-    background: var(--gradient-child, #fff);
+    background: #fff;
     color: var(--color-text);
     width: 100%;
     cursor: pointer;
-    transition: background-color 0.15s ease;
-}
-
-.area-selector select:hover,
-.area-selector select:focus,
-.area-selector select:focus-visible,
-.dictionary-sheet-select:hover,
-.dictionary-sheet-select:focus,
-.dictionary-sheet-select:focus-visible {
-    outline: none;
-    box-shadow: none;
-    background: var(--gradient-parent, #e4e1ec);
 }
 
 
@@ -214,20 +201,6 @@
     display: none;
 }
 
-#input-panel::after,
-.search-wrapper::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    mix-blend-mode: lighten;
-    z-index: 1;
-    background: linear-gradient(225deg in oklch,
-        var(--editor-accent-red) 0%,
-        40%,
-        var(--editor-accent-blue) 100%);
-}
-
 
 .editor-suggestions {
     position: absolute;
@@ -236,10 +209,8 @@
     max-width: calc(100% - 1rem);
     max-height: 220px;
     overflow-y: auto;
-    background: rgba(255, 255, 255, 0.75);
-    backdrop-filter: blur(4px);
+    background: #fff;
     border: var(--border-main);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     z-index: 20;
 }
 
@@ -312,22 +283,6 @@
     white-space: pre-wrap;
 }
 
-#output-display::-webkit-scrollbar {
-    width: 10px;
-}
-
-#output-display::-webkit-scrollbar-track {
-    background: var(--color-light);
-}
-
-#output-display::-webkit-scrollbar-thumb {
-    background: var(--color-medium);
-    border-radius: 5px;
-}
-
-#output-display::-webkit-scrollbar-thumb:hover {
-    background: var(--color-secondary);
-}
 
 
 .stack-area {
@@ -459,8 +414,6 @@
     align-items: flex-start;
     align-content: flex-start;
     overflow-y: auto;
-    background-color: rgba(0, 0, 0, 0.06);
-    border-radius: 6px;
     padding: 4px;
     cursor: pointer;
 }
@@ -524,7 +477,6 @@
     gap: 0.5rem;
     min-height: 0;
     width: 100%;
-    background: var(--gradient-child);
     overflow: hidden;
 }
 
@@ -540,75 +492,39 @@
 .word-button {
     margin: 2px;
     padding: 0.2rem 0.4rem;
-    background-color: rgba(255, 255, 255, 0.5);
+    background: #fff;
     color: var(--color-text);
     border: var(--border-main);
     font-family: var(--font-stack-mono);
     font-size: 0.75rem;
     font-weight: 400;
     cursor: pointer;
-    border-radius: 4px;
-}
-
-.word-button:hover {
-    background: var(--color-light);
+    border-radius: var(--radius-main);
 }
 
 
 .word-button.core {
     border-color: var(--color-core);
-    background: #fff;
     color: var(--color-core);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.core:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 .word-button.dependency {
     border-color: var(--color-dependency);
-    background: #fff;
     color: var(--color-dependency);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.dependency:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 .word-button.non-dependency {
     border-color: var(--color-non-dependency);
-    background: #fff;
     color: var(--color-non-dependency);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.non-dependency:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 /* Module words are built-ins too: keep the same visual treatment as Core words. */
 .word-button.module {
     border-color: var(--color-core);
-    background: #fff;
     color: var(--color-core);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.module:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
@@ -660,7 +576,6 @@
     background-color: #DDDDDD;
     font-weight: bold;
     padding: 2px 5px;
-    border-radius: 4px;
 }
 
 
@@ -668,7 +583,6 @@
 #stack-display.blink-top .stack-item:last-child .stack-node[data-depth="1"] {
     background-color: #DDDDDD;
     padding: 2px 5px;
-    border-radius: 4px;
 }
 
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -16,9 +16,9 @@
 
     --gradient-purple-blue: #6b5b95;
     --gradient-purple-red: #b5688c;
-    --gradient-background: #f6f5f9;
-    --gradient-parent: #e4e1ec;
-    --gradient-child: #edebf2;
+    --gradient-background: #ffffff;
+    --gradient-parent: #ffffff;
+    --gradient-child: #ffffff;
     --gradient-menu: #7d6fa2;
     --gradient-menu-hover: #9185b0;
 


### PR DESCRIPTION
### Motivation
- Reduce visual complexity by replacing gradient backgrounds and heavy decorative effects with a flat, neutral appearance.
- Normalize UI surfaces to improve legibility and consistency across components.
- Preserve accessibility by keeping explicit focus outlines while removing some non-essential visual effects.

### Description
- Replaced gradient and translucent backgrounds with solid white surfaces across styles in `src/styles/base.css` and `src/styles/components.css` and updated token defaults in `src/styles/tokens.css` to set gradient variables to `#ffffff`.
- Simplified header, footer, buttons, skip link, and various UI elements to use flat colors (e.g. header/footer `background: #fff`, primary buttons `background: #000`) and adjusted text colors to use existing color tokens like `--color-text` and `--color-text-light`.
- Removed or reduced decorative effects including `backdrop-filter`, some `box-shadow`, complex scrollbars, gradient overlays, hover transform animations, and color-mix usage in focus `box-shadow`.
- Updated component surface styles and radii such as `.word-button`, `.dictionary-sheet`, `.editor-suggestions`, and `.display-area` to use borders and the `--border-main` token for consistent delineation.

### Testing
- No automated tests were run for these style-only changes.
- Visual verification is recommended (local dev build or visual regression) to confirm layout and contrast after the CSS adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de27c486883269ecfe9e578115458)