### PR TITLE
Guard module word descriptions against multi-line text

### DIFF
--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -900,3 +900,33 @@ pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MODULE_SPECS;
+
+    // The word-info area renders a module word's `description` on a single
+    // line (CSS nowrap + ellipsis). A multi-line description overflows and
+    // gets clipped, so descriptions must stay single-line.
+    #[test]
+    fn module_descriptions_are_single_line() {
+        for module in MODULE_SPECS {
+            for word in module.words {
+                assert!(
+                    !word.description.contains('\n'),
+                    "module {} word {} has a multi-line description",
+                    module.name,
+                    word.short_name
+                );
+            }
+            for sample in module.sample_words {
+                assert!(
+                    !sample.description.contains('\n'),
+                    "module {} sample {} has a multi-line description",
+                    module.name,
+                    sample.name
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

module辞書ワードの使用例表示が冗長で見切れていた問題(#977 でレンダリング側を修正済み)について、新しいモジュールワードを追加した際に同じ問題が再発しないようガードを追加します。

## 背景

使用例表示欄は単一行(CSS `nowrap` + `ellipsis`)で描画されます。#977 でレンダリング側は簡潔な `description` のみを表示するよう修正しましたが、`MODULE_SPECS` に**改行を含む `description`** を書くと再び見切れが発生し得ます。

## 変更内容

`rust/src/interpreter/modules/module_builtins.rs` に単体テストを追加し、全モジュールワード・サンプルワードの `description` に改行が含まれないことを検証します。新規エントリが複数行ガイダンスを再導入した場合、CIで自動的に検出されます。

## テスト計画

- [x] `cargo test module_descriptions_are_single_line` が通過することを確認
- [ ] CI(Rust Tests)で実行されることを確認

https://claude.ai/code/session_01SoqYQC48RvQo7xQSU4UgEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoqYQC48RvQo7xQSU4UgEZ)_