### PR TITLE
Reference animated gradient stops directly so the cycle repaints

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -184,7 +184,7 @@
     flex: 1;
     line-height: 1.5;
     background-color: oklch(78.7% 0.1 340);
-    background: var(--input-gradient);
+    background: linear-gradient(to top right in oklch, var(--grad-bl) 0%, var(--grad-tr) 100%);
     color: var(--input-text);
     animation: hydrangea-tr 60s linear infinite, hydrangea-bl 60s linear infinite;
 }
@@ -324,7 +324,7 @@
     font-size: 0.85rem;
     font-family: var(--font-stack-mono);
     background-color: oklch(78.7% 0.1 340);
-    background: var(--input-gradient);
+    background: linear-gradient(to top right in oklch, var(--grad-bl) 0%, var(--grad-tr) 100%);
     color: var(--input-text);
     min-width: 120px;
     max-width: 200px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -19,9 +19,6 @@
     --color-light: #f8f9fa;
     --color-medium: #eaecf0;
 
-    --input-gradient: linear-gradient(to top right in oklch,
-        var(--grad-bl) 0%,
-        var(--grad-tr) 100%);
     --input-text: oklch(38% 0.06 305);
     --input-placeholder: oklch(58% 0.028 305);
 


### PR DESCRIPTION
Inlining the linear-gradient with var(--grad-bl)/var(--grad-tr) on each input lets the browser re-evaluate it as the @property stops animate; the previous indirection through a :root --input-gradient token did not trigger repaints in some engines. Drop the now-unused token.

https://claude.ai/code/session_01Xikc8sTyGgR9yafccUYbTp

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
