### PR TITLE
Restore input borders and soften focus/placeholder

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -146,7 +146,7 @@
     width: 100%;
     min-height: 0;
     padding: 0.75rem;
-    border: none;
+    border: var(--border-main);
     font-family: var(--font-stack-mono);
     font-size: 0.95rem;
     resize: none;
@@ -154,10 +154,12 @@
     line-height: 1.5;
     background-color: var(--color-light);
     color: var(--input-text);
+    transition: background-color 0.15s ease;
 }
 
 #code-input:focus {
     outline: none;
+    background-color: var(--color-medium);
 }
 
 #code-input::placeholder {
@@ -286,7 +288,7 @@
 
 .vocabulary-search-input {
     padding: 0.25rem 1.75rem 0.25rem 0.5rem;
-    border: none;
+    border: var(--border-main);
     border-radius: 0;
     font-size: 0.85rem;
     font-family: var(--font-stack-mono);
@@ -294,10 +296,12 @@
     color: var(--input-text);
     min-width: 120px;
     max-width: 200px;
+    transition: background-color 0.15s ease;
 }
 
 .vocabulary-search-input:focus {
     outline: none;
+    background-color: var(--color-medium);
 }
 
 .vocabulary-search-input::placeholder {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -20,7 +20,7 @@
     --color-medium: #eaecf0;
 
     --input-text: oklch(38% 0.06 305);
-    --input-placeholder: oklch(58% 0.028 305);
+    --input-placeholder: oklch(68% 0.022 305);
 
     --color-core: #E65100;
     --color-dependency: #E69500;


### PR DESCRIPTION
## 概要

移ろいグラデーションを header/footer へ移植した後のエディタ・検索窓まわりの仕上げです。

## 変更点

- **枠線の回復**: テキストエディタ (`#code-input`) とワードボタン絞り込み検索窓 (`.vocabulary-search-input`) に `--border-main` の枠線を復活。薄い灰色 (`--color-light`) の背景はそのまま維持。
- **フォーカス表現の刷新**: 紫の太いアウトラインをやめ、フォーカス時はセレクタ自身の背景色を `--color-light` → `--color-medium` へ穏やかに変化させる方式に変更（header の Reference ボタンと同様の色味の移ろい、0.15s のトランジション付き）。
- **プレースホルダー**: `--input-placeholder` の明度を上げ彩度を下げて、存在感を希薄に。

## テスト

- [ ] エディタ・検索窓に枠線が表示されることを確認
- [ ] フォーカス時に紫枠ではなく背景トーンが滑らかに変化することを確認
- [ ] プレースホルダーが以前より薄く見えることを確認

https://claude.ai/code/session_01TexeDVneSfMFs7JBaarsGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TexeDVneSfMFs7JBaarsGA)_