### PR TITLE
feat: ContinuedFraction serialization role + >CF word (SPEC §4.2.3/§12.2)

### DIFF
--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -1303,3 +1303,61 @@ mod exact_scalar_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod continued_fraction_role_tests {
+    use crate::interpreter::Interpreter;
+    use crate::types::display::{format_as_continued_fraction, format_with_hint};
+    use crate::types::Interpretation;
+
+    // `>CF` on a rational: 5/2 = [2; 2] -> "( 2 ( 2 ) )".
+    #[tokio::test]
+    async fn to_cf_rational_nested_form() {
+        let mut interp = Interpreter::new();
+        interp.execute("5/2 >CF").await.unwrap();
+        let stack = interp.get_stack();
+        assert_eq!(stack.len(), 1);
+        let hints = interp.collect_stack_hints();
+        assert_eq!(hints.last(), Some(&Interpretation::ContinuedFraction));
+        let s = format_with_hint(&stack[0], Interpretation::ContinuedFraction);
+        assert_eq!(s, "( 2 ( 2 ) )");
+    }
+
+    // `>CF` on √2 = [1; 2,2,2,...] -> lazy, truncated.
+    #[tokio::test]
+    async fn to_cf_sqrt2_truncated_form() {
+        let mut interp = Interpreter::new();
+        interp.execute("'math' IMPORT 2 SQRT >CF").await.unwrap();
+        let stack = interp.get_stack();
+        assert_eq!(stack.len(), 1);
+        let s = format_as_continued_fraction(&stack[0]);
+        assert!(s.starts_with("( 1"), "expected '( 1' prefix, got {s:?}");
+        assert!(s.contains("( 1 ( 2 ( 2 "), "expected √2 expansion, got {s:?}");
+        assert!(s.contains("...)"), "expected truncation marker, got {s:?}");
+        let opens = s.matches('(').count();
+        let closes = s.matches(')').count();
+        assert_eq!(opens, closes, "unbalanced parens in {s:?}");
+    }
+
+    // `>CF` only retags; the underlying value is byte-for-byte identical to
+    // an untagged √2 (same structural rendering, no data mutation).
+    #[tokio::test]
+    async fn to_cf_preserves_value() {
+        let mut tagged = Interpreter::new();
+        tagged.execute("'math' IMPORT 2 SQRT >CF").await.unwrap();
+        let mut plain = Interpreter::new();
+        plain.execute("'math' IMPORT 2 SQRT").await.unwrap();
+
+        let tagged_stack = tagged.get_stack();
+        let plain_stack = plain.get_stack();
+        assert_eq!(tagged_stack.len(), 1);
+        assert_eq!(plain_stack.len(), 1);
+
+        // The retagged value's underlying data renders identically to the
+        // untagged √2 under the structural (RawNumber) role.
+        assert_eq!(
+            format_with_hint(&tagged_stack[0], Interpretation::RawNumber),
+            format_with_hint(&plain_stack[0], Interpretation::RawNumber)
+        );
+    }
+}

--- a/rust/src/builtins/builtin_word_definitions.rs
+++ b/rust/src/builtins/builtin_word_definitions.rs
@@ -53,6 +53,7 @@ pub enum BuiltinExecutorKey {
     Unimport,
     UnimportOnly,
     Force,
+    ToCf,
     Print,
     Insert,
     Replace,
@@ -505,6 +506,20 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
         },
 
     // === Cast ===
+    BuiltinSpec {
+
+        name: ">CF",
+        category: "conversion",
+        hover_summary: ">CF — tag value for continued-fraction serialization",
+        hover_syntax: "2 MATH@SQRT >CF",
+        word_shape: WordShape::Map,
+        detail_group: BuiltinDetailGroup::StringCast,
+        executor_key: Some(BuiltinExecutorKey::ToCf),
+        summary: "Tag a numeric scalar for canonical continued-fraction serialization (SPEC 12.2).",
+        role: "Conversion modifier: request the ContinuedFraction display/serialization role.",
+        stack_effect: "[ x ] -> [ x ]",
+        ..SPEC_DEFAULT
+        },
     BuiltinSpec {
 
         name: "CHARS",

--- a/rust/src/elastic/purity_table.rs
+++ b/rust/src/elastic/purity_table.rs
@@ -93,7 +93,7 @@ pub fn builtin_purity(key: BuiltinExecutorKey) -> PurityInfo {
         True | False | Nil | Idle => pure_trivial,
 
         // ── Pure casts / string ops ───────────────────────────────────────
-        Str | Num | Bool | Chr | Chars | Join => pure_light,
+        Str | Num | Bool | Chr | Chars | Join | ToCf => pure_light,
         Trim | TrimLeft | TrimRight | Tokenize | Substitute | StartsWith | EndsWith => pure_light,
 
         // ── Pure vector ops ───────────────────────────────────────────────

--- a/rust/src/interpreter/cast/cast_value_helpers.rs
+++ b/rust/src/interpreter/cast/cast_value_helpers.rs
@@ -10,6 +10,7 @@ pub(crate) fn is_string_value(val: &Value) -> bool {
 pub(crate) fn is_string_value_with_hint(val: &Value, hint: Interpretation) -> bool {
     match hint {
         Interpretation::RawNumber
+        | Interpretation::ContinuedFraction
         | Interpretation::Interval
         | Interpretation::TruthValue
         | Interpretation::Timestamp

--- a/rust/src/interpreter/execute_builtin.rs
+++ b/rust/src/interpreter/execute_builtin.rs
@@ -9,7 +9,8 @@ use super::compiled_plan::{
 
 use super::{
     arithmetic, cast, comparison, control, control_cond, execute_def, execute_del, execute_lookup,
-    higher_order, higher_order_fold, io, logic, modules, tensor_cmds, vector_ops, Interpreter,
+    higher_order, higher_order_fold, interval_ops, io, logic, modules, tensor_cmds, vector_ops,
+    Interpreter,
 };
 
 #[cfg(feature = "trace-compile")]
@@ -258,6 +259,7 @@ impl Interpreter {
             BuiltinExecutorKey::Kill => self.op_kill(),
             BuiltinExecutorKey::Monitor => self.op_monitor(),
             BuiltinExecutorKey::Supervise => self.op_supervise(),
+            BuiltinExecutorKey::ToCf => interval_ops::op_to_cf(self),
             BuiltinExecutorKey::Precompute => Err(AjisaiError::from(
                 "PRECOMPUTE can only be used during definition-time precomputation",
             )),

--- a/rust/src/interpreter/interval_ops.rs
+++ b/rust/src/interpreter/interval_ops.rs
@@ -60,6 +60,23 @@ pub(crate) fn op_interval(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
+/// `>CF` — tag the top-of-stack value with the ContinuedFraction
+/// interpretation role (SPEC §12.2). Value-preserving: it only retags
+/// the existing top, leaving the underlying data untouched.
+pub(crate) fn op_to_cf(interp: &mut Interpreter) -> Result<()> {
+    if interp.operation_target_mode != OperationTargetMode::StackTop {
+        return Err(AjisaiError::from(">CF: Stack mode is not supported"));
+    }
+    let len = interp.stack.len();
+    if len == 0 {
+        return Err(AjisaiError::StackUnderflow);
+    }
+    interp
+        .semantic_registry
+        .update_hint_at(len - 1, Interpretation::ContinuedFraction);
+    Ok(())
+}
+
 pub(crate) fn op_lower(interp: &mut Interpreter) -> Result<()> {
     unary_interval_accessor(interp, |i| i.lo)
 }

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -90,6 +90,21 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
         }
 
         if chars[i] == '>' {
+            // `>NAME` (e.g. `>CF`) is a single conversion-modifier identifier,
+            // not the `>` comparison operator followed by a word.
+            if i + 1 < chars.len() && chars[i + 1].is_ascii_alphabetic() {
+                let start = i;
+                i += 1;
+                while i < chars.len()
+                    && !chars[i].is_whitespace()
+                    && !is_special_char(chars[i])
+                {
+                    i += 1;
+                }
+                let token_str: String = chars[start..i].iter().collect();
+                tokens.push(Token::Symbol(token_str.into()));
+                continue;
+            }
             if i + 1 < chars.len() && chars[i + 1] == '=' {
                 tokens.push(Token::Symbol(">=".into()));
                 i += 2;

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -28,6 +28,106 @@ pub fn format_with_hint(value: &Value, hint: Interpretation) -> String {
         Interpretation::Text => format_as_string(&value.data),
         Interpretation::TruthValue => format_as_boolean(&value.data),
         Interpretation::Timestamp => format_as_datetime(&value.data),
+        Interpretation::ContinuedFraction => format_as_continued_fraction(value),
+    }
+}
+
+/// Display budget for lazy continued fractions (SPEC §4.2.3:
+/// "implementation-defined display budget").
+const CF_DISPLAY_BUDGET: usize = 32;
+
+/// Render a numeric scalar value as the canonical nested
+/// continued-fraction form (SPEC §4.2.3): `( a0 ( a1 ( a2 ) ) )`.
+/// Lazy irrationals truncate at CF_DISPLAY_BUDGET terms with a `...)`
+/// marker on the innermost level.
+pub(crate) fn format_as_continued_fraction(value: &Value) -> String {
+    // Obtain the partial-quotient sequence and whether it is truncated.
+    let (terms, truncated): (Vec<BigInt>, bool) = match &value.data {
+        ValueData::Scalar(f) => {
+            // Rational: finite canonical CF.
+            match ExactReal::from_fraction(f.clone()).partial_quotients() {
+                Some(qs) => (qs, false),
+                None => (Vec::new(), false), // nil fraction
+            }
+        }
+        ValueData::ExactScalar(er) => match er.partial_quotients() {
+            Some(qs) => (qs, false), // collapsed to rational
+            None => {
+                let qs = er.partial_quotients_bounded(CF_DISPLAY_BUDGET);
+                let truncated = qs.len() == CF_DISPLAY_BUDGET;
+                (qs, truncated)
+            }
+        },
+        // Non-scalar values fall back to the structural rendering.
+        _ => return format_value_recursive(&value.data, 0),
+    };
+    render_cf_nested(&terms, truncated)
+}
+
+/// Build the nested right-associative CF string from partial quotients.
+/// finite [a0,a1,a2] -> "( a0 ( a1 ( a2 ) ) )"
+/// truncated [a0,a1,a2] -> "( a0 ( a1 ( a2 ...) ) )"
+fn render_cf_nested(terms: &[BigInt], truncated: bool) -> String {
+    if terms.is_empty() {
+        return "( )".to_string();
+    }
+    let mut s = String::new();
+    for t in terms {
+        s.push_str("( ");
+        s.push_str(&t.to_string());
+        s.push(' ');
+    }
+    if truncated {
+        // The `...)` marker provides the innermost closing paren.
+        s.push_str("...)");
+    } else {
+        s.push(')');
+    }
+    // Close the remaining opened levels.
+    for _ in 0..terms.len() - 1 {
+        s.push_str(" )");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_cf_nested;
+    use num_bigint::BigInt;
+
+    fn bi(n: i64) -> BigInt {
+        BigInt::from(n)
+    }
+
+    #[test]
+    fn render_cf_nested_exact_forms() {
+        assert_eq!(render_cf_nested(&[bi(1)], false), "( 1 )");
+        assert_eq!(render_cf_nested(&[bi(1), bi(2)], false), "( 1 ( 2 ) )");
+        assert_eq!(
+            render_cf_nested(&[bi(1), bi(2), bi(2)], false),
+            "( 1 ( 2 ( 2 ) ) )"
+        );
+        assert_eq!(
+            render_cf_nested(&[bi(1), bi(2), bi(2)], true),
+            "( 1 ( 2 ( 2 ...) ) )"
+        );
+        assert_eq!(render_cf_nested(&[], false), "( )");
+    }
+
+    #[test]
+    fn render_cf_nested_balanced_parens() {
+        for terms in [
+            vec![bi(1)],
+            vec![bi(1), bi(2)],
+            vec![bi(2), bi(2), bi(2), bi(2)],
+        ] {
+            for truncated in [false, true] {
+                let s = render_cf_nested(&terms, truncated);
+                let opens = s.matches('(').count();
+                let closes = s.matches(')').count();
+                assert_eq!(opens, closes, "unbalanced parens in {s:?}");
+            }
+        }
     }
 }
 

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -303,6 +303,11 @@ pub enum Interpretation {
     Timestamp,
     /// A diagnostic absence value.
     Nil,
+    /// Canonical AI-readable continued-fraction serialization
+    /// (SPEC §4.2.3, §12.2): the nested right-associative form
+    /// `( a0 ( a1 ( a2 ) ) )`, with a `...)` truncation marker for
+    /// lazy irrationals. Round-trip-safe machine serialization role.
+    ContinuedFraction,
 }
 
 #[derive(Debug, Clone)]

--- a/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
@@ -236,6 +236,7 @@ fn interpretation_protocol_str(hint: Interpretation) -> &'static str {
         Interpretation::TruthValue => "truthValue",
         Interpretation::Timestamp => "timestamp",
         Interpretation::Nil => "nil",
+        Interpretation::ContinuedFraction => "continuedFraction",
     }
 }
 
@@ -373,6 +374,20 @@ pub(crate) fn value_to_protocol(
     external_hint_opt: Option<Interpretation>,
 ) -> ProtocolNode {
     let effective = external_hint_opt.unwrap_or(value.hint);
+    // The ContinuedFraction role serializes numeric scalars as the canonical
+    // nested-form string (SPEC §12.2), not a lossy rational approximation.
+    if effective == Interpretation::ContinuedFraction
+        && matches!(value.data, ValueData::Scalar(_) | ValueData::ExactScalar(_))
+    {
+        return ProtocolNode {
+            type_str: "string",
+            value: ProtocolValue::Text(
+                crate::types::display::format_as_continued_fraction(value),
+            ),
+            display_hint: effective,
+            semantics: None,
+        };
+    }
     let (type_str, protocol_value) = match &value.data {
         ValueData::Nil => ("nil", ProtocolValue::Null),
         ValueData::ExactScalar(er) => {


### PR DESCRIPTION
## Summary

未対応論点（**Display ラウンドトリップ損失** と **表現タグ分岐 vs SPEC §4.2.4**）に取り組み、両者を SPEC §4.2.3/§12.2 が規定する **`ContinuedFraction` 正規シリアライズロール**の実装に収束させました。

### 調査で判明したこと

- SPEC §12.2 は `RawNumber` が「lazy irrational で情報を失いうる」ことを**明示的に許容**し、ラウンドトリップ安全な正規形は `ContinuedFraction` ロール（ネスト形 `( a0 ( a1 ... )))`）と規定。真の欠落はこのロールが未実装だったこと。
- §4.2.4 の「表現タグを分岐してはならない」は観測可能な値同一性の話。全スカラを CF 列としてシリアライズすればタグ非依存になり、懸念が根本解消する。
- パーサは括弧を禁止しており CF 形は**出力専用シリアライズ**（外部機械消費者向け）。

### 変更内容

**ロールとシリアライザ**
- `types/mod.rs`: `Interpretation::ContinuedFraction` を追加
- `types/display.rs`: `format_as_continued_fraction` + `render_cf_nested` がネスト右結合形 `( a0 ( a1 ( a2 ) ) )` を生成。lazy irrational は32項の表示予算で打ち切り、最内に `...)` マーカー
- `wasm_value_conversion.rs`: `ContinuedFraction` ロール時はスカラを正規ネスト形の文字列としてシリアライズ（損失近似ではなく）。protocol 型文字列 `"continuedFraction"` も追加

**`>CF` コア語**
- `BuiltinExecutorKey::ToCf` と `>CF` の `BuiltinSpec` を追加（Total/Passthrough/A、値不変）
- `interval_ops.rs`: `op_to_cf` — TOS のロールを `ContinuedFraction` に再タグ（data 不変）
- `tokenizer.rs`: `>NAME`（例 `>CF`）を単一識別子として字句解析。`>`/`>=`/`>`+数字は影響なし

**配線**
- `purity_table.rs`/`cast_value_helpers.rs`/`execute_builtin.rs`: ToCf と新ロールを配線（display/WASM 以外では `RawNumber` と同等挙動）

### テスト（5本追加）

| テスト | 内容 |
|---|---|
| `render_cf_nested_exact_forms` | `[1]`→`( 1 )`、`[1,2,2]`→`( 1 ( 2 ( 2 ) ) )`、切り詰め→`( 1 ( 2 ( 2 ...) ) )` |
| `render_cf_nested_balanced_parens` | 括弧バランス |
| `to_cf_rational_nested_form` | `5/2 >CF` → `( 2 ( 2 ) )` + ロール検証 |
| `to_cf_sqrt2_truncated_form` | `2 SQRT >CF` → `( 1` 始まり・`...)` 含む・括弧バランス |
| `to_cf_preserves_value` | `>CF` が値を保存 |

## Test plan

- [x] `cargo test --lib` 全 1206 テスト通過（+5）
- [x] 新規CF/シリアライザテスト緑
- [x] clippy 新規警告ゼロ（既存警告のみ）
- [x] トークナイザ `>=`/`>`+数字 の非回帰を確認

https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj

---
_Generated by [Claude Code](https://claude.ai/code/session_018f5BpxwhgN2YuaKAnAF4Pj)_