### PR TITLE
fix: correct contract metadata for EQ/NEQ/LT/LTE/GT/GTE (SPEC §7.14)

### DIFF
--- a/rust/src/builtins/builtin_word_definitions.rs
+++ b/rust/src/builtins/builtin_word_definitions.rs
@@ -821,6 +821,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Comparison primitive: Test equality of two values.",
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -836,6 +839,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Comparison primitive: Test less-than comparison.",
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -851,6 +857,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Comparison primitive: Test less-than-or-equal comparison.",
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -866,6 +875,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Comparison primitive: Test greater-than comparison.",
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -881,6 +893,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Comparison primitive: Test greater-than-or-equal comparison.",
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -896,6 +911,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Comparison primitive: Test inequality of two values.",
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
 

--- a/rust/src/builtins/builtin_word_details.rs
+++ b/rust/src/builtins/builtin_word_details.rs
@@ -169,6 +169,23 @@ mod tests {
     }
 
     #[test]
+    fn comparison_words_have_uniform_stack_effect() {
+        // All six comparison primitives must use the same stack-effect
+        // notation so the four-section template is consistent across the
+        // comparison category.
+        const EXPECTED: &str = "[ a ] [ b ] -> [ TRUE | FALSE ]";
+        for name in &["EQ", "NEQ", "LT", "LTE", "GT", "GTE"] {
+            let spec = crate::builtins::builtin_word_definitions::lookup_builtin_spec(name)
+                .unwrap_or_else(|| panic!("{} must have a BuiltinSpec", name));
+            assert_eq!(
+                spec.stack_effect, EXPECTED,
+                "{} stack_effect deviates from the comparison-word standard",
+                name
+            );
+        }
+    }
+
+    #[test]
     fn lookup_output_is_ascii() {
         for name in ["ADD", "MAP", "LOOKUP", "DEF", "OR-NIL", "TOP", "PRINT"] {
             let body = lookup_builtin_detail(name);

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -711,6 +711,36 @@ mod tests {
     }
 
     #[test]
+    fn aq_ver_contract_f_comparison_words_create_nil_under_undecidable() {
+        // SPEC §7.14 line 611 and §9.4 table require all six comparison
+        // primitives to be Projecting/CreatesNil/B — matching DIV — because
+        // the comparison-budget exhaustion path (§7.4.1) can produce an
+        // Undecidable NIL instead of a boolean.
+        for name in &["EQ", "NEQ", "LT", "LTE", "GT", "GTE"] {
+            let meta = get_coreword_metadata(name)
+                .unwrap_or_else(|| panic!("{} must be in registry", name));
+            assert_eq!(
+                meta.partiality,
+                Partiality::Projecting,
+                "{} must be Projecting (SPEC §7.14)",
+                name
+            );
+            assert_eq!(
+                meta.nil_policy,
+                NilPolicy::CreatesNil,
+                "{} must be CreatesNil (SPEC §7.14)",
+                name
+            );
+            assert_eq!(
+                meta.safety_level,
+                SafetyLevel::B,
+                "{} must be SafetyLevel B (SPEC §9.4)",
+                name
+            );
+        }
+    }
+
+    #[test]
     fn aq_ver_contract_c_effectful_words_have_d_or_quarantined_safety() {
         let registry = get_builtin_word_registry();
         for word in registry

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -72,12 +72,10 @@ const CORE_PASSTHROUGH: &[(&str, NilClass)] = &[
     ("FLOOR", NilClass::UnaryNil),
     ("CEIL", NilClass::UnaryNil),
     ("ROUND", NilClass::UnaryNil),
-    ("LT", NilClass::BinaryBlanket),
-    ("LTE", NilClass::BinaryBlanket),
-    ("GT", NilClass::BinaryBlanket),
-    ("GTE", NilClass::BinaryBlanket),
-    ("EQ", NilClass::BinaryBlanket),
-    ("NEQ", NilClass::BinaryBlanket),
+    // Comparison words (EQ/NEQ/LT/LTE/GT/GTE) are Projecting/CreatesNil
+    // per SPEC §7.14 (comparison-budget exhaustion can produce Undecidable
+    // NIL). They are covered by the projecting_word_set_matches_registry
+    // and bubble_creation_comparison_nil_input probes below.
     ("NOT", NilClass::UnaryNil),
     ("AND", NilClass::ThreeValAnd),
     ("OR", NilClass::ThreeValOr),
@@ -197,8 +195,14 @@ async fn three_valued_or() {
 const PROJECTING_WORDS: &[&str] = &[
     "CHR",
     "DIV",
+    "EQ",
     "GET",
+    "GT",
+    "GTE",
     "INDEX-OF",
+    "LT",
+    "LTE",
+    "NEQ",
     "NUM",
     "PARSE-ISO",
     "POW",
@@ -271,6 +275,27 @@ async fn bubble_creation_well_formed_domain_miss() {
         reason_of(stack.last().unwrap()),
         Some(NilReason::InvalidEncoding)
     );
+}
+
+#[tokio::test]
+async fn bubble_creation_comparison_nil_input() {
+    // Comparison words are Projecting/CreatesNil (SPEC §7.14). A NIL operand
+    // propagates as NIL output via the Bubble Rule (SPEC §4.5.1, §11.2).
+    for name in &["EQ", "NEQ", "LT", "LTE", "GT", "GTE"] {
+        for code in [
+            format!("NIL 1 {name}"),
+            format!("1 NIL {name}"),
+            format!("NIL NIL {name}"),
+        ] {
+            let stack = run_ok(&code).await;
+            assert_eq!(stack.len(), 1, "`{code}` must leave exactly one value");
+            assert!(
+                is_nil(&stack[0]),
+                "`{code}` must produce NIL, got {:?}",
+                stack[0]
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/rust/src/types/continued_fraction.rs
+++ b/rust/src/types/continued_fraction.rs
@@ -2693,4 +2693,81 @@ mod tests {
             cloned.partial_quotients_bounded(10)
         );
     }
+
+    // -----------------------------------------------------------------
+    // cmp_with_budget reachability — verifies that the AlgebraicSqrt and
+    // Gosper branches inside cmp_with_budget are live and return correct
+    // results. This guards against the path being inadvertently dead-coded
+    // before ValueData::Scalar is migrated to ExactReal (SPEC §7.4.1).
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn cmp_with_budget_sqrt_vs_sqrt_same_radicand_is_equal() {
+        let a = sqrt_of(2, 1);
+        let b = sqrt_of(2, 1);
+        assert_eq!(
+            a.cmp_with_budget(&b, DEFAULT_COMPARISON_BUDGET),
+            Some(std::cmp::Ordering::Equal),
+            "√2 == √2 must decide Equal"
+        );
+    }
+
+    #[test]
+    fn cmp_with_budget_sqrt_vs_sqrt_different_radicands_decide_correctly() {
+        let sqrt2 = sqrt_of(2, 1);
+        let sqrt3 = sqrt_of(3, 1);
+        assert_eq!(
+            sqrt2.cmp_with_budget(&sqrt3, DEFAULT_COMPARISON_BUDGET),
+            Some(std::cmp::Ordering::Less),
+            "√2 < √3 must decide Less"
+        );
+        assert_eq!(
+            sqrt3.cmp_with_budget(&sqrt2, DEFAULT_COMPARISON_BUDGET),
+            Some(std::cmp::Ordering::Greater),
+            "√3 > √2 must decide Greater"
+        );
+    }
+
+    #[test]
+    fn cmp_with_budget_sqrt_vs_rational_decides_correctly() {
+        // √2 ≈ 1.414, so √2 > 1 and √2 < 2.
+        let sqrt2 = sqrt_of(2, 1);
+        let one = rational(1, 1);
+        let two = rational(2, 1);
+        assert_eq!(
+            sqrt2.cmp_with_budget(&one, DEFAULT_COMPARISON_BUDGET),
+            Some(std::cmp::Ordering::Greater),
+            "√2 > 1 must decide Greater"
+        );
+        assert_eq!(
+            sqrt2.cmp_with_budget(&two, DEFAULT_COMPARISON_BUDGET),
+            Some(std::cmp::Ordering::Less),
+            "√2 < 2 must decide Less"
+        );
+    }
+
+    #[test]
+    fn cmp_with_budget_zero_budget_returns_none() {
+        // Budget of 0 must always yield None (undecidable) regardless of
+        // operand type, confirming the budget-exhaustion path is reachable.
+        let sqrt2 = sqrt_of(2, 1);
+        let sqrt3 = sqrt_of(3, 1);
+        assert_eq!(
+            sqrt2.cmp_with_budget(&sqrt3, 0),
+            None,
+            "zero budget must yield None"
+        );
+    }
+
+    #[test]
+    fn cmp_with_budget_gosper_vs_rational_decides_correctly() {
+        // √2 + 0 via Gosper add — exercises the Gosper CF streaming path.
+        let gosper_sqrt2 = sqrt_of(2, 1).add(&rational(0, 1));
+        let one = rational(1, 1);
+        assert_eq!(
+            gosper_sqrt2.cmp_with_budget(&one, DEFAULT_COMPARISON_BUDGET),
+            Some(std::cmp::Ordering::Greater),
+            "Gosper(√2 + 0) > 1 must decide Greater"
+        );
+    }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **比較6語の契約メタデータ修正**（1-1）: EQ/NEQ/LT/LTE/GT/GTE の `BuiltinSpec` を `SPEC_DEFAULT`（Total/Passthrough/A）から SPEC §7.14 要求の `Projecting/CreatesNil/SafetyLevel::B` に修正。DIV と同形。
- **コントラクトテスト追加**（1-1）: `coreword_registry.rs` に `aq_ver_contract_f_comparison_words_create_nil_under_undecidable` を追加し、6語の宣言を CI で固定。
- **NIL 適合テスト更新**（1-1）: `nil_conformance_tests.rs` の `CORE_PASSTHROUGH` から比較語を除き `PROJECTING_WORDS` へ移動。NIL 入力への挙動プローブ `bubble_creation_comparison_nil_input` を追加。
- **CF 到達性テスト追加**（1-2）: `continued_fraction.rs` に5本のテストを追加。`AlgebraicSqrt` 同士・対 Rational・Gosper 経路・予算ゼロ（`None`）の各分岐が生きていることを担保。
- **スタイル固定テスト追加**（4-2）: `builtin_word_details.rs` に `comparison_words_have_uniform_stack_effect` を追加し、比較語の `stack_effect` 記法が `[ a ] [ b ] -> [ TRUE | FALSE ]` で統一されていることを CI で強制。

## 変更の根拠

SPEC §7.14（line 611）・§9.4 表（line 809）・互換性チェックリスト §11 は、比較語が comparison-budget 枯渇時に `Undecidable` NIL を生成し得るため `Projecting/CreatesNil/B` であることを**必須**と規定している。今回の修正は振る舞い変更ではなく、既存実装の宣言を仕様に合わせる純粋な是正。

## Test plan

- [x] `cargo test` 全 1188 テスト通過を確認
- [x] `aq_ver_contract_f_comparison_words_create_nil_under_undecidable` が6語を全て検査
- [x] `projecting_word_set_matches_registry` が比較6語を含む新リストで通過
- [x] `bubble_creation_comparison_nil_input` が NIL 入力を全6語・3パターンで検証
- [x] `cmp_with_budget_*` 5本が AlgebraicSqrt/Gosper/budget-zero 各経路を直接行使
- [x] `comparison_words_have_uniform_stack_effect` が stack_effect 記法を固定

https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj)_