### PR TITLE
Add TIME PARSE-ISO, ADD-MONTHS, ADD-YEARS

### DIFF
--- a/rust/src/interpreter/datetime_tests.rs
+++ b/rust/src/interpreter/datetime_tests.rs
@@ -156,6 +156,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn add_months_clamps_and_rolls_over() {
+        assert_eq!(ints("[ 2024 1 31 ] 1 ADD-MONTHS").await, vec![2024, 2, 29]);
+        assert_eq!(ints("[ 2023 1 31 ] 1 ADD-MONTHS").await, vec![2023, 2, 28]);
+        assert_eq!(ints("[ 2024 12 15 ] 1 ADD-MONTHS").await, vec![2025, 1, 15]);
+        // time-of-day preserved on a datetime
+        assert_eq!(
+            ints("[ 2024 1 31 9 30 0 ] 1 ADD-MONTHS").await,
+            vec![2024, 2, 29, 9, 30, 0]
+        );
+    }
+
+    #[tokio::test]
+    async fn add_years_clamps_leap_day() {
+        assert_eq!(ints("[ 2024 2 29 ] 1 ADD-YEARS").await, vec![2025, 2, 28]);
+        assert_eq!(ints("[ 2020 2 29 ] 4 ADD-YEARS").await, vec![2024, 2, 29]);
+    }
+
+    #[tokio::test]
+    async fn parse_iso_date_and_datetime() {
+        assert_eq!(
+            ints("'2024-11-25' PARSE-ISO").await,
+            vec![2024, 11, 25, 0, 0, 0]
+        );
+        assert_eq!(
+            ints("'2024-11-25T14:30:05' PARSE-ISO").await,
+            vec![2024, 11, 25, 14, 30, 5]
+        );
+        // space separator is also accepted
+        assert_eq!(
+            ints("'2024-11-25 14:30:05' PARSE-ISO").await,
+            vec![2024, 11, 25, 14, 30, 5]
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_fractional_second_is_exact() {
+        assert_eq!(civil("'1970-01-01T00:00:00.5' PARSE-ISO").await[5], (1, 2));
+    }
+
+    #[tokio::test]
+    async fn parse_roundtrips_with_format() {
+        assert_eq!(
+            text("'2024-11-25T14:30:05' PARSE-ISO FORMAT").await,
+            "'2024-11-25T14:30:05'"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_invalid_text_is_bubble() {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'time' IMPORT 'not-a-date' PARSE-ISO")
+            .await
+            .expect("unparseable text is a Bubble, not an error");
+        assert!(interp.stack[0].is_nil());
+        // a fallback datetime can be supplied with OR-NIL
+        let mut interp2 = Interpreter::new();
+        interp2
+            .execute("'time' IMPORT [ 1970 1 1 0 0 0 ] '13-99' PARSE-ISO =>")
+            .await
+            .expect("should succeed");
+        assert_eq!(
+            interp2.stack[0]
+                .as_vector_view()
+                .unwrap()
+                .iter()
+                .map(|e| e.as_scalar().unwrap().to_i64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![1970, 1, 1, 0, 0, 0]
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_non_text_errors() {
+        let mut interp = Interpreter::new();
+        let result = interp.execute("'time' IMPORT 42 PARSE-ISO").await;
+        assert!(result.is_err(), "PARSE of a number is malformed use");
+    }
+
+    #[tokio::test]
     async fn datetime_rejects_stack_mode() {
         let mut interp = Interpreter::new();
         let result = interp.execute("'time' IMPORT 0 0 .. DATETIME").await;

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -736,6 +736,42 @@ const TIME_WORDS: &[ModuleWord] = &[
         Stability::Stable,
         Capabilities::TIME
     ),
+    module_word!(
+        "PARSE-ISO",
+        "Parse an ISO-8601 civil string into a datetime; Bubble/NIL if invalid",
+        time_ops::op_parse,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::TIME
+    ),
+    module_word!(
+        "ADD-MONTHS",
+        "Add N months to a date/datetime, clamping to the month end",
+        time_ops::op_add_months,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::TIME
+    ),
+    module_word!(
+        "ADD-YEARS",
+        "Add N years to a date/datetime, clamping Feb 29 in non-leap years",
+        time_ops::op_add_years,
+        WordPurity::Pure,
+        &[],
+        true,
+        true,
+        false,
+        Stability::Stable,
+        Capabilities::TIME
+    ),
 ];
 
 const CRYPTO_WORDS: &[ModuleWord] = &[
@@ -1218,6 +1254,9 @@ fn contract_override(module: &str, word: &str) -> Option<(Partiality, NilPolicy)
         // ALGO@INDEX-OF projects a well-formed miss (value absent from a
         // valid vector) onto Bubble/NIL with reason = missingField.
         ("ALGO", "INDEX-OF") => Some((Partiality::Projecting, NilPolicy::CreatesNil)),
+        // TIME@PARSE-ISO projects an unparseable-but-well-formed text value
+        // onto Bubble/NIL with reason = invalidEncoding (cf. NUM).
+        ("TIME", "PARSE-ISO") => Some((Partiality::Projecting, NilPolicy::CreatesNil)),
         _ => None,
     }
 }

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -194,7 +194,16 @@ async fn three_valued_or() {
 /// Projecting words: a well-formed domain miss yields Bubble/NIL with a
 /// reason; malformed use raises an ordinary error. `READ` is host/serial
 /// dependent (needs a port) so only its registry presence is asserted.
-const PROJECTING_WORDS: &[&str] = &["CHR", "DIV", "GET", "INDEX-OF", "NUM", "POW", "READ"];
+const PROJECTING_WORDS: &[&str] = &[
+    "CHR",
+    "DIV",
+    "GET",
+    "INDEX-OF",
+    "NUM",
+    "PARSE-ISO",
+    "POW",
+    "READ",
+];
 
 #[test]
 fn projecting_word_set_matches_registry() {
@@ -253,6 +262,14 @@ async fn bubble_creation_well_formed_domain_miss() {
     assert_eq!(
         reason_of(stack.last().unwrap()),
         Some(NilReason::MissingField)
+    );
+
+    // well-formed text that is not a valid ISO-8601 civil value
+    let stack = run_ok("'time' IMPORT 'not-a-date' PARSE-ISO").await;
+    assert!(is_nil(stack.last().unwrap()));
+    assert_eq!(
+        reason_of(stack.last().unwrap()),
+        Some(NilReason::InvalidEncoding)
     );
 }
 

--- a/rust/src/interpreter/time_calendar.rs
+++ b/rust/src/interpreter/time_calendar.rs
@@ -51,6 +51,23 @@ pub fn iso_weekday(y: i64, m: i64, d: i64) -> i64 {
     (days_from_civil(y, m, d) + 3).rem_euclid(7) + 1
 }
 
+/// Number of days in a civil month, leap years included.
+pub fn days_in_month(y: i64, m: i64) -> i64 {
+    let (ny, nm) = if m == 12 { (y + 1, 1) } else { (y, m + 1) };
+    days_from_civil(ny, nm, 1) - days_from_civil(y, m, 1)
+}
+
+/// Add `n` whole months to a civil date, clamping the day to the last day of
+/// the target month (e.g. Jan 31 + 1 month -> Feb 28/29). The `12 * years`
+/// case yields year arithmetic with the same end-of-month clamping.
+pub fn add_months_civil(y: i64, m: i64, d: i64, n: i64) -> (i64, i64, i64) {
+    let total = (m - 1) + n;
+    let new_year = y + total.div_euclid(12);
+    let new_month = total.rem_euclid(12) + 1;
+    let clamped_day = d.min(days_in_month(new_year, new_month));
+    (new_year, new_month, clamped_day)
+}
+
 /// A timezone offset in hours east of UTC, converted to an exact number of
 /// seconds. `+9` (Asia/Tokyo) -> `32400`, `+5.5` (India) -> `19800`.
 pub fn offset_seconds(offset_hours: &Fraction) -> Fraction {
@@ -136,5 +153,22 @@ mod tests {
     fn known_weekdays() {
         assert_eq!(iso_weekday(2024, 11, 25), 1); // Monday
         assert_eq!(iso_weekday(2000, 1, 1), 6); // Saturday
+    }
+
+    #[test]
+    fn month_lengths_and_leap() {
+        assert_eq!(days_in_month(2024, 2), 29); // leap
+        assert_eq!(days_in_month(2023, 2), 28);
+        assert_eq!(days_in_month(2024, 1), 31);
+        assert_eq!(days_in_month(2024, 4), 30);
+    }
+
+    #[test]
+    fn add_months_clamps_to_month_end() {
+        assert_eq!(add_months_civil(2024, 1, 31, 1), (2024, 2, 29)); // leap Feb
+        assert_eq!(add_months_civil(2023, 1, 31, 1), (2023, 2, 28));
+        assert_eq!(add_months_civil(2024, 12, 15, 1), (2025, 1, 15)); // year rollover
+        assert_eq!(add_months_civil(2024, 3, 15, -4), (2023, 11, 15)); // backward
+        assert_eq!(add_months_civil(2024, 2, 29, 12), (2025, 2, 28)); // +1 year clamps
     }
 }

--- a/rust/src/interpreter/time_ops.rs
+++ b/rust/src/interpreter/time_ops.rs
@@ -8,12 +8,19 @@
 //! - DATE (civil): `[year month day]`.
 //! - TIME (civil): `[hour minute second]` (second exact).
 
-use crate::error::{AjisaiError, Result};
+use num_bigint::BigInt;
+
+use crate::error::{AjisaiError, NilReason, Result};
+use crate::interpreter::cast::cast_value_helpers::is_string_value_with_hint;
 use crate::interpreter::time_calendar::{
-    civil_from_days, civil_to_instant, days_from_civil, instant_to_civil, iso_weekday, Civil,
+    add_months_civil, civil_from_days, civil_to_instant, days_from_civil, instant_to_civil,
+    iso_weekday, Civil,
 };
-use crate::interpreter::value_extraction_helpers::{extract_operands, push_result};
+use crate::interpreter::value_extraction_helpers::{
+    extract_operands, push_result, value_as_string,
+};
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::semantic::{AbsenceOrigin, Recoverability};
 use crate::types::fraction::Fraction;
 use crate::types::{Interpretation, Value};
 
@@ -328,5 +335,145 @@ pub fn op_format(interp: &mut Interpreter) -> Result<()> {
         Ok(Value::from_string(&text))
     })?;
     interp.semantic_registry.push_hint(Interpretation::Text);
+    Ok(())
+}
+
+/// Shared body for ADD-MONTHS / ADD-YEARS: shift the date part by `months`,
+/// clamping to the target month end, and preserve any time-of-day fields.
+fn shift_months(interp: &mut Interpreter, word: &str, months_per_unit: i64) -> Result<()> {
+    require_stack_top(interp, word)?;
+    let operands = extract_operands(interp, 2)?;
+    let result = (|| {
+        let components = civil_components(&operands[0], word, &[3, 6])?;
+        let units = integer_field(&operands[1], word, "amount")?;
+        let y = integer_field(&components[0], word, "year")?;
+        let m = integer_field(&components[1], word, "month")?;
+        let d = integer_field(&components[2], word, "day")?;
+        let (ny, nm, nd) = add_months_civil(y, m, d, units * months_per_unit);
+        let mut out = vec![
+            Value::from_int(ny),
+            Value::from_int(nm),
+            Value::from_int(nd),
+        ];
+        for elem in components.iter().skip(3) {
+            out.push(elem.clone());
+        }
+        Ok(Value::from_vector(out))
+    })();
+    match result {
+        Ok(value) => {
+            interp.stack.push(value);
+            Ok(())
+        }
+        Err(e) => {
+            restore(interp, operands);
+            Err(e)
+        }
+    }
+}
+
+/// `date|datetime n -- date|datetime`. Add `n` months, clamping the day to the
+/// target month's last day (Jan 31 + 1 -> Feb 28/29).
+pub fn op_add_months(interp: &mut Interpreter) -> Result<()> {
+    shift_months(interp, "ADD-MONTHS", 1)
+}
+
+/// `date|datetime n -- date|datetime`. Add `n` years, clamping Feb 29 to
+/// Feb 28 in non-leap target years.
+pub fn op_add_years(interp: &mut Interpreter) -> Result<()> {
+    shift_months(interp, "ADD-YEARS", 12)
+}
+
+// --- Parsing ---------------------------------------------------------------
+
+/// Parse an ISO-8601 civil string into `[Y M D h m s]`. Accepts a bare date
+/// `YYYY-MM-DD` (time defaults to `00:00:00`) or a datetime with a `T` or
+/// space separator and optional fractional seconds. Returns `None` for any
+/// shape or out-of-range field it cannot interpret.
+fn parse_iso_civil(text: &str) -> Option<Civil> {
+    let text = text.trim();
+    let (date_part, time_part) = match text.split_once(['T', ' ']) {
+        Some((d, t)) => (d, Some(t)),
+        None => (text, None),
+    };
+
+    let mut date_fields = date_part.split('-');
+    let year: i64 = date_fields.next()?.parse().ok()?;
+    let month: i64 = date_fields.next()?.parse().ok()?;
+    let day: i64 = date_fields.next()?.parse().ok()?;
+    if date_fields.next().is_some() || !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+
+    let (hour, minute, second) = match time_part {
+        None => (0, 0, Fraction::from(0)),
+        Some(t) => {
+            let mut time_fields = t.split(':');
+            let hour: i64 = time_fields.next()?.parse().ok()?;
+            let minute: i64 = time_fields.next()?.parse().ok()?;
+            let second = parse_second(time_fields.next()?)?;
+            if time_fields.next().is_some()
+                || !(0..=23).contains(&hour)
+                || !(0..=59).contains(&minute)
+            {
+                return None;
+            }
+            (hour, minute, second)
+        }
+    };
+
+    Some(Civil {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+    })
+}
+
+/// Parse a second field `ss` or `ss.fff` into an exact rational in `[0, 61)`.
+fn parse_second(field: &str) -> Option<Fraction> {
+    let (int_part, frac_part) = match field.split_once('.') {
+        Some((i, f)) => (i, Some(f)),
+        None => (field, None),
+    };
+    let secs: i64 = int_part.parse().ok()?;
+    if !(0..=60).contains(&secs) {
+        return None;
+    }
+    let mut value = Fraction::from(secs);
+    if let Some(frac) = frac_part {
+        if frac.is_empty() || !frac.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let numerator: BigInt = frac.parse().ok()?;
+        let denominator = BigInt::from(10).pow(frac.len() as u32);
+        value = value.add(&Fraction::new(numerator, denominator));
+    }
+    Some(value)
+}
+
+/// `text -- datetime`. Parse an ISO-8601 civil string. Non-text input is
+/// malformed use and raises an error (cf. `NUM`); a well-formed string that is
+/// not a valid ISO civil value projects to Bubble/NIL (`reason =
+/// invalidEncoding`).
+pub fn op_parse(interp: &mut Interpreter) -> Result<()> {
+    require_stack_top(interp, "PARSE")?;
+    let hint = interp.semantic_registry.lookup_last_hint();
+    let operands = extract_operands(interp, 1)?;
+    if !is_string_value_with_hint(&operands[0], hint) {
+        restore(interp, operands);
+        return Err(AjisaiError::from("PARSE: expected an ISO-8601 text value"));
+    }
+    let text = value_as_string(&operands[0]).unwrap_or_default();
+    match parse_iso_civil(&text) {
+        Some(civil) => interp.stack.push(datetime_value(&civil)),
+        None => interp.stack.push(Value::bubble_with_reason(
+            NilReason::InvalidEncoding,
+            AbsenceOrigin::InvalidEncoding,
+            Recoverability::Recoverable,
+        )),
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

TIMEモジュールのフォローアップ。日付の入出力往復と暦算術を完成させました。すべて正確有理数・ホスト非依存です。

| ワード | スタック効果 | 挙動 |
|--------|------------|------|
| `PARSE-ISO` | `text -- datetime` | ISO-8601 civil文字列をdatetimeに解析。日付のみ(`YYYY-MM-DD`)は時刻0、`T`/空白区切りの日時、小数秒に対応 |
| `ADD-MONTHS` | `date\|datetime n -- 同型` | Nヶ月加算、月末クランプ（1/31 +1ヶ月 → 2/28 or 2/29） |
| `ADD-YEARS` | `date\|datetime n -- 同型` | N年加算、閏日クランプ（2/29 +1年 → 2/28） |

### Bubble Rule（§11.2）
`PARSE-ISO` は `NUM` に倣い、**テキストだが解釈不能** → 理由付き Bubble/NIL（`invalidEncoding`）、**非テキスト入力** → エラー。`Projecting`/`CreatesNil` を `contract_override` に登録し、`PROJECTING_WORDS` と Bubble プローブも更新。`=>`(OR-NIL) でフォールバック値を与えられることもテスト済み。

### 命名
新ワードを `PARSE` ではなく **`PARSE-ISO`** としたのは、既存 `JSON@PARSE` とのベア名衝突を避けるため（2つのモジュールが同一ベア名を持つと名前解決が曖昧になり、namespace-overlap 整合性テストが正しく検出します）。`FORMAT`(既存)と `PARSE-ISO` で入出力が対になります。

## Test plan
- [x] `time_calendar` 単体（月日数・閏年、ADD-MONTHSクランプ前後・年跨ぎ）
- [x] TIME統合（PARSE-ISO 日付/日時/空白区切り/小数秒/往復、ADD-MONTHS/ADD-YEARSクランプ、非テキストエラー、泡＋OR-NILフォールバック）
- [x] `cargo test` 全1160件成功（`projecting_word_set_matches_registry`・`namespace_overlap` 含む回帰なし）
- [x] rustfmt適用済み、新規clippy警告なし

## Follow-ups（任意）
IANA名前付きゾーン/DST対応、`ADD-SECONDS`等のヘルパ（瞬間はスカラなのでCore `ADD`/`SUB`で代替可）、`DAYOFYEAR`/`WEEK`番号など。

https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNxiKYJDYmcN2zoXB2P7b9)_