### PR TITLE
Fix element-wise arithmetic and equality on ragged/nested vectors

### DIFF
--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -1002,3 +1002,129 @@ mod phase_seven_eq_budget_tests {
         assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
     }
 }
+
+#[cfg(test)]
+mod ragged_broadcast_tests {
+    use crate::interpreter::Interpreter;
+
+    async fn eval(code: &str) -> String {
+        let mut interp = Interpreter::new();
+        interp.execute(code).await.unwrap();
+        let stack = interp.get_stack();
+        assert_eq!(stack.len(), 1, "expected single result for: {code}");
+        format!("{}", stack[0])
+    }
+
+    #[tokio::test]
+    async fn test_scalar_mul_over_mixed_nested_vector() {
+        let result = eval("[ 10 [ 1 2 3 ] 10 ] 10 *").await;
+        assert_eq!(result, "[ 100/1 [ 10/1 20/1 30/1 ] 100/1 ]");
+    }
+
+    #[tokio::test]
+    async fn test_scalar_mul_left_operand() {
+        let result = eval("10 [ 10 [ 1 2 3 ] 10 ] *").await;
+        assert_eq!(result, "[ 100/1 [ 10/1 20/1 30/1 ] 100/1 ]");
+    }
+
+    #[tokio::test]
+    async fn test_scalar_add_over_mixed_nested_vector() {
+        let result = eval("[ 1 [ 2 3 ] 4 ] 10 +").await;
+        assert_eq!(result, "[ 11/1 [ 12/1 13/1 ] 14/1 ]");
+    }
+
+    #[tokio::test]
+    async fn test_deeply_nested_ragged() {
+        let result = eval("[ 1 [ 2 [ 3 4 ] ] ] 2 *").await;
+        assert_eq!(result, "[ 2/1 [ 4/1 [ 6/1 8/1 ] ] ]");
+    }
+
+    #[tokio::test]
+    async fn test_elementwise_ragged_same_structure() {
+        let result = eval("[ 1 [ 2 3 ] ] [ 10 [ 20 30 ] ] *").await;
+        assert_eq!(result, "[ 10/1 [ 40/1 90/1 ] ]");
+    }
+
+    #[tokio::test]
+    async fn test_ragged_length_mismatch_errors() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("[ 1 [ 2 3 ] ] [ 10 [ 20 30 40 ] ] *").await;
+        assert!(result.is_err(), "mismatched nested lengths should error");
+    }
+
+    #[tokio::test]
+    async fn test_regular_nested_still_works() {
+        let result = eval("[ [ 1 2 ] [ 3 4 ] ] 10 *").await;
+        assert_eq!(result, "[ [ 10/1 20/1 ] [ 30/1 40/1 ] ]");
+    }
+
+    #[tokio::test]
+    async fn test_singleton_vector_sibling_preserved() {
+        let result = eval("[ [ 1 ] 2 ] 10 *").await;
+        assert_eq!(result, "[ [ 10/1 ] 20/1 ]");
+    }
+}
+
+#[cfg(test)]
+mod ragged_unary_tests {
+    use crate::interpreter::Interpreter;
+
+    async fn eval(code: &str) -> String {
+        let mut interp = Interpreter::new();
+        interp.execute(code).await.unwrap();
+        let stack = interp.get_stack();
+        assert_eq!(stack.len(), 1, "expected single result for: {code}");
+        format!("{}", stack[0])
+    }
+
+    #[tokio::test]
+    async fn test_floor_over_mixed_nested_vector() {
+        let result = eval("[ 7/2 [ 5/2 9/4 ] 3/2 ] FLOOR").await;
+        assert_eq!(result, "[ 3/1 [ 2/1 2/1 ] 1/1 ]");
+    }
+
+    #[tokio::test]
+    async fn test_not_over_mixed_nested_vector() {
+        let result = eval("[ 0 [ 1 0 ] 5 ] NOT").await;
+        assert_eq!(result, "[ 1/1 [ 0/1 1/1 ] 0/1 ]");
+    }
+
+    #[tokio::test]
+    async fn test_mod_over_mixed_nested_vector() {
+        let result = eval("[ 10 [ 7 8 ] 9 ] 3 %").await;
+        assert_eq!(result, "[ 1/1 [ 1/1 2/1 ] 0/1 ]");
+    }
+}
+
+#[cfg(test)]
+mod ragged_equality_tests {
+    use crate::types::Value;
+
+    #[test]
+    fn ragged_vector_not_equal_to_dense_tensor() {
+        // Dense tensor [1 2] must not equal ragged nested vector [[1] 2].
+        let dense = Value::from_tensor(
+            vec![1i64.into(), 2i64.into()],
+            vec![2],
+        );
+        let ragged = Value::from_children(vec![
+            Value::from_children(vec![Value::from_int(1)]),
+            Value::from_int(2),
+        ]);
+        assert_ne!(dense, ragged);
+        assert_ne!(ragged, dense);
+    }
+
+    #[test]
+    fn matching_nested_vector_equals_dense_tensor() {
+        let dense = Value::from_tensor(
+            vec![1i64.into(), 2i64.into(), 3i64.into(), 4i64.into()],
+            vec![2, 2],
+        );
+        let nested = Value::from_children(vec![
+            Value::from_children(vec![Value::from_int(1), Value::from_int(2)]),
+            Value::from_children(vec![Value::from_int(3), Value::from_int(4)]),
+        ]);
+        assert_eq!(dense, nested);
+    }
+}

--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -1103,10 +1103,7 @@ mod ragged_equality_tests {
     #[test]
     fn ragged_vector_not_equal_to_dense_tensor() {
         // Dense tensor [1 2] must not equal ragged nested vector [[1] 2].
-        let dense = Value::from_tensor(
-            vec![1i64.into(), 2i64.into()],
-            vec![2],
-        );
+        let dense = Value::from_tensor(vec![1i64.into(), 2i64.into()], vec![2]);
         let ragged = Value::from_children(vec![
             Value::from_children(vec![Value::from_int(1)]),
             Value::from_int(2),

--- a/rust/src/interpreter/tensor_cmds.rs
+++ b/rust/src/interpreter/tensor_cmds.rs
@@ -206,7 +206,7 @@ pub fn op_transpose(interp: &mut Interpreter) -> Result<()> {
 
 fn apply_unary_math<F>(interp: &mut Interpreter, op: F, op_name: &str) -> Result<()>
 where
-    F: Fn(&Fraction) -> Fraction,
+    F: Fn(&Fraction) -> Fraction + Copy,
 {
     if interp.operation_target_mode == OperationTargetMode::Stack {
         return Err(AjisaiError::ModeUnsupported {

--- a/rust/src/interpreter/tensor_ops.rs
+++ b/rust/src/interpreter/tensor_ops.rs
@@ -266,9 +266,9 @@ fn rectangular_shape(value: &Value) -> Option<Vec<usize>> {
             shape.extend(first);
             Some(shape)
         }
-        ValueData::CodeBlock(_)
-        | ValueData::ProcessHandle(_)
-        | ValueData::SupervisorHandle(_) => None,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            None
+        }
     }
 }
 

--- a/rust/src/interpreter/tensor_ops.rs
+++ b/rust/src/interpreter/tensor_ops.rs
@@ -237,6 +237,124 @@ pub(crate) fn build_nested_value(data: &[Fraction], shape: &[usize]) -> Value {
     }
 }
 
+/// The rectangular tensor shape of `value`, or `None` when the value cannot
+/// be faithfully represented as a flat tensor.
+///
+/// A value is rectangular when every leaf is a numeric scalar (or NIL lane)
+/// and all sibling sub-vectors share an identical shape. Ragged structures —
+/// mixed scalar/vector siblings (e.g. `[ 10 [ 1 2 3 ] 10 ]`) or sub-vectors
+/// of differing shape — return `None`. Such values must be broadcast
+/// structurally (see [`apply_recursive_broadcast`]) rather than flattened,
+/// because `shape()` collapses them to a top-level count that disagrees with
+/// the recursively flattened element count.
+fn rectangular_shape(value: &Value) -> Option<Vec<usize>> {
+    match &value.data {
+        ValueData::Scalar(_) | ValueData::Nil => Some(Vec::new()),
+        ValueData::Tensor { shape, .. } => Some((**shape).clone()),
+        ValueData::Vector(items) | ValueData::Record { pairs: items, .. } => {
+            if items.is_empty() {
+                return Some(vec![0]);
+            }
+            let first: Vec<usize> = rectangular_shape(&items[0])?;
+            for item in items.iter().skip(1) {
+                if rectangular_shape(item)? != first {
+                    return None;
+                }
+            }
+            let mut shape = Vec::with_capacity(first.len() + 1);
+            shape.push(items.len());
+            shape.extend(first);
+            Some(shape)
+        }
+        ValueData::CodeBlock(_)
+        | ValueData::ProcessHandle(_)
+        | ValueData::SupervisorHandle(_) => None,
+    }
+}
+
+/// One level of children for a value, or `None` for a leaf (scalar/NIL) or a
+/// non-broadcastable value. Dense tensors are decomposed into their outermost
+/// rows so that recursive broadcasting treats them like nested vectors.
+fn broadcast_children(value: &Value) -> Option<Vec<Value>> {
+    match &value.data {
+        ValueData::Vector(items) | ValueData::Record { pairs: items, .. } => {
+            Some(items.as_ref().clone())
+        }
+        ValueData::Tensor { data, shape } => {
+            let nested = build_nested_value(&data.to_fractions(), shape);
+            match nested.data {
+                ValueData::Vector(items) => Some(items.as_ref().clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The numeric leaf fraction of a value (scalar or NIL lane), or `None` when
+/// the value is not a numeric leaf.
+fn broadcast_leaf(value: &Value) -> Option<Fraction> {
+    match &value.data {
+        ValueData::Scalar(f) => Some(f.clone()),
+        ValueData::Nil => Some(Fraction::nil()),
+        _ => None,
+    }
+}
+
+/// Structural element-wise broadcast for ragged or nested values.
+///
+/// Mirrors NumPy-style scalar broadcasting but follows the actual value tree
+/// instead of a flattened tensor, so it stays correct when scalars and
+/// vectors are mixed as siblings or sub-vectors have differing shapes. A
+/// scalar paired with a vector is broadcast across every element; two vectors
+/// of equal length combine element-wise; unequal lengths raise
+/// `VectorLengthMismatch`. The leaf operation is the same `op` used by the
+/// flat path, so NIL-lane handling is identical.
+fn apply_recursive_broadcast<F>(a: &Value, b: &Value, op: F) -> Result<Value>
+where
+    F: Fn(&Fraction, &Fraction) -> Result<Fraction> + Copy,
+{
+    match (broadcast_children(a), broadcast_children(b)) {
+        (None, None) => {
+            let (Some(fa), Some(fb)) = (broadcast_leaf(a), broadcast_leaf(b)) else {
+                return Err(AjisaiError::create_structure_error(
+                    "number or vector",
+                    "non-numeric value",
+                ));
+            };
+            Ok(Value::from_fraction(op(&fa, &fb)?))
+        }
+        (Some(children), None) => {
+            let out: Vec<Value> = children
+                .iter()
+                .map(|child| apply_recursive_broadcast(child, b, op))
+                .collect::<Result<Vec<Value>>>()?;
+            Ok(Value::from_children(out))
+        }
+        (None, Some(children)) => {
+            let out: Vec<Value> = children
+                .iter()
+                .map(|child| apply_recursive_broadcast(a, child, op))
+                .collect::<Result<Vec<Value>>>()?;
+            Ok(Value::from_children(out))
+        }
+        (Some(a_children), Some(b_children)) => {
+            if a_children.len() != b_children.len() {
+                return Err(AjisaiError::VectorLengthMismatch {
+                    len1: a_children.len(),
+                    len2: b_children.len(),
+                });
+            }
+            let out: Vec<Value> = a_children
+                .iter()
+                .zip(b_children.iter())
+                .map(|(x, y)| apply_recursive_broadcast(x, y, op))
+                .collect::<Result<Vec<Value>>>()?;
+            Ok(Value::from_children(out))
+        }
+    }
+}
+
 /// Metrics-aware tensor broadcast.
 ///
 /// When `metrics` is `Some`, observational VTU counters are incremented at
@@ -254,6 +372,13 @@ where
 {
     if a.is_nil() || b.is_nil() {
         return Err(AjisaiError::from("Cannot broadcast NIL values"));
+    }
+
+    // Ragged or nested-mixed structures (e.g. `[ 10 [ 1 2 3 ] 10 ]`) cannot be
+    // flattened to a single tensor whose shape matches its element count, so
+    // they are broadcast structurally by following the value tree.
+    if rectangular_shape(a).is_none() || rectangular_shape(b).is_none() {
+        return apply_recursive_broadcast(a, b, op);
     }
 
     let tensor_a = FlatTensor::from_value(a)?;
@@ -311,6 +436,34 @@ where
     Ok(out_tensor.to_value())
 }
 
+/// Structural element-wise unary map for ragged or nested values, mirroring
+/// [`apply_recursive_broadcast`]. Follows the value tree instead of a
+/// flattened tensor so it stays correct when scalars and vectors are mixed as
+/// siblings.
+fn apply_recursive_unary<F>(val: &Value, op: F) -> Result<Value>
+where
+    F: Fn(&Fraction) -> Fraction + Copy,
+{
+    match broadcast_children(val) {
+        Some(children) => {
+            let out: Vec<Value> = children
+                .iter()
+                .map(|child| apply_recursive_unary(child, op))
+                .collect::<Result<Vec<Value>>>()?;
+            Ok(Value::from_children(out))
+        }
+        None => {
+            let Some(f) = broadcast_leaf(val) else {
+                return Err(AjisaiError::create_structure_error(
+                    "number or vector",
+                    "non-numeric value",
+                ));
+            };
+            Ok(Value::from_fraction(op(&f)))
+        }
+    }
+}
+
 /// Metrics-aware unary flat tensor operation. See
 /// [`apply_binary_broadcast_with_metrics`] for the metrics contract.
 pub(crate) fn apply_unary_flat_with_metrics<F>(
@@ -319,8 +472,14 @@ pub(crate) fn apply_unary_flat_with_metrics<F>(
     mut metrics: Option<&mut RuntimeMetrics>,
 ) -> Result<Value>
 where
-    F: Fn(&Fraction) -> Fraction,
+    F: Fn(&Fraction) -> Fraction + Copy,
 {
+    // Ragged or nested-mixed structures cannot be flattened to a tensor whose
+    // shape matches its element count, so map over the value tree directly.
+    if rectangular_shape(val).is_none() {
+        return apply_recursive_unary(val, op);
+    }
+
     let tensor = FlatTensor::from_value(val)?;
     let element_count = tensor.data.len();
     record_flatten(&mut metrics, element_count);

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -403,9 +403,9 @@ fn element_rect_shape(value: &Value) -> Option<Vec<usize>> {
         ValueData::Vector(items) | ValueData::Record { pairs: items, .. } => {
             nested_vector_shape(items)
         }
-        ValueData::CodeBlock(_)
-        | ValueData::ProcessHandle(_)
-        | ValueData::SupervisorHandle(_) => None,
+        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {
+            None
+        }
     }
 }
 

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -361,7 +361,13 @@ impl PartialEq for ValueData {
 }
 
 fn tensor_eq_vector(data: &DenseTensor, shape: &[usize], v: &[Value]) -> bool {
-    let nested_shape = nested_vector_shape(v);
+    // A dense tensor is always rectangular, so a ragged nested vector (no
+    // well-defined rectangular shape) can never equal one. `nested_vector_shape`
+    // returns `None` for ragged structures, which fails the comparison here
+    // rather than colliding with the dense shape via a count-only fallback.
+    let Some(nested_shape) = nested_vector_shape(v) else {
+        return false;
+    };
     if nested_shape != shape {
         return false;
     }
@@ -369,18 +375,37 @@ fn tensor_eq_vector(data: &DenseTensor, shape: &[usize], v: &[Value]) -> bool {
     nested_flatten_matches(v, data, &mut idx) && idx == data.len()
 }
 
-fn nested_vector_shape(v: &[Value]) -> Vec<usize> {
+/// The rectangular shape of a nested vector, or `None` when the structure is
+/// ragged (sibling elements with differing shapes, or mixed scalar/vector
+/// siblings). Used only for dense-tensor equality, which requires a
+/// rectangular counterpart.
+fn nested_vector_shape(v: &[Value]) -> Option<Vec<usize>> {
     if v.is_empty() {
-        return vec![0];
+        return Some(vec![0]);
     }
-    let first_shape = v[0].shape();
-    let all_same = v.iter().skip(1).all(|c| c.shape() == first_shape);
-    if all_same && !first_shape.is_empty() {
-        let mut s = vec![v.len()];
-        s.extend(first_shape);
-        s
-    } else {
-        vec![v.len()]
+    let first_shape = element_rect_shape(&v[0])?;
+    for child in v.iter().skip(1) {
+        if element_rect_shape(child)? != first_shape {
+            return None;
+        }
+    }
+    let mut s = vec![v.len()];
+    s.extend(first_shape);
+    Some(s)
+}
+
+/// Rectangular shape of a single value, or `None` for non-numeric leaves or
+/// ragged sub-structures.
+fn element_rect_shape(value: &Value) -> Option<Vec<usize>> {
+    match &value.data {
+        ValueData::Scalar(_) | ValueData::Nil => Some(Vec::new()),
+        ValueData::Tensor { shape, .. } => Some((**shape).clone()),
+        ValueData::Vector(items) | ValueData::Record { pairs: items, .. } => {
+            nested_vector_shape(items)
+        }
+        ValueData::CodeBlock(_)
+        | ValueData::ProcessHandle(_)
+        | ValueData::SupervisorHandle(_) => None,
     }
 }
 


### PR DESCRIPTION
## 概要

`[ 10 [ 1 2 3 ] 10 ] 10 *` が誤って `[100/1 10/1 20/1]` を返す不具合を修正しました。正しくは各要素にスカラーをブロードキャストした `[ 100/1 [ 10/1 20/1 30/1 ] 100/1 ]` です。

### 根本原因
スカラー×ベクトルのブロードキャストは値を平坦テンソルへ変換してから計算しますが、不規則（ragged）なネストベクトルでは `shape()` がトップレベルの個数だけを返す（例: `[3]`）一方、`collect_fractions_flat_into()` は再帰的に全要素を平坦化する（例: 5要素）ため、形状とデータ個数が食い違い、先頭N個だけが計算されて残りが脱落していました。

Ajisaiのスタックは実態がVectorのため、ネストVectorの扱いの不備はあらゆる操作に波及しうるとのご指摘を受け、関連する全経路を点検しました。

### 修正内容
- **二項演算 (ADD/SUB/MUL/DIV/MOD/AND/OR)**: ragged / nested-mixed な値を、平坦化せず値ツリーをたどる構造的な要素ごとブロードキャストへ振り分け。矩形テンソルは従来どおり高速な flat / SIMD 経路を維持。
- **単項演算 (FLOOR/CEIL/ROUND/NOT)**: 同様に ragged 値を再帰的マップへ振り分け（従来はエラーになっていた）。
- **dense tensor と nested vector の等価判定**: ragged なベクトルが、count-only のフォールバック形状が dense 形状と偶然一致したときに誤って等しいと判定される不具合を修正（例: `[[1] 2] == [1 2]`）。

### 点検して問題なしと確認した箇所
SHAPE/RANK（トップレベル長を返すのは妥当）、RESHAPE/TRANSPOSE（平坦データのみ使用 or 非2Dを正しく拒否）、比較（単一要素以外は正しくエラー）、CSPRNG/HASH（単一要素判定）、SORT等のvector_ops（構造的に要素を不透明に扱う）、SIMD/sparse高速経路（raggedでは正しくフォールバック）。

## テスト計画
- [x] ragged broadcast 8件（混在ネスト、左右オペランド、深いネスト、要素ごと、長さ不一致エラー、矩形維持、`[[1] 2]` シングルトン保持）
- [x] ragged unary 3件（FLOOR / NOT / MOD over ネスト）
- [x] ragged equality 2件（dense と ragged が非等価 / 一致ネストは等価）
- [x] 既存スイート全 1070 件パス（リグレッションなし）

https://claude.ai/code/session_01FtRwhu7e87sKQNspBq45Ld

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtRwhu7e87sKQNspBq45Ld)_