### PR TITLE
Phase 2: inbound SERIAL@READ with host-injected receive inbox

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -697,9 +697,11 @@ Modules may provide sample words for demonstration. Sample words are part of the
 
 ### 9.4 SERIAL module (host-mediated serial output)
 
-The `SERIAL` module exposes a serial port to Ajisai programs. Serial access is a property of the host environment, not of the runtime: the runtime never opens, writes, or closes a port itself. Each `SERIAL` word is effectful and produces a single host command at the IO/semantic boundary (Section 5.2); the host environment consumes that command and performs the actual port operation. The serial transport itself (a browser Web Serial implementation, a native serial backend, or none) is a host capability outside this specification. The absence of a serial-capable host is an environment condition, not a language semantic error.
+The `SERIAL` module exposes a serial port to Ajisai programs. Serial access is a property of the host environment, not of the runtime: the runtime never opens, writes, reads, or closes a port itself. Outbound words are effectful and produce a single host command at the IO/semantic boundary (Section 5.2); the host environment consumes that command and performs the actual port operation. The serial transport itself (a browser Web Serial implementation, a native serial backend, or none) is a host capability outside this specification. The absence of a serial-capable host is an environment condition, not a language semantic error.
 
 A serial connection is identified by an **opaque port-id text value** that the host environment assigns when the user grants access. Programs treat the port id as a connection handle and thread it along the stack. The port id is `Text`; the runtime does not interpret its contents.
+
+**Receive model.** Inbound data is delivered to a program through a per-run *receive buffer* (inbox). The host environment injects the bytes received on each open port before a run begins; `READ` drains the inbox for a port. A run therefore observes exactly the bytes that arrived since the previous run — an event-poll model, not a blocking read. Within a single run the inbox is fixed, so a run is deterministic with respect to its injected input. Each `READ` consumes the buffered bytes for its port; a subsequent `READ` in the same run with no further data projects `noData` (Section 11.2).
 
 The module provides the following words:
 
@@ -709,12 +711,13 @@ The module provides the following words:
 | `OPEN` | `port-id -- port-id` | Open the named port; the port id remains on the stack as the connection handle |
 | `CONFIGURE` | `port-id baud-rate -- port-id` | Set the baud rate of an open port |
 | `WRITE` | `port-id bytes -- port-id` | Send a byte vector (each element an integer `0`–`255`) to an open port |
+| `READ` | `port-id -- bytes` | Drain the port's receive buffer, returning a byte vector; Bubble/NIL when none is available |
 | `FLUSH` | `port-id -- port-id` | Flush the port's outgoing data |
 | `CLOSE` | `port-id --` | Close the port and release the connection |
 
-Contract classification (Section 7.14): every `SERIAL` word has `purity = Effectful`, `deterministic = false`, `safe_preview = false`, `partiality = Partial`, `nil_policy = RejectsNil`, and `safety_level = D`. Because they drive external hardware, `SERIAL` words are never eligible for speculative reordering, caching, or `safe_preview` execution.
+Contract classification (Section 7.14): every `SERIAL` word has `purity = Effectful`, `deterministic = false`, `safe_preview = false`, and `safety_level = D`. The outbound words (`LIST-PORTS`, `OPEN`, `CONFIGURE`, `WRITE`, `FLUSH`, `CLOSE`) are `partiality = Partial`, `nil_policy = RejectsNil`. `READ` is `partiality = Projecting`, `nil_policy = CreatesNil`: it projects the no-data and disconnected conditions onto Bubble/NIL. Because they drive or observe external hardware, `SERIAL` words are never eligible for speculative reordering, caching, or `safe_preview` execution.
 
-Misuse raises an error rather than producing Bubble/NIL (Section 11.2 "malformed use → error"): a non-text port id, a byte outside `0`–`255`, a non-positive baud rate, or a missing operand raises `StructureError` or `StackUnderflow`. The host-side outcome of a well-formed command (for example a device that is physically disconnected) is reported through the host environment and does not change the runtime stack effect of the word.
+Misuse raises an error rather than producing Bubble/NIL (Section 11.2 "malformed use → error"): a non-text port id, a byte outside `0`–`255`, a non-positive baud rate, or a missing operand raises `StructureError` or `StackUnderflow`. For `READ`, the absence of data is a well-formed outcome, not misuse: with no buffered bytes it projects Bubble/NIL with `reason = noData`, or `reason = portDisconnected` when the host has reported the port gone. The host-side outcome of a well-formed outbound command (for example a device that is physically disconnected) is reported through the host environment and does not change the runtime stack effect of the word.
 
 ---
 
@@ -792,6 +795,7 @@ Initial Core words following this rule include:
 | `NUM` | Text cannot be parsed as a number (`NilReason::InvalidEncoding`) | Input shape is not convertible text |
 | `CHR` | Numeric code point is outside the valid Unicode scalar range (`NilReason::InvalidEncoding`) | Operand is not numeric, or numeric operand is not an integer |
 | `EQ` / `NEQ` / `LT` / `LTE` / `GT` / `GTE` | Comparison budget exhausted on lazy continued fractions (`NilReason::Undecidable`, `absence.origin = comparisonBudget`; see Section 7.4.1) | Non-numeric operands or malformed shapes |
+| `SERIAL@READ` | Receive buffer empty (`NilReason::NoData`); host reported the port disconnected with no remaining data (`NilReason::PortDisconnected`); both with `absence.origin = hostEnvironment` (Section 9.4) | Non-text port id, or a missing operand |
 
 `OR-NIL` (`=>`) replaces Bubble/NIL with a fallback value. Existing NIL passthrough behavior preserves the reason as Bubble/NIL flows through later operations.
 

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -161,7 +161,7 @@ pub fn purity_by_name(name: &str) -> Option<PurityInfo> {
         // Serial I/O drives external hardware: always impure, order-sensitive,
         // and never eligible for speculative reordering or caching.
         "SERIAL@LIST-PORTS" | "SERIAL@OPEN" | "SERIAL@CONFIGURE" | "SERIAL@WRITE"
-        | "SERIAL@FLUSH" | "SERIAL@CLOSE" => Some(PurityInfo {
+        | "SERIAL@READ" | "SERIAL@FLUSH" | "SERIAL@CLOSE" => Some(PurityInfo {
             purity: Purity::Impure,
             cost: EvalCost::Heavy,
             order_sensitive: true,

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -20,6 +20,12 @@ pub enum NilReason {
     /// `absence.origin = comparisonBudget` rather than a SAFE-caught
     /// error.
     Undecidable,
+    /// A host-mediated read (`SERIAL@READ`) found no buffered data. The Bubble
+    /// Rule projects this to NIL with `absence.origin = hostEnvironment`.
+    NoData,
+    /// A host-mediated port was reported disconnected with no remaining
+    /// buffered data. Projected to NIL with `absence.origin = hostEnvironment`.
+    PortDisconnected,
     SafeCaught(Box<ErrorCategory>),
 }
 
@@ -88,6 +94,8 @@ impl NilReason {
             NilReason::UnknownWord => "unknownWord",
             NilReason::ExecutionFailure => "executionFailure",
             NilReason::Undecidable => "undecidable",
+            NilReason::NoData => "noData",
+            NilReason::PortDisconnected => "portDisconnected",
             NilReason::SafeCaught(_) => "safeCaught",
         }
     }

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -52,7 +52,9 @@ fn error_category_for_nil_reason(reason: &NilReason) -> Option<ErrorCategory> {
         | NilReason::InvalidEncoding
         | NilReason::InvalidLens
         | NilReason::ExecutionFailure
-        | NilReason::Undecidable => Some(ErrorCategory::Custom),
+        | NilReason::Undecidable
+        | NilReason::NoData
+        | NilReason::PortDisconnected => Some(ErrorCategory::Custom),
     }
 }
 

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -216,6 +216,14 @@ pub struct Interpreter {
     pub(crate) input_buffer: String,
     pub(crate) io_output_buffer: String,
 
+    /// Host-injected serial receive buffers, keyed by opaque port id. Filled
+    /// before execution from the platform serial adapter (Section 9.4); drained
+    /// by `SERIAL@READ`.
+    pub(crate) serial_inbox: HashMap<String, Vec<u8>>,
+    /// Port ids the host has reported disconnected. `SERIAL@READ` projects this
+    /// to `NilReason::PortDisconnected` once the inbox for the port is empty.
+    pub(crate) serial_disconnected: HashSet<String>,
+
     pub(crate) module_vocabulary: HashMap<String, ModuleDictionary>,
     pub(crate) dictionary_dependencies: HashMap<String, DictionaryDependencyInfo>,
     pub(crate) next_registration_order: u64,
@@ -270,6 +278,8 @@ impl Interpreter {
             max_execution_steps: DEFAULT_MAX_EXECUTION_STEPS,
             input_buffer: String::new(),
             io_output_buffer: String::new(),
+            serial_inbox: HashMap::new(),
+            serial_disconnected: HashSet::new(),
             module_vocabulary: HashMap::new(),
             dictionary_dependencies: HashMap::new(),
             next_registration_order: 1,

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,5 +1,7 @@
 use crate::builtins::WordShape;
-use crate::coreword_registry::{self, CanonicalHome, CorewordMetadata, WordPurity};
+use crate::coreword_registry::{
+    self, CanonicalHome, CorewordMetadata, NilPolicy, Partiality, WordPurity,
+};
 use crate::interpreter::{audio, datetime, hash, interval_ops, json, random, serial, sort};
 use crate::types::{Capabilities, Stability};
 
@@ -728,6 +730,18 @@ const SERIAL_WORDS: &[ModuleWord] = &[
         Capabilities::IO
     ),
     module_word!(
+        "READ",
+        "Drain received bytes from an open serial port; Bubble/NIL when none",
+        serial::op_read,
+        WordPurity::Effectful,
+        &["serial-read"],
+        false,
+        false,
+        false,
+        Stability::Experimental,
+        Capabilities::IO
+    ),
+    module_word!(
         "FLUSH",
         "Flush the outgoing buffer of an open serial port",
         serial::op_flush,
@@ -834,6 +848,13 @@ pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
                 metadata.listed_in_core = false;
                 metadata.listed_in_modules = vec![spec.name.to_string()];
                 metadata.listed_in_categories = Vec::new();
+                // SERIAL@READ projects the no-data / disconnected condition onto
+                // Bubble/NIL (Section 9.4), so it is Projecting/CreatesNil rather
+                // than the effectful default of Partial/RejectsNil.
+                if spec.name == "SERIAL" && word.short_name == "READ" {
+                    metadata.partiality = Partiality::Projecting;
+                    metadata.nil_policy = NilPolicy::CreatesNil;
+                }
                 metadata
             })
         })

--- a/rust/src/interpreter/serial/execute_serial_commands.rs
+++ b/rust/src/interpreter/serial/execute_serial_commands.rs
@@ -6,8 +6,10 @@
 //! can be threaded through a pipeline.
 
 use super::super::Interpreter;
-use crate::error::{AjisaiError, Result};
+use crate::error::{AjisaiError, NilReason, Result};
 use crate::interpreter::value_extraction_helpers::{extract_integer_from_value, value_as_string};
+use crate::semantic::{AbsenceOrigin, Recoverability};
+use crate::types::fraction::Fraction;
 use crate::types::{Value, ValueData};
 use serde_json::json;
 
@@ -134,5 +136,35 @@ pub fn op_close(interp: &mut Interpreter) -> Result<()> {
     let handle = pop(interp)?;
     let id = require_port_id(&handle)?;
     emit(interp, json!({ "op": "close", "portId": id }));
+    Ok(())
+}
+
+/// `handle -- bytes` : drain the host-injected receive buffer for the port,
+/// returning a byte vector. With no buffered data this projects a Bubble/NIL:
+/// `portDisconnected` if the host reported the port gone, otherwise `noData`.
+pub fn op_read(interp: &mut Interpreter) -> Result<()> {
+    let handle = pop(interp)?;
+    let id = require_port_id(&handle)?;
+
+    let bytes = interp.serial_inbox.remove(&id).unwrap_or_default();
+    if !bytes.is_empty() {
+        let elements: Vec<Value> = bytes
+            .into_iter()
+            .map(|b| Value::from_fraction(Fraction::from(b as i64)))
+            .collect();
+        interp.stack.push(Value::from_vector(elements));
+    } else if interp.serial_disconnected.contains(&id) {
+        interp.stack.push(Value::bubble_with_reason(
+            NilReason::PortDisconnected,
+            AbsenceOrigin::HostEnvironment,
+            Recoverability::Fatal,
+        ));
+    } else {
+        interp.stack.push(Value::bubble_with_reason(
+            NilReason::NoData,
+            AbsenceOrigin::HostEnvironment,
+            Recoverability::Retryable,
+        ));
+    }
     Ok(())
 }

--- a/rust/src/interpreter/serial/mod.rs
+++ b/rust/src/interpreter/serial/mod.rs
@@ -1,18 +1,20 @@
 //! `SERIAL` module — Web Serial / native serial port I/O.
 //!
-//! Phase 1 scope: outbound (send-side) words only. Each word emits a single
-//! `SERIAL:{json}` command line into the interpreter output buffer, mirroring
-//! how the `MUSIC` module emits `AUDIO:` commands. The Rust core never touches
-//! a real port; the main-thread platform adapter consumes these commands and
-//! drives `navigator.serial` (web) or a native serial backend (Tauri).
+//! Outbound (send-side) words emit a single `SERIAL:{json}` command line into
+//! the interpreter output buffer, mirroring how the `MUSIC` module emits
+//! `AUDIO:` commands. The Rust core never touches a real port; the main-thread
+//! platform adapter consumes these commands and drives `navigator.serial`
+//! (web) or a native serial backend (Tauri).
 //!
-//! Inbound (read-side) words and the received-byte inbox are Phase 2 and are
-//! intentionally absent here. See `docs/dev/web-serial-module-design.md`.
+//! Inbound: `READ` drains the host-injected receive buffer (`serial_inbox` on
+//! the interpreter), returning a byte vector or a reasoned Bubble/NIL when no
+//! data is available. See `docs/dev/web-serial-module-design.md` and
+//! SPECIFICATION.md §9.4.
 
 mod execute_serial_commands;
 
 pub use execute_serial_commands::{
-    op_close, op_configure, op_flush, op_list_ports, op_open, op_write,
+    op_close, op_configure, op_flush, op_list_ports, op_open, op_read, op_write,
 };
 
 #[cfg(test)]

--- a/rust/src/interpreter/serial/serial_command_tests.rs
+++ b/rust/src/interpreter/serial/serial_command_tests.rs
@@ -1,7 +1,10 @@
-//! Phase-1 contract tests for the `SERIAL` module. Hardware is never exercised;
-//! these assert the emitted `SERIAL:` command lines and the misuse error paths.
+//! Contract tests for the `SERIAL` module. Hardware is never exercised; these
+//! assert the emitted `SERIAL:` command lines (outbound), the host-injected
+//! receive-buffer behavior of `READ` (inbound), and the misuse error paths.
 
+use crate::error::NilReason;
 use crate::interpreter::Interpreter;
+use crate::semantic::AbsenceOrigin;
 
 async fn run(code: &str) -> (Result<(), crate::error::AjisaiError>, String) {
     let mut interp = Interpreter::new();
@@ -104,16 +107,98 @@ fn serial_words_have_effectful_hardware_contract() {
 
     let words = get_canonical_module_words(Some("SERIAL"));
     let names: Vec<&str> = words.iter().map(|w| w.name.as_str()).collect();
-    for expected in ["LIST-PORTS", "OPEN", "CONFIGURE", "WRITE", "FLUSH", "CLOSE"] {
+    for expected in [
+        "LIST-PORTS",
+        "OPEN",
+        "CONFIGURE",
+        "WRITE",
+        "READ",
+        "FLUSH",
+        "CLOSE",
+    ] {
         assert!(names.contains(&expected), "SERIAL should expose {expected}");
     }
 
     for w in &words {
         assert_eq!(w.purity, WordPurity::Effectful, "{} purity", w.name);
-        assert_eq!(w.partiality, Partiality::Partial, "{} partiality", w.name);
-        assert_eq!(w.nil_policy, NilPolicy::RejectsNil, "{} nil_policy", w.name);
         assert_eq!(w.safety_level, SafetyLevel::D, "{} safety_level", w.name);
         assert!(!w.deterministic, "{} must be non-deterministic", w.name);
         assert!(!w.safe_preview, "{} must not be safe-preview", w.name);
+        if w.name == "READ" {
+            // READ projects the no-data / disconnected condition onto Bubble/NIL.
+            assert_eq!(w.partiality, Partiality::Projecting, "READ partiality");
+            assert_eq!(w.nil_policy, NilPolicy::CreatesNil, "READ nil_policy");
+        } else {
+            assert_eq!(w.partiality, Partiality::Partial, "{} partiality", w.name);
+            assert_eq!(w.nil_policy, NilPolicy::RejectsNil, "{} nil_policy", w.name);
+        }
     }
+}
+
+#[tokio::test]
+async fn read_returns_injected_bytes() {
+    let mut interp = Interpreter::new();
+    interp.execute("'serial' IMPORT").await.unwrap();
+    interp
+        .serial_inbox
+        .insert("p1".to_string(), vec![65, 66, 67]);
+    interp.execute("'p1' SERIAL@READ").await.unwrap();
+    let stack = interp.get_stack();
+    let top = stack.last().expect("READ pushes a result");
+    assert!(
+        !top.is_nil(),
+        "READ with buffered data returns a byte vector"
+    );
+    assert_eq!(top.len(), 3, "all three injected bytes are returned");
+}
+
+#[tokio::test]
+async fn read_no_data_projects_nodata_bubble() {
+    let mut interp = Interpreter::new();
+    interp
+        .execute("'serial' IMPORT 'p1' SERIAL@READ")
+        .await
+        .unwrap();
+    let stack = interp.get_stack();
+    let absence = stack
+        .last()
+        .unwrap()
+        .absence_metadata()
+        .expect("no buffered data projects NIL");
+    assert_eq!(absence.reason, Some(NilReason::NoData));
+    assert_eq!(absence.origin, AbsenceOrigin::HostEnvironment);
+}
+
+#[tokio::test]
+async fn read_disconnected_projects_portdisconnected_bubble() {
+    let mut interp = Interpreter::new();
+    interp.execute("'serial' IMPORT").await.unwrap();
+    interp.serial_disconnected.insert("p1".to_string());
+    interp.execute("'p1' SERIAL@READ").await.unwrap();
+    let stack = interp.get_stack();
+    let absence = stack
+        .last()
+        .unwrap()
+        .absence_metadata()
+        .expect("a disconnected port with no data projects NIL");
+    assert_eq!(absence.reason, Some(NilReason::PortDisconnected));
+    assert_eq!(absence.origin, AbsenceOrigin::HostEnvironment);
+}
+
+#[tokio::test]
+async fn read_drains_inbox_so_second_read_is_nodata() {
+    let mut interp = Interpreter::new();
+    interp.execute("'serial' IMPORT").await.unwrap();
+    interp.serial_inbox.insert("p1".to_string(), vec![1, 2]);
+    interp
+        .execute("'p1' SERIAL@READ 'p1' SERIAL@READ")
+        .await
+        .unwrap();
+    let stack = interp.get_stack();
+    let absence = stack
+        .last()
+        .unwrap()
+        .absence_metadata()
+        .expect("the second READ finds a drained inbox and projects NIL");
+    assert_eq!(absence.reason, Some(NilReason::NoData));
 }

--- a/rust/src/types/value_operations.rs
+++ b/rust/src/types/value_operations.rs
@@ -20,6 +20,8 @@ fn absence_origin_for_reason(reason: &NilReason) -> AbsenceOrigin {
         NilReason::UnknownWord => AbsenceOrigin::UnknownWord,
         NilReason::ExecutionFailure => AbsenceOrigin::ExecutionFailure,
         NilReason::Undecidable => AbsenceOrigin::ComparisonBudget,
+        NilReason::NoData => AbsenceOrigin::HostEnvironment,
+        NilReason::PortDisconnected => AbsenceOrigin::HostEnvironment,
         NilReason::SafeCaught(_) => AbsenceOrigin::SafeProjection,
         NilReason::DivisionByZero => AbsenceOrigin::SafeProjection,
     }

--- a/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
@@ -349,6 +349,29 @@ impl AjisaiInterpreter {
         self.interpreter.input_buffer = text;
     }
 
+    /// Inject the host-received bytes for a serial port (Section 9.4). Replaces
+    /// any buffer previously set for this port id and clears the port's
+    /// disconnected flag. `SERIAL@READ` drains this buffer.
+    #[wasm_bindgen]
+    pub fn update_serial_inbox(&mut self, port_id: String, bytes: Vec<u8>) {
+        self.interpreter.serial_disconnected.remove(&port_id);
+        self.interpreter.serial_inbox.insert(port_id, bytes);
+    }
+
+    /// Mark a serial port as disconnected by the host. Once its inbox is empty,
+    /// `SERIAL@READ` projects `NilReason::PortDisconnected`.
+    #[wasm_bindgen]
+    pub fn mark_serial_disconnected(&mut self, port_id: String) {
+        self.interpreter.serial_disconnected.insert(port_id);
+    }
+
+    /// Clear all injected serial receive buffers and disconnected flags.
+    #[wasm_bindgen]
+    pub fn clear_serial_inboxes(&mut self) {
+        self.interpreter.serial_inbox.clear();
+        self.interpreter.serial_disconnected.clear();
+    }
+
     #[wasm_bindgen]
     pub fn extract_io_output_buffer(&self) -> String {
         self.interpreter.io_output_buffer.clone()

--- a/src/gui/interpreter-execution-utils.ts
+++ b/src/gui/interpreter-execution-utils.ts
@@ -2,9 +2,18 @@
 import {
     applyInterpreterSnapshot,
     createInterpreterSnapshot,
-    type InterpreterSnapshot
+    type InterpreterSnapshot,
+    type SerialInboxEntry
 } from '../workers/interpreter-snapshot';
+import { getPlatform } from '../platform';
 import type { AjisaiInterpreter, ExecuteResult, UserWord } from '../wasm-interpreter-types';
+
+// Drain any host-received serial bytes so this run's SERIAL@READ sees the data
+// that arrived since the previous run. Returns undefined when nothing is open.
+const collectSerialInbox = (): SerialInboxEntry[] | undefined => {
+    const entries = getPlatform().serial.drainAllInboxes();
+    return entries.length > 0 ? entries : undefined;
+};
 
 const collectUserWords = (interpreter: AjisaiInterpreter): UserWord[] => {
     const userWordsInfo = interpreter.collect_user_words_info();
@@ -21,7 +30,8 @@ export const createExecutionSnapshot = (interpreter: AjisaiInterpreter): Interpr
         stack: interpreter.collect_stack(),
         userWords: collectUserWords(interpreter),
         importedModules: interpreter.collect_imported_modules(),
-        executionMode: interpreter.get_execution_mode()
+        executionMode: interpreter.get_execution_mode(),
+        serialInbox: collectSerialInbox()
     });
 
 export const syncInterpreterState = (

--- a/src/platform/platform-adapter.ts
+++ b/src/platform/platform-adapter.ts
@@ -72,6 +72,13 @@ export interface SerialPortInfo {
     readonly label?: string;
 }
 
+/** Received bytes drained from one port, plus its host-reported connection state. */
+export interface SerialInboxData {
+    readonly portId: string;
+    readonly bytes: number[];
+    readonly disconnected: boolean;
+}
+
 /**
  * Host serial-port capability. The interpreter core never calls this directly;
  * it emits `SERIAL:` commands that the output dispatcher forwards here. The
@@ -92,8 +99,10 @@ export interface SerialAdapter {
     configure(portId: string, options: { readonly baudRate: number }): Promise<void>;
     write(portId: string, bytes: Uint8Array): Promise<void>;
     flush(portId: string): Promise<void>;
-    /** Phase 2: received bytes since the last drain. Phase 1 returns empty. */
+    /** Received bytes for one port since the last drain. */
     drainInbox(portId: string): Uint8Array;
+    /** Drain every open port's received bytes, for injection into a run's snapshot. */
+    drainAllInboxes(): SerialInboxData[];
     close(portId: string): Promise<void>;
 }
 

--- a/src/platform/tauri/tauri-serial.ts
+++ b/src/platform/tauri/tauri-serial.ts
@@ -1,4 +1,4 @@
-import type { SerialAdapter, SerialPortInfo } from '../platform-adapter';
+import type { SerialAdapter, SerialInboxData, SerialPortInfo } from '../platform-adapter';
 
 /**
  * Tauri serial backend — typed stub (Phase 3).
@@ -43,6 +43,10 @@ export class TauriSerialAdapter implements SerialAdapter {
 
     drainInbox(_portId: string): Uint8Array {
         return new Uint8Array(0);
+    }
+
+    drainAllInboxes(): SerialInboxData[] {
+        return [];
     }
 
     async close(_portId: string): Promise<void> {

--- a/src/platform/web/web-serial.ts
+++ b/src/platform/web/web-serial.ts
@@ -1,4 +1,4 @@
-import type { SerialAdapter, SerialPortInfo } from '../platform-adapter';
+import type { SerialAdapter, SerialInboxData, SerialPortInfo } from '../platform-adapter';
 
 // Minimal local declarations for the W3C Web Serial API so the build does not
 // depend on the surrounding TS DOM lib shipping these types yet.
@@ -6,6 +6,7 @@ interface WebSerialPort {
     open(options: { baudRate: number }): Promise<void>;
     close(): Promise<void>;
     readonly writable: WritableStream<Uint8Array> | null;
+    readonly readable: ReadableStream<Uint8Array> | null;
     getInfo?(): { usbVendorId?: number; usbProductId?: number };
 }
 
@@ -25,6 +26,11 @@ interface GrantedPort {
     baudRate: number;
     opened: boolean;
     writer: WritableStreamDefaultWriter<Uint8Array> | null;
+    reader: ReadableStreamDefaultReader<Uint8Array> | null;
+    /** Bytes received since the last drain. */
+    rx: number[];
+    /** Set when the RX loop ends unexpectedly (device unplugged / stream error). */
+    disconnected: boolean;
 }
 
 /**
@@ -57,10 +63,48 @@ export class WebSerialAdapter implements SerialAdapter {
             port,
             baudRate: DEFAULT_BAUD_RATE,
             opened: false,
-            writer: null
+            writer: null,
+            reader: null,
+            rx: [],
+            disconnected: false
         };
         this.ports.push(entry);
         return entry;
+    }
+
+    // Continuously drain the port's readable stream into the rx buffer. Runs
+    // until the reader is cancelled (on close/reopen) or the stream errors,
+    // which is treated as a host-side disconnect.
+    private startReadLoop(entry: GrantedPort): void {
+        const readable = entry.port.readable;
+        if (!readable || entry.reader) return;
+        const reader = readable.getReader();
+        entry.reader = reader;
+        entry.disconnected = false;
+        void (async () => {
+            try {
+                for (;;) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    if (value) {
+                        for (const b of value) entry.rx.push(b);
+                    }
+                }
+            } catch {
+                entry.disconnected = true;
+            } finally {
+                try { reader.releaseLock(); } catch { /* ignore */ }
+                if (entry.reader === reader) entry.reader = null;
+            }
+        })();
+    }
+
+    private async stopReadLoop(entry: GrantedPort): Promise<void> {
+        const reader = entry.reader;
+        if (!reader) return;
+        entry.reader = null;
+        try { await reader.cancel(); } catch { /* ignore */ }
+        try { reader.releaseLock(); } catch { /* ignore */ }
     }
 
     private require(portId: string): GrantedPort {
@@ -92,6 +136,7 @@ export class WebSerialAdapter implements SerialAdapter {
     }
 
     private async reopen(entry: GrantedPort): Promise<void> {
+        await this.stopReadLoop(entry);
         if (entry.writer) {
             try { entry.writer.releaseLock(); } catch { /* ignore */ }
             entry.writer = null;
@@ -102,6 +147,7 @@ export class WebSerialAdapter implements SerialAdapter {
         }
         await entry.port.open({ baudRate: entry.baudRate });
         entry.opened = true;
+        this.startReadLoop(entry);
     }
 
     open(portId: string): Promise<void> {
@@ -111,6 +157,7 @@ export class WebSerialAdapter implements SerialAdapter {
                 await entry.port.open({ baudRate: entry.baudRate });
                 entry.opened = true;
             }
+            this.startReadLoop(entry);
         });
     }
 
@@ -141,6 +188,7 @@ export class WebSerialAdapter implements SerialAdapter {
                 entry.writer = writable.getWriter();
             }
             await entry.writer.write(bytes);
+            this.startReadLoop(entry);
         });
     }
 
@@ -151,15 +199,28 @@ export class WebSerialAdapter implements SerialAdapter {
         });
     }
 
-    drainInbox(_portId: string): Uint8Array {
-        // Phase 2: a per-port RX reader loop will fill a buffer drained here and
-        // injected into the next execution snapshot. Phase 1 is send-only.
-        return new Uint8Array(0);
+    drainInbox(portId: string): Uint8Array {
+        const entry = this.ports.find(p => p.id === portId);
+        if (!entry || entry.rx.length === 0) return new Uint8Array(0);
+        const bytes = Uint8Array.from(entry.rx);
+        entry.rx = [];
+        return bytes;
+    }
+
+    drainAllInboxes(): SerialInboxData[] {
+        return this.ports
+            .filter(entry => entry.opened || entry.rx.length > 0 || entry.disconnected)
+            .map(entry => {
+                const bytes = entry.rx;
+                entry.rx = [];
+                return { portId: entry.id, bytes, disconnected: entry.disconnected };
+            });
     }
 
     close(portId: string): Promise<void> {
         return this.enqueue(async () => {
             const entry = this.require(portId);
+            await this.stopReadLoop(entry);
             if (entry.writer) {
                 try { entry.writer.releaseLock(); } catch { /* ignore */ }
                 entry.writer = null;

--- a/src/wasm-interpreter-types.ts
+++ b/src/wasm-interpreter-types.ts
@@ -45,6 +45,11 @@ export interface AjisaiInterpreter {
     set_execution_mode(mode: ExecutionMode): void;
     get_execution_mode(): ExecutionMode;
     collect_hedged_trace(): string[];
+    // Serial RX inbox injection (SPECIFICATION.md §9.4). Filled before execution
+    // from the platform serial adapter; drained by SERIAL@READ.
+    update_serial_inbox(portId: string, bytes: Uint8Array): void;
+    mark_serial_disconnected(portId: string): void;
+    clear_serial_inboxes(): void;
 }
 
 export interface ProtocolDiagnosis {

--- a/src/workers/interpreter-snapshot.ts
+++ b/src/workers/interpreter-snapshot.ts
@@ -1,10 +1,18 @@
 import type { AjisaiInterpreter, ExecutionMode, UserWord, Value } from '../wasm-interpreter-types';
 
+export interface SerialInboxEntry {
+    readonly portId: string;
+    readonly bytes: number[];
+    readonly disconnected?: boolean;
+}
+
 export interface InterpreterSnapshot {
     readonly stack: Value[];
     readonly userWords: UserWord[];
     readonly importedModules: string[];
     readonly executionMode: ExecutionMode;
+    /** Host-received serial bytes to inject before this run (SERIAL@READ). */
+    readonly serialInbox?: SerialInboxEntry[];
 }
 
 export const createInterpreterSnapshot = (snapshot: {
@@ -12,11 +20,13 @@ export const createInterpreterSnapshot = (snapshot: {
     readonly userWords: UserWord[];
     readonly importedModules?: string[];
     readonly executionMode?: ExecutionMode;
+    readonly serialInbox?: SerialInboxEntry[];
 }): InterpreterSnapshot => ({
     stack: snapshot.stack,
     userWords: snapshot.userWords,
     importedModules: snapshot.importedModules ?? [],
-    executionMode: snapshot.executionMode ?? "greedy"
+    executionMode: snapshot.executionMode ?? "greedy",
+    serialInbox: snapshot.serialInbox
 });
 
 export const applyInterpreterSnapshot = (
@@ -37,5 +47,14 @@ export const applyInterpreterSnapshot = (
     }
     if (snapshot.executionMode) {
         interpreter.set_execution_mode(snapshot.executionMode);
+    }
+    if (snapshot.serialInbox) {
+        for (const entry of snapshot.serialInbox) {
+            // update_serial_inbox clears the disconnected flag, so mark after.
+            interpreter.update_serial_inbox(entry.portId, Uint8Array.from(entry.bytes));
+            if (entry.disconnected) {
+                interpreter.mark_serial_disconnected(entry.portId);
+            }
+        }
     }
 };


### PR DESCRIPTION
## Summary

Phase 2 of Web Serial: the inbound (receive) path. Builds on the merged Phase 0 (spec) and Phase 1 (outbound). Modeled on the existing `IO@INPUT` injected-buffer precedent.

- **`SERIAL@READ`** (`port-id -- bytes`): drains the port's host-injected receive buffer and returns a byte vector. With no data it projects Bubble/NIL — `reason = noData`, or `reason = portDisconnected` when the host reported the port gone (`absence.origin = hostEnvironment`). Classified `Projecting`/`CreatesNil`, `safety_level D`.
- **Rust core**: per-port `serial_inbox` + `serial_disconnected` interpreter state; two new `NilReason` variants (`NoData`, `PortDisconnected`) with protocol strings and origin mapping; a per-word contract override so READ is Projecting/CreatesNil; READ added to the impure purity table.
- **WASM boundary**: `update_serial_inbox(portId, bytes)`, `mark_serial_disconnected(portId)`, `clear_serial_inboxes()` (mirroring `update_input_buffer`).
- **TypeScript**: `WebSerialAdapter` now runs an RX reader loop per open port and drains via `drainInbox`/`drainAllInboxes`; the execution snapshot carries `serialInbox`, injected into the worker interpreter before each run. Tauri stub returns empty. Receive model is event-poll: a run sees the bytes that arrived since the previous run, deterministic within the run.
- **Spec**: §9.4 gains the receive model + `READ`; §11.2 gains the `noData`/`portDisconnected` bubble row.

## Test plan
- [x] `cargo test --lib` / `--tests` (1051 passed; +4 READ tests covering data, noData, portDisconnected, drain; contract test updated for READ's Projecting/CreatesNil)
- [x] `cargo check --target wasm32-unknown-unknown` compiles the new fields/setters
- [x] `tsc --noEmit` clean on all changed files (pre-existing `vitest` env errors only)
- [x] clippy clean on serial code; my Rust files rustfmt-clean
- [ ] **Cannot hardware-test in CI**: the WebSerialAdapter RX loop and worker injection are exercised only against the in-Rust inbox (mocked via `serial_inbox`). End-to-end behavior needs a real serial device over HTTPS/localhost in a Web Serial-capable browser.
- [ ] The committed `src/wasm/generated/` bundle is left to the deploy pipeline to rebuild (advisory stale-bundle check), consistent with Phase 1.

## Notes
Phase 3 (native Tauri `serialport` backend filling in `TauriSerialAdapter`) remains.

https://claude.ai/code/session_01649K3MLhxhDKTy9F9e6w5D

---
_Generated by [Claude Code](https://claude.ai/code/session_01649K3MLhxhDKTy9F9e6w5D)_