### PR TITLE
Phase 0: promote SERIAL module into SPECIFICATION.md

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,7 +1,7 @@
 # Ajisai Language Specification
 
 Status: **Canonical**
-Version: **2026-05-13**
+Version: **2026-05-22**
 
 This document is the single design authority for Ajisai. It describes Ajisai as it is. It does not record development history or transitional states. If any other document conflicts with this document, this document takes precedence.
 
@@ -672,6 +672,7 @@ Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object 
 | `CRYPTO` | Cryptographically secure random and hash |
 | `ALGO` | Sorting and other deterministic algorithms |
 | `MATH` | Square root and exact-rational interval arithmetic |
+| `SERIAL` | Host-mediated serial port output |
 
 ### 9.2 Import and unimport syntax
 
@@ -693,6 +694,27 @@ Selectors that name Core words merely listed in a module view are no-ops for `IM
 ### 9.3 Module-provided sample words
 
 Modules may provide sample words for demonstration. Sample words are part of the module dictionary for import visibility: they can be introduced with `IMPORT` / `IMPORT-ONLY` and hidden with `UNIMPORT` / `UNIMPORT-ONLY`, but they are not destructively deleted with `DEL`.
+
+### 9.4 SERIAL module (host-mediated serial output)
+
+The `SERIAL` module exposes a serial port to Ajisai programs. Serial access is a property of the host environment, not of the runtime: the runtime never opens, writes, or closes a port itself. Each `SERIAL` word is effectful and produces a single host command at the IO/semantic boundary (Section 5.2); the host environment consumes that command and performs the actual port operation. The serial transport itself (a browser Web Serial implementation, a native serial backend, or none) is a host capability outside this specification. The absence of a serial-capable host is an environment condition, not a language semantic error.
+
+A serial connection is identified by an **opaque port-id text value** that the host environment assigns when the user grants access. Programs treat the port id as a connection handle and thread it along the stack. The port id is `Text`; the runtime does not interpret its contents.
+
+The module provides the following words:
+
+| Word | Stack effect | Description |
+|------|--------------|-------------|
+| `LIST-PORTS` | `--` | Request host enumeration of available ports |
+| `OPEN` | `port-id -- port-id` | Open the named port; the port id remains on the stack as the connection handle |
+| `CONFIGURE` | `port-id baud-rate -- port-id` | Set the baud rate of an open port |
+| `WRITE` | `port-id bytes -- port-id` | Send a byte vector (each element an integer `0`–`255`) to an open port |
+| `FLUSH` | `port-id -- port-id` | Flush the port's outgoing data |
+| `CLOSE` | `port-id --` | Close the port and release the connection |
+
+Contract classification (Section 7.14): every `SERIAL` word has `purity = Effectful`, `deterministic = false`, `safe_preview = false`, `partiality = Partial`, `nil_policy = RejectsNil`, and `safety_level = D`. Because they drive external hardware, `SERIAL` words are never eligible for speculative reordering, caching, or `safe_preview` execution.
+
+Misuse raises an error rather than producing Bubble/NIL (Section 11.2 "malformed use → error"): a non-text port id, a byte outside `0`–`255`, a non-positive baud rate, or a missing operand raises `StructureError` or `StackUnderflow`. The host-side outcome of a well-formed command (for example a device that is physically disconnected) is reported through the host environment and does not change the runtime stack effect of the word.
 
 ---
 

--- a/rust/src/interpreter/serial/serial_command_tests.rs
+++ b/rust/src/interpreter/serial/serial_command_tests.rs
@@ -92,3 +92,28 @@ async fn open_underflow_errors() {
     let (result, _) = run("SERIAL@OPEN").await;
     assert!(result.is_err(), "OPEN with empty stack must underflow");
 }
+
+// Conformance with SPECIFICATION.md §9.4 / §7.14: every SERIAL word is an
+// effectful, partial, NIL-rejecting, safety-D hardware word that is never
+// deterministic or safe-preview eligible.
+#[test]
+fn serial_words_have_effectful_hardware_contract() {
+    use crate::coreword_registry::{
+        get_canonical_module_words, NilPolicy, Partiality, SafetyLevel, WordPurity,
+    };
+
+    let words = get_canonical_module_words(Some("SERIAL"));
+    let names: Vec<&str> = words.iter().map(|w| w.name.as_str()).collect();
+    for expected in ["LIST-PORTS", "OPEN", "CONFIGURE", "WRITE", "FLUSH", "CLOSE"] {
+        assert!(names.contains(&expected), "SERIAL should expose {expected}");
+    }
+
+    for w in &words {
+        assert_eq!(w.purity, WordPurity::Effectful, "{} purity", w.name);
+        assert_eq!(w.partiality, Partiality::Partial, "{} partiality", w.name);
+        assert_eq!(w.nil_policy, NilPolicy::RejectsNil, "{} nil_policy", w.name);
+        assert_eq!(w.safety_level, SafetyLevel::D, "{} safety_level", w.name);
+        assert!(!w.deterministic, "{} must be non-deterministic", w.name);
+        assert!(!w.safe_preview, "{} must not be safe-preview", w.name);
+    }
+}


### PR DESCRIPTION
## Summary

The Phase 1 `SERIAL` module merged (#964) before its semantics were promoted into the canonical spec. This PR closes that gap (the design note's Phase 0) and re-verifies the existing Phase 1 implementation against the now-canonical text.

- **`SPECIFICATION.md`**: add `SERIAL` to the §9.1 module table; add **§9.4** documenting the host-mediated outbound model, the six words and their stack effects, the shared contract classification (`Effectful` / `Partial` / `RejectsNil` / `safety_level D`, non-deterministic, non-`safe_preview`), and the misuse→error behavior. Bump the spec version to `2026-05-22`.
- **Conformance test**: `serial_words_have_effectful_hardware_contract` asserts the Coreword registry metadata for every `SERIAL` word matches §9.4 — a mechanical re-check of Phase 1 against the spec.

Strictly "as-is": no forward references to the unimplemented Phase 2 read/inbox path, so the spec continues to describe Ajisai as it is.

### Phase 1 re-verification result
- Word names, stack effects, and error behavior in the implementation match §9.4.
- One discrepancy found and fixed in the spec draft: the registry classifies all effectful module words as `Partial` uniformly, so the spec states `partiality = Partial` for all six (rather than singling out `LIST-PORTS` as total) to match the actual metadata.

## Test plan
- [x] `cargo test --lib` (1047 passed; +1 new contract test)
- [x] `rustfmt --check` clean on the changed test file
- [ ] No code paths changed, so no runtime/UI re-test needed beyond the existing Phase 1 verification

https://claude.ai/code/session_01649K3MLhxhDKTy9F9e6w5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01649K3MLhxhDKTy9F9e6w5D)_