### PR TITLE
Round button corners to distinguish them from selectors

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -188,7 +188,7 @@ footer a:hover {
     font-weight: 500;
     line-height: 1.2;
     border: var(--border-main);
-    border-radius: var(--radius-main);
+    border-radius: var(--radius-button);
     cursor: pointer;
     text-decoration: none;
     color: var(--color-text);

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -471,7 +471,7 @@
     font-size: 0.75rem;
     font-weight: 400;
     cursor: pointer;
-    border-radius: var(--radius-main);
+    border-radius: var(--radius-word-button);
 }
 
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -3,6 +3,8 @@
     --font-stack-mono: "SF Mono", Consolas, "Liberation Mono", Monaco, monospace;
 
     --radius-main: 2px;
+    --radius-button: 6px;
+    --radius-word-button: 4px;
     --col-left-flex: 1;
     --col-right-flex: 1;
 


### PR DESCRIPTION
Selectors stay near-square (--radius-main 2px). Action buttons (.btn: Reference/Test/Copy/Export/Import/IO-JSON, etc.) get --radius-button 6px. Word buttons get a smaller --radius-word-button 4px so the small pills don't read as over-rounded.

https://claude.ai/code/session_01Xikc8sTyGgR9yafccUYbTp

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
