### PR TITLE
Add scalar utility words to MATH module

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -671,7 +671,7 @@ Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object 
 | `TIME` | Wall-clock time and datetime conversion |
 | `CRYPTO` | Cryptographically secure random and hash |
 | `ALGO` | Sorting and other deterministic algorithms |
-| `MATH` | Square root and exact-rational interval arithmetic |
+| `MATH` | Square root, exact-rational interval arithmetic, and scalar utilities (`ABS`, `NEG`, `SIGN`, `MIN`, `MAX`) |
 | `SERIAL` | Host-mediated serial port output |
 
 ### 9.2 Import and unimport syntax

--- a/rust/src/interpreter/math_ops.rs
+++ b/rust/src/interpreter/math_ops.rs
@@ -42,7 +42,9 @@ where
         }
     };
     push_result(interp, Value::from_fraction(op(scalar)));
-    interp.semantic_registry.push_hint(Interpretation::RawNumber);
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::RawNumber);
     Ok(())
 }
 
@@ -69,7 +71,9 @@ where
         }
     };
     push_result(interp, Value::from_fraction(op(a, b)));
-    interp.semantic_registry.push_hint(Interpretation::RawNumber);
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::RawNumber);
     Ok(())
 }
 

--- a/rust/src/interpreter/math_ops.rs
+++ b/rust/src/interpreter/math_ops.rs
@@ -1,0 +1,102 @@
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::value_extraction_helpers::{
+    extract_operands, nil_passthrough_binary, nil_passthrough_unary, push_result,
+};
+use crate::interpreter::{Interpreter, OperationTargetMode};
+use crate::types::fraction::Fraction;
+use crate::types::{Interpretation, Value};
+
+fn require_stack_top(interp: &Interpreter, word: &str) -> Result<()> {
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from(format!(
+            "{}: Stack mode is not supported",
+            word
+        )));
+    }
+    Ok(())
+}
+
+fn extract_scalar(value: &Value, word: &str) -> Result<Fraction> {
+    value
+        .as_scalar()
+        .cloned()
+        .ok_or_else(|| AjisaiError::from(format!("{}: expected a number", word)))
+}
+
+fn apply_unary<F>(interp: &mut Interpreter, word: &str, op: F) -> Result<()>
+where
+    F: Fn(Fraction) -> Fraction,
+{
+    require_stack_top(interp, word)?;
+    if nil_passthrough_unary(interp) {
+        return Ok(());
+    }
+    let operands = extract_operands(interp, 1)?;
+    let scalar = match extract_scalar(&operands[0], word) {
+        Ok(s) => s,
+        Err(e) => {
+            if interp.consumption_mode != crate::interpreter::ConsumptionMode::Keep {
+                interp.stack.extend(operands);
+            }
+            return Err(e);
+        }
+    };
+    push_result(interp, Value::from_fraction(op(scalar)));
+    interp.semantic_registry.push_hint(Interpretation::RawNumber);
+    Ok(())
+}
+
+fn apply_binary<F>(interp: &mut Interpreter, word: &str, op: F) -> Result<()>
+where
+    F: Fn(Fraction, Fraction) -> Fraction,
+{
+    require_stack_top(interp, word)?;
+    if nil_passthrough_binary(interp) {
+        return Ok(());
+    }
+    let operands = extract_operands(interp, 2)?;
+    let parsed = (
+        extract_scalar(&operands[0], word),
+        extract_scalar(&operands[1], word),
+    );
+    let (a, b) = match parsed {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => {
+            if interp.consumption_mode != crate::interpreter::ConsumptionMode::Keep {
+                interp.stack.extend(operands);
+            }
+            return Err(AjisaiError::from(format!("{}: expected two numbers", word)));
+        }
+    };
+    push_result(interp, Value::from_fraction(op(a, b)));
+    interp.semantic_registry.push_hint(Interpretation::RawNumber);
+    Ok(())
+}
+
+pub(crate) fn op_abs(interp: &mut Interpreter) -> Result<()> {
+    apply_unary(interp, "ABS", |f| f.abs())
+}
+
+pub(crate) fn op_neg(interp: &mut Interpreter) -> Result<()> {
+    apply_unary(interp, "NEG", |f| Fraction::from(0).sub(&f))
+}
+
+pub(crate) fn op_sign(interp: &mut Interpreter) -> Result<()> {
+    apply_unary(interp, "SIGN", |f| {
+        if f.is_zero() {
+            Fraction::from(0)
+        } else if f.lt(&Fraction::from(0)) {
+            Fraction::from(-1)
+        } else {
+            Fraction::from(1)
+        }
+    })
+}
+
+pub(crate) fn op_min(interp: &mut Interpreter) -> Result<()> {
+    apply_binary(interp, "MIN", |a, b| if a.le(&b) { a } else { b })
+}
+
+pub(crate) fn op_max(interp: &mut Interpreter) -> Result<()> {
+    apply_binary(interp, "MAX", |a, b| if a.ge(&b) { a } else { b })
+}

--- a/rust/src/interpreter/math_ops_tests.rs
+++ b/rust/src/interpreter/math_ops_tests.rs
@@ -6,7 +6,10 @@ mod tests {
 
     async fn top_i64(program: &str) -> i64 {
         let mut interp = Interpreter::new();
-        interp.execute(program).await.expect("program should succeed");
+        interp
+            .execute(program)
+            .await
+            .expect("program should succeed");
         assert_eq!(interp.stack.len(), 1, "program: {program}");
         interp.stack[0]
             .as_scalar()
@@ -79,7 +82,10 @@ mod tests {
     async fn non_number_input_errors() {
         let mut interp = Interpreter::new();
         let result = interp.execute("'math' IMPORT 'hello' ABS").await;
-        assert!(result.is_err(), "ABS of text should be a malformed-use error");
+        assert!(
+            result.is_err(),
+            "ABS of text should be a malformed-use error"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/interpreter/math_ops_tests.rs
+++ b/rust/src/interpreter/math_ops_tests.rs
@@ -1,0 +1,103 @@
+//! Test suite for `crate::interpreter::math_ops` (MATH module ABS/NEG/SIGN/MIN/MAX).
+
+#[cfg(test)]
+mod tests {
+    use crate::interpreter::Interpreter;
+
+    async fn top_i64(program: &str) -> i64 {
+        let mut interp = Interpreter::new();
+        interp.execute(program).await.expect("program should succeed");
+        assert_eq!(interp.stack.len(), 1, "program: {program}");
+        interp.stack[0]
+            .as_scalar()
+            .expect("expected scalar result")
+            .to_i64()
+            .expect("expected integer result")
+    }
+
+    #[tokio::test]
+    async fn abs_of_negative_is_positive() {
+        assert_eq!(top_i64("'math' IMPORT -7 ABS").await, 7);
+    }
+
+    #[tokio::test]
+    async fn neg_flips_sign() {
+        assert_eq!(top_i64("'math' IMPORT 5 NEG").await, -5);
+        assert_eq!(top_i64("'math' IMPORT -3 NEG").await, 3);
+    }
+
+    #[tokio::test]
+    async fn sign_reports_three_values() {
+        assert_eq!(top_i64("'math' IMPORT -42 SIGN").await, -1);
+        assert_eq!(top_i64("'math' IMPORT 0 SIGN").await, 0);
+        assert_eq!(top_i64("'math' IMPORT 42 SIGN").await, 1);
+    }
+
+    #[tokio::test]
+    async fn min_and_max_pick_correctly() {
+        assert_eq!(top_i64("'math' IMPORT 3 8 MIN").await, 3);
+        assert_eq!(top_i64("'math' IMPORT 3 8 MAX").await, 8);
+        assert_eq!(top_i64("'math' IMPORT -2 -9 MIN").await, -9);
+        assert_eq!(top_i64("'math' IMPORT -2 -9 MAX").await, -2);
+    }
+
+    #[tokio::test]
+    async fn abs_handles_fractions() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT -3/4 ABS")
+            .await
+            .expect("should succeed");
+        let scalar = interp.stack[0].as_scalar().expect("scalar");
+        assert_eq!(scalar.numerator().to_string(), "3");
+        assert_eq!(scalar.denominator().to_string(), "4");
+    }
+
+    #[tokio::test]
+    async fn nil_passes_through_unary() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT NIL ABS")
+            .await
+            .expect("NIL passthrough should not error");
+        assert_eq!(interp.stack.len(), 1);
+        assert!(interp.stack[0].is_nil(), "ABS of NIL should be NIL");
+    }
+
+    #[tokio::test]
+    async fn nil_passes_through_binary() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT NIL 5 MIN")
+            .await
+            .expect("NIL passthrough should not error");
+        assert_eq!(interp.stack.len(), 1);
+        assert!(interp.stack[0].is_nil(), "MIN with NIL should be NIL");
+    }
+
+    #[tokio::test]
+    async fn non_number_input_errors() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("'math' IMPORT 'hello' ABS").await;
+        assert!(result.is_err(), "ABS of text should be a malformed-use error");
+    }
+
+    #[tokio::test]
+    async fn stack_mode_is_rejected() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("'math' IMPORT 1 2 3 .. MAX").await;
+        assert!(result.is_err(), "MAX should reject Stack mode");
+        assert!(result.unwrap_err().to_string().contains("Stack mode"));
+    }
+
+    #[tokio::test]
+    async fn keep_mode_retains_operands() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 3 8 ,, MIN")
+            .await
+            .expect("keep mode should succeed");
+        assert_eq!(interp.stack.len(), 3, "operands retained plus result");
+        assert_eq!(interp.stack[2].as_scalar().unwrap().to_i64().unwrap(), 3);
+    }
+}

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -22,6 +22,7 @@ pub mod interval_ops;
 pub mod io;
 pub mod json;
 pub mod logic;
+pub mod math_ops;
 pub mod modules;
 pub(crate) mod naming_convention_checker;
 pub(crate) mod optimization_hooks;
@@ -65,6 +66,8 @@ mod dictionary_tier_tests;
 mod error_flow_trace_tests;
 #[cfg(test)]
 mod hash_tests;
+#[cfg(test)]
+mod math_ops_tests;
 #[cfg(test)]
 mod nil_conformance_tests;
 #[cfg(test)]

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -2,7 +2,9 @@ use crate::builtins::WordShape;
 use crate::coreword_registry::{
     self, CanonicalHome, CorewordMetadata, NilPolicy, Partiality, WordPurity,
 };
-use crate::interpreter::{audio, datetime, hash, interval_ops, json, random, serial, sort};
+use crate::interpreter::{
+    audio, datetime, hash, interval_ops, json, math_ops, random, serial, sort,
+};
 use crate::types::{Capabilities, Stability};
 
 use super::module_word_types::{ModuleSpec, ModuleWord, SampleWord};
@@ -670,6 +672,71 @@ const MATH_WORDS: &[ModuleWord] = &[
         WordShape::Map,
         "True for exact number or degenerate interval.",
         interval_ops::op_is_exact,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "ABS",
+        WordShape::Map,
+        "Absolute value of a number.",
+        math_ops::op_abs,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "NEG",
+        WordShape::Map,
+        "Negate a number.",
+        math_ops::op_neg,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "SIGN",
+        WordShape::Map,
+        "Sign of a number: -1, 0, or 1.",
+        math_ops::op_sign,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "MIN",
+        WordShape::Form,
+        "Smaller of two numbers.",
+        math_ops::op_min,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "MAX",
+        WordShape::Form,
+        "Larger of two numbers.",
+        math_ops::op_max,
         WordPurity::Pure,
         &[],
         true,


### PR DESCRIPTION
## Summary

実用言語としてモジュール辞書を充実させる第一歩として、`MATH` モジュールに利用価値の高いスカラー演算ワードを追加しました。

追加したワード (すべて `MATH` モジュール / Pure / NIL-passthrough / 正確有理数):

- `ABS` — 絶対値
- `NEG` — 符号反転
- `SIGN` — 符号 (-1 / 0 / 1)
- `MIN` — 2値の小さい方
- `MAX` — 2値の大きい方

いずれも数値入力に対して全域 (Total) で、既存の interval 系ワードと同じスタイル (StackTop のみ、KEEP対応) に揃えています。連続フラクション表現の正確性を損なわない演算のみを対象にしました (`POW` / `GCD` / `LCM` などの整数限定・部分関数ワードは partiality メタデータの拡張が必要なため後続で対応予定)。

## Changes

- `rust/src/interpreter/math_ops.rs` — 新規実装 (unary/binary ヘルパ + 5ワード)
- `rust/src/interpreter/modules/module_builtins.rs` — `MATH_WORDS` に登録
- `rust/src/interpreter/mod.rs` — モジュール宣言とテスト宣言
- `rust/src/interpreter/math_ops_tests.rs` — 新規テスト (成功・NIL passthrough・型エラー・Stackモード拒否・KEEP)
- `SPECIFICATION.md` — `MATH` モジュールの purpose 行を更新

Coreword contract メタデータは既存の `module_word_metadata_entries` により Pure (Total / Passthrough) として自動生成されます。

## Test plan

- [x] `cargo build` 警告のみ (既存の dead-code 警告)
- [x] `cargo test math_ops` 10件すべて成功
- [x] `cargo test` 全1111件成功 (回帰なし)

https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9)_