### PR TITLE
Give editor and search inputs a soft hydrangea gradient

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -152,8 +152,9 @@
     resize: none;
     flex: 1;
     line-height: 1.5;
-    background-color: var(--code-bg);
-    color: var(--code-text);
+    background-color: oklch(78.7% 0.1 340);
+    background: var(--input-gradient);
+    color: var(--input-text);
 }
 
 #code-input:focus {
@@ -161,7 +162,7 @@
 }
 
 #code-input::placeholder {
-    color: #ffffff;
+    color: var(--input-placeholder);
 }
 
 
@@ -172,7 +173,7 @@
     padding: 0;
     border: none;
     background: none;
-    color: var(--code-comment);
+    color: var(--input-text);
     font-size: 1.15rem;
     line-height: 1;
     cursor: pointer;
@@ -192,7 +193,7 @@
     top: 0.5rem;
     right: 0.5rem;
     z-index: 2;
-    color: var(--code-text);
+    color: var(--input-text);
 }
 
 #code-input:placeholder-shown ~ #clear-btn {
@@ -290,8 +291,9 @@
     border-radius: 0;
     font-size: 0.85rem;
     font-family: var(--font-stack-mono);
-    background-color: var(--code-bg);
-    color: var(--code-text);
+    background-color: oklch(78.7% 0.1 340);
+    background: var(--input-gradient);
+    color: var(--input-text);
     min-width: 120px;
     max-width: 200px;
 }
@@ -301,7 +303,7 @@
 }
 
 .vocabulary-search-input::placeholder {
-    color: #ffffff;
+    color: var(--input-placeholder);
 }
 
 .vocabulary-search-clear-btn {
@@ -309,7 +311,7 @@
     top: 50%;
     transform: translateY(-50%);
     z-index: 2;
-    color: var(--code-text);
+    color: var(--input-text);
 }
 
 .vocabulary-search-input:placeholder-shown ~ .vocabulary-search-clear-btn {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -19,9 +19,11 @@
     --color-light: #f8f9fa;
     --color-medium: #eaecf0;
 
-    --code-bg: #393544;
-    --code-text: #f8f8f2;
-    --code-comment: #a69dbf;
+    --input-gradient: linear-gradient(to top right in oklch,
+        oklch(78.68% 0.091 305) 0%,
+        oklch(78.78% 0.109 4.54) 100%);
+    --input-text: oklch(38% 0.06 305);
+    --input-placeholder: oklch(58% 0.028 305);
 
     --color-core: #E65100;
     --color-dependency: #E69500;


### PR DESCRIPTION
Replace the harsh near-black input background with an OKLCH diagonal gradient (bottom-left oklch(78.68% 0.091 305) to top-right oklch(78.78% 0.109 4.54)). Switch input text to a dark same-family purple and placeholders to a fainter same-family tone. Drop the now-unused --code-* tokens.

https://claude.ai/code/session_01Xikc8sTyGgR9yafccUYbTp

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
