### PR TITLE
Slowly cycle the input gradient through hydrangea hues

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -142,6 +142,37 @@
 }
 
 
+/* "七変化": the editor and search inputs share a hydrangea gradient whose two
+ * diagonal endpoints slowly cycle through four hydrangea hues. The endpoints
+ * are offset in the cycle so the pair is always two distinct colors. */
+@property --grad-tr {
+    syntax: "<color>";
+    inherits: false;
+    initial-value: oklch(78.78% 0.109 4.54);
+}
+
+@property --grad-bl {
+    syntax: "<color>";
+    inherits: false;
+    initial-value: oklch(78.68% 0.091 305);
+}
+
+@keyframes hydrangea-tr {
+    0%   { --grad-tr: oklch(78.78% 0.109 4.54); }
+    25%  { --grad-tr: oklch(80.17% 0.091 258.88); }
+    50%  { --grad-tr: oklch(88.77% 0.096 147.71); }
+    75%  { --grad-tr: oklch(78.68% 0.091 305); }
+    100% { --grad-tr: oklch(78.78% 0.109 4.54); }
+}
+
+@keyframes hydrangea-bl {
+    0%   { --grad-bl: oklch(88.77% 0.096 147.71); }
+    25%  { --grad-bl: oklch(78.68% 0.091 305); }
+    50%  { --grad-bl: oklch(78.78% 0.109 4.54); }
+    75%  { --grad-bl: oklch(80.17% 0.091 258.88); }
+    100% { --grad-bl: oklch(88.77% 0.096 147.71); }
+}
+
 #code-input {
     width: 100%;
     min-height: 0;
@@ -155,6 +186,7 @@
     background-color: oklch(78.7% 0.1 340);
     background: var(--input-gradient);
     color: var(--input-text);
+    animation: hydrangea-tr 60s linear infinite, hydrangea-bl 60s linear infinite;
 }
 
 #code-input:focus {
@@ -296,6 +328,14 @@
     color: var(--input-text);
     min-width: 120px;
     max-width: 200px;
+    animation: hydrangea-tr 60s linear infinite, hydrangea-bl 60s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #code-input,
+    .vocabulary-search-input {
+        animation: none;
+    }
 }
 
 .vocabulary-search-input:focus {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -20,8 +20,8 @@
     --color-medium: #eaecf0;
 
     --input-gradient: linear-gradient(to top right in oklch,
-        oklch(78.68% 0.091 305) 0%,
-        oklch(78.78% 0.109 4.54) 100%);
+        var(--grad-bl) 0%,
+        var(--grad-tr) 100%);
     --input-text: oklch(38% 0.06 305);
     --input-placeholder: oklch(58% 0.028 305);
 


### PR DESCRIPTION
The editor and search backgrounds now animate their two diagonal OKLCH endpoints through four hydrangea colors ("七変化") via @property-registered custom properties over a 60s loop, offset so the pair stays distinct. Honors prefers-reduced-motion.

https://claude.ai/code/session_01Xikc8sTyGgR9yafccUYbTp

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
