### PR TITLE
Refactor styles: switch to flat white theme and update header/button visuals

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -14,7 +14,7 @@ body {
 
 body {
     font-family: var(--font-stack-primary);
-    background: var(--gradient-background);
+    background: #fff;
     color: var(--color-text);
     line-height: 1.6;
 }
@@ -22,7 +22,6 @@ body {
 a {
     color: var(--color-primary);
     text-decoration: none;
-    transition: color 0.3s;
 }
 
 a:hover {
@@ -34,14 +33,11 @@ a:hover {
     position: absolute;
     top: -40px;
     left: 0;
-    background: var(--color-primary);
+    background: #000;
     color: #fff;
     padding: 8px 16px;
     z-index: 1000;
     text-decoration: none;
-    font-weight: 500;
-    border-radius: 0 0 var(--radius-main) 0;
-    transition: top 0.2s;
 }
 
 .skip-link:focus {
@@ -72,7 +68,6 @@ textarea:focus-visible,
 select:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 
@@ -91,6 +86,7 @@ header {
     align-items: stretch;
     gap: 0.5rem;
     flex-shrink: 0;
+    color: var(--header-text);
 }
 
 .app-header-top {
@@ -215,9 +211,8 @@ footer a:hover {
 
 .btn-primary {
     font-weight: 500;
-    background: var(--color-primary);
+    background: #000;
     color: #fff;
-    border: var(--border-main);
     transition: background-color 0.2s ease;
 }
 
@@ -229,12 +224,29 @@ footer a:hover {
 .btn-secondary {
     background: var(--color-light);
     color: var(--color-text);
-    border: var(--border-main);
     transition: background-color 0.2s ease;
 }
 
 .btn-secondary:hover {
     background: var(--color-medium);
+}
+
+header .btn-primary,
+header .btn-secondary {
+    border: none;
+    background: linear-gradient(225deg in oklch,
+        var(--gradient-purple-red) 0%,
+        40%,
+        var(--gradient-purple-blue) 100%);
+    color: var(--header-text);
+}
+
+header .btn-primary:hover,
+header .btn-secondary:hover {
+    background: linear-gradient(225deg in oklch,
+        var(--gradient-purple-blue) 0%,
+        40%,
+        var(--gradient-purple-red) 100%);
 }
 
 #test-btn svg {
@@ -260,7 +272,8 @@ footer a:hover {
 }
 
 .display-area,
-.state-display {
+.state-display,
+.words-display {
     background-color: rgba(255, 255, 255, 0.5);
     padding: 0.75rem;
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -14,8 +14,7 @@
     gap: 0;
     padding: 0;
     min-height: 0;
-    border: 1px solid var(--color-border-strong, #999);
-    background: var(--gradient-child, #fff);
+    background: #fff;
 }
 
 
@@ -29,24 +28,11 @@
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--color-border-strong, #999);
-    border-radius: 3px;
-    background: var(--gradient-child, #fff);
+    border: none;
+    background: #fff;
     color: var(--color-text);
     width: 100%;
     cursor: pointer;
-    transition: background-color 0.15s ease;
-}
-
-.area-selector select:hover,
-.area-selector select:focus,
-.area-selector select:focus-visible,
-.dictionary-sheet-select:hover,
-.dictionary-sheet-select:focus,
-.dictionary-sheet-select:focus-visible {
-    outline: none;
-    box-shadow: none;
-    background: var(--gradient-parent, #e4e1ec);
 }
 
 
@@ -100,7 +86,10 @@
     min-height: 0;
     padding: 0.75rem;
     overflow: hidden;
-    background: transparent;
+    background: linear-gradient(225deg in oklch,
+        var(--gradient-purple-red) 0%,
+        40%,
+        var(--gradient-purple-blue) 100%);
     position: relative;
 }
 
@@ -110,7 +99,6 @@
 
 
 #editor-panel {
-    border-right: 1px solid var(--color-border-strong, #999);
 }
 
 
@@ -214,20 +202,6 @@
     display: none;
 }
 
-#input-panel::after,
-.search-wrapper::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    mix-blend-mode: lighten;
-    z-index: 1;
-    background: linear-gradient(225deg in oklch,
-        var(--editor-accent-red) 0%,
-        40%,
-        var(--editor-accent-blue) 100%);
-}
-
 
 .editor-suggestions {
     position: absolute;
@@ -236,17 +210,13 @@
     max-width: calc(100% - 1rem);
     max-height: 220px;
     overflow-y: auto;
-    background: rgba(255, 255, 255, 0.75);
-    backdrop-filter: blur(4px);
-    border: var(--border-main);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    background: #fff;
     z-index: 20;
 }
 
 .editor-suggestion-item {
     width: 100%;
     border: none;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
     background: transparent;
     text-align: left;
     padding: 0.45rem 0.6rem;
@@ -278,14 +248,12 @@
     width: auto;
     min-height: 2.25rem;
     padding: 0.35rem 0;
-    border: 1px solid rgba(0, 0, 0, 0.08);
     text-align: center;
     font-size: 1rem;
     line-height: 1;
 }
 
 .editor-suggestions--symbols .editor-suggestion-item:last-child {
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 
@@ -312,22 +280,6 @@
     white-space: pre-wrap;
 }
 
-#output-display::-webkit-scrollbar {
-    width: 10px;
-}
-
-#output-display::-webkit-scrollbar-track {
-    background: var(--color-light);
-}
-
-#output-display::-webkit-scrollbar-thumb {
-    background: var(--color-medium);
-    border-radius: 5px;
-}
-
-#output-display::-webkit-scrollbar-thumb:hover {
-    background: var(--color-secondary);
-}
 
 
 .stack-area {
@@ -398,7 +350,6 @@
     min-width: 12rem;
     padding: 0.125rem;
     background: #fff;
-    border: var(--border-main);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
@@ -459,8 +410,6 @@
     align-items: flex-start;
     align-content: flex-start;
     overflow-y: auto;
-    background-color: rgba(0, 0, 0, 0.06);
-    border-radius: 6px;
     padding: 4px;
     cursor: pointer;
 }
@@ -524,7 +473,6 @@
     gap: 0.5rem;
     min-height: 0;
     width: 100%;
-    background: var(--gradient-child);
     overflow: hidden;
 }
 
@@ -540,75 +488,39 @@
 .word-button {
     margin: 2px;
     padding: 0.2rem 0.4rem;
-    background-color: rgba(255, 255, 255, 0.5);
+    background: #fff;
     color: var(--color-text);
     border: var(--border-main);
     font-family: var(--font-stack-mono);
     font-size: 0.75rem;
     font-weight: 400;
     cursor: pointer;
-    border-radius: 4px;
-}
-
-.word-button:hover {
-    background: var(--color-light);
+    border-radius: var(--radius-main);
 }
 
 
 .word-button.core {
     border-color: var(--color-core);
-    background: #fff;
     color: var(--color-core);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.core:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 .word-button.dependency {
     border-color: var(--color-dependency);
-    background: #fff;
     color: var(--color-dependency);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.dependency:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 .word-button.non-dependency {
     border-color: var(--color-non-dependency);
-    background: #fff;
     color: var(--color-non-dependency);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.non-dependency:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 /* Module words are built-ins too: keep the same visual treatment as Core words. */
 .word-button.module {
     border-color: var(--color-core);
-    background: #fff;
     color: var(--color-core);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.module:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
@@ -660,7 +572,6 @@
     background-color: #DDDDDD;
     font-weight: bold;
     padding: 2px 5px;
-    border-radius: 4px;
 }
 
 
@@ -668,7 +579,6 @@
 #stack-display.blink-top .stack-item:last-child .stack-node[data-depth="1"] {
     background-color: #DDDDDD;
     padding: 2px 5px;
-    border-radius: 4px;
 }
 
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -16,9 +16,9 @@
 
     --gradient-purple-blue: #6b5b95;
     --gradient-purple-red: #b5688c;
-    --gradient-background: #f6f5f9;
-    --gradient-parent: #e4e1ec;
-    --gradient-child: #edebf2;
+    --gradient-background: #ffffff;
+    --gradient-parent: #ffffff;
+    --gradient-child: #ffffff;
     --gradient-menu: #7d6fa2;
     --gradient-menu-hover: #9185b0;
 


### PR DESCRIPTION
### Motivation

- Unify and simplify the app's visual theme by removing pervasive gradients and strong borders in favor of a flatter white background.  
- Make header and primary actions visually distinct and readable by introducing header-specific color and button gradients.  
- Improve consistency across components (suggestions, context menus, word buttons, panels) for a cleaner UI and predictable styling.

### Description

- Updated `src/styles/base.css` to replace global gradient backgrounds with `#fff`, set `.skip-link` and default `.btn-primary` backgrounds to `#000`, and add `color: var(--header-text)` to `header`.  
- Added header-scoped button styles so `.btn-primary` and `.btn-secondary` inside `header` use an OKLCH gradient and have hover variants that swap the gradient direction.  
- Modified `src/styles/components.css` to remove many gradient/border treatments, set panels and suggestion/context backgrounds to white, simplify controls (selects, buttons) and normalize word-button appearance using `--radius-main`.  
- Updated `src/styles/tokens.css` to set gradient tokens (`--gradient-background`, `--gradient-parent`, `--gradient-child`) to `#ffffff` and keep other color/token definitions intact.

### Testing

- Ran `npm run lint` and fixed any style issues introduced by the changes, which completed successfully.  
- Built the app with `npm run build`, and the build completed without errors.  
- Executed the automated test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de27c486883269ecfe9e578115458)