### PR TITLE
Fix boolean tensor rendering and align stale GUI tests with spec

### DIFF
--- a/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
@@ -316,7 +316,7 @@ pub(crate) fn value_to_js(value: &Value, external_hint_opt: Option<Interpretatio
                 set_prop(&obj, "value", &text.into());
             } else {
                 let tensor_values = data.to_fractions();
-                let js_array = tensor_data_to_js_array(&tensor_values, shape);
+                let js_array = tensor_data_to_js_array(&tensor_values, shape, effective_hint);
                 set_prop(&obj, "type", &"vector".into());
                 set_prop(&obj, "value", &js_array.into());
             }
@@ -348,27 +348,39 @@ pub(crate) fn value_to_js(value: &Value, external_hint_opt: Option<Interpretatio
 fn tensor_data_to_js_array(
     data: &[crate::types::fraction::Fraction],
     shape: &[usize],
+    leaf_hint: Interpretation,
 ) -> js_sys::Array {
+    // Mirror the Vector serialization path: only the TruthValue role is
+    // propagated to leaves (numbers otherwise). A promoted dense boolean
+    // vector must render its elements as booleans, matching the Display
+    // path's `format_as_boolean`.
+    let leaves_are_bool = leaf_hint == Interpretation::TruthValue;
     let arr = js_sys::Array::new();
     if shape.is_empty() || shape.len() == 1 {
         for f in data {
-            let num_obj = js_sys::Object::new();
-            js_sys::Reflect::set(
-                &num_obj,
-                &"numerator".into(),
-                &f.numerator().to_string().into(),
-            )
-            .unwrap();
-            js_sys::Reflect::set(
-                &num_obj,
-                &"denominator".into(),
-                &f.denominator().to_string().into(),
-            )
-            .unwrap();
             let elem = js_sys::Object::new();
-            js_sys::Reflect::set(&elem, &"type".into(), &"number".into()).unwrap();
-            js_sys::Reflect::set(&elem, &"value".into(), &num_obj).unwrap();
-            js_sys::Reflect::set(&elem, &"displayHint".into(), &"rawNumber".into()).unwrap();
+            if leaves_are_bool {
+                js_sys::Reflect::set(&elem, &"type".into(), &"boolean".into()).unwrap();
+                js_sys::Reflect::set(&elem, &"value".into(), &(!f.is_zero()).into()).unwrap();
+                js_sys::Reflect::set(&elem, &"displayHint".into(), &"truthValue".into()).unwrap();
+            } else {
+                let num_obj = js_sys::Object::new();
+                js_sys::Reflect::set(
+                    &num_obj,
+                    &"numerator".into(),
+                    &f.numerator().to_string().into(),
+                )
+                .unwrap();
+                js_sys::Reflect::set(
+                    &num_obj,
+                    &"denominator".into(),
+                    &f.denominator().to_string().into(),
+                )
+                .unwrap();
+                js_sys::Reflect::set(&elem, &"type".into(), &"number".into()).unwrap();
+                js_sys::Reflect::set(&elem, &"value".into(), &num_obj).unwrap();
+                js_sys::Reflect::set(&elem, &"displayHint".into(), &"rawNumber".into()).unwrap();
+            }
             let element_value = Value::from_fraction(f.clone());
             js_sys::Reflect::set(
                 &elem,
@@ -382,12 +394,18 @@ fn tensor_data_to_js_array(
         let outer = shape[0];
         let rest = &shape[1..];
         let stride: usize = rest.iter().product();
+        let inner_hint_str = if leaves_are_bool {
+            "truthValue"
+        } else {
+            "unassigned"
+        };
         for i in 0..outer {
-            let inner = tensor_data_to_js_array(&data[i * stride..(i + 1) * stride], rest);
+            let inner =
+                tensor_data_to_js_array(&data[i * stride..(i + 1) * stride], rest, leaf_hint);
             let elem = js_sys::Object::new();
             js_sys::Reflect::set(&elem, &"type".into(), &"vector".into()).unwrap();
             js_sys::Reflect::set(&elem, &"value".into(), &inner).unwrap();
-            js_sys::Reflect::set(&elem, &"displayHint".into(), &"unassigned".into()).unwrap();
+            js_sys::Reflect::set(&elem, &"displayHint".into(), &inner_hint_str.into()).unwrap();
             arr.push(&elem);
         }
     }
@@ -488,7 +506,7 @@ pub(crate) fn arena_node_to_js(
                 js_sys::Reflect::set(&obj, &"type".into(), &"string".into()).unwrap();
                 js_sys::Reflect::set(&obj, &"value".into(), &text.into()).unwrap();
             } else {
-                let js_array = tensor_data_to_js_array(data, shape);
+                let js_array = tensor_data_to_js_array(data, shape, effective_hint);
                 js_sys::Reflect::set(&obj, &"type".into(), &"vector".into()).unwrap();
                 js_sys::Reflect::set(&obj, &"value".into(), &js_array).unwrap();
             }

--- a/src/gui/gui-interpreter-test-cases.ts
+++ b/src/gui/gui-interpreter-test-cases.ts
@@ -123,9 +123,9 @@ export const TEST_CASES: TestCase[] = [
         category: "Arithmetic"
     },
     {
-        name: "Division by zero - error",
+        name: "Division by zero - yields NIL",
         code: "[ 1 ] [ 0 ] /",
-        expectError: true,
+        expectedStack: [createNil()],
         category: "Arithmetic"
     },
     {
@@ -157,43 +157,43 @@ export const TEST_CASES: TestCase[] = [
     {
         name: "Less than - true",
         code: "[ 3 ] [ 5 ] <",
-        expectedStack: [createVector([createBoolean(true)])],
+        expectedStack: [createBoolean(true)],
         category: "Comparison"
     },
     {
         name: "Less than - false",
         code: "[ 5 ] [ 3 ] <",
-        expectedStack: [createVector([createBoolean(false)])],
+        expectedStack: [createBoolean(false)],
         category: "Comparison"
     },
     {
         name: "Greater than (via <= NOT)",
         code: "[ 5 ] [ 3 ] <= NOT",
-        expectedStack: [createVector([createBoolean(true)])],
+        expectedStack: [createBoolean(true)],
         category: "Comparison"
     },
     {
         name: "Less than or equal",
         code: "[ 3 ] [ 3 ] <=",
-        expectedStack: [createVector([createBoolean(true)])],
+        expectedStack: [createBoolean(true)],
         category: "Comparison"
     },
     {
         name: "Greater than or equal (via < NOT)",
         code: "[ 3 ] [ 3 ] < NOT",
-        expectedStack: [createVector([createBoolean(true)])],
+        expectedStack: [createBoolean(true)],
         category: "Comparison"
     },
     {
         name: "Equal - numbers",
         code: "[ 5 ] [ 5 ] =",
-        expectedStack: [createVector([createBoolean(true)])],
+        expectedStack: [createBoolean(true)],
         category: "Comparison"
     },
     {
         name: "Equal - fraction auto-reduction",
         code: "[ 1/2 ] [ 2/4 ] =",
-        expectedStack: [createVector([createBoolean(true)])],
+        expectedStack: [createBoolean(true)],
         category: "Comparison"
     },
 
@@ -599,10 +599,13 @@ export const TEST_CASES: TestCase[] = [
         category: "Error Cases"
     },
     {
-        name: "Error - index out of bounds",
+        name: "GET - index out of bounds yields NIL",
         code: "[ 1 2 3 ] [ 10 ] GET",
-        expectError: true,
-        category: "Error Cases"
+        expectedStack: [
+            createVector([createNumber('1'), createNumber('2'), createNumber('3')]),
+            createNil()
+        ],
+        category: "Vector Operations"
     },
     {
 
@@ -621,7 +624,7 @@ export const TEST_CASES: TestCase[] = [
     {
 
         name: "Sort already sorted succeeds",
-        code: "[ 1 2 3 ] SORT",
+        code: "'ALGO' IMPORT [ 1 2 3 ] SORT",
         expectedStack: [createVector([createNumber('1'), createNumber('2'), createNumber('3')])],
         category: "Vector Operations"
     }


### PR DESCRIPTION
## 背景

GUI テストスイートの 17 件の失敗を、実装・正典仕様(SPECIFICATION.md)・既存 Rust ユニットテストと突き合わせて原因を切り分けました。結論として、原因は 2 種類でした。

1. **実装の本物のバグ(7件)** — ブール値のテンソル直列化漏れ
2. **テスト側が仕様/実装と食い違っていた(10件)** — 古い期待値

実装とネイティブで各スニペットを実行して挙動を確定したうえで修正しています。仕様(SPECIFICATION.md)はこれらの挙動と既に一致していたため、仕様の変更は不要でした。

## 修正内容

### 1. 実装バグ修正: `rust/src/.../wasm_value_conversion.rs`
`[ TRUE ]` や `AND`/`OR`/`NOT` の結果は密(promoted)テンソルになりますが、テンソルの直列化経路 `tensor_data_to_js_array` が `TruthValue` ロールを無視し常に数値を出力していました(Vector 経路と Display 経路の `format_as_boolean` は正しくブール表示)。そのため GUI 上で `TRUE` が `1/1` と表示されていました(スカラ比較は影響を受けないので `<` 等は正しく表示)。

→ テンソル葉に `TruthValue` を伝播させ、Vector 経路と同じく boolean を出力するよう修正。これにより以下 7 件が通ります: Boolean TRUE/FALSE, AND ×2, OR, NOT ×2。

### 2. 古いテストの是正: `src/gui/gui-interpreter-test-cases.ts`
実装・仕様に合わせて期待値を更新(`仕様を真・テストを更新`の方針に基づく):
- **ゼロ除算** `[ 1 ] [ 0 ] /` → エラーではなく **NIL**(§7.3 / §11.2 Bubble Rule。Rust テスト `test_interval_division_by_zero_interval_bubbles` も NIL を保証)
- **範囲外 GET** `[ 1 2 3 ] [ 10 ] GET` → エラーではなく **元ベクタ + NIL**(§11.2)
- **比較 ×7** `<` `<=` `=` 等 → ベクタ包みではなく **スカラのブール**(§7.4「encoded as Scalar with the TruthValue role」)
- **SORT** → `ALGO` モジュール語のため `'ALGO' IMPORT` を前置(§ モジュール解決)

## 検証
- Rust ネイティブテスト全 1070 件パス(`cargo test --lib`)。
- `value_to_js` を忠実に再現したネイティブプローブで、修正後に全 17 スニペットが期待出力と一致することを確認(プローブは調査用で本コミットには含めていません)。

## 注意: WASM バンドルの再ビルドが必要
コミット済みの `src/wasm/generated/*.wasm` は実装バグ修正を反映していません。`build.yml` は main への push 時に `scripts/rebuild-wasm.sh` で WASM をソースから再生成するため、main マージ後のデプロイには自動反映されます。ローカル GUI で確認する場合は `bash scripts/rebuild-wasm.sh` を実行してください(この環境では wasm-pack 導入がネットワーク制約で不可のため未再ビルド)。

https://claude.ai/code/session_01XcQ7USbjddozveiWcyt9mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcQ7USbjddozveiWcyt9mE)_