### PR TITLE
Soften select focus to a tone shift

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -34,6 +34,13 @@
     color: var(--color-text);
     width: 100%;
     cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.area-selector select:focus,
+.dictionary-sheet-select:focus {
+    outline: none;
+    background: var(--color-light);
 }
 
 


### PR DESCRIPTION
## 概要

「セレクタ」= パネル切替・辞書シートの `<select>` ドロップダウンのフォーカス表現を修正します。前回の改修はテキストエディタ／検索窓に適用されていましたが、本来意図されていたのは `<select>` でした。

## 変更点

- `.area-selector select`（モバイル・左・右パネルの切替）と `.dictionary-sheet-select` のフォーカス時に、紫の太いアウトラインを廃止。
- 代わりにフォーカス時は背景色を白 → `--color-light` へ穏やかに変化（0.15s トランジション）。header の Reference ボタンと同じ色味の移ろい方。

## テスト

- [ ] 各 select にフォーカス／クリックした際、紫枠が出ず背景トーンが滑らかに変化することを確認

https://claude.ai/code/session_01TexeDVneSfMFs7JBaarsGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TexeDVneSfMFs7JBaarsGA)_