### PR TITLE
Add POW, GCD, LCM to MATH module

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -671,7 +671,7 @@ Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object 
 | `TIME` | Wall-clock time and datetime conversion |
 | `CRYPTO` | Cryptographically secure random and hash |
 | `ALGO` | Sorting and other deterministic algorithms |
-| `MATH` | Square root, exact-rational interval arithmetic, and scalar utilities (`ABS`, `NEG`, `SIGN`, `MIN`, `MAX`) |
+| `MATH` | Square root, exact-rational interval arithmetic, and scalar utilities (`ABS`, `NEG`, `SIGN`, `MIN`, `MAX`, `POW`, `GCD`, `LCM`) |
 | `SERIAL` | Host-mediated serial port output |
 
 ### 9.2 Import and unimport syntax

--- a/rust/src/interpreter/math_ops.rs
+++ b/rust/src/interpreter/math_ops.rs
@@ -1,10 +1,22 @@
-use crate::error::{AjisaiError, Result};
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::Zero;
+
+use crate::error::{AjisaiError, NilReason, Result};
 use crate::interpreter::value_extraction_helpers::{
-    extract_operands, nil_passthrough_binary, nil_passthrough_unary, push_result,
+    extract_bigint_from_value, extract_operands, nil_passthrough_binary, nil_passthrough_unary,
+    push_result,
 };
-use crate::interpreter::{Interpreter, OperationTargetMode};
+use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::semantic::{AbsenceOrigin, Recoverability};
 use crate::types::fraction::Fraction;
 use crate::types::{Interpretation, Value};
+
+/// Runtime safety bound on `POW` exponent magnitude, analogous to the
+/// execution step budget (SPEC §5.3). It prevents a single well-formed
+/// `POW` from materializing an astronomically large exact rational and
+/// exhausting memory; it is not a language-level semantic constraint.
+const MAX_POW_EXPONENT: i64 = 1_000_000;
 
 fn require_stack_top(interp: &Interpreter, word: &str) -> Result<()> {
     if interp.operation_target_mode != OperationTargetMode::StackTop {
@@ -103,4 +115,136 @@ pub(crate) fn op_min(interp: &mut Interpreter) -> Result<()> {
 
 pub(crate) fn op_max(interp: &mut Interpreter) -> Result<()> {
     apply_binary(interp, "MAX", |a, b| if a.ge(&b) { a } else { b })
+}
+
+fn restore_operands(interp: &mut Interpreter, operands: Vec<Value>) {
+    if interp.consumption_mode != ConsumptionMode::Keep {
+        interp.stack.extend(operands);
+    }
+}
+
+fn pow_fraction(base: &Fraction, mut exp: u64) -> Fraction {
+    let mut result = Fraction::from(1);
+    let mut b = base.clone();
+    while exp > 0 {
+        if exp & 1 == 1 {
+            result = result.mul(&b);
+        }
+        exp >>= 1;
+        if exp > 0 {
+            b = b.mul(&b);
+        }
+    }
+    result
+}
+
+/// `base exp -- result`. Integer-exponent exact power. A non-integer or
+/// non-numeric operand is malformed use and raises an error (cf. `CHR`).
+/// `0` raised to a negative exponent is a well-formed domain miss and
+/// projects to Bubble/NIL with `reason = divisionByZero` (Bubble Rule).
+pub(crate) fn op_pow(interp: &mut Interpreter) -> Result<()> {
+    require_stack_top(interp, "POW")?;
+    if nil_passthrough_binary(interp) {
+        return Ok(());
+    }
+    let operands = extract_operands(interp, 2)?;
+    let base = match extract_scalar(&operands[0], "POW") {
+        Ok(b) => b,
+        Err(e) => {
+            restore_operands(interp, operands);
+            return Err(e);
+        }
+    };
+    let exp = match extract_bigint_from_value(&operands[1]) {
+        Ok(e) => e,
+        Err(_) => {
+            restore_operands(interp, operands);
+            return Err(AjisaiError::from("POW: exponent must be an integer"));
+        }
+    };
+    let exp_i64: i64 = match (&exp).try_into() {
+        Ok(n) => n,
+        Err(_) => {
+            restore_operands(interp, operands);
+            return Err(AjisaiError::from(
+                "POW: exponent magnitude exceeds the supported bound",
+            ));
+        }
+    };
+    if exp_i64.abs() > MAX_POW_EXPONENT {
+        restore_operands(interp, operands);
+        return Err(AjisaiError::from(
+            "POW: exponent magnitude exceeds the supported bound",
+        ));
+    }
+
+    let result = if exp_i64 == 0 {
+        Value::from_fraction(Fraction::from(1))
+    } else if exp_i64 > 0 {
+        Value::from_fraction(pow_fraction(&base, exp_i64 as u64))
+    } else if base.is_zero() {
+        Value::bubble_with_reason(
+            NilReason::DivisionByZero,
+            AbsenceOrigin::ExecutionFailure,
+            Recoverability::Recoverable,
+        )
+    } else {
+        let positive = pow_fraction(&base, exp_i64.unsigned_abs());
+        Value::from_fraction(Fraction::new(positive.denominator(), positive.numerator()))
+    };
+    let is_bubble = result.is_nil();
+    push_result(interp, result);
+    if !is_bubble {
+        interp
+            .semantic_registry
+            .push_hint(Interpretation::RawNumber);
+    }
+    Ok(())
+}
+
+fn apply_integer_binary<F>(interp: &mut Interpreter, word: &str, op: F) -> Result<()>
+where
+    F: Fn(&BigInt, &BigInt) -> BigInt,
+{
+    require_stack_top(interp, word)?;
+    if nil_passthrough_binary(interp) {
+        return Ok(());
+    }
+    let operands = extract_operands(interp, 2)?;
+    let parsed = (
+        extract_bigint_from_value(&operands[0]),
+        extract_bigint_from_value(&operands[1]),
+    );
+    let (a, b) = match parsed {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => {
+            restore_operands(interp, operands);
+            return Err(AjisaiError::from(format!(
+                "{}: expected two integers",
+                word
+            )));
+        }
+    };
+    push_result(
+        interp,
+        Value::from_fraction(Fraction::new(op(&a, &b), BigInt::from(1))),
+    );
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::RawNumber);
+    Ok(())
+}
+
+pub(crate) fn op_gcd(interp: &mut Interpreter) -> Result<()> {
+    apply_integer_binary(interp, "GCD", |a, b| a.gcd(b))
+}
+
+pub(crate) fn op_lcm(interp: &mut Interpreter) -> Result<()> {
+    apply_integer_binary(interp, "LCM", |a, b| {
+        if a.is_zero() || b.is_zero() {
+            BigInt::from(0)
+        } else {
+            a.lcm(b)
+        }
+    })
 }

--- a/rust/src/interpreter/math_ops_tests.rs
+++ b/rust/src/interpreter/math_ops_tests.rs
@@ -97,6 +97,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pow_positive_exponent() {
+        assert_eq!(top_i64("'math' IMPORT 2 10 POW").await, 1024);
+        assert_eq!(top_i64("'math' IMPORT 5 0 POW").await, 1);
+        assert_eq!(top_i64("'math' IMPORT -3 3 POW").await, -27);
+    }
+
+    #[tokio::test]
+    async fn pow_negative_exponent_is_reciprocal() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 2 -2 POW")
+            .await
+            .expect("should succeed");
+        let scalar = interp.stack[0].as_scalar().expect("scalar");
+        assert_eq!(scalar.numerator().to_string(), "1");
+        assert_eq!(scalar.denominator().to_string(), "4");
+    }
+
+    #[tokio::test]
+    async fn pow_zero_to_negative_is_bubble() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 0 -1 POW")
+            .await
+            .expect("0^negative should be a well-formed Bubble, not an error");
+        assert_eq!(interp.stack.len(), 1);
+        assert!(interp.stack[0].is_nil(), "0^negative should project to NIL");
+    }
+
+    #[tokio::test]
+    async fn pow_non_integer_exponent_errors() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("'math' IMPORT 2 1/2 POW").await;
+        assert!(result.is_err(), "non-integer exponent is malformed use");
+    }
+
+    #[tokio::test]
+    async fn pow_huge_exponent_is_bounded() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("'math' IMPORT 2 2000000 POW").await;
+        assert!(result.is_err(), "exponent past the safety bound errors");
+    }
+
+    #[tokio::test]
+    async fn pow_nil_passes_through() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT NIL 2 POW")
+            .await
+            .expect("NIL passthrough should not error");
+        assert!(interp.stack[0].is_nil());
+    }
+
+    #[tokio::test]
+    async fn gcd_and_lcm_basic() {
+        assert_eq!(top_i64("'math' IMPORT 12 18 GCD").await, 6);
+        assert_eq!(top_i64("'math' IMPORT -12 18 GCD").await, 6);
+        assert_eq!(top_i64("'math' IMPORT 0 0 GCD").await, 0);
+        assert_eq!(top_i64("'math' IMPORT 4 6 LCM").await, 12);
+        assert_eq!(top_i64("'math' IMPORT 0 5 LCM").await, 0);
+    }
+
+    #[tokio::test]
+    async fn gcd_non_integer_errors() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("'math' IMPORT 3/2 6 GCD").await;
+        assert!(result.is_err(), "GCD of a non-integer is malformed use");
+    }
+
+    #[tokio::test]
+    async fn lcm_nil_passes_through() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 4 NIL LCM")
+            .await
+            .expect("NIL passthrough should not error");
+        assert!(interp.stack[0].is_nil());
+    }
+
+    #[tokio::test]
     async fn keep_mode_retains_operands() {
         let mut interp = Interpreter::new();
         interp

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -745,6 +745,45 @@ const MATH_WORDS: &[ModuleWord] = &[
         Stability::Stable,
         Capabilities::PURE
     ),
+    module_word!(
+        "POW",
+        WordShape::Form,
+        "Integer-exponent exact power: base exp -- base^exp.",
+        math_ops::op_pow,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "GCD",
+        WordShape::Form,
+        "Greatest common divisor of two integers.",
+        math_ops::op_gcd,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "LCM",
+        WordShape::Form,
+        "Least common multiple of two integers.",
+        math_ops::op_lcm,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
 ];
 
 const SERIAL_WORDS: &[ModuleWord] = &[
@@ -928,6 +967,25 @@ pub(crate) fn module_word_description(module_name: &str, short_name: &str) -> Op
         .map(|w| w.description)
 }
 
+/// Per-word contract overrides for module words whose `partiality` /
+/// `nil_policy` differ from the purity-class default produced by
+/// `coreword_registry::{pure,observable,effectful}`.
+fn contract_override(module: &str, word: &str) -> Option<(Partiality, NilPolicy)> {
+    match (module, word) {
+        // SERIAL@READ projects the no-data / disconnected condition onto
+        // Bubble/NIL (Section 9.4), so it is Projecting/CreatesNil rather
+        // than the effectful default of Partial/RejectsNil.
+        ("SERIAL", "READ") => Some((Partiality::Projecting, NilPolicy::CreatesNil)),
+        // MATH@POW projects 0 raised to a negative exponent onto Bubble/NIL
+        // (reason = divisionByZero) while erroring on malformed use.
+        ("MATH", "POW") => Some((Partiality::Projecting, NilPolicy::CreatesNil)),
+        // MATH@GCD / MATH@LCM raise an error on non-integer numeric inputs
+        // (malformed use, cf. CHR) and pass NIL operands through.
+        ("MATH", "GCD") | ("MATH", "LCM") => Some((Partiality::Partial, NilPolicy::Passthrough)),
+        _ => None,
+    }
+}
+
 pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
     MODULE_SPECS
         .iter()
@@ -955,12 +1013,11 @@ pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
                 metadata.listed_in_core = false;
                 metadata.listed_in_modules = vec![spec.name.to_string()];
                 metadata.listed_in_categories = Vec::new();
-                // SERIAL@READ projects the no-data / disconnected condition onto
-                // Bubble/NIL (Section 9.4), so it is Projecting/CreatesNil rather
-                // than the effectful default of Partial/RejectsNil.
-                if spec.name == "SERIAL" && word.short_name == "READ" {
-                    metadata.partiality = Partiality::Projecting;
-                    metadata.nil_policy = NilPolicy::CreatesNil;
+                if let Some((partiality, nil_policy)) =
+                    contract_override(spec.name, word.short_name)
+                {
+                    metadata.partiality = partiality;
+                    metadata.nil_policy = nil_policy;
                 }
                 metadata
             })

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -194,7 +194,7 @@ async fn three_valued_or() {
 /// Projecting words: a well-formed domain miss yields Bubble/NIL with a
 /// reason; malformed use raises an ordinary error. `READ` is host/serial
 /// dependent (needs a port) so only its registry presence is asserted.
-const PROJECTING_WORDS: &[&str] = &["CHR", "DIV", "GET", "NUM", "READ"];
+const PROJECTING_WORDS: &[&str] = &["CHR", "DIV", "GET", "NUM", "POW", "READ"];
 
 #[test]
 fn projecting_word_set_matches_registry() {
@@ -238,6 +238,14 @@ async fn bubble_creation_well_formed_domain_miss() {
     let stack = run_ok("1114112 CHR").await;
     assert!(is_nil(&stack[0]));
     assert_eq!(reason_of(&stack[0]), Some(NilReason::InvalidEncoding));
+
+    // zero raised to a negative exponent: well-formed domain miss
+    let stack = run_ok("'math' IMPORT 0 -1 POW").await;
+    assert!(is_nil(stack.last().unwrap()));
+    assert_eq!(
+        reason_of(stack.last().unwrap()),
+        Some(NilReason::DivisionByZero)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`MATH` モジュール拡充の続きとして、部分関数系の数値ワードを3つ追加しました（#979 で追加した `ABS`/`NEG`/`SIGN`/`MIN`/`MAX` の続き）。

- `POW` (`base exp -- base^exp`) — 整数指数の正確べき乗。負の指数は逆数。非整数指数や非数値は **誤用 → エラー**（`CHR` に倣う）。`0` の負べきは **正しい形だが値を作れない → Bubble/NIL**（`reason = divisionByZero`、Bubble Rule §11.2）。指数の絶対値には実行ステップ予算（§5.3）に類するランタイム安全上限を設けています。
- `GCD` — 2整数の最大公約数（`gcd(0,0)=0`）。
- `LCM` — 2整数の最小公倍数（`lcm(0,x)=0`）。非整数入力は誤用 → エラー。NIL はパススルー。

## Contract metadata

部分/射影ワードが正しい `partiality` / `nil_policy` を宣言できるよう、`module_word_metadata_entries` 内の `SERIAL@READ` インライン分岐を再利用可能な `contract_override` ヘルパに整理しました。

- `MATH@POW` → `Projecting` / `CreatesNil`
- `MATH@GCD`, `MATH@LCM` → `Partial` / `Passthrough`
- `SERIAL@READ` → `Projecting` / `CreatesNil`（従来通り）

`POW` は `nil_conformance_tests` の `PROJECTING_WORDS` と Bubble 振る舞いプローブにも追加済みです。

## Test plan

- [x] `cargo build` 警告は既存の dead-code/private-interface のみ（新規なし）
- [x] `cargo test math_ops` 19件成功
- [x] `cargo test` 全1120件成功（`projecting_word_set_matches_registry` 含む回帰なし）
- [x] rustfmt 適用済み

https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9)_