### PR TITLE
fix: harmonize NIL policy for FLOOR/CEIL/ROUND/MOD on CF exhaustion

### DIFF
--- a/rust/src/builtins/builtin_word_definitions.rs
+++ b/rust/src/builtins/builtin_word_definitions.rs
@@ -1420,7 +1420,8 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Arithmetic primitive: Modulo (remainder) of two numeric values.",
 
         stack_effect: "[ a ] [ b ] -> [ a mod b ]",
-        partiality: Partiality::Partial,
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
@@ -1437,6 +1438,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Arithmetic primitive: Round toward negative infinity.",
 
         stack_effect: "[ x ] -> [ floor x ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -1452,6 +1456,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Arithmetic primitive: Round toward positive infinity.",
 
         stack_effect: "[ x ] -> [ ceil x ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
     BuiltinSpec {
@@ -1467,6 +1474,9 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         role: "Arithmetic primitive: Round to nearest integer (half-up).",
 
         stack_effect: "[ x ] -> [ round x ]",
+        partiality: Partiality::Projecting,
+        nil_policy: NilPolicy::CreatesNil,
+        safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
 

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -741,6 +741,50 @@ mod tests {
     }
 
     #[test]
+    fn aq_ver_contract_g_rounding_modulo_create_nil_under_undecidable() {
+        // MOD/FLOOR/CEIL/ROUND operate on ExactScalar (CF) operands whose
+        // partial-quotient budget can exhaust, yielding an Undecidable NIL
+        // (SPEC §7.4.1). They are therefore Projecting/CreatesNil/B, matching
+        // DIV and the comparison words. ADD/SUB/MUL stay Total because their
+        // CF arithmetic always yields a value (never a budget miss).
+        for name in &["MOD", "FLOOR", "CEIL", "ROUND"] {
+            let meta = get_coreword_metadata(name)
+                .unwrap_or_else(|| panic!("{} must be in registry", name));
+            assert_eq!(
+                meta.partiality,
+                Partiality::Projecting,
+                "{} must be Projecting (SPEC §7.4.1)",
+                name
+            );
+            assert_eq!(
+                meta.nil_policy,
+                NilPolicy::CreatesNil,
+                "{} must be CreatesNil (SPEC §7.4.1)",
+                name
+            );
+            assert_eq!(
+                meta.safety_level,
+                SafetyLevel::B,
+                "{} must be SafetyLevel B",
+                name
+            );
+        }
+
+        // ADD/SUB/MUL must remain Total: their ExactReal arithmetic always
+        // produces a value, so they never create a budget-exhaustion NIL.
+        for name in &["ADD", "SUB", "MUL"] {
+            let meta = get_coreword_metadata(name)
+                .unwrap_or_else(|| panic!("{} must be in registry", name));
+            assert_eq!(
+                meta.nil_policy,
+                NilPolicy::Passthrough,
+                "{} must stay Passthrough (CF arithmetic is total)",
+                name
+            );
+        }
+    }
+
+    #[test]
     fn aq_ver_contract_c_effectful_words_have_d_or_quarantined_safety() {
         let registry = get_builtin_word_registry();
         for word in registry

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -68,10 +68,11 @@ const CORE_PASSTHROUGH: &[(&str, NilClass)] = &[
     ("ADD", NilClass::BinaryBlanket),
     ("SUB", NilClass::BinaryBlanket),
     ("MUL", NilClass::BinaryBlanket),
-    ("MOD", NilClass::BinaryBlanket),
-    ("FLOOR", NilClass::UnaryNil),
-    ("CEIL", NilClass::UnaryNil),
-    ("ROUND", NilClass::UnaryNil),
+    // MOD/FLOOR/CEIL/ROUND are Projecting/CreatesNil: on ExactScalar (CF)
+    // operands the partial-quotient budget can exhaust, yielding an
+    // Undecidable NIL (SPEC §7.4.1) — the same treatment as comparison
+    // words. They are covered by projecting_word_set_matches_registry and
+    // the arithmetic NIL-input probes below.
     // Comparison words (EQ/NEQ/LT/LTE/GT/GTE) are Projecting/CreatesNil
     // per SPEC §7.14 (comparison-budget exhaustion can produce Undecidable
     // NIL). They are covered by the projecting_word_set_matches_registry
@@ -193,20 +194,24 @@ async fn three_valued_or() {
 /// reason; malformed use raises an ordinary error. `READ` is host/serial
 /// dependent (needs a port) so only its registry presence is asserted.
 const PROJECTING_WORDS: &[&str] = &[
+    "CEIL",
     "CHR",
     "DIV",
     "EQ",
+    "FLOOR",
     "GET",
     "GT",
     "GTE",
     "INDEX-OF",
     "LT",
     "LTE",
+    "MOD",
     "NEQ",
     "NUM",
     "PARSE-ISO",
     "POW",
     "READ",
+    "ROUND",
 ];
 
 #[test]
@@ -295,6 +300,25 @@ async fn bubble_creation_comparison_nil_input() {
                 stack[0]
             );
         }
+    }
+}
+
+#[tokio::test]
+async fn projecting_arithmetic_nil_input_passes_through() {
+    // MOD/FLOOR/CEIL/ROUND are Projecting/CreatesNil, but a NIL operand
+    // still propagates as NIL via the universal Bubble Rule (SPEC §4.5.1)
+    // — the CreatesNil policy is about CF-budget exhaustion on irrational
+    // operands, not about rejecting NIL inputs.
+    for name in &["FLOOR", "CEIL", "ROUND"] {
+        let code = format!("NIL {name}");
+        let stack = run_ok(&code).await;
+        assert_eq!(stack.len(), 1, "`{code}` must leave exactly one value");
+        assert!(is_nil(&stack[0]), "`{code}` must produce NIL");
+    }
+    for code in ["NIL 1 MOD", "1 NIL MOD", "NIL NIL MOD"] {
+        let stack = run_ok(code).await;
+        assert_eq!(stack.len(), 1, "`{code}` must leave exactly one value");
+        assert!(is_nil(&stack[0]), "`{code}` must produce NIL");
     }
 }
 

--- a/rust/src/interpreter/tensor_cmds.rs
+++ b/rust/src/interpreter/tensor_cmds.rs
@@ -1,11 +1,26 @@
-use crate::error::{AjisaiError, Result};
+use crate::error::{AjisaiError, NilReason, Result};
 use crate::interpreter::value_extraction_helpers::{
     create_number_value, nil_passthrough_binary, nil_passthrough_unary,
 };
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::continued_fraction::{ExactReal, DEFAULT_COMPARISON_BUDGET};
 use crate::types::fraction::Fraction;
-use crate::types::{Value, ValueData};
+use crate::types::{Interpretation, Value, ValueData};
+
+/// Push a SPEC §7.4.1 Undecidable NIL. Used when an exact-real (CF)
+/// arithmetic word cannot resolve its result within the partial-quotient
+/// budget; the Bubble Rule (SPEC §11.2) places NIL on the stack instead
+/// of raising an error, matching the comparison-budget exhaustion path.
+fn push_undecidable_nil(interp: &mut Interpreter) {
+    interp
+        .stack
+        .push(Value::nil_with_reason(NilReason::Undecidable));
+    let stack_len = interp.stack.len();
+    interp.semantic_registry.normalize_to_stack_len(stack_len);
+    interp
+        .semantic_registry
+        .update_hint_at(stack_len - 1, Interpretation::Nil);
+}
 
 use super::tensor_ops::{
     apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics, build_nested_value,
@@ -251,23 +266,16 @@ where
         }
     }
 
-    // ExactScalar path: exact irrational via CF (SPEC §4.2.2)
+    // ExactScalar path: exact irrational via CF (SPEC §4.2.2). When the
+    // CF stream exhausts its partial-quotient budget the result is
+    // undecidable, so project to a Bubble NIL (SPEC §7.4.1, §11.2)
+    // instead of raising an error — matching the comparison-budget path.
     if let ValueData::ExactScalar(er) = &val.data {
         match exact_op(er) {
-            Some(result) => {
-                interp.stack.push(Value::from_exact_real(result));
-                return Ok(());
-            }
-            None => {
-                if !is_keep_mode {
-                    interp.stack.push(val);
-                }
-                return Err(AjisaiError::from(format!(
-                    "{} requires number or vector",
-                    op_name
-                )));
-            }
+            Some(result) => interp.stack.push(Value::from_exact_real(result)),
+            None => push_undecidable_nil(interp),
         }
+        return Ok(());
     }
 
     if val.is_vector() {
@@ -349,14 +357,20 @@ pub fn op_mod(interp: &mut Interpreter) -> Result<()> {
                 if b_is_zero {
                     return Err(AjisaiError::from("Modulo by zero"));
                 }
-                if let Some(result) = a.div(&b).and_then(|q| q.floor()).map(|fl| a.sub(&b.mul(&fl))) {
-                    if interp.consumption_mode != ConsumptionMode::Keep {
-                        interp.stack.pop();
-                        interp.stack.pop();
-                    }
-                    interp.stack.push(Value::from_exact_real(result));
-                    return Ok(());
+                // a mod b = a - b * floor(a/b). A `None` here (after the
+                // zero check) means the CF division/floor exhausted its
+                // budget, so the result is undecidable: project to a
+                // Bubble NIL (SPEC §7.4.1) rather than erroring.
+                let modulo = a.div(&b).and_then(|q| q.floor()).map(|fl| a.sub(&b.mul(&fl)));
+                if interp.consumption_mode != ConsumptionMode::Keep {
+                    interp.stack.pop();
+                    interp.stack.pop();
                 }
+                match modulo {
+                    Some(result) => interp.stack.push(Value::from_exact_real(result)),
+                    None => push_undecidable_nil(interp),
+                }
+                return Ok(());
             }
         }
     }


### PR DESCRIPTION
## Summary

セッションのレビューで判明した **NIL ポリシーの非対称** を是正します。

レビューの所見：比較語は CF 予算枯渇時に Undecidable NIL を返す（#987）が、FLOOR/CEIL/ROUND/MOD は同じ状況でエラーを投げていた。さらに精査の結果、この非対称が生じるのは**この4語だけ**で、ADD/SUB/MUL は CF 算術が常に値を生む（`None` を返さない）ため真に Total であることが判明しました。

### 変更内容

**`builtin_word_definitions.rs`**
- FLOOR/CEIL/ROUND/MOD を `Projecting/CreatesNil/B` に変更（DIV・比較語と同形）
- ADD/SUB/MUL は `Total/Passthrough/A` のまま（`aq_ver_contract_b` の「ADD=Total」コントラストを維持）

**`tensor_cmds.rs`**
- `push_undecidable_nil` ヘルパーを追加（comparison.rs と同じ Bubble Rule 実装）
- `apply_unary_math`：ExactReal の `None`（CF 枯渇）を誤誘導エラーではなく Undecidable NIL に
- `op_mod`：ゼロ除数チェック後の `None`（CF 枯渇）を Undecidable NIL に（ゼロ除数自体は従来通りエラー）

**`nil_conformance_tests.rs`**
- 4語を `CORE_PASSTHROUGH` → `PROJECTING_WORDS` へ移動
- `projecting_arithmetic_nil_input_passes_through` を追加し、NIL入力 → NIL passthrough の被覆を維持

**`coreword_registry.rs`**
- `aq_ver_contract_g` を追加：4語が Projecting/CreatesNil/B、ADD/SUB/MUL が Passthrough であることを固定

### 設計判断の根拠

| 語 | CF枯渇で `None`? | 契約 |
|---|---|---|
| ADD/SUB/MUL | しない（常に値） | Total/Passthrough（不変）|
| DIV | する（ゼロ除数） | Projecting/CreatesNil（既存）|
| MOD/FLOOR/CEIL/ROUND | する（Gosper 近整数エッジ）| Projecting/CreatesNil（本PR）|
| EQ/NEQ/LT/LTE/GT/GTE | する（予算枯渇）| Projecting/CreatesNil（#987）|

floor/ceil/round は数学的には全域だが、Gosper 値の近整数判定は予算内で決定不能になりうるため、`None` を Undecidable NIL として扱うのが DIV・比較語と一貫します。AlgebraicSqrt の一般ケースでは枯渇せず正常に整数化されます（既存テストで確認済み）。

## Test plan

- [x] `cargo test --lib` 全 1201 テスト通過（+2: 契約テスト・NIL入力プローブ）
- [x] `aq_ver_contract_g` が4語の Projecting/CreatesNil/B と ADD/SUB/MUL の Passthrough を検査
- [x] `projecting_word_set_matches_registry` が拡張後のリストで通過
- [x] `NIL FLOOR/CEIL/ROUND → NIL`、`NIL MOD/1 NIL MOD → NIL` を確認
- [x] floor(√2)=1 等の正常系（非NIL）が維持されていることを確認

https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj

---
_Generated by [Claude Code](https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj)_