### PR TITLE
feat: ExactScalar (Gosper) path for FLOOR/CEIL/ROUND/MOD (改修プラン §2-3)

### DIFF
--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -1211,4 +1211,95 @@ mod exact_scalar_tests {
             "√2 + 1 must be a non-nil scalar, got: {val}"
         );
     }
+
+    #[tokio::test]
+    async fn exact_scalar_floor_is_exact_rational() {
+        // floor(√2) = 1 exactly
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 2 SQRT FLOOR")
+            .await
+            .unwrap();
+        let val = &interp.get_stack()[0];
+        let f = val.as_scalar().expect("floor(√2) must be exact rational");
+        assert_eq!(
+            f.to_i64(),
+            Some(1),
+            "floor(√2) must equal 1, got {f}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_scalar_ceil_is_exact_rational() {
+        // ceil(√2) = 2 exactly
+        let mut interp = Interpreter::new();
+        interp.execute("'math' IMPORT 2 SQRT CEIL").await.unwrap();
+        let val = &interp.get_stack()[0];
+        let f = val.as_scalar().expect("ceil(√2) must be exact rational");
+        assert_eq!(
+            f.to_i64(),
+            Some(2),
+            "ceil(√2) must equal 2, got {f}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_scalar_round_is_exact_rational() {
+        // round(√2) = 1 (√2 ≈ 1.414 → nearest integer is 1)
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 2 SQRT ROUND")
+            .await
+            .unwrap();
+        let val = &interp.get_stack()[0];
+        let f = val.as_scalar().expect("round(√2) must be exact rational");
+        assert_eq!(
+            f.to_i64(),
+            Some(1),
+            "round(√2) must equal 1, got {f}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_scalar_floor_sqrt3_is_exact_rational() {
+        // floor(√3) = 1 exactly
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 3 SQRT FLOOR")
+            .await
+            .unwrap();
+        let val = &interp.get_stack()[0];
+        let f = val.as_scalar().expect("floor(√3) must be exact rational");
+        assert_eq!(
+            f.to_i64(),
+            Some(1),
+            "floor(√3) must equal 1, got {f}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_scalar_mod_rational_is_exact() {
+        // √2 mod 1 = √2 - 1 (irrational, stays ExactScalar)
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 2 SQRT 1 MOD")
+            .await
+            .unwrap();
+        let val = &interp.get_stack()[0];
+        assert!(
+            val.is_scalar() && !val.is_nil(),
+            "√2 mod 1 must be a non-nil scalar, got: {val}"
+        );
+        // Result should be less than 1
+        let mut interp2 = Interpreter::new();
+        interp2
+            .execute("'math' IMPORT 2 SQRT 1 MOD 1 <")
+            .await
+            .unwrap();
+        let cmp = &interp2.get_stack()[0];
+        assert!(
+            !cmp.is_nil() && cmp.as_scalar().map(|f| !f.is_zero()).unwrap_or(false),
+            "(√2 mod 1) < 1 must be TRUE"
+        );
+    }
 }

--- a/rust/src/interpreter/tensor_cmds.rs
+++ b/rust/src/interpreter/tensor_cmds.rs
@@ -3,8 +3,9 @@ use crate::interpreter::value_extraction_helpers::{
     create_number_value, nil_passthrough_binary, nil_passthrough_unary,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::types::continued_fraction::{ExactReal, DEFAULT_COMPARISON_BUDGET};
 use crate::types::fraction::Fraction;
-use crate::types::Value;
+use crate::types::{Value, ValueData};
 
 use super::tensor_ops::{
     apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics, build_nested_value,
@@ -204,9 +205,10 @@ pub fn op_transpose(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-fn apply_unary_math<F>(interp: &mut Interpreter, op: F, op_name: &str) -> Result<()>
+fn apply_unary_math<F, G>(interp: &mut Interpreter, op: F, exact_op: G, op_name: &str) -> Result<()>
 where
     F: Fn(&Fraction) -> Fraction + Copy,
+    G: Fn(&ExactReal) -> Option<ExactReal>,
 {
     if interp.operation_target_mode == OperationTargetMode::Stack {
         return Err(AjisaiError::ModeUnsupported {
@@ -249,6 +251,25 @@ where
         }
     }
 
+    // ExactScalar path: exact irrational via CF (SPEC §4.2.2)
+    if let ValueData::ExactScalar(er) = &val.data {
+        match exact_op(er) {
+            Some(result) => {
+                interp.stack.push(Value::from_exact_real(result));
+                return Ok(());
+            }
+            None => {
+                if !is_keep_mode {
+                    interp.stack.push(val);
+                }
+                return Err(AjisaiError::from(format!(
+                    "{} requires number or vector",
+                    op_name
+                )));
+            }
+        }
+    }
+
     if val.is_vector() {
         match apply_unary_flat_with_metrics(&val, op, Some(&mut interp.runtime_metrics)) {
             Ok(result) => {
@@ -277,15 +298,15 @@ where
 }
 
 pub fn op_floor(interp: &mut Interpreter) -> Result<()> {
-    apply_unary_math(interp, |f| f.floor(), "FLOOR")
+    apply_unary_math(interp, |f| f.floor(), |er| er.floor(), "FLOOR")
 }
 
 pub fn op_ceil(interp: &mut Interpreter) -> Result<()> {
-    apply_unary_math(interp, |f| f.ceil(), "CEIL")
+    apply_unary_math(interp, |f| f.ceil(), |er| er.ceil(), "CEIL")
 }
 
 pub fn op_round(interp: &mut Interpreter) -> Result<()> {
-    apply_unary_math(interp, |f| f.round(), "ROUND")
+    apply_unary_math(interp, |f| f.round(), |er| er.round(), "ROUND")
 }
 
 pub fn op_mod(interp: &mut Interpreter) -> Result<()> {
@@ -298,6 +319,46 @@ pub fn op_mod(interp: &mut Interpreter) -> Result<()> {
 
     if nil_passthrough_binary(interp) {
         return Ok(());
+    }
+
+    // ExactScalar path: a mod b = a - b * floor(a/b) via CF (SPEC §4.2.2)
+    if interp.operation_target_mode == OperationTargetMode::StackTop
+        && interp.stack.len() >= 2
+    {
+        let stack_len = interp.stack.len();
+        let a_ref = &interp.stack[stack_len - 2];
+        let b_ref = &interp.stack[stack_len - 1];
+        let has_exact = matches!(&a_ref.data, ValueData::ExactScalar(_))
+            || matches!(&b_ref.data, ValueData::ExactScalar(_));
+        if has_exact {
+            let a_er = match &a_ref.data {
+                ValueData::Scalar(f) => Some(ExactReal::from_fraction(f.clone())),
+                ValueData::ExactScalar(er) => Some(er.clone()),
+                _ => None,
+            };
+            let b_er = match &b_ref.data {
+                ValueData::Scalar(f) => Some(ExactReal::from_fraction(f.clone())),
+                ValueData::ExactScalar(er) => Some(er.clone()),
+                _ => None,
+            };
+            if let (Some(a), Some(b)) = (a_er, b_er) {
+                let zero = ExactReal::from_fraction(Fraction::from(0i64));
+                let b_is_zero = b
+                    .eq_with_budget(&zero, DEFAULT_COMPARISON_BUDGET)
+                    .unwrap_or(false);
+                if b_is_zero {
+                    return Err(AjisaiError::from("Modulo by zero"));
+                }
+                if let Some(result) = a.div(&b).and_then(|q| q.floor()).map(|fl| a.sub(&b.mul(&fl))) {
+                    if interp.consumption_mode != ConsumptionMode::Keep {
+                        interp.stack.pop();
+                        interp.stack.pop();
+                    }
+                    interp.stack.push(Value::from_exact_real(result));
+                    return Ok(());
+                }
+            }
+        }
     }
 
     let is_keep_mode: bool = interp.consumption_mode == ConsumptionMode::Keep;


### PR DESCRIPTION
## Summary

改修プラン §2-3（算術 Gosper 化）の残り4語（FLOOR/CEIL/ROUND/MOD）を実装。

### 変更内容

**`interpreter/tensor_cmds.rs`**
- `apply_unary_math` に `G: Fn(&ExactReal) -> Option<ExactReal>` パラメータを追加
- FLOOR/CEIL/ROUND が `apply_unary_math` 経由で `ExactReal::floor/ceil/round` を呼ぶ ExactScalar ブランチを追加（CF ストリーミングによる厳密整数化、SPEC §4.2.2）
- `op_mod` に ExactScalar 早期分岐を追加 — `a mod b = a − b × floor(a/b)` を ExactReal 算術で計算（Gosper transform）
- MOD のゼロ除数チェックは `eq_with_budget` による CF 比較で判定

**`arithmetic_operation_tests.rs`** — 新規テスト5本

| テスト | 検証内容 |
|---|---|
| `exact_scalar_floor_is_exact_rational` | floor(√2) = 1（Fraction に折り畳み）|
| `exact_scalar_ceil_is_exact_rational` | ceil(√2) = 2 |
| `exact_scalar_round_is_exact_rational` | round(√2) = 1 |
| `exact_scalar_floor_sqrt3_is_exact_rational` | floor(√3) = 1 |
| `exact_scalar_mod_rational_is_exact` | √2 mod 1 < 1（ExactScalar として維持）|

### これで揃った ExactScalar カバレッジ

| 演算 | ExactReal パス | PR |
|---|---|---|
| ADD / SUB / MUL / DIV | Gosper bihomographic | #988 |
| SQRT | AlgebraicSqrt | #988 |
| EQ / NEQ / LT / LTE / GT / GTE | cmp_with_budget | #987 |
| FLOOR / CEIL / ROUND | CF floor/ceil/round | 本 PR |
| MOD | a − b×floor(a/b) via Gosper | 本 PR |

## Test plan

- [x] `cargo test --lib` 全 1199 テスト通過（1194 既存 + 5 新規）
- [x] `floor(√2) = 1`、`ceil(√2) = 2`、`round(√2) = 1` が exact Fraction として返ること
- [x] `√2 mod 1 < 1` が TRUE（CF 比較経由）

https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj

---
_Generated by [Claude Code](https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj)_