### PR TITLE
Web Serial support: design note + Phase 1 SERIAL module

### DIFF
--- a/docs/dev/web-serial-module-design.md
+++ b/docs/dev/web-serial-module-design.md
@@ -1,0 +1,250 @@
+# Web Serial (`SERIAL` module) — Design Note
+
+Status: **Non-canonical** (developer note).
+Authority: this document does not define Ajisai semantics. The canonical
+source is `SPECIFICATION.md`. If anything here conflicts with the
+specification, the specification wins. Nothing in this note is binding
+until the relevant parts are promoted into `SPECIFICATION.md`.
+
+## Motivation
+
+Web Serial (W3C Serial API) lets a browser talk to physical serial
+devices (microcontrollers, sensors, instruments) over USB/CDC and the
+like. With a second major browser engine adding support, exposing serial
+I/O from Ajisai becomes worthwhile: it turns the playground into a way to
+drive real hardware from an exact-real dataflow language.
+
+The implementation must **not** be tied to one browser. It is gated on
+runtime capability detection (`'serial' in navigator`) and degrades
+gracefully where the API is absent.
+
+## Two delivery targets, one core
+
+Ajisai ships in two channels and both must be served by a *single*
+canonical interpreter (per `SPECIFICATION.md` §14.1, no dual-mode drift):
+
+- **Web playground** — Vite build, interpreter compiled to WASM, executed
+  in a Web Worker, GUI in the main thread.
+- **Tauri desktop** (current/near-future) — the *same* frontend and the
+  *same* WASM interpreter run inside the Tauri WebView; native
+  capabilities are reached through TypeScript adapters that call Tauri
+  commands (`invoke`), exactly as `tauri-plugin-fs` / `-dialog` /
+  `-store` are reached today.
+
+Consequently the interpreter core is identical in both channels, and the
+only place that differs is the platform adapter.
+
+## Core principle: the core never knows about serial
+
+The Rust core does not reference `navigator.serial` or any native
+`serialport` crate. It does exactly two things:
+
+1. **Outbox** — effectful serial words emit a single command line into
+   `interp.output_buffer`, prefixed `SERIAL:` and carrying a JSON
+   payload. This mirrors how the `MUSIC` module emits `AUDIO:` commands
+   (`rust/src/interpreter/audio/build_audio_structure.rs`).
+2. **Inbox** — received bytes are made available to a run by being
+   injected into the interpreter state at *execution start*; a read word
+   pulls from that injected inbox.
+
+Because of this, the same WASM binary and the same language semantics
+serve both the web and Tauri channels. Platform differences are confined
+to the adapter described below.
+
+### Why not native synchronous reads under Tauri
+
+Even under Tauri the interpreter runs as WASM in the WebView, and adapter
+calls are asynchronous (`invoke` returns a Promise). The interpreter's
+execution loop is synchronous Rust; it cannot `await` mid-execution
+without a major rearchitecture that would also break the step-budget
+determinism model and child-runtime isolation. Adding a Tauri-only
+synchronous-read path would be precisely the dual-mode drift that
+§14.1 forbids. The inbox/outbox model is therefore the single canonical
+mechanism for both channels.
+
+## The effect bridge (existing precedent)
+
+Tracing the audio path that this design reuses:
+
+1. Rust word writes `AUDIO:{json}\n` to `interp.output_buffer`
+   (`build_audio_structure.rs:287`). The core never touches the browser.
+2. The WASM boundary returns `output_buffer` as a string after execution
+   (`wasm_interpreter_bindings/wasm_interpreter_execution.rs`).
+3. TypeScript splits the output by line prefix
+   (`AUDIO:` / `CONFIG:` / `EFFECT:` / `JSONEXPORT:`) in
+   `src/gui/output-display-renderer.ts:307`.
+4. The main thread dispatches to the host API (`src/audio/audio-engine.ts`).
+
+Key property: this path is **one-way and fire-and-forget**. Execution
+runs in a Web Worker (`src/workers/interpreter-execution-worker.ts`);
+side effects run on the main thread *after* the worker returns. There is
+no channel for the host to hand a value back into a running execution.
+Serial writes fit this exactly; serial reads do not, which is what the
+inbox model resolves.
+
+## Inbox / outbox model
+
+### Outbox (OPEN / CONFIGURE / WRITE / CLOSE / FLUSH)
+
+Fire-and-forget, identical in shape to audio:
+
+```
+SERIAL:{"op":"open","portId":"p1"}
+SERIAL:{"op":"configure","portId":"p1","baudRate":115200}
+SERIAL:{"op":"write","portId":"p1","bytes":[72,73]}
+SERIAL:{"op":"close","portId":"p1"}
+```
+
+The main-thread `Serial` adapter consumes these and drives the real port.
+
+### Inbox (READ)
+
+The main-thread adapter continuously reads each open port into a per-port
+RX buffer. At the **start of each execution**, the bytes accumulated since
+the previous run are injected as part of the
+`InterpreterStateSnapshot` (`src/platform/platform-adapter.ts`). `READ`
+pops from this injected inbox.
+
+The result is an **event-poll model**: a run sees the data that arrived
+since the last run. There is no blocking read. Within a single execution
+the inbox is fixed, so a run remains deterministic with respect to its
+inputs — consistent with the step budget, child-runtime isolation, and
+hedged/elastic re-execution (`rust/src/elastic/`).
+
+### Connection lifetime and handles
+
+The open port lives in the main-thread adapter, keyed by an opaque
+`portId`. The runtime holds only that id (an opaque handle value). Because
+the port is owned by the main thread, not the worker, the connection
+survives across executions and across worker recycling in both channels.
+
+### User-gesture and security constraints (web only)
+
+- `navigator.serial.requestPort()` requires a user gesture and must be
+  called synchronously within a click handler. The worker round-trip
+  loses the gesture, so port *selection* is driven by a dedicated
+  "Connect serial port" UI control, not by a `SERIAL:` command emitted
+  from a program run. Once a port is granted, programs reference it by id.
+- Web Serial requires a secure context (HTTPS or localhost). GitHub Pages
+  qualifies.
+- Under Tauri these constraints do not apply; the abstract interface is
+  designed for the stricter (web) case so the Tauri backend satisfies it
+  trivially.
+
+## Platform adapter: one interface, two backends
+
+A new abstract `Serial` member is added to `PlatformAdapter`. It is
+defined for the stricter web case so Tauri satisfies it without special
+casing.
+
+```ts
+export interface SerialPortInfo {
+    readonly portId: string;
+    readonly label?: string;
+}
+
+export interface SerialAdapter {
+    readonly available: boolean;            // capability detection
+    requestAccess(): Promise<SerialPortInfo | null>;   // web: requestPort under gesture
+    listPorts(): Promise<SerialPortInfo[]>;
+    open(portId: string): Promise<void>;
+    configure(portId: string, options: { baudRate: number }): Promise<void>;
+    write(portId: string, bytes: Uint8Array): Promise<void>;
+    drainInbox(portId: string): Uint8Array;  // bytes since last call (for snapshot injection)
+    close(portId: string): Promise<void>;
+}
+```
+
+| Concern | Web backend | Tauri backend |
+|---------|-------------|---------------|
+| Implementation | `WebSerialAdapter` → `navigator.serial` | `TauriSerialAdapter` → `invoke('serial_*')` |
+| Native side | n/a | `serialport` crate + commands in `src-tauri` |
+| Gesture | `requestPort()` in click handler | not required |
+| Secure context | HTTPS/localhost | not required |
+| RX read | `ReadableStream` reader loop on main thread | native read thread → Tauri event → buffer |
+| Capability | `'serial' in navigator` | always true |
+
+The interface ships with the web backend first. The Tauri backend is a
+typed stub initially (so the contract is fixed) and is filled in during
+Phase 3 without touching the core or the language semantics.
+
+## Vocabulary (canonical English names)
+
+Module `SERIAL`. Action-object names per `SPECIFICATION.md` §8.5.
+
+| Word | Stack effect (sketch) | Direction |
+|------|-----------------------|-----------|
+| `LIST-PORTS` | `-- ports` | query |
+| `OPEN` | `port-id -- handle` | outbox |
+| `CONFIGURE` | `handle options -- handle` | outbox |
+| `WRITE` | `handle bytes -- ` | outbox |
+| `READ` | `handle -- bytes` | inbox |
+| `FLUSH` | `handle -- ` | outbox |
+| `CLOSE` | `handle -- ` | outbox |
+
+Exact stack effects, byte/vector encoding, and option-record shape are
+finalized when promoted to `SPECIFICATION.md`.
+
+## Contract metadata (per §7.14)
+
+Every word gets a Coreword contract entry:
+
+- `purity = Effectful`, `deterministic = false`, `safe_preview = false`.
+- `safety_level = D` (effectful; external state). Serial words are
+  **excluded from speculative / hedged execution**
+  (`rust/src/elastic/purity_table.rs`) and are not eligible for
+  self-host preview.
+- `nil_policy` / `partiality` per word.
+- `canonical_home = Module("SERIAL")`, listed under the `SERIAL` module.
+
+## Bubble Rule (per §11.2)
+
+"Could not produce a value → bubble; misuse → error."
+
+- `READ` with no buffered data → Bubble/NIL, `reason = noData`.
+- Port dropped/disconnected during use → Bubble/NIL,
+  `reason = portDisconnected`.
+- `WRITE`/`READ` against a non-handle, or malformed options → ordinary
+  error (`StructureError`).
+
+`noData` and `portDisconnected` are new protocol strings to be registered
+when promoted to the specification.
+
+## Specification changes required (Phase 0 → promotion)
+
+- §9.1: add `SERIAL` to the module table.
+- §7.x: register the `SERIAL` vocabulary with English canonical names.
+- §7.14: contract entries (`partiality`, `nil_policy`, `safety_level`).
+- §11.2: add `noData` / `portDisconnected` bubble cases and protocol
+  strings.
+- Confirm hedged/elastic execution never speculatively runs serial words.
+
+## Phased plan
+
+- **Phase 0** — this note; then promote the agreed parts into
+  `SPECIFICATION.md`; fix the abstract `Serial` interface (web + Tauri).
+- **Phase 1** — Web send MVP: Rust `SERIAL` module (emit only:
+  `LIST-PORTS`/`OPEN`/`CONFIGURE`/`WRITE`/`CLOSE`/`FLUSH`), module
+  registration + contract metadata; `WebSerialAdapter`; `SERIAL:` line
+  dispatch in the output renderer; a "Connect serial port" UI control;
+  a typed `TauriSerialAdapter` stub. Tests cover command emission and
+  contracts (no real hardware in CI).
+- **Phase 2** — Inbox: RX buffering on the main thread, snapshot
+  injection, `READ`, bubble reasons, tests; semantics shared by both
+  channels.
+- **Phase 3** — Tauri backend: add the `serialport` crate and
+  `serial_*` commands in `src-tauri`, implement `TauriSerialAdapter`. The
+  web channel is unchanged.
+
+## Risks / constraints
+
+- Ajisai's identity (exact-real, deterministic, mechanically verifiable)
+  is in tension with serial I/O (non-deterministic, effectful, stateful).
+  The inbox model preserves *within-run* determinism, and `safety_level`
+  `D` plus exclusion from speculative execution keep the effect isolated.
+- Hardware cannot be exercised in CI. Tests assert command emission and
+  contract metadata (as `audio_effect_tests.rs` does) and exercise inbox
+  injection at the state-snapshot level; the adapter is mocked.
+- Web Serial requires a secure context and is browser-gated; the feature
+  is capability-detected and the playground remains fully usable without
+  it.

--- a/index.html
+++ b/index.html
@@ -43,6 +43,12 @@
                     </svg>
                     Test
                 </button>
+                <button id="serial-connect-btn" class="btn" type="button" hidden>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M7 8V6a2 2 0 012-2h6a2 2 0 012 2v2M5 8h14v10a2 2 0 01-2 2H7a2 2 0 01-2-2V8z"/>
+                    </svg>
+                    Connect serial
+                </button>
             </div>
         </header>
 

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -158,6 +158,14 @@ pub fn purity_by_name(name: &str) -> Option<PurityInfo> {
             cost: EvalCost::Light,
             order_sensitive: true,
         }),
+        // Serial I/O drives external hardware: always impure, order-sensitive,
+        // and never eligible for speculative reordering or caching.
+        "SERIAL@LIST-PORTS" | "SERIAL@OPEN" | "SERIAL@CONFIGURE" | "SERIAL@WRITE"
+        | "SERIAL@FLUSH" | "SERIAL@CLOSE" => Some(PurityInfo {
+            purity: Purity::Impure,
+            cost: EvalCost::Heavy,
+            order_sensitive: true,
+        }),
         "HASH" | "CRYPTO@HASH" | "SORT" | "ALGO@SORT" => Some(PurityInfo {
             purity: Purity::Pure,
             cost: EvalCost::Light,

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -30,6 +30,7 @@ pub mod random;
 pub mod redundancy_layer;
 mod resolve_cache;
 mod shadow_validation;
+pub mod serial;
 pub(crate) mod simd_ops;
 pub mod sort;
 pub mod tensor_cmds;

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,6 +1,6 @@
 use crate::builtins::WordShape;
 use crate::coreword_registry::{self, CanonicalHome, CorewordMetadata, WordPurity};
-use crate::interpreter::{audio, datetime, hash, interval_ops, json, random, sort};
+use crate::interpreter::{audio, datetime, hash, interval_ops, json, random, serial, sort};
 use crate::types::{Capabilities, Stability};
 
 use super::module_word_types::{ModuleSpec, ModuleWord, SampleWord};
@@ -678,6 +678,81 @@ const MATH_WORDS: &[ModuleWord] = &[
     ),
 ];
 
+const SERIAL_WORDS: &[ModuleWord] = &[
+    module_word!(
+        "LIST-PORTS",
+        "Ask the host to enumerate available serial ports",
+        serial::op_list_ports,
+        WordPurity::Effectful,
+        &["serial-query"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+    module_word!(
+        "OPEN",
+        "Open a serial port by id; leaves the port-id handle on the stack",
+        serial::op_open,
+        WordPurity::Effectful,
+        &["serial-control"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+    module_word!(
+        "CONFIGURE",
+        "Set the baud rate of an open serial port",
+        serial::op_configure,
+        WordPurity::Effectful,
+        &["serial-control"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+    module_word!(
+        "WRITE",
+        "Write a byte vector to an open serial port",
+        serial::op_write,
+        WordPurity::Effectful,
+        &["serial-write"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+    module_word!(
+        "FLUSH",
+        "Flush the outgoing buffer of an open serial port",
+        serial::op_flush,
+        WordPurity::Effectful,
+        &["serial-control"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+    module_word!(
+        "CLOSE",
+        "Close an open serial port",
+        serial::op_close,
+        WordPurity::Effectful,
+        &["serial-control"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+];
+
 const MUSIC_SAMPLES: &[SampleWord] = &[];
 
 
@@ -715,6 +790,11 @@ pub(super) const MODULE_SPECS: &[ModuleSpec] = &[
     ModuleSpec {
         name: "MATH",
         words: MATH_WORDS,
+        sample_words: &[],
+    },
+    ModuleSpec {
+        name: "SERIAL",
+        words: SERIAL_WORDS,
         sample_words: &[],
     },
 ];

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -755,7 +755,6 @@ const SERIAL_WORDS: &[ModuleWord] = &[
 
 const MUSIC_SAMPLES: &[SampleWord] = &[];
 
-
 pub(super) const MODULE_SPECS: &[ModuleSpec] = &[
     ModuleSpec {
         name: "MUSIC",

--- a/rust/src/interpreter/serial/execute_serial_commands.rs
+++ b/rust/src/interpreter/serial/execute_serial_commands.rs
@@ -9,7 +9,6 @@ use super::super::Interpreter;
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::{extract_integer_from_value, value_as_string};
 use crate::types::{Value, ValueData};
-use num_traits::ToPrimitive;
 use serde_json::json;
 
 fn pop(interp: &mut Interpreter) -> Result<Value> {
@@ -45,7 +44,10 @@ fn extract_bytes(val: &Value) -> Result<Vec<u8>> {
     let mut bytes = Vec::with_capacity(fractions.len());
     for f in fractions {
         if !f.is_integer() {
-            return Err(AjisaiError::create_structure_error("integer byte 0-255", "fraction"));
+            return Err(AjisaiError::create_structure_error(
+                "integer byte 0-255",
+                "fraction",
+            ));
         }
         let n = f
             .to_i64()
@@ -96,7 +98,10 @@ pub fn op_configure(interp: &mut Interpreter) -> Result<()> {
     if baud <= 0 {
         return Err(AjisaiError::from("Serial baud rate must be positive"));
     }
-    emit(interp, json!({ "op": "configure", "portId": id, "baudRate": baud }));
+    emit(
+        interp,
+        json!({ "op": "configure", "portId": id, "baudRate": baud }),
+    );
     interp.stack.push(handle);
     Ok(())
 }
@@ -107,7 +112,10 @@ pub fn op_write(interp: &mut Interpreter) -> Result<()> {
     let handle = pop(interp)?;
     let id = require_port_id(&handle)?;
     let bytes = extract_bytes(&payload)?;
-    emit(interp, json!({ "op": "write", "portId": id, "bytes": bytes }));
+    emit(
+        interp,
+        json!({ "op": "write", "portId": id, "bytes": bytes }),
+    );
     interp.stack.push(handle);
     Ok(())
 }

--- a/rust/src/interpreter/serial/execute_serial_commands.rs
+++ b/rust/src/interpreter/serial/execute_serial_commands.rs
@@ -1,0 +1,130 @@
+//! Outbound `SERIAL` command words (Phase 1).
+//!
+//! Stack discipline follows the `MUSIC` precedent: each word pops its operands
+//! and writes one `SERIAL:{json}` line to `interp.output_buffer`. Words that
+//! represent an ongoing connection push the opaque port-id handle back so it
+//! can be threaded through a pipeline.
+
+use super::super::Interpreter;
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::value_extraction_helpers::{extract_integer_from_value, value_as_string};
+use crate::types::{Value, ValueData};
+use num_traits::ToPrimitive;
+use serde_json::json;
+
+fn pop(interp: &mut Interpreter) -> Result<Value> {
+    interp.stack.pop().ok_or(AjisaiError::StackUnderflow)
+}
+
+/// The handle is an opaque port id, surfaced as a text value. A Phase-2
+/// dedicated handle type may replace this; until then a string is the handle.
+///
+/// A bare scalar would decode to a single codepoint, so the shape is guarded
+/// here: only a text-shaped (vector) value is a valid port id. Passing a number
+/// is misuse and raises a `StructureError` per the Bubble Rule.
+fn require_port_id(val: &Value) -> Result<String> {
+    if !matches!(&val.data, ValueData::Vector(_) | ValueData::Tensor { .. }) {
+        return Err(AjisaiError::create_structure_error(
+            "serial port-id text",
+            "non-text value",
+        ));
+    }
+    value_as_string(val)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| AjisaiError::create_structure_error("serial port-id text", "non-text value"))
+}
+
+fn extract_bytes(val: &Value) -> Result<Vec<u8>> {
+    let fractions = val.collect_fractions_flat();
+    if fractions.is_empty() {
+        return Err(AjisaiError::create_structure_error(
+            "non-empty byte vector",
+            "empty or non-numeric value",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(fractions.len());
+    for f in fractions {
+        if !f.is_integer() {
+            return Err(AjisaiError::create_structure_error("integer byte 0-255", "fraction"));
+        }
+        let n = f
+            .to_i64()
+            .ok_or_else(|| AjisaiError::from("Serial byte value is too large"))?;
+        if !(0..=255).contains(&n) {
+            return Err(AjisaiError::create_structure_error(
+                "integer byte 0-255",
+                "out-of-range integer",
+            ));
+        }
+        bytes.push(n as u8);
+    }
+    Ok(bytes)
+}
+
+fn emit(interp: &mut Interpreter, command: serde_json::Value) {
+    if !interp.output_buffer.is_empty() && !interp.output_buffer.ends_with('\n') {
+        interp.output_buffer.push('\n');
+    }
+    interp.output_buffer.push_str("SERIAL:");
+    interp.output_buffer.push_str(&command.to_string());
+    interp.output_buffer.push('\n');
+}
+
+/// `-- ` : ask the host adapter to enumerate available ports. The result is
+/// surfaced by the adapter (program output); a stack-returning form is Phase 2.
+pub fn op_list_ports(interp: &mut Interpreter) -> Result<()> {
+    emit(interp, json!({ "op": "listPorts" }));
+    Ok(())
+}
+
+/// `port-id -- handle` : open the named port; leaves the port-id on the stack
+/// as the connection handle.
+pub fn op_open(interp: &mut Interpreter) -> Result<()> {
+    let handle = pop(interp)?;
+    let id = require_port_id(&handle)?;
+    emit(interp, json!({ "op": "open", "portId": id }));
+    interp.stack.push(handle);
+    Ok(())
+}
+
+/// `handle baud-rate -- handle` : set the baud rate of an open port.
+pub fn op_configure(interp: &mut Interpreter) -> Result<()> {
+    let options = pop(interp)?;
+    let handle = pop(interp)?;
+    let id = require_port_id(&handle)?;
+    let baud = extract_integer_from_value(&options)?;
+    if baud <= 0 {
+        return Err(AjisaiError::from("Serial baud rate must be positive"));
+    }
+    emit(interp, json!({ "op": "configure", "portId": id, "baudRate": baud }));
+    interp.stack.push(handle);
+    Ok(())
+}
+
+/// `handle bytes -- handle` : write a byte vector to an open port.
+pub fn op_write(interp: &mut Interpreter) -> Result<()> {
+    let payload = pop(interp)?;
+    let handle = pop(interp)?;
+    let id = require_port_id(&handle)?;
+    let bytes = extract_bytes(&payload)?;
+    emit(interp, json!({ "op": "write", "portId": id, "bytes": bytes }));
+    interp.stack.push(handle);
+    Ok(())
+}
+
+/// `handle -- handle` : flush the port's outgoing buffer.
+pub fn op_flush(interp: &mut Interpreter) -> Result<()> {
+    let handle = pop(interp)?;
+    let id = require_port_id(&handle)?;
+    emit(interp, json!({ "op": "flush", "portId": id }));
+    interp.stack.push(handle);
+    Ok(())
+}
+
+/// `handle -- ` : close the port and release the connection.
+pub fn op_close(interp: &mut Interpreter) -> Result<()> {
+    let handle = pop(interp)?;
+    let id = require_port_id(&handle)?;
+    emit(interp, json!({ "op": "close", "portId": id }));
+    Ok(())
+}

--- a/rust/src/interpreter/serial/mod.rs
+++ b/rust/src/interpreter/serial/mod.rs
@@ -1,0 +1,19 @@
+//! `SERIAL` module — Web Serial / native serial port I/O.
+//!
+//! Phase 1 scope: outbound (send-side) words only. Each word emits a single
+//! `SERIAL:{json}` command line into the interpreter output buffer, mirroring
+//! how the `MUSIC` module emits `AUDIO:` commands. The Rust core never touches
+//! a real port; the main-thread platform adapter consumes these commands and
+//! drives `navigator.serial` (web) or a native serial backend (Tauri).
+//!
+//! Inbound (read-side) words and the received-byte inbox are Phase 2 and are
+//! intentionally absent here. See `docs/dev/web-serial-module-design.md`.
+
+mod execute_serial_commands;
+
+pub use execute_serial_commands::{
+    op_close, op_configure, op_flush, op_list_ports, op_open, op_write,
+};
+
+#[cfg(test)]
+mod serial_command_tests;

--- a/rust/src/interpreter/serial/serial_command_tests.rs
+++ b/rust/src/interpreter/serial/serial_command_tests.rs
@@ -17,15 +17,24 @@ async fn open_emits_command_and_keeps_handle() {
     assert!(result.is_ok(), "OPEN should succeed: {:?}", result);
     assert!(output.contains("SERIAL:"), "should emit a SERIAL command");
     assert!(output.contains("\"op\":\"open\""), "op should be open");
-    assert!(output.contains("\"portId\":\"COM3\""), "portId should round-trip");
+    assert!(
+        output.contains("\"portId\":\"COM3\""),
+        "portId should round-trip"
+    );
 }
 
 #[tokio::test]
 async fn configure_emits_baud_rate() {
     let (result, output) = run("'COM3' SERIAL@OPEN 115200 SERIAL@CONFIGURE").await;
     assert!(result.is_ok(), "CONFIGURE should succeed: {:?}", result);
-    assert!(output.contains("\"op\":\"configure\""), "op should be configure");
-    assert!(output.contains("\"baudRate\":115200"), "baud rate should be emitted");
+    assert!(
+        output.contains("\"op\":\"configure\""),
+        "op should be configure"
+    );
+    assert!(
+        output.contains("\"baudRate\":115200"),
+        "baud rate should be emitted"
+    );
 }
 
 #[tokio::test]
@@ -33,28 +42,43 @@ async fn write_emits_byte_array() {
     let (result, output) = run("'COM3' SERIAL@OPEN [ 72 73 ] SERIAL@WRITE").await;
     assert!(result.is_ok(), "WRITE should succeed: {:?}", result);
     assert!(output.contains("\"op\":\"write\""), "op should be write");
-    assert!(output.contains("\"bytes\":[72,73]"), "bytes should be emitted as array");
+    assert!(
+        output.contains("\"bytes\":[72,73]"),
+        "bytes should be emitted as array"
+    );
 }
 
 #[tokio::test]
 async fn flush_then_close_emit_commands() {
     let (result, output) = run("'COM3' SERIAL@OPEN SERIAL@FLUSH SERIAL@CLOSE").await;
     assert!(result.is_ok(), "FLUSH/CLOSE should succeed: {:?}", result);
-    assert!(output.contains("\"op\":\"flush\""), "op should include flush");
-    assert!(output.contains("\"op\":\"close\""), "op should include close");
+    assert!(
+        output.contains("\"op\":\"flush\""),
+        "op should include flush"
+    );
+    assert!(
+        output.contains("\"op\":\"close\""),
+        "op should include close"
+    );
 }
 
 #[tokio::test]
 async fn list_ports_emits_query() {
     let (result, output) = run("SERIAL@LIST-PORTS").await;
     assert!(result.is_ok(), "LIST-PORTS should succeed: {:?}", result);
-    assert!(output.contains("\"op\":\"listPorts\""), "should emit listPorts query");
+    assert!(
+        output.contains("\"op\":\"listPorts\""),
+        "should emit listPorts query"
+    );
 }
 
 #[tokio::test]
 async fn write_rejects_out_of_range_byte() {
     let (result, _) = run("'COM3' SERIAL@OPEN [ 999 ] SERIAL@WRITE").await;
-    assert!(result.is_err(), "byte 999 is out of range and must error (misuse)");
+    assert!(
+        result.is_err(),
+        "byte 999 is out of range and must error (misuse)"
+    );
 }
 
 #[tokio::test]

--- a/rust/src/interpreter/serial/serial_command_tests.rs
+++ b/rust/src/interpreter/serial/serial_command_tests.rs
@@ -1,0 +1,70 @@
+//! Phase-1 contract tests for the `SERIAL` module. Hardware is never exercised;
+//! these assert the emitted `SERIAL:` command lines and the misuse error paths.
+
+use crate::interpreter::Interpreter;
+
+async fn run(code: &str) -> (Result<(), crate::error::AjisaiError>, String) {
+    let mut interp = Interpreter::new();
+    interp.execute("'serial' IMPORT").await.unwrap();
+    let result = interp.execute(code).await;
+    let output = interp.collect_output();
+    (result, output)
+}
+
+#[tokio::test]
+async fn open_emits_command_and_keeps_handle() {
+    let (result, output) = run("'COM3' SERIAL@OPEN").await;
+    assert!(result.is_ok(), "OPEN should succeed: {:?}", result);
+    assert!(output.contains("SERIAL:"), "should emit a SERIAL command");
+    assert!(output.contains("\"op\":\"open\""), "op should be open");
+    assert!(output.contains("\"portId\":\"COM3\""), "portId should round-trip");
+}
+
+#[tokio::test]
+async fn configure_emits_baud_rate() {
+    let (result, output) = run("'COM3' SERIAL@OPEN 115200 SERIAL@CONFIGURE").await;
+    assert!(result.is_ok(), "CONFIGURE should succeed: {:?}", result);
+    assert!(output.contains("\"op\":\"configure\""), "op should be configure");
+    assert!(output.contains("\"baudRate\":115200"), "baud rate should be emitted");
+}
+
+#[tokio::test]
+async fn write_emits_byte_array() {
+    let (result, output) = run("'COM3' SERIAL@OPEN [ 72 73 ] SERIAL@WRITE").await;
+    assert!(result.is_ok(), "WRITE should succeed: {:?}", result);
+    assert!(output.contains("\"op\":\"write\""), "op should be write");
+    assert!(output.contains("\"bytes\":[72,73]"), "bytes should be emitted as array");
+}
+
+#[tokio::test]
+async fn flush_then_close_emit_commands() {
+    let (result, output) = run("'COM3' SERIAL@OPEN SERIAL@FLUSH SERIAL@CLOSE").await;
+    assert!(result.is_ok(), "FLUSH/CLOSE should succeed: {:?}", result);
+    assert!(output.contains("\"op\":\"flush\""), "op should include flush");
+    assert!(output.contains("\"op\":\"close\""), "op should include close");
+}
+
+#[tokio::test]
+async fn list_ports_emits_query() {
+    let (result, output) = run("SERIAL@LIST-PORTS").await;
+    assert!(result.is_ok(), "LIST-PORTS should succeed: {:?}", result);
+    assert!(output.contains("\"op\":\"listPorts\""), "should emit listPorts query");
+}
+
+#[tokio::test]
+async fn write_rejects_out_of_range_byte() {
+    let (result, _) = run("'COM3' SERIAL@OPEN [ 999 ] SERIAL@WRITE").await;
+    assert!(result.is_err(), "byte 999 is out of range and must error (misuse)");
+}
+
+#[tokio::test]
+async fn open_rejects_non_text_port_id() {
+    let (result, _) = run("42 SERIAL@OPEN").await;
+    assert!(result.is_err(), "numeric port-id must error (misuse)");
+}
+
+#[tokio::test]
+async fn open_underflow_errors() {
+    let (result, _) = run("SERIAL@OPEN").await;
+    assert!(result.is_err(), "OPEN with empty stack must underflow");
+}

--- a/src/gui/gui-dom-cache.ts
+++ b/src/gui/gui-dom-cache.ts
@@ -32,6 +32,7 @@ export interface GUIElements {
     readonly mobileDictionarySearch: HTMLInputElement;
     readonly mobileDictionarySearchClearBtn: HTMLButtonElement;
     readonly copyOutputBtn: HTMLButtonElement;
+    readonly serialConnectBtn: HTMLButtonElement | null;
 }
 
 type ElementConstructor<T extends HTMLElement> = {
@@ -51,6 +52,14 @@ function requireElementById<T extends HTMLElement>(id: string, expectedConstruct
     }
 
     return element as T;
+}
+
+function optionalElementById<T extends HTMLElement>(id: string, expectedConstructor: ElementConstructor<T>): T | null {
+    const element = document.getElementById(id);
+    if (!element) {
+        return null;
+    }
+    return element instanceof expectedConstructor ? (element as T) : null;
 }
 
 function requireElementBySelector<T extends HTMLElement>(selector: string, expectedConstructor: ElementConstructor<T>): T {
@@ -96,7 +105,8 @@ export const cacheElements = (): GUIElements => ({
     mobilePanelDictionarySearch: requireElementById('mobile-panel-dictionary-search', HTMLElement),
     mobileDictionarySearch: requireElementById('mobile-dictionary-search', HTMLInputElement),
     mobileDictionarySearchClearBtn: requireElementById('mobile-dictionary-search-clear-btn', HTMLButtonElement),
-    copyOutputBtn: requireElementById('copy-output-btn', HTMLButtonElement)
+    copyOutputBtn: requireElementById('copy-output-btn', HTMLButtonElement),
+    serialConnectBtn: optionalElementById('serial-connect-btn', HTMLButtonElement)
 });
 
 export const extractDisplayElements = (elements: GUIElements): DisplayElements => ({

--- a/src/gui/gui-event-bindings.ts
+++ b/src/gui/gui-event-bindings.ts
@@ -1,4 +1,5 @@
 import { WORKER_MANAGER } from '../workers/execution-worker-manager';
+import { getPlatform } from '../platform';
 import type { Display } from './output-display-renderer';
 import type { Editor } from './code-input-editor';
 import type { MobileHandler, ViewMode } from './mobile-view-switcher';
@@ -157,6 +158,27 @@ function bindInteractionEvents(context: GuiEventBindingContext): void {
 
     elements.exportBtn?.addEventListener('click', () => persistence.exportUserWords());
     elements.importBtn?.addEventListener('click', () => persistence.importUserWords());
+
+    {
+        const serialBtn = elements.serialConnectBtn;
+        const serial = getPlatform().serial;
+        if (serialBtn && serial.available) {
+            serialBtn.hidden = false;
+            serialBtn.addEventListener('click', async () => {
+                // requestAccess() must run inside this user gesture (Web Serial).
+                try {
+                    const info = await serial.requestAccess();
+                    if (info) {
+                        display.renderInfo(`Serial port connected as '${info.portId}'.`, true);
+                    } else {
+                        display.renderInfo('No serial port was selected.', true);
+                    }
+                } catch (error) {
+                    display.renderError(error as Error);
+                }
+            });
+        }
+    }
 
     elements.codeInput.addEventListener('keydown', (e: KeyboardEvent) => {
         if (e.key === 'Enter' && e.shiftKey) {

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -1,5 +1,6 @@
 import type { Value, ExecuteResult } from '../wasm-interpreter-types';
 import { AUDIO_ENGINE } from '../audio/audio-engine';
+import { getPlatform } from '../platform';
 
 export interface DisplayElements {
     outputDisplay: HTMLElement;
@@ -290,6 +291,7 @@ interface ParsedOutput {
     readonly config: readonly string[];
     readonly effect: readonly string[];
     readonly jsonExport: readonly string[];
+    readonly serial: readonly string[];
     /** Output lines with all special command lines removed, joined by newlines. */
     readonly program: string;
 }
@@ -301,6 +303,7 @@ const parseOutputCommands = (output: string): ParsedOutput => {
     const config: string[] = [];
     const effect: string[] = [];
     const jsonExport: string[] = [];
+    const serial: string[] = [];
     const programLines: string[] = [];
 
     for (const line of output.split('\n')) {
@@ -308,10 +311,11 @@ const parseOutputCommands = (output: string): ParsedOutput => {
         else if (line.startsWith('CONFIG:')) config.push(line.substring(7));
         else if (line.startsWith('EFFECT:')) effect.push(line.substring(7));
         else if (line.startsWith('JSONEXPORT:')) jsonExport.push(line.substring(11));
+        else if (line.startsWith('SERIAL:')) serial.push(line.substring(7));
         else programLines.push(line);
     }
 
-    return { audio, config, effect, jsonExport, program: programLines.join('\n') };
+    return { audio, config, effect, jsonExport, serial, program: programLines.join('\n') };
 };
 
 const formatErrorMessage = (error: Error | { message?: string } | string): string =>
@@ -364,9 +368,59 @@ const applyConfigCommands = (commands: readonly string[]): void => {
     });
 };
 
-const executeAudioCommands = (parsed: ParsedOutput): void => {
+interface SerialCommand {
+    readonly op: string;
+    readonly portId?: string;
+    readonly baudRate?: number;
+    readonly bytes?: number[];
+}
+
+const applySerialCommands = (commands: readonly string[]): void => {
+    if (commands.length === 0) return;
+    const serial = getPlatform().serial;
+    const guard = (op: string, p: Promise<unknown>): void => {
+        p.catch(err => console.error(`Serial command '${op}' failed:`, err));
+    };
+
+    commands.forEach(commandStr => {
+        let cmd: SerialCommand;
+        try {
+            cmd = JSON.parse(commandStr);
+        } catch {
+            console.error('Failed to parse SERIAL command:', commandStr);
+            return;
+        }
+        switch (cmd.op) {
+            case 'listPorts':
+                guard('listPorts', serial.listPorts().then(ports => {
+                    console.log('Serial ports:', ports);
+                }));
+                break;
+            case 'open':
+                guard('open', serial.open(cmd.portId ?? ''));
+                break;
+            case 'configure':
+                guard('configure', serial.configure(cmd.portId ?? '', { baudRate: cmd.baudRate ?? 0 }));
+                break;
+            case 'write':
+                guard('write', serial.write(cmd.portId ?? '', Uint8Array.from(cmd.bytes ?? [])));
+                break;
+            case 'flush':
+                guard('flush', serial.flush(cmd.portId ?? ''));
+                break;
+            case 'close':
+                guard('close', serial.close(cmd.portId ?? ''));
+                break;
+            default:
+                console.error('Unknown SERIAL op:', cmd.op);
+        }
+    });
+};
+
+const executeHostCommands = (parsed: ParsedOutput): void => {
     applyEffectCommands(parsed.effect);
     applyConfigCommands(parsed.config);
+    applySerialCommands(parsed.serial);
 
     parsed.audio.forEach(commandStr => {
         try {
@@ -424,7 +478,7 @@ export const createDisplay = (elements: DisplayElements): Display => {
 
     const renderExecutionResult = (result: ExecuteResult): void => {
         const parsed = parseOutputCommands(result.output || '');
-        executeAudioCommands(parsed);
+        executeHostCommands(parsed);
 
         const debug = (result.debugOutput || '').trim();
         const program = parsed.program.trim();
@@ -453,7 +507,7 @@ export const createDisplay = (elements: DisplayElements): Display => {
 
     const appendExecutionResult = (result: ExecuteResult): void => {
         const parsed = parseOutputCommands(result.output || '');
-        executeAudioCommands(parsed);
+        executeHostCommands(parsed);
         const filteredOutput = parsed.program.trim();
 
         if (filteredOutput) {
@@ -463,7 +517,7 @@ export const createDisplay = (elements: DisplayElements): Display => {
 
     const renderOutput = (text: string): void => {
         const parsed = parseOutputCommands(text);
-        executeAudioCommands(parsed);
+        executeHostCommands(parsed);
 
         mainOutput = parsed.program;
         clearElement(elements.outputDisplay);

--- a/src/platform/platform-adapter.ts
+++ b/src/platform/platform-adapter.ts
@@ -67,8 +67,39 @@ export interface Runtime {
     onReady(callback: () => void): void;
 }
 
+export interface SerialPortInfo {
+    readonly portId: string;
+    readonly label?: string;
+}
+
+/**
+ * Host serial-port capability. The interpreter core never calls this directly;
+ * it emits `SERIAL:` commands that the output dispatcher forwards here. The
+ * interface is shaped for the stricter web case (capability detection,
+ * user-gesture-driven access) so a native Tauri backend satisfies it trivially.
+ *
+ * Phase 1 covers the outbound methods. `drainInbox` is the Phase-2 receive
+ * seam: it returns the bytes received since the previous call, to be injected
+ * into the next execution snapshot.
+ */
+export interface SerialAdapter {
+    /** Capability detection: false when the host has no serial API. */
+    readonly available: boolean;
+    /** Prompt the user to grant a port (web requires a user gesture). */
+    requestAccess(): Promise<SerialPortInfo | null>;
+    listPorts(): Promise<SerialPortInfo[]>;
+    open(portId: string): Promise<void>;
+    configure(portId: string, options: { readonly baudRate: number }): Promise<void>;
+    write(portId: string, bytes: Uint8Array): Promise<void>;
+    flush(portId: string): Promise<void>;
+    /** Phase 2: received bytes since the last drain. Phase 1 returns empty. */
+    drainInbox(portId: string): Uint8Array;
+    close(portId: string): Promise<void>;
+}
+
 export interface PlatformAdapter {
     readonly persistence: Persistence;
     readonly fileIO: FileIO;
     readonly runtime: Runtime;
+    readonly serial: SerialAdapter;
 }

--- a/src/platform/tauri/tauri-platform-adapter.ts
+++ b/src/platform/tauri/tauri-platform-adapter.ts
@@ -1,6 +1,7 @@
 import type { PlatformAdapter } from '../platform-adapter';
 import { TauriFileIO } from './tauri-file-io';
 import { TauriPersistence } from './tauri-persistence';
+import { TauriSerialAdapter } from './tauri-serial';
 
 declare const __AJISAI_CHANGE_NOTE__: string;
 declare const __AJISAI_BUILD_TIMESTAMP__: string;
@@ -8,6 +9,7 @@ declare const __AJISAI_BUILD_TIMESTAMP__: string;
 export const TAURI_PLATFORM_ADAPTER: PlatformAdapter = {
     persistence: new TauriPersistence(),
     fileIO: new TauriFileIO(),
+    serial: new TauriSerialAdapter(),
     runtime: {
         kind: 'tauri',
         version: __AJISAI_CHANGE_NOTE__,

--- a/src/platform/tauri/tauri-serial.ts
+++ b/src/platform/tauri/tauri-serial.ts
@@ -1,0 +1,51 @@
+import type { SerialAdapter, SerialPortInfo } from '../platform-adapter';
+
+/**
+ * Tauri serial backend — typed stub (Phase 3).
+ *
+ * The contract is fixed now so the rest of the system compiles against a single
+ * `SerialAdapter` interface. The implementation will route to native `serial_*`
+ * Tauri commands backed by the `serialport` crate in `src-tauri`. Until then the
+ * adapter reports itself unavailable and the outbound methods throw.
+ *
+ * See `docs/dev/web-serial-module-design.md`.
+ */
+export class TauriSerialAdapter implements SerialAdapter {
+    readonly available = false;
+
+    private notImplemented(): never {
+        throw new Error('SERIAL is not yet implemented in the Tauri backend (Phase 3).');
+    }
+
+    async requestAccess(): Promise<SerialPortInfo | null> {
+        return null;
+    }
+
+    async listPorts(): Promise<SerialPortInfo[]> {
+        return [];
+    }
+
+    async open(_portId: string): Promise<void> {
+        this.notImplemented();
+    }
+
+    async configure(_portId: string, _options: { readonly baudRate: number }): Promise<void> {
+        this.notImplemented();
+    }
+
+    async write(_portId: string, _bytes: Uint8Array): Promise<void> {
+        this.notImplemented();
+    }
+
+    async flush(_portId: string): Promise<void> {
+        this.notImplemented();
+    }
+
+    drainInbox(_portId: string): Uint8Array {
+        return new Uint8Array(0);
+    }
+
+    async close(_portId: string): Promise<void> {
+        this.notImplemented();
+    }
+}

--- a/src/platform/web/web-platform-adapter.ts
+++ b/src/platform/web/web-platform-adapter.ts
@@ -1,6 +1,7 @@
 import type { PlatformAdapter } from '../platform-adapter';
 import webPersistence from './web-persistence';
 import { WebFileIO } from './web-file-io';
+import { WebSerialAdapter } from './web-serial';
 
 declare const __AJISAI_CHANGE_NOTE__: string;
 declare const __AJISAI_BUILD_TIMESTAMP__: string;
@@ -9,6 +10,7 @@ declare const __AJISAI_BUILD_TIMESTAMP__: string;
 export const WEB_PLATFORM_ADAPTER: PlatformAdapter = {
     persistence: webPersistence,
     fileIO: new WebFileIO(),
+    serial: new WebSerialAdapter(),
     runtime: {
         kind: 'web',
         version: __AJISAI_CHANGE_NOTE__,

--- a/src/platform/web/web-serial.ts
+++ b/src/platform/web/web-serial.ts
@@ -1,0 +1,173 @@
+import type { SerialAdapter, SerialPortInfo } from '../platform-adapter';
+
+// Minimal local declarations for the W3C Web Serial API so the build does not
+// depend on the surrounding TS DOM lib shipping these types yet.
+interface WebSerialPort {
+    open(options: { baudRate: number }): Promise<void>;
+    close(): Promise<void>;
+    readonly writable: WritableStream<Uint8Array> | null;
+    getInfo?(): { usbVendorId?: number; usbProductId?: number };
+}
+
+interface WebSerial {
+    requestPort(): Promise<WebSerialPort>;
+    getPorts(): Promise<WebSerialPort[]>;
+}
+
+const getNavigatorSerial = (): WebSerial | undefined =>
+    (navigator as unknown as { serial?: WebSerial }).serial;
+
+const DEFAULT_BAUD_RATE = 9600;
+
+interface GrantedPort {
+    readonly id: string;
+    readonly port: WebSerialPort;
+    baudRate: number;
+    opened: boolean;
+    writer: WritableStreamDefaultWriter<Uint8Array> | null;
+}
+
+/**
+ * Web Serial backend. Real `SerialPort` objects live here, on the main thread,
+ * keyed by an opaque string id that Ajisai programs use as the connection
+ * handle. Operations are serialized through a single promise chain so the
+ * fire-and-forget command stream (open → configure → write → close) executes
+ * in order even though the dispatcher does not await between commands.
+ */
+export class WebSerialAdapter implements SerialAdapter {
+    private readonly ports: GrantedPort[] = [];
+    private queue: Promise<unknown> = Promise.resolve();
+
+    get available(): boolean {
+        return getNavigatorSerial() !== undefined;
+    }
+
+    private enqueue<T>(op: () => Promise<T>): Promise<T> {
+        const result = this.queue.then(op);
+        // Keep the chain alive even if an op rejects.
+        this.queue = result.catch(() => undefined);
+        return result;
+    }
+
+    private register(port: WebSerialPort): GrantedPort {
+        const existing = this.ports.find(p => p.port === port);
+        if (existing) return existing;
+        const entry: GrantedPort = {
+            id: `serial-${this.ports.length}`,
+            port,
+            baudRate: DEFAULT_BAUD_RATE,
+            opened: false,
+            writer: null
+        };
+        this.ports.push(entry);
+        return entry;
+    }
+
+    private require(portId: string): GrantedPort {
+        const entry = this.ports.find(p => p.id === portId);
+        if (!entry) {
+            throw new Error(`Serial port '${portId}' has not been granted. Use the connect control first.`);
+        }
+        return entry;
+    }
+
+    requestAccess(): Promise<SerialPortInfo | null> {
+        return this.enqueue(async () => {
+            const serial = getNavigatorSerial();
+            if (!serial) return null;
+            const port = await serial.requestPort();
+            const entry = this.register(port);
+            return { portId: entry.id };
+        });
+    }
+
+    listPorts(): Promise<SerialPortInfo[]> {
+        return this.enqueue(async () => {
+            const serial = getNavigatorSerial();
+            if (!serial) return [];
+            const granted = await serial.getPorts();
+            granted.forEach(port => this.register(port));
+            return this.ports.map(entry => ({ portId: entry.id }));
+        });
+    }
+
+    private async reopen(entry: GrantedPort): Promise<void> {
+        if (entry.writer) {
+            try { entry.writer.releaseLock(); } catch { /* ignore */ }
+            entry.writer = null;
+        }
+        if (entry.opened) {
+            await entry.port.close();
+            entry.opened = false;
+        }
+        await entry.port.open({ baudRate: entry.baudRate });
+        entry.opened = true;
+    }
+
+    open(portId: string): Promise<void> {
+        return this.enqueue(async () => {
+            const entry = this.require(portId);
+            if (!entry.opened) {
+                await entry.port.open({ baudRate: entry.baudRate });
+                entry.opened = true;
+            }
+        });
+    }
+
+    configure(portId: string, options: { readonly baudRate: number }): Promise<void> {
+        return this.enqueue(async () => {
+            const entry = this.require(portId);
+            const changed = entry.baudRate !== options.baudRate;
+            entry.baudRate = options.baudRate;
+            // Web Serial cannot change baud rate while open; reopen if needed.
+            if (entry.opened && changed) {
+                await this.reopen(entry);
+            }
+        });
+    }
+
+    write(portId: string, bytes: Uint8Array): Promise<void> {
+        return this.enqueue(async () => {
+            const entry = this.require(portId);
+            if (!entry.opened) {
+                await entry.port.open({ baudRate: entry.baudRate });
+                entry.opened = true;
+            }
+            const writable = entry.port.writable;
+            if (!writable) {
+                throw new Error(`Serial port '${portId}' is not writable.`);
+            }
+            if (!entry.writer) {
+                entry.writer = writable.getWriter();
+            }
+            await entry.writer.write(bytes);
+        });
+    }
+
+    flush(portId: string): Promise<void> {
+        // Writes are not buffered at this layer; flush is a no-op acknowledgement.
+        return this.enqueue(async () => {
+            this.require(portId);
+        });
+    }
+
+    drainInbox(_portId: string): Uint8Array {
+        // Phase 2: a per-port RX reader loop will fill a buffer drained here and
+        // injected into the next execution snapshot. Phase 1 is send-only.
+        return new Uint8Array(0);
+    }
+
+    close(portId: string): Promise<void> {
+        return this.enqueue(async () => {
+            const entry = this.require(portId);
+            if (entry.writer) {
+                try { entry.writer.releaseLock(); } catch { /* ignore */ }
+                entry.writer = null;
+            }
+            if (entry.opened) {
+                await entry.port.close();
+                entry.opened = false;
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Adds Web Serial support to Ajisai in two parts, keeping the web (WASM playground) channel and a future Tauri channel served by a single canonical interpreter.

### A. Design note (`docs/dev/web-serial-module-design.md`)
Non-canonical developer note describing the optimal cross-platform design:
- **Single platform-agnostic core**: the Rust core never references `navigator.serial` or any native `serialport` crate. It only emits `SERIAL:{json}` outbox commands and (Phase 2) reads an injected inbox.
- **One `SerialAdapter` interface, two backends**: web (`navigator.serial`) and Tauri (native `serialport` via `invoke`). Platform differences are confined to the adapter; semantics are shared.
- **Inbox/outbox model** preserves within-run determinism and avoids dual-mode drift (§14.1).

### B. Phase 1 — outbound serial (this PR)
- **Rust `SERIAL` module** (`rust/src/interpreter/serial/`): `LIST-PORTS`, `OPEN`, `CONFIGURE`, `WRITE`, `FLUSH`, `CLOSE`. Each emits a fire-and-forget `SERIAL:` command into `output_buffer`, mirroring the `MUSIC` `AUDIO:` precedent. Registered in `MODULE_SPECS` with `Effectful` contract metadata; marked `Impure` in the purity table so they are never speculatively reordered or cached.
- **TS `SerialAdapter` seam** on `PlatformAdapter`: `WebSerialAdapter` (real `navigator.serial`, per-port operation serialization, baud-rate reopen handling) and a typed `TauriSerialAdapter` stub for Phase 3.
- **Output dispatcher** parses `SERIAL:` lines and forwards to the adapter.
- **"Connect serial" control**: a header button (hidden unless `navigator.serial` is available) calls `requestPort()` inside the user gesture and reports the granted port id.

Bidirectional read (`READ` + RX inbox) and the native Tauri backend are deliberately out of scope here (Phases 2 and 3 in the design note).

## Test plan
- [x] `cargo test --lib` (1046 passed) — includes 8 new SERIAL contract/error tests
- [x] `cargo test --tests` (1046 passed)
- [x] `tsc --noEmit` clean on all changed/added files (pre-existing `vitest` type errors are environmental, dev deps not installed)
- [ ] Manual hardware check in a Web Serial-capable browser (cannot run in CI; needs a physical/emulated serial device over HTTPS/localhost)
- [ ] Promote the agreed `SERIAL` vocabulary, contracts, and bubble reasons into `SPECIFICATION.md` (Phase 0 follow-up)

https://claude.ai/code/session_01649K3MLhxhDKTy9F9e6w5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01649K3MLhxhDKTy9F9e6w5D)_