### PR TITLE
Phase B: contract-driven NIL/Bubble behavioral conformance suite

### DIFF
--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -66,6 +66,8 @@ mod error_flow_trace_tests;
 #[cfg(test)]
 mod hash_tests;
 #[cfg(test)]
+mod nil_conformance_tests;
+#[cfg(test)]
 mod higher_order_fold_tests;
 #[cfg(test)]
 mod higher_order_operations_mcdc_tests;

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -1,0 +1,349 @@
+//! Contract-driven NIL / Bubble-Rule behavioral conformance (phase B).
+//!
+//! Earlier coverage asserted the *metadata* of the Coreword registry
+//! (every word has a contract, fields are internally consistent). This
+//! suite closes the complementary gap: it drives the interpreter and
+//! asserts the *runtime* honors each word's declared `nil_policy` and the
+//! Bubble Rule (SPEC §4.5.1, §7.12, §11.2).
+//!
+//! The completeness tests are registry-driven: they enumerate the live
+//! registry and fail if a newly added Core passthrough / projecting word
+//! is not covered by a behavioral probe here. That coupling is what lets
+//! coverage grow automatically with the language instead of drifting.
+//!
+//! Trace: docs/quality/TRACEABILITY_MATRIX.md (NIL/Bubble conformance).
+
+use crate::coreword_registry::{get_builtin_word_registry, CanonicalHome, NilPolicy};
+use crate::error::{ErrorCategory, NilReason};
+use crate::interpreter::Interpreter;
+use crate::types::Value;
+
+async fn run(code: &str) -> Result<Vec<Value>, String> {
+    let mut interp = Interpreter::new();
+    interp.execute(code).await.map_err(|e| e.to_string())?;
+    Ok(interp.get_stack().to_vec())
+}
+
+async fn run_ok(code: &str) -> Vec<Value> {
+    run(code)
+        .await
+        .unwrap_or_else(|e| panic!("`{code}` unexpectedly errored: {e}"))
+}
+
+fn is_nil(v: &Value) -> bool {
+    v.is_nil()
+}
+
+fn is_true(v: &Value) -> bool {
+    !v.is_nil() && v.as_scalar().map(|f| !f.is_zero()).unwrap_or(false)
+}
+
+fn is_false(v: &Value) -> bool {
+    !v.is_nil() && v.as_scalar().map(|f| f.is_zero()).unwrap_or(false)
+}
+
+fn reason_of(v: &Value) -> Option<NilReason> {
+    v.nil_reason().cloned()
+}
+
+// --- Core passthrough classification (SPEC §7.12) -------------------------
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum NilClass {
+    /// Any NIL operand collapses the result to NIL (arithmetic, comparison).
+    BinaryBlanket,
+    /// Unary word: NIL operand yields NIL.
+    UnaryNil,
+    /// Three-valued AND: NIL with definite-false => false, else NIL.
+    ThreeValAnd,
+    /// Three-valued OR: NIL with definite-true => true, else NIL.
+    ThreeValOr,
+}
+
+/// The Core (canonical-home == Core) passthrough words and their NIL
+/// behavior class. `core_passthrough_completeness` keeps this in lockstep
+/// with the registry: adding a Core arithmetic/comparison/logic passthrough
+/// word without classifying it here fails the build.
+const CORE_PASSTHROUGH: &[(&str, NilClass)] = &[
+    ("ADD", NilClass::BinaryBlanket),
+    ("SUB", NilClass::BinaryBlanket),
+    ("MUL", NilClass::BinaryBlanket),
+    ("MOD", NilClass::BinaryBlanket),
+    ("FLOOR", NilClass::UnaryNil),
+    ("CEIL", NilClass::UnaryNil),
+    ("ROUND", NilClass::UnaryNil),
+    ("LT", NilClass::BinaryBlanket),
+    ("LTE", NilClass::BinaryBlanket),
+    ("GT", NilClass::BinaryBlanket),
+    ("GTE", NilClass::BinaryBlanket),
+    ("EQ", NilClass::BinaryBlanket),
+    ("NEQ", NilClass::BinaryBlanket),
+    ("NOT", NilClass::UnaryNil),
+    ("AND", NilClass::ThreeValAnd),
+    ("OR", NilClass::ThreeValOr),
+];
+
+/// Categories whose Core passthrough words this suite is responsible for.
+/// Module-canonical passthrough words (MUSIC/MATH/...) have their own
+/// operand shapes and import needs and are covered by module suites.
+const COVERED_CATEGORIES: &[&str] = &["arithmetic", "comparison", "logic"];
+
+fn lookup_class(name: &str) -> Option<NilClass> {
+    CORE_PASSTHROUGH
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, c)| *c)
+}
+
+#[test]
+fn core_passthrough_completeness() {
+    // Every Core passthrough word in a covered category must be classified,
+    // and every classified word must still be a Core passthrough word.
+    for meta in get_builtin_word_registry() {
+        let covered = meta.canonical_home == CanonicalHome::Core
+            && meta.nil_policy == NilPolicy::Passthrough
+            && COVERED_CATEGORIES.contains(&meta.category.as_str());
+        if covered {
+            assert!(
+                lookup_class(&meta.name).is_some(),
+                "Core passthrough word `{}` (category {}) is not classified in \
+                 CORE_PASSTHROUGH; add its NIL behavior class",
+                meta.name,
+                meta.category
+            );
+        }
+    }
+
+    for (name, _) in CORE_PASSTHROUGH {
+        let meta = get_builtin_word_registry()
+            .iter()
+            .find(|m| &m.name == name)
+            .unwrap_or_else(|| panic!("classified word `{name}` is not registered"));
+        assert_eq!(
+            meta.nil_policy,
+            NilPolicy::Passthrough,
+            "`{name}` is classified as passthrough but registry says {:?}",
+            meta.nil_policy
+        );
+        assert_eq!(
+            meta.canonical_home,
+            CanonicalHome::Core,
+            "`{name}` is classified as a Core passthrough word but is not Core"
+        );
+    }
+}
+
+#[tokio::test]
+async fn passthrough_blanket_and_unary_collapse_to_nil() {
+    for (name, class) in CORE_PASSTHROUGH {
+        match class {
+            NilClass::BinaryBlanket => {
+                // §4.5.1: any NIL operand => single NIL result.
+                for code in [
+                    format!("NIL NIL {name}"),
+                    format!("1 NIL {name}"),
+                    format!("NIL 1 {name}"),
+                ] {
+                    let stack = run_ok(&code).await;
+                    assert_eq!(stack.len(), 1, "`{code}` must leave exactly one value");
+                    assert!(is_nil(&stack[0]), "`{code}` must produce NIL");
+                }
+            }
+            NilClass::UnaryNil => {
+                let code = format!("NIL {name}");
+                let stack = run_ok(&code).await;
+                assert_eq!(stack.len(), 1, "`{code}` must leave exactly one value");
+                assert!(is_nil(&stack[0]), "`{code}` must produce NIL");
+            }
+            // Three-valued words are verified by their dedicated truth-table
+            // tests below; the completeness test guarantees they are present.
+            NilClass::ThreeValAnd | NilClass::ThreeValOr => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn three_valued_and() {
+    // SPEC §7.12: NIL with a definite false collapses to false; otherwise NIL.
+    let nil_cases = ["TRUE NIL AND", "NIL TRUE AND", "NIL NIL AND"];
+    for code in nil_cases {
+        let stack = run_ok(code).await;
+        assert!(is_nil(&stack[0]), "`{code}` must be NIL");
+    }
+    for code in ["FALSE NIL AND", "NIL FALSE AND"] {
+        let stack = run_ok(code).await;
+        assert!(is_false(&stack[0]), "`{code}` must collapse to FALSE");
+    }
+}
+
+#[tokio::test]
+async fn three_valued_or() {
+    // SPEC §7.12: NIL with a definite true collapses to true; otherwise NIL.
+    for code in ["FALSE NIL OR", "NIL FALSE OR", "NIL NIL OR"] {
+        let stack = run_ok(code).await;
+        assert!(is_nil(&stack[0]), "`{code}` must be NIL");
+    }
+    for code in ["TRUE NIL OR", "NIL TRUE OR"] {
+        let stack = run_ok(code).await;
+        assert!(is_true(&stack[0]), "`{code}` must collapse to TRUE");
+    }
+}
+
+// --- Bubble creation: Projecting / CreatesNil words (SPEC §11.2) ----------
+
+/// Projecting words: a well-formed domain miss yields Bubble/NIL with a
+/// reason; malformed use raises an ordinary error. `READ` is host/serial
+/// dependent (needs a port) so only its registry presence is asserted.
+const PROJECTING_WORDS: &[&str] = &["CHR", "DIV", "GET", "NUM", "READ"];
+
+#[test]
+fn projecting_word_set_matches_registry() {
+    let mut registry: Vec<&str> = get_builtin_word_registry()
+        .iter()
+        .filter(|m| m.nil_policy == NilPolicy::CreatesNil)
+        .map(|m| m.name.as_str())
+        .collect();
+    registry.sort_unstable();
+    let mut expected: Vec<&str> = PROJECTING_WORDS.to_vec();
+    expected.sort_unstable();
+    assert_eq!(
+        registry, expected,
+        "CreatesNil word set drifted from PROJECTING_WORDS; add a Bubble \
+         behavioral probe for any new word"
+    );
+}
+
+#[tokio::test]
+async fn bubble_creation_well_formed_domain_miss() {
+    // divisor reduces to zero
+    let stack = run_ok("1 0 DIV").await;
+    assert!(is_nil(&stack[0]));
+    assert_eq!(reason_of(&stack[0]), Some(NilReason::DivisionByZero));
+
+    // valid vector, out-of-range index: source kept, NIL pushed
+    let stack = run_ok("[ 1 2 3 ] [ 10 ] GET").await;
+    assert_eq!(stack.len(), 2, "GET keeps its source vector");
+    assert!(is_nil(stack.last().unwrap()));
+    assert_eq!(
+        reason_of(stack.last().unwrap()),
+        Some(NilReason::IndexOutOfBounds)
+    );
+
+    // unparseable text
+    let stack = run_ok("'abc' NUM").await;
+    assert!(is_nil(&stack[0]));
+    assert_eq!(reason_of(&stack[0]), Some(NilReason::InvalidEncoding));
+
+    // code point above the Unicode scalar range (0x10FFFF == 1114111)
+    let stack = run_ok("1114112 CHR").await;
+    assert!(is_nil(&stack[0]));
+    assert_eq!(reason_of(&stack[0]), Some(NilReason::InvalidEncoding));
+}
+
+#[tokio::test]
+async fn malformed_use_raises_error_not_bubble() {
+    // SPEC §11.2: "そもそも使い方が違う -> エラー". A non-numeric DIV operand
+    // and a malformed GET index are structural misuse, not domain misses.
+    assert!(
+        run("'x' 1 DIV").await.is_err(),
+        "non-numeric DIV operand must raise an error, not Bubble/NIL"
+    );
+    assert!(
+        run("1 [ 1 2 ] GET").await.is_err(),
+        "malformed GET index must raise an error, not Bubble/NIL"
+    );
+}
+
+// --- OR-NIL (=>) replaces Bubble/NIL with a fallback (SPEC §11.2) ---------
+
+#[tokio::test]
+async fn or_nil_supplies_fallback_and_clears_reason() {
+    // bare NIL replaced by the fallback
+    let stack = run_ok("NIL => [ 0 ]").await;
+    assert_eq!(format!("{}", stack[0]), "[ 0/1 ]");
+
+    // non-NIL value passes through unchanged
+    let stack = run_ok("[ 42 ] => [ 0 ]").await;
+    assert_eq!(format!("{}", stack[0]), "[ 42/1 ]");
+
+    // a reasoned Bubble (division by zero) is replaced; no NIL survives
+    let stack = run_ok("1 0 DIV => [ 7 ]").await;
+    assert!(!is_nil(&stack[0]), "OR-NIL must consume the Bubble");
+    assert_eq!(format!("{}", stack[0]), "[ 7/1 ]");
+}
+
+// --- SAFE (~) projects malformed-use errors to NIL (SPEC §11.3) ----------
+
+#[tokio::test]
+async fn safe_projects_malformed_errors_with_caught_category() {
+    // guarded stack underflow
+    let stack = run_ok("~ ADD").await;
+    assert_eq!(stack.len(), 1);
+    assert!(is_nil(&stack[0]));
+    match reason_of(&stack[0]) {
+        Some(NilReason::SafeCaught(cat)) => assert_eq!(*cat, ErrorCategory::StackUnderflow),
+        other => panic!("expected SafeCaught(StackUnderflow), got {other:?}"),
+    }
+
+    // guarded unknown word
+    let stack = run_ok("~ __NO_SUCH_WORD__").await;
+    assert!(is_nil(&stack[0]));
+    match reason_of(&stack[0]) {
+        Some(NilReason::SafeCaught(cat)) => assert_eq!(*cat, ErrorCategory::UnknownWord),
+        other => panic!("expected SafeCaught(UnknownWord), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn safe_preserves_direct_bubble_reason_without_rewrapping() {
+    // SPEC §11.3: a well-formed Bubble produced under SAFE keeps its own
+    // reason; SAFE does not rewrap it as SafeCaught.
+    let stack = run_ok("1 0 ~ DIV").await;
+    assert!(is_nil(&stack[0]));
+    assert_eq!(
+        reason_of(&stack[0]),
+        Some(NilReason::DivisionByZero),
+        "SAFE must not rewrap a direct Bubble as SafeCaught"
+    );
+}
+
+// --- Property: NIL passthrough is total over the numeric domain -----------
+
+#[cfg(test)]
+mod properties {
+    use super::run;
+    use crate::error::NilReason;
+    use proptest::prelude::*;
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        // For any scalar, a NIL co-operand makes a blanket-passthrough binary
+        // op total and NIL — never an error, never a definite value.
+        #[test]
+        fn binary_passthrough_with_nil_is_nil(a in -50i64..50) {
+            for op in ["ADD", "SUB", "MUL", "MOD", "LT", "LTE", "GT", "GTE", "EQ", "NEQ"] {
+                let stack = block_on(run(&format!("{a} NIL {op}")))
+                    .unwrap_or_else(|e| panic!("`{a} NIL {op}` errored: {e}"));
+                prop_assert_eq!(stack.len(), 1);
+                prop_assert!(stack[0].is_nil(), "`{} NIL {}` must be NIL", a, op);
+            }
+        }
+
+        // Division by a zero divisor is a total projection to a reasoned Bubble.
+        #[test]
+        fn division_by_zero_is_reasoned_bubble(a in -50i64..50) {
+            let stack = block_on(run(&format!("{a} 0 DIV")))
+                .unwrap_or_else(|e| panic!("`{a} 0 DIV` errored: {e}"));
+            prop_assert!(stack[0].is_nil());
+            prop_assert_eq!(stack[0].nil_reason().cloned(), Some(NilReason::DivisionByZero));
+        }
+    }
+}


### PR DESCRIPTION
「GUIスイート廃止 → Rust層でDO-178B風テストを厚く(A→B→C)」の **フェーズB**。

## 目的
既存のレジストリ系テストは Coreword コントラクトの **メタデータ**(全語が契約を持つ・フィールド整合)を検証していました。本PRは欠けていた **振る舞いの適合性** を追加します。インタプリタを実行し、各語の宣言された `nil_policy` と Bubble Rule(SPEC §4.5.1 / §7.12 / §11.2)を実行時に満たすことを検証します。これは前回の調査で「最も手薄」と指摘した NIL/Bubble 意味論の中心です。

## レジストリ駆動(自動成長)
- `core_passthrough_completeness`:生きたレジストリを列挙し、新しい Core の arithmetic/comparison/logic passthrough 語が**未分類なら失敗**。
- `projecting_word_set_matches_registry`:`CreatesNil` 集合を固定し、新しい Bubble 生成語が**振る舞いプローブ無しで増えたら失敗**。

これにより、言語が成長すると網羅が自動で追従します(ドリフトしない)。

## 振る舞いカバレッジ
- blanket/unary passthrough → NIL collapse(ADD/SUB/MUL/MOD/FLOOR/CEIL/ROUND, LT/LTE/GT/GTE/EQ/NEQ, NOT)
- 三値論理 AND/OR の真理値表(NIL∧false→false, NIL∨true→true 等)
- Bubble生成 + reason:DIV→DivisionByZero, GET範囲外→IndexOutOfBounds(source保持), NUM→InvalidEncoding, CHR範囲外→InvalidEncoding
- 「不正使用→エラー / 領域ミス→Bubble」の区別(`'x' 1 DIV`・`1 [ 1 2 ] GET` はエラー)
- OR-NIL(`=>`)のフォールバックと reason クリア
- SAFE(`~`)が不正使用エラーを NIL へ射影し caughtCategory を保持、直接 Bubble の reason は再ラップしない
- proptest 2件:数値域全体で「NIL passthrough の全域性」「ゼロ除算の Bubble 射影」

## 検証
- ネイティブテスト全 **1100件パス**(本PRで +12)。
- 新ファイルは rustfmt clean。

## 位置づけ
振る舞いは変えず、テストのみ追加。次は **C(`wasm-bindgen-test` でグルー結合担保)**。その後、境界カバレッジ喪失なしに GUI スイート本体を削除します。なお本PRのスコープは Core の arithmetic/comparison/logic に限定(モジュール語=MUSIC/MATH等のpassthrough適合性は各モジュールのスイートで別途)。

https://claude.ai/code/session_01XcQ7USbjddozveiWcyt9mE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcQ7USbjddozveiWcyt9mE)_