### PR TITLE
Add HAS, VALUES, MERGE, DELETE to JSON module

### DIFF
--- a/rust/src/interpreter/json.rs
+++ b/rust/src/interpreter/json.rs
@@ -299,6 +299,172 @@ pub fn op_json_export(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
+/// Borrow the `[key, value]` pairs of a JSON object. Both the canonical
+/// `Record` form and a raw vector-of-pairs are accepted; anything else
+/// (scalar, NIL, code block, ...) is not an object and yields `None`.
+fn object_pairs(val: &Value) -> Option<&[Value]> {
+    match &val.data {
+        ValueData::Record { pairs, .. } => Some(pairs.as_slice()),
+        ValueData::Vector(v) => Some(v.as_slice()),
+        _ => None,
+    }
+}
+
+fn pair_key(pair: &Value) -> Option<String> {
+    if let ValueData::Vector(kv) = &pair.data {
+        if kv.len() == 2 {
+            return Some(extract_string_content_from_value(&kv[0]));
+        }
+    }
+    None
+}
+
+/// Build a canonical `Record` from a list of `[key, value]` pairs, deriving
+/// the key index from the final pair order.
+fn build_record(pairs: Vec<Value>) -> Value {
+    let mut index: HashMap<String, usize> = HashMap::new();
+    for (i, pair) in pairs.iter().enumerate() {
+        if let Some(k) = pair_key(pair) {
+            index.insert(k, i);
+        }
+    }
+    Value {
+        data: ValueData::Record {
+            pairs: Rc::new(pairs),
+            index,
+        },
+        hint: Interpretation::Unassigned,
+        absence: None,
+    }
+}
+
+pub fn op_json_has(interp: &mut Interpreter) -> Result<()> {
+    let is_keep = interp.consumption_mode == ConsumptionMode::Keep;
+
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+
+    let key_val = extract_stack_value(interp, is_keep, 0)?;
+    let obj_val = if is_keep {
+        extract_stack_value(interp, true, 1)?
+    } else {
+        extract_stack_value(interp, false, 0)?
+    };
+
+    let key_str = extract_string_content_from_value(&key_val);
+    let found = object_pairs(&obj_val).is_some_and(|pairs| {
+        pairs
+            .iter()
+            .any(|pair| pair_key(pair).as_deref() == Some(key_str.as_str()))
+    });
+
+    interp.stack.push(Value::from_bool(found));
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::TruthValue);
+    Ok(())
+}
+
+pub fn op_json_values(interp: &mut Interpreter) -> Result<()> {
+    let is_keep = interp.consumption_mode == ConsumptionMode::Keep;
+
+    let obj_val = extract_stack_value(interp, is_keep, 0)?;
+
+    let Some(pairs) = object_pairs(&obj_val) else {
+        interp.stack.push(Value::nil());
+        return Ok(());
+    };
+
+    let mut values = Vec::new();
+    for pair in pairs {
+        if let ValueData::Vector(kv) = &pair.data {
+            if kv.len() == 2 {
+                values.push(kv[1].clone());
+            }
+        }
+    }
+
+    if values.is_empty() {
+        interp.stack.push(Value::nil());
+    } else {
+        interp.stack.push(Value {
+            data: ValueData::Vector(Rc::new(values)),
+            hint: Interpretation::Unassigned,
+            absence: None,
+        });
+    }
+    Ok(())
+}
+
+pub fn op_json_merge(interp: &mut Interpreter) -> Result<()> {
+    let is_keep = interp.consumption_mode == ConsumptionMode::Keep;
+
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+
+    let overlay_val = extract_stack_value(interp, is_keep, 0)?;
+    let base_val = if is_keep {
+        extract_stack_value(interp, true, 1)?
+    } else {
+        extract_stack_value(interp, false, 0)?
+    };
+
+    let mut merged: Vec<Value> = Vec::new();
+    let mut position: HashMap<String, usize> = HashMap::new();
+
+    for source in [&base_val, &overlay_val] {
+        let Some(pairs) = object_pairs(source) else {
+            continue;
+        };
+        for pair in pairs {
+            let Some(key) = pair_key(pair) else {
+                continue;
+            };
+            if let Some(&idx) = position.get(&key) {
+                merged[idx] = pair.clone();
+            } else {
+                position.insert(key, merged.len());
+                merged.push(pair.clone());
+            }
+        }
+    }
+
+    interp.stack.push(build_record(merged));
+    Ok(())
+}
+
+pub fn op_json_delete(interp: &mut Interpreter) -> Result<()> {
+    let is_keep = interp.consumption_mode == ConsumptionMode::Keep;
+
+    if interp.stack.len() < 2 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+
+    let key_val = extract_stack_value(interp, is_keep, 0)?;
+    let obj_val = if is_keep {
+        extract_stack_value(interp, true, 1)?
+    } else {
+        extract_stack_value(interp, false, 0)?
+    };
+
+    let key_str = extract_string_content_from_value(&key_val);
+    let Some(pairs) = object_pairs(&obj_val) else {
+        interp.stack.push(Value::nil());
+        return Ok(());
+    };
+
+    let kept: Vec<Value> = pairs
+        .iter()
+        .filter(|pair| pair_key(pair).as_deref() != Some(key_str.as_str()))
+        .cloned()
+        .collect();
+
+    interp.stack.push(build_record(kept));
+    Ok(())
+}
+
 fn extract_string_content_from_value(val: &Value) -> String {
     if let Some(view) = val.as_vector_view() {
         if view.iter().all(|c| matches!(c.data, ValueData::Scalar(_))) {

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -467,6 +467,54 @@ const JSON_WORDS: &[ModuleWord] = &[
         Capabilities::PURE
     ),
     module_word!(
+        "HAS",
+        "True if a JSON object contains the given key",
+        json::op_json_has,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "VALUES",
+        "Get all values from a JSON object",
+        json::op_json_values,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "MERGE",
+        "Merge two JSON objects; right-hand keys win on conflict",
+        json::op_json_merge,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
+        "DELETE",
+        "Remove a key from a JSON object",
+        json::op_json_delete,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::PURE
+    ),
+    module_word!(
         "EXPORT",
         "Export stack top as JSON file download",
         json::op_json_export,

--- a/rust/src/json_io_tests.rs
+++ b/rust/src/json_io_tests.rs
@@ -4,7 +4,6 @@
 mod json_io_tests {
     use crate::interpreter::Interpreter;
 
-
     #[tokio::test]
     async fn test_parse_integer() {
         let mut interp = Interpreter::new();
@@ -102,7 +101,6 @@ mod json_io_tests {
         assert_eq!(parsed, "42/1");
     }
 
-
     #[tokio::test]
     async fn test_stringify_integer() {
         let mut interp = Interpreter::new();
@@ -158,7 +156,6 @@ mod json_io_tests {
         assert_eq!(result, "'[1,2,3]'");
     }
 
-
     #[tokio::test]
     async fn test_input_empty() {
         let mut interp = Interpreter::new();
@@ -202,7 +199,6 @@ mod json_io_tests {
         assert!(!interp.io_output_buffer.is_empty());
     }
 
-
     #[tokio::test]
     async fn test_json_get_existing_key() {
         let mut interp = Interpreter::new();
@@ -244,7 +240,6 @@ mod json_io_tests {
         assert_eq!(result, "42/1");
     }
 
-
     #[tokio::test]
     async fn test_json_keys() {
         let mut interp = Interpreter::new();
@@ -268,7 +263,6 @@ mod json_io_tests {
         assert_eq!(stack.len(), 1);
         assert!(stack[0].is_nil());
     }
-
 
     #[tokio::test]
     async fn test_json_set_new_key() {
@@ -309,7 +303,6 @@ mod json_io_tests {
         assert_eq!(stack[0].len(), 1);
     }
 
-
     #[tokio::test]
     async fn test_parse_stringify_roundtrip_number() {
         let mut interp = Interpreter::new();
@@ -338,7 +331,6 @@ mod json_io_tests {
         assert_eq!(result, "'[1,2,3]'");
     }
 
-
     #[tokio::test]
     async fn test_input_parse_process_stringify_output() {
         let mut interp = Interpreter::new();
@@ -352,7 +344,6 @@ mod json_io_tests {
         assert_eq!(stack.len(), 0);
         assert_eq!(interp.io_output_buffer, "'[2,4,6]'");
     }
-
 
     #[tokio::test]
     async fn test_json_get_large_object() {
@@ -446,5 +437,107 @@ mod json_io_tests {
         assert!(result.contains("alpha"));
         assert!(result.contains("beta"));
         assert!(result.contains("gamma"));
+    }
+
+    #[tokio::test]
+    async fn test_json_has_present_and_absent() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+
+        interp
+            .execute(r#"'{"a": 1, "b": 2}' JSON@PARSE 'a' JSON@HAS"#)
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "1/1");
+
+        interp.stack.clear();
+        interp
+            .execute(r#"'{"a": 1}' JSON@PARSE 'missing' JSON@HAS"#)
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "0/1");
+    }
+
+    #[tokio::test]
+    async fn test_json_has_non_object_is_false() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        interp.execute("42 'a' JSON@HAS").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack()[0]), "0/1");
+    }
+
+    #[tokio::test]
+    async fn test_json_values() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        interp
+            .execute(r#"'{"a": 10, "b": 20}' JSON@PARSE JSON@VALUES"#)
+            .await
+            .unwrap();
+        let stack = interp.get_stack();
+        assert_eq!(stack.len(), 1);
+        assert!(stack[0].is_vector());
+        assert_eq!(stack[0].len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_json_values_non_object_is_nil() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        interp.execute("42 JSON@VALUES").await.unwrap();
+        assert!(interp.get_stack()[0].is_nil());
+    }
+
+    #[tokio::test]
+    async fn test_json_merge_overlay_wins() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        interp
+            .execute(r#"'{"a": 1, "b": 2}' JSON@PARSE '{"b": 99, "c": 3}' JSON@PARSE JSON@MERGE"#)
+            .await
+            .unwrap();
+        // b overridden to 99, c added, a preserved
+        interp.execute("'b' JSON@GET").await.unwrap();
+        assert_eq!(format!("{}", interp.get_stack().last().unwrap()), "99/1");
+
+        interp.stack.clear();
+        interp
+            .execute(
+                r#"'{"a": 1, "b": 2}' JSON@PARSE '{"b": 99, "c": 3}' JSON@PARSE JSON@MERGE 'a' JSON@GET"#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp.get_stack().last().unwrap()), "1/1");
+    }
+
+    #[tokio::test]
+    async fn test_json_delete_removes_key() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        interp
+            .execute(r#"'{"a": 1, "b": 2}' JSON@PARSE 'a' JSON@DELETE 'a' JSON@HAS"#)
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp.get_stack().last().unwrap()), "0/1");
+
+        interp.stack.clear();
+        interp
+            .execute(r#"'{"a": 1, "b": 2}' JSON@PARSE 'a' JSON@DELETE 'b' JSON@HAS"#)
+            .await
+            .unwrap();
+        assert_eq!(format!("{}", interp.get_stack().last().unwrap()), "1/1");
+    }
+
+    #[tokio::test]
+    async fn test_json_delete_missing_key_is_unchanged() {
+        let mut interp = Interpreter::new();
+        interp.execute("'json' IMPORT 'io' IMPORT").await.unwrap();
+        interp
+            .execute(r#"'{"a": 1}' JSON@PARSE 'zzz' JSON@DELETE JSON@KEYS"#)
+            .await
+            .unwrap();
+        let stack = interp.get_stack();
+        assert!(stack.last().unwrap().is_vector());
+        assert_eq!(stack.last().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

実用言語化に向けたモジュール辞書拡充の続きとして、`JSON` モジュールによく使うオブジェクト操作ワードを4つ追加しました。

| ワード | スタック効果 | 挙動 |
|--------|------------|------|
| `HAS` | `obj key -- bool` | キーの存在を真偽値で返す。非オブジェクトは `false` |
| `VALUES` | `obj -- vector` | 全値を取得（既存 `KEYS` の対）。非オブジェクト/空は NIL |
| `MERGE` | `a b -- merged` | 2オブジェクトを統合。衝突時は右辺(b)優先 |
| `DELETE` | `obj key -- obj` | キーを削除。存在しなければ等価出力（成功, §11.3） |

いずれも純粋（Pure）で、正規の `Record` 形式と生の vector-of-pairs の両方を受理します（既存の `GET`/`KEYS`/`SET` の寛容な扱いに合わせています）。共通処理は `object_pairs` / `pair_key` / `build_record` ヘルパに切り出しました。

## Test plan

- [x] `cargo test json` 42件成功（新規7テスト含む）
- [x] `cargo test` 全1127件成功（回帰なし）
- [x] rustfmt 適用済み、`json.rs` に新規 clippy 警告なし

## Notes

`JSON` モジュールの purpose は仕様§9.1で既に「parsing, generation, and **manipulation**」と記載されているため、`SPECIFICATION.md` の変更は不要でした。contract メタデータは既存JSONワードと同じく `pure()` 既定（Total/Passthrough）を踏襲しています（モジュールワードは Core passthrough 完全性テストの対象外）。

https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9)_