### PR TITLE
Move shifting gradient from inputs to header/footer

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -91,8 +91,67 @@ select:focus-visible {
 }
 
 
+/* "移ろい": header and footer share a slowly shifting OKLCH gradient. Each of
+ * the two gradient endpoints rotates its hue around the full colour wheel, so
+ * warm and cool tones flow into one another with no seam — hue 360 is hue 0,
+ * so the cycle never visibly "restarts". The endpoints counter-rotate at
+ * different periods and a slower wave drifts the lightness, so the pair's
+ * relationship keeps changing and the combined motion has no obvious repeat. */
+@property --mv-h1 {
+    syntax: "<number>";
+    inherits: false;
+    initial-value: 20;
+}
+
+@property --mv-h2 {
+    syntax: "<number>";
+    inherits: false;
+    initial-value: 230;
+}
+
+@property --mv-l {
+    syntax: "<percentage>";
+    inherits: false;
+    initial-value: 87%;
+}
+
+@keyframes mv-hue1 {
+    from { --mv-h1: 20; }
+    to   { --mv-h1: 380; }
+}
+
+@keyframes mv-hue2 {
+    from { --mv-h2: 590; }
+    to   { --mv-h2: 230; }
+}
+
+@keyframes mv-light {
+    0%   { --mv-l: 87%; }
+    50%  { --mv-l: 92%; }
+    100% { --mv-l: 87%; }
+}
+
+header,
+footer {
+    background: linear-gradient(
+        to right in oklch,
+        oklch(var(--mv-l) 0.1 var(--mv-h1)) 0%,
+        oklch(var(--mv-l) 0.09 var(--mv-h2)) 100%
+    );
+    animation:
+        mv-hue1 240s linear infinite,
+        mv-hue2 300s linear infinite,
+        mv-light 170s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    header,
+    footer {
+        animation: none;
+    }
+}
+
 header {
-    background: #fff;
     border-bottom: var(--border-main);
     padding: 1rem 2rem;
     display: flex;
@@ -149,7 +208,6 @@ header h1 a {
 
 
 footer {
-    background: #fff;
     border-top: var(--border-main);
     padding: 0.75rem 2rem;
     display: flex;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -142,37 +142,6 @@
 }
 
 
-/* "七変化": the editor and search inputs share a hydrangea gradient whose two
- * diagonal endpoints slowly cycle through four hydrangea hues. The endpoints
- * are offset in the cycle so the pair is always two distinct colors. */
-@property --grad-tr {
-    syntax: "<color>";
-    inherits: false;
-    initial-value: oklch(78.78% 0.109 4.54);
-}
-
-@property --grad-bl {
-    syntax: "<color>";
-    inherits: false;
-    initial-value: oklch(78.68% 0.091 305);
-}
-
-@keyframes hydrangea-tr {
-    0%   { --grad-tr: oklch(78.78% 0.109 4.54); }
-    25%  { --grad-tr: oklch(80.17% 0.091 258.88); }
-    50%  { --grad-tr: oklch(88.77% 0.096 147.71); }
-    75%  { --grad-tr: oklch(78.68% 0.091 305); }
-    100% { --grad-tr: oklch(78.78% 0.109 4.54); }
-}
-
-@keyframes hydrangea-bl {
-    0%   { --grad-bl: oklch(88.77% 0.096 147.71); }
-    25%  { --grad-bl: oklch(78.68% 0.091 305); }
-    50%  { --grad-bl: oklch(78.78% 0.109 4.54); }
-    75%  { --grad-bl: oklch(80.17% 0.091 258.88); }
-    100% { --grad-bl: oklch(88.77% 0.096 147.71); }
-}
-
 #code-input {
     width: 100%;
     min-height: 0;
@@ -183,10 +152,8 @@
     resize: none;
     flex: 1;
     line-height: 1.5;
-    background-color: oklch(78.7% 0.1 340);
-    background: linear-gradient(to top right in oklch, var(--grad-bl) 0%, var(--grad-tr) 100%);
+    background-color: var(--color-light);
     color: var(--input-text);
-    animation: hydrangea-tr 180s linear infinite, hydrangea-bl 180s linear infinite;
 }
 
 #code-input:focus {
@@ -323,19 +290,10 @@
     border-radius: 0;
     font-size: 0.85rem;
     font-family: var(--font-stack-mono);
-    background-color: oklch(78.7% 0.1 340);
-    background: linear-gradient(to top right in oklch, var(--grad-bl) 0%, var(--grad-tr) 100%);
+    background-color: var(--color-light);
     color: var(--input-text);
     min-width: 120px;
     max-width: 200px;
-    animation: hydrangea-tr 180s linear infinite, hydrangea-bl 180s linear infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    #code-input,
-    .vocabulary-search-input {
-        animation: none;
-    }
 }
 
 .vocabulary-search-input:focus {


### PR DESCRIPTION
## 概要

移ろいグラデーションをテキストエディタとワードボタン絞り込み検索窓から廃止し、header と footer の背景として再利用しました。

## 変更点

- **エディタ・検索窓**: アニメーション付きグラデーションを削除し、安定した単色背景 (`--color-light`) に変更。モバイルで画面遷移してエディタに戻った際に背景色が変わって戸惑う問題を解消。
- **header / footer**: 移ろいグラデーションを移設。改良点:
  - 2 つのグラデーション端点それぞれの色相を OKLCH 色相環を一周させることで、暖色系↔寒色系の変化を継ぎ目なく自然に表現（色相 360 = 0 のためループの「切り替わり」が見えない）。以前の「一周して再び始まった」印象を解消。
  - 2 端点を異なる周期で逆回転させ、さらに別周期で明度を揺らすことで、組み合わせの繰り返し感をなくしランダム性を付与。
  - OKLCH 色空間に基づき全色相を使用（淡いパステル調を維持）。
- `prefers-reduced-motion` 対応も header/footer 側へ移設。

## テスト

- [ ] ブラウザでヘッダー・フッターのグラデーションが滑らかに移ろうことを確認
- [ ] モバイルモードでエディタの背景が画面遷移前後で変わらないことを確認

https://claude.ai/code/session_01TexeDVneSfMFs7JBaarsGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TexeDVneSfMFs7JBaarsGA)_