### PR TITLE
Simplify theme: replace colorful gradients with neutral white/gray palette and update component styles

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -14,7 +14,7 @@ body {
 
 body {
     font-family: var(--font-stack-primary);
-    background: var(--gradient-background);
+    background: #fff;
     color: var(--color-text);
     line-height: 1.6;
 }
@@ -22,7 +22,6 @@ body {
 a {
     color: var(--color-primary);
     text-decoration: none;
-    transition: color 0.3s;
 }
 
 a:hover {
@@ -34,14 +33,11 @@ a:hover {
     position: absolute;
     top: -40px;
     left: 0;
-    background: var(--color-primary);
+    background: #000;
     color: #fff;
     padding: 8px 16px;
     z-index: 1000;
     text-decoration: none;
-    font-weight: 500;
-    border-radius: 0 0 var(--radius-main) 0;
-    transition: top 0.2s;
 }
 
 .skip-link:focus {
@@ -72,7 +68,6 @@ textarea:focus-visible,
 select:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 
@@ -84,13 +79,15 @@ select:focus-visible {
 
 
 header {
-    background: linear-gradient(in oklch to right, var(--gradient-purple-red) 0%, var(--gradient-purple-blue) 50%, var(--gradient-purple-red) 100%);
+    background: linear-gradient(45deg, #ffffff 0%, #b3b3b3 100%);
+    background: linear-gradient(45deg in oklch, #ffffff 0%, #b3b3b3 100%);
     padding: 1rem 2rem;
     display: flex;
     flex-direction: column;
     align-items: stretch;
     gap: 0.5rem;
     flex-shrink: 0;
+    color: var(--header-text);
 }
 
 .app-header-top {
@@ -175,7 +172,8 @@ header h1 a {
 
 
 footer {
-    background: linear-gradient(in oklch to right, var(--gradient-purple-blue) 0%, var(--gradient-purple-red) 50%, var(--gradient-purple-blue) 100%);
+    background: linear-gradient(45deg, #ffffff 0%, #b3b3b3 100%);
+    background: linear-gradient(45deg in oklch, #ffffff 0%, #b3b3b3 100%);
     padding: 0.75rem 2rem;
     display: flex;
     align-items: center;
@@ -215,9 +213,8 @@ footer a:hover {
 
 .btn-primary {
     font-weight: 500;
-    background: var(--color-primary);
+    background: #000;
     color: #fff;
-    border: var(--border-main);
     transition: background-color 0.2s ease;
 }
 
@@ -229,12 +226,52 @@ footer a:hover {
 .btn-secondary {
     background: var(--color-light);
     color: var(--color-text);
-    border: var(--border-main);
     transition: background-color 0.2s ease;
 }
 
 .btn-secondary:hover {
     background: var(--color-medium);
+}
+
+header .btn-primary,
+header .btn-secondary {
+    border: none;
+    background: linear-gradient(225deg in oklch,
+        #ffffff 0%,
+        40%,
+        #b3b3b3 100%);
+    color: var(--header-text);
+}
+
+header .btn-primary:hover,
+header .btn-secondary:hover {
+    background: linear-gradient(225deg in oklch,
+        #b3b3b3 0%,
+        40%,
+        #ffffff 100%);
+}
+
+#copy-output-btn,
+#export-btn,
+#import-btn,
+.json-download-link {
+    border: none;
+    background: linear-gradient(45deg, #ffffff 0%, #b3b3b3 100%);
+    background: linear-gradient(45deg in oklch, #ffffff 0%, #b3b3b3 100%);
+    background-color: #ffffff;
+    background-image: linear-gradient(45deg, #ffffff 0%, #b3b3b3 100%);
+    color: var(--header-text);
+}
+
+#copy-output-btn:hover,
+#export-btn:hover,
+#import-btn:hover,
+.json-download-link:hover {
+    background: linear-gradient(45deg, #b3b3b3 0%, #ffffff 100%);
+    background: linear-gradient(45deg in oklch, #b3b3b3 0%, #ffffff 100%);
+    background-color: #b3b3b3;
+    background-image: linear-gradient(45deg, #b3b3b3 0%, #ffffff 100%);
+    color: var(--header-text);
 }
 
 #test-btn svg {
@@ -260,7 +297,8 @@ footer a:hover {
 }
 
 .display-area,
-.state-display {
+.state-display,
+.words-display {
     background-color: rgba(255, 255, 255, 0.5);
     padding: 0.75rem;
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -14,8 +14,7 @@
     gap: 0;
     padding: 0;
     min-height: 0;
-    border: 1px solid var(--color-border-strong, #999);
-    background: var(--gradient-child, #fff);
+    background: #fff;
 }
 
 
@@ -29,24 +28,12 @@
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--color-border-strong, #999);
-    border-radius: 3px;
-    background: var(--gradient-child, #fff);
+    border: none;
+    background: linear-gradient(45deg, #ffffff 0%, #b3b3b3 100%);
+    background: linear-gradient(45deg in oklch, #ffffff 0%, #b3b3b3 100%);
     color: var(--color-text);
     width: 100%;
     cursor: pointer;
-    transition: background-color 0.15s ease;
-}
-
-.area-selector select:hover,
-.area-selector select:focus,
-.area-selector select:focus-visible,
-.dictionary-sheet-select:hover,
-.dictionary-sheet-select:focus,
-.dictionary-sheet-select:focus-visible {
-    outline: none;
-    box-shadow: none;
-    background: var(--gradient-parent, #e4e1ec);
 }
 
 
@@ -100,7 +87,10 @@
     min-height: 0;
     padding: 0.75rem;
     overflow: hidden;
-    background: transparent;
+    background: linear-gradient(225deg in oklch,
+        #ffffff 0%,
+        40%,
+        #b3b3b3 100%);
     position: relative;
 }
 
@@ -110,7 +100,6 @@
 
 
 #editor-panel {
-    border-right: 1px solid var(--color-border-strong, #999);
 }
 
 
@@ -214,20 +203,6 @@
     display: none;
 }
 
-#input-panel::after,
-.search-wrapper::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    mix-blend-mode: lighten;
-    z-index: 1;
-    background: linear-gradient(225deg in oklch,
-        var(--editor-accent-red) 0%,
-        40%,
-        var(--editor-accent-blue) 100%);
-}
-
 
 .editor-suggestions {
     position: absolute;
@@ -236,17 +211,13 @@
     max-width: calc(100% - 1rem);
     max-height: 220px;
     overflow-y: auto;
-    background: rgba(255, 255, 255, 0.75);
-    backdrop-filter: blur(4px);
-    border: var(--border-main);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    background: #fff;
     z-index: 20;
 }
 
 .editor-suggestion-item {
     width: 100%;
     border: none;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
     background: transparent;
     text-align: left;
     padding: 0.45rem 0.6rem;
@@ -278,29 +249,27 @@
     width: auto;
     min-height: 2.25rem;
     padding: 0.35rem 0;
-    border: 1px solid rgba(0, 0, 0, 0.08);
     text-align: center;
     font-size: 1rem;
     line-height: 1;
 }
 
 .editor-suggestions--symbols .editor-suggestion-item:last-child {
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 
 .json-download-link {
-    display: inline-block;
-    padding: 0.25rem 0.5rem;
-    color: var(--color-primary);
-    text-decoration: underline;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.125rem;
+    padding: 0.5rem 1rem;
+    text-decoration: none;
     cursor: pointer;
     font-family: var(--font-stack-mono);
-    font-size: 0.85rem;
-}
-
-.json-download-link:hover {
-    color: var(--color-secondary);
+    font-size: 0.875rem;
+    line-height: 1.2;
+    border-radius: var(--radius-main);
 }
 
 
@@ -312,22 +281,6 @@
     white-space: pre-wrap;
 }
 
-#output-display::-webkit-scrollbar {
-    width: 10px;
-}
-
-#output-display::-webkit-scrollbar-track {
-    background: var(--color-light);
-}
-
-#output-display::-webkit-scrollbar-thumb {
-    background: var(--color-medium);
-    border-radius: 5px;
-}
-
-#output-display::-webkit-scrollbar-thumb:hover {
-    background: var(--color-secondary);
-}
 
 
 .stack-area {
@@ -398,7 +351,6 @@
     min-width: 12rem;
     padding: 0.125rem;
     background: #fff;
-    border: var(--border-main);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
@@ -459,9 +411,10 @@
     align-items: flex-start;
     align-content: flex-start;
     overflow-y: auto;
-    background-color: rgba(0, 0, 0, 0.06);
-    border-radius: 6px;
     padding: 4px;
+    border: none;
+    background: linear-gradient(45deg, #ffffff 0%, #b3b3b3 100%);
+    background: linear-gradient(45deg in oklch, #ffffff 0%, #b3b3b3 100%);
     cursor: pointer;
 }
 
@@ -524,7 +477,6 @@
     gap: 0.5rem;
     min-height: 0;
     width: 100%;
-    background: var(--gradient-child);
     overflow: hidden;
 }
 
@@ -540,75 +492,39 @@
 .word-button {
     margin: 2px;
     padding: 0.2rem 0.4rem;
-    background-color: rgba(255, 255, 255, 0.5);
+    background: #fff;
     color: var(--color-text);
     border: var(--border-main);
     font-family: var(--font-stack-mono);
     font-size: 0.75rem;
     font-weight: 400;
     cursor: pointer;
-    border-radius: 4px;
-}
-
-.word-button:hover {
-    background: var(--color-light);
+    border-radius: var(--radius-main);
 }
 
 
 .word-button.core {
     border-color: var(--color-core);
-    background: #fff;
     color: var(--color-core);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.core:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 .word-button.dependency {
     border-color: var(--color-dependency);
-    background: #fff;
     color: var(--color-dependency);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.dependency:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 .word-button.non-dependency {
     border-color: var(--color-non-dependency);
-    background: #fff;
     color: var(--color-non-dependency);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.non-dependency:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
 /* Module words are built-ins too: keep the same visual treatment as Core words. */
 .word-button.module {
     border-color: var(--color-core);
-    background: #fff;
     color: var(--color-core);
-    box-shadow: 0 2px 0 var(--color-medium);
-    transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.word-button.module:hover {
-    transform: translateY(2px);
-    box-shadow: 0 0 0 var(--color-medium);
 }
 
 
@@ -660,7 +576,6 @@
     background-color: #DDDDDD;
     font-weight: bold;
     padding: 2px 5px;
-    border-radius: 4px;
 }
 
 
@@ -668,7 +583,6 @@
 #stack-display.blink-top .stack-item:last-child .stack-node[data-depth="1"] {
     background-color: #DDDDDD;
     padding: 2px 5px;
-    border-radius: 4px;
 }
 
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -16,9 +16,9 @@
 
     --gradient-purple-blue: #6b5b95;
     --gradient-purple-red: #b5688c;
-    --gradient-background: #f6f5f9;
-    --gradient-parent: #e4e1ec;
-    --gradient-child: #edebf2;
+    --gradient-background: #ffffff;
+    --gradient-parent: #ffffff;
+    --gradient-child: #ffffff;
     --gradient-menu: #7d6fa2;
     --gradient-menu-hover: #9185b0;
 


### PR DESCRIPTION
### Motivation
- Unify and simplify the application's visual theme by replacing complex/colorful gradients with a neutral white/gray palette for a cleaner look.
- Reduce heavy borders and decorative effects to modernize UI elements and ensure consistent button/header/footer appearance.
- Make small accessibility and contrast adjustments (e.g. skip link background and header text color usage) to preserve usability after the visual changes.

### Description
- Replaced many gradient backgrounds across `base.css`, `components.css`, and `tokens.css` with flat `#fff` or neutral gray gradients and updated token values (`--gradient-background`, `--gradient-parent`, `--gradient-child`).
- Updated header and footer styling to use neutral linear gradients and added `--header-text` color usage, plus new header button gradient/hovers and color adjustments for several action buttons and download link styles.
- Removed or simplified multiple border and box-shadow declarations across components, adjusted button/background radii, and normalized backgrounds for suggestion lists, words display, dictionary sheets, and other panes.
- Touched focus/skip-link and a few interactive controls by changing the `.skip-link` background to black and ensuring consistent focus outlines across interactive elements.

### Testing
- Ran unit tests with `npm test`, and all tests passed.
- Ran linter with `npm run lint`, and no lint errors were reported.
- Built the project with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de27c486883269ecfe9e578115458)