### PR TITLE
Make module word info display consistent with core words

### DIFF
--- a/src/gui/module-selector-sheets.ts
+++ b/src/gui/module-selector-sheets.ts
@@ -255,17 +255,13 @@ export const createModuleTabManager = (
                 const moduleTitle = `${shortName}
 Built-in word from module ${moduleSheet.moduleName}.
 ${stateLine}`;
-                const moduleInfo = `${description}
-
-Built-in word from module ${moduleSheet.moduleName}.
-${stateLine}`;
                 const className = `word-button core module${imported ? '' : ' is-inactive'}`;
                 const button = createWordButtonElement(
                     shortName,
                     moduleTitle,
                     className,
                     () => onWordClick(shortName),
-                    () => { renderWordInfo(wordInfo as HTMLElement, moduleInfo); },
+                    () => { renderWordInfo(wordInfo as HTMLElement, description); },
                     () => { resetWordInfoDisplay(wordInfo as HTMLElement); },
                     (event) => renderContextMenu(contextMenu, event, imported ? [{
                         label: `Unimport ${moduleSheet.moduleName}@${shortName}`,


### PR DESCRIPTION
## 概要

ワードボタン区画上部の「使用例」表示欄について、Core word・User word・module辞書ワードで見せ方が異なり、特にmodule辞書ワードのガイダンスが冗長でエリアに収まり切らず見切れていた問題を修正します。

## 原因

使用例表示欄(`.word-info-display`)は CSS で単一行表示(`white-space: nowrap` / `overflow: hidden` / `text-overflow: ellipsis`)に固定されています。

- **Core word**(理想形): `hover_syntax` の簡潔な1行だけを表示
- **module辞書ワード**: `${description}` に加えて「Built-in word from module X.」「Long-press to ...」といった複数行のボイラープレートを連結して流し込んでいたため、単一行欄からはみ出し見切れていた

## 変更内容

`src/gui/module-selector-sheets.ts` で、使用例欄には簡潔な `description` のみを表示するように変更し、Core word と同じ単一行の見せ方に揃えました。モジュール名やインポート状態の案内は、これまで通りネイティブの `title` ツールチップ(長押し時の案内含む)に残しているため情報は失われません。

## テスト計画

- [ ] ブラウザでmodule辞書ワードにホバーし、使用例欄が見切れず単一行で表示されることを確認
- [ ] Core word / User word の表示が従来通りであることを確認
- [ ] module辞書ワードにホバー時、`title` ツールチップにモジュール名・インポート状態が表示されることを確認

https://claude.ai/code/session_01SoqYQC48RvQo7xQSU4UgEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoqYQC48RvQo7xQSU4UgEZ)_