### PR TITLE
feat(Phase 1): implement third truth value Unknown (U) — CF × K3 logic

### DIFF
--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -242,10 +242,8 @@ mod num_tests {
 
 #[cfg(test)]
 mod interval_tests {
-    use crate::error::NilReason;
     use crate::interpreter::interval_ops::value_to_interval;
     use crate::interpreter::Interpreter;
-    use crate::semantic::AbsenceOrigin;
     use crate::types::fraction::Fraction;
 
     #[tokio::test]
@@ -367,11 +365,16 @@ mod interval_tests {
             .execute("'math' IMPORT 2 3 INTERVAL 3 4 INTERVAL <")
             .await
             .unwrap();
-        let absence = interp_undetermined.get_stack()[0]
-            .absence_metadata()
-            .expect("overlapping interval comparison projects to NIL");
-        assert_eq!(absence.reason, Some(NilReason::Undecidable));
-        assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
+        // SPEC §7.4.1 (revised): an undecidable comparison yields the logical
+        // truth value `Unknown` (U), observed as `truthValue = unknown`, not
+        // a `reason = undecidable` NIL.
+        let result = &interp_undetermined.get_stack()[0];
+        assert!(
+            result.is_unknown(),
+            "overlapping interval comparison projects to the logical Unknown"
+        );
+        assert_eq!(result.truth_value(), Some("unknown"));
+        assert_eq!(format!("{}", result), "UNKNOWN");
 
         let mut interp_eq = Interpreter::new();
         interp_eq
@@ -505,9 +508,7 @@ mod ai_first_comparison_tests {
     //! that matches its intent directly rather than rewriting it as a
     //! negation or operand swap.
 
-    use crate::error::NilReason;
     use crate::interpreter::Interpreter;
-    use crate::semantic::AbsenceOrigin;
 
     async fn run(source: &str) -> Interpreter {
         let mut interp = Interpreter::new();
@@ -625,17 +626,62 @@ mod ai_first_comparison_tests {
     }
 
     #[tokio::test]
-    async fn gt_on_overlapping_intervals_projects_undecidable_nil() {
+    async fn gt_on_overlapping_intervals_projects_unknown() {
         let mut interp = Interpreter::new();
         interp
             .execute("'math' IMPORT 2 3 INTERVAL 2 4 INTERVAL GT")
             .await
             .unwrap();
-        let absence = interp.get_stack()[0]
-            .absence_metadata()
-            .expect("overlapping interval comparison projects to NIL");
-        assert_eq!(absence.reason, Some(NilReason::Undecidable));
-        assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
+        // SPEC §7.4.1 (revised): undecidable comparison yields the logical
+        // truth value `Unknown` (U), not a `reason = undecidable` NIL.
+        let result = &interp.get_stack()[0];
+        assert!(
+            result.is_unknown(),
+            "overlapping interval GT yields Unknown"
+        );
+        assert_eq!(result.truth_value(), Some("unknown"));
+    }
+
+    #[tokio::test]
+    async fn finite_cf_comparison_always_decides() {
+        for (code, expected) in [("1 1 EQ", "1/1"), ("1 2 EQ", "0/1"), ("1 2 LT", "1/1")] {
+            let mut interp = Interpreter::new();
+            interp.execute(code).await.unwrap();
+            let v = &interp.get_stack()[0];
+            assert!(!v.is_unknown(), "`{code}` must decide, not be Unknown");
+            assert_eq!(format!("{}", v), expected, "`{code}`");
+        }
+    }
+
+    #[tokio::test]
+    async fn equal_irrationals_compare_unknown() {
+        // sqrt(2) - sqrt(2) is, structurally, a Gosper node the budget cannot
+        // distinguish from 0; EQ / LT against 0 therefore yield Unknown (U).
+        for code in ["2 SQRT 2 SQRT SUB 0 EQ", "2 SQRT 2 SQRT SUB 0 LT"] {
+            let mut interp = Interpreter::new();
+            interp
+                .execute(&format!("'math' IMPORT {code}"))
+                .await
+                .unwrap();
+            let v = &interp.get_stack()[0];
+            assert!(v.is_unknown(), "`{code}` must be the logical Unknown");
+            assert_eq!(v.truth_value(), Some("unknown"), "`{code}`");
+            assert_eq!(format!("{}", v), "UNKNOWN", "`{code}`");
+        }
+    }
+
+    #[tokio::test]
+    async fn distinct_irrationals_decide_at_finite_prefix() {
+        for (code, expected) in [("2 SQRT 3 SQRT EQ", "0/1"), ("2 SQRT 3 SQRT LT", "1/1")] {
+            let mut interp = Interpreter::new();
+            interp
+                .execute(&format!("'math' IMPORT {code}"))
+                .await
+                .unwrap();
+            let v = &interp.get_stack()[0];
+            assert!(!v.is_unknown(), "`{code}` must decide, not be Unknown");
+            assert_eq!(format!("{}", v), expected, "`{code}`");
+        }
     }
 
     // ── NIL passthrough for the new ops (contract: nil_policy = Passthrough)

--- a/rust/src/builtins/builtin_word_definitions.rs
+++ b/rust/src/builtins/builtin_word_definitions.rs
@@ -757,7 +757,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
         partiality: Partiality::Projecting,
-        nil_policy: NilPolicy::CreatesNil,
+        nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
@@ -773,7 +773,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
         partiality: Partiality::Projecting,
-        nil_policy: NilPolicy::CreatesNil,
+        nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
@@ -789,7 +789,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
         partiality: Partiality::Projecting,
-        nil_policy: NilPolicy::CreatesNil,
+        nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
@@ -805,7 +805,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
         partiality: Partiality::Projecting,
-        nil_policy: NilPolicy::CreatesNil,
+        nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
@@ -821,7 +821,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
         partiality: Partiality::Projecting,
-        nil_policy: NilPolicy::CreatesNil,
+        nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },
@@ -837,7 +837,7 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ a ] [ b ] -> [ TRUE | FALSE ]",
         partiality: Partiality::Projecting,
-        nil_policy: NilPolicy::CreatesNil,
+        nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::B,
         ..SPEC_DEFAULT
         },

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -711,11 +711,14 @@ mod tests {
     }
 
     #[test]
-    fn aq_ver_contract_f_comparison_words_create_nil_under_undecidable() {
-        // SPEC §7.14 line 611 and §9.4 table require all six comparison
-        // primitives to be Projecting/CreatesNil/B — matching DIV — because
-        // the comparison-budget exhaustion path (§7.4.1) can produce an
-        // Undecidable NIL instead of a boolean.
+    fn aq_ver_contract_f_comparison_words_project_undecidable_to_unknown() {
+        // SPEC §7.14 (revised): all six comparison primitives are
+        // Projecting/Passthrough/B. They are Projecting because every
+        // well-shaped input yields a `TruthValue` result — the
+        // comparison-budget exhaustion path (§7.4.1) projects onto the
+        // logical `Unknown` (U), a TruthValue result, not a reasoned NIL.
+        // They are Passthrough because they still pass NIL operands through
+        // (§7.12); they are no longer CreatesNil for the undecidable case.
         for name in &["EQ", "NEQ", "LT", "LTE", "GT", "GTE"] {
             let meta = get_coreword_metadata(name)
                 .unwrap_or_else(|| panic!("{} must be in registry", name));
@@ -727,8 +730,8 @@ mod tests {
             );
             assert_eq!(
                 meta.nil_policy,
-                NilPolicy::CreatesNil,
-                "{} must be CreatesNil (SPEC §7.14)",
+                NilPolicy::Passthrough,
+                "{} must be Passthrough (SPEC §7.14, revised)",
                 name
             );
             assert_eq!(

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -20,6 +20,15 @@ pub enum NilReason {
     /// `absence.origin = comparisonBudget` rather than a SAFE-caught
     /// error.
     Undecidable,
+    /// The logical truth value `Unknown` (U) of the three-valued (Kleene)
+    /// logic, SPEC §7.5. Unlike `Undecidable` (an operational NIL), this
+    /// marks a *logical* undecidability: a continued-fraction comparison
+    /// (SPEC §7.4.1) that did not settle true or false within its budget.
+    /// A value carrying this reason together with `Interpretation::TruthValue`
+    /// is the runtime representation of U; observe it through the
+    /// `truthValue` axis (`unknown`), never by inspecting this reason
+    /// directly. Use `Value::is_unknown()` / `Value::unknown()`.
+    LogicallyUnknown,
     /// A host-mediated read (`SERIAL@READ`) found no buffered data. The Bubble
     /// Rule projects this to NIL with `absence.origin = hostEnvironment`.
     NoData,
@@ -94,6 +103,7 @@ impl NilReason {
             NilReason::UnknownWord => "unknownWord",
             NilReason::ExecutionFailure => "executionFailure",
             NilReason::Undecidable => "undecidable",
+            NilReason::LogicallyUnknown => "logicallyUnknown",
             NilReason::NoData => "noData",
             NilReason::PortDisconnected => "portDisconnected",
             NilReason::SafeCaught(_) => "safeCaught",

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -1,4 +1,4 @@
-use crate::error::{AjisaiError, NilReason, Result};
+use crate::error::{AjisaiError, Result};
 use crate::interpreter::interval_ops::value_to_interval;
 use crate::interpreter::tensor_ops::FlatTensor;
 use crate::interpreter::value_extraction_helpers::{
@@ -34,8 +34,8 @@ impl OrderingKind {
 
     /// Apply the relation to a budgeted `ExactReal` three-way
     /// comparison result. `None` propagates the budget-exhaustion
-    /// case unchanged so callers project it to the §7.4.1
-    /// Undecidable NIL.
+    /// case unchanged so callers project it to the §7.4.1 logical
+    /// `Unknown` (U).
     fn apply_to_ordering(self, ord: Option<std::cmp::Ordering>) -> Option<bool> {
         use std::cmp::Ordering;
         ord.map(|o| match self {
@@ -56,25 +56,25 @@ fn push_boolean_result(interp: &mut Interpreter, result: bool) {
         .update_hint_at(stack_len - 1, Interpretation::TruthValue);
 }
 
-/// Push the SPEC §7.4.1 undecidable-NIL: reason = `Undecidable`,
-/// origin = `ComparisonBudget`. The Bubble Rule (SPEC §11.2) places
-/// this on the stack instead of raising an error, so subsequent
-/// NIL-passthrough words can continue the pipeline.
-fn push_undecidable_nil(interp: &mut Interpreter) {
-    interp
-        .stack
-        .push(Value::nil_with_reason(NilReason::Undecidable));
+/// Push the SPEC §7.4.1 logical `Unknown` (U): a `TruthValue`-role value
+/// produced when the partial-quotient budget is exhausted before two
+/// continued fractions decide. U is a logical truth value, not an
+/// operational NIL — it flows into the three-valued logic of SPEC §7.5
+/// directly. The `TruthValue` interpretation role makes it observable as
+/// `truthValue = unknown`.
+fn push_unknown(interp: &mut Interpreter) {
+    interp.stack.push(Value::unknown());
     let stack_len = interp.stack.len();
     interp.semantic_registry.normalize_to_stack_len(stack_len);
     interp
         .semantic_registry
-        .update_hint_at(stack_len - 1, Interpretation::Nil);
+        .update_hint_at(stack_len - 1, Interpretation::TruthValue);
 }
 
 /// Compare two scalar values under an ordering kind. Returns `Ok(Some(bool))`
 /// when the comparison decides, `Ok(None)` when the comparison budget
-/// exhausts (SPEC §7.4.1) — the caller projects `None` to an Undecidable
-/// NIL. Returns `Err(_)` for structurally-non-comparable operands.
+/// exhausts (SPEC §7.4.1) — the caller projects `None` to the logical
+/// `Unknown` (U). Returns `Err(_)` for structurally-non-comparable operands.
 ///
 /// Both-Rational operands take the Fraction fast path (always
 /// decidable per SPEC §7.4.1: "the budget value itself is not part
@@ -158,8 +158,8 @@ fn extract_scalar_for_comparison(val: &Value) -> Result<Fraction> {
 /// Returns `Ok(Some(bool))` when the property is decidable for every
 /// pair, `Ok(None)` when some pair triggers SPEC §7.4.1's comparison
 /// budget short-circuit. SPEC §7.4 requires the entire STAK-mode
-/// result to be NIL on the first NIL-producing pair regardless of
-/// later pairs.
+/// result to be the logical `Unknown` (U) on the first U-producing
+/// pair regardless of later pairs.
 fn check_all_adjacent_pairs(items: &[Value], kind: OrderingKind) -> Result<Option<bool>> {
     for pair in items.windows(2) {
         match compare_scalar_pair(&pair[0], &pair[1], kind)? {
@@ -219,7 +219,7 @@ fn apply_binary_comparison(
 
             match compare_scalar_pair(&a_val, &b_val, kind) {
                 Ok(Some(b)) => push_boolean_result(interp, b),
-                Ok(None) => push_undecidable_nil(interp),
+                Ok(None) => push_unknown(interp),
                 Err(e) => {
                     if !is_keep_mode {
                         interp.stack.push(a_val);
@@ -259,7 +259,7 @@ fn apply_binary_comparison(
 
             match check_all_adjacent_pairs(&items, kind) {
                 Ok(Some(decided)) => push_boolean_result(interp, decided),
-                Ok(None) => push_undecidable_nil(interp),
+                Ok(None) => push_unknown(interp),
                 Err(e) => {
                     if !is_keep_mode {
                         interp.stack.extend(items);
@@ -319,7 +319,7 @@ where
                 interp.stack.pop();
                 interp.stack.pop();
             }
-            push_undecidable_nil(interp);
+            push_unknown(interp);
             Ok(())
         }
     })
@@ -399,7 +399,8 @@ pub fn op_neq(interp: &mut Interpreter) -> Result<()> {
 
 /// Three-valued pairwise equality matching the SPEC §7.4.1
 /// discipline: `Some(true)` / `Some(false)` for decidable pairs,
-/// `None` when budget exhaustion makes the comparison undecidable.
+/// `None` when budget exhaustion makes the comparison undecidable
+/// (the caller projects `None` to the logical `Unknown` U).
 /// `None` is only reachable for scalar pairs where at least one
 /// operand is a non-Rational `ExactReal`; the structural Vector /
 /// Tensor / Record paths and the singleton-projection paths always
@@ -484,7 +485,7 @@ fn apply_equality(interp: &mut Interpreter, invert: bool) -> Result<()> {
 
             match pairwise_eq(&a_val, &b_val) {
                 Some(eq) => push_boolean_result(interp, if invert { !eq } else { eq }),
-                None => push_undecidable_nil(interp),
+                None => push_unknown(interp),
             }
             Ok(())
         }
@@ -517,7 +518,7 @@ fn apply_equality(interp: &mut Interpreter, invert: bool) -> Result<()> {
 
             match check_all_adjacent_eq(&items, invert) {
                 Some(decided) => push_boolean_result(interp, decided),
-                None => push_undecidable_nil(interp),
+                None => push_unknown(interp),
             }
             Ok(())
         }

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -48,6 +48,10 @@ fn error_category_for_nil_reason(reason: &NilReason) -> Option<ErrorCategory> {
         NilReason::StackUnderflow => Some(ErrorCategory::StackUnderflow),
         NilReason::UnknownWord => Some(ErrorCategory::UnknownWord),
         NilReason::SafeCaught(category) => Some((**category).clone()),
+        // The logical Unknown (U) is not an error/absence and never carries
+        // an error category. It is excluded from error-flow tracing by
+        // `top_direct_nil_reason`, so this arm is defensive.
+        NilReason::LogicallyUnknown => None,
         NilReason::EmptySequence
         | NilReason::MissingField
         | NilReason::InvalidEncoding
@@ -65,7 +69,12 @@ fn top_direct_nil_reason(interp: &Interpreter) -> Option<NilReason> {
         return None;
     }
     let reason = top.nil_reason()?.clone();
-    if matches!(reason, NilReason::SafeCaught(_)) {
+    // The logical Unknown (U) is a TruthValue result, not an error/absence:
+    // keep it out of the error-flow trace (SPEC §4.5.2).
+    if matches!(
+        reason,
+        NilReason::SafeCaught(_) | NilReason::LogicallyUnknown
+    ) {
         None
     } else {
         Some(reason)

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -1,29 +1,20 @@
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::interpreter_core::RuntimeMetrics;
+use crate::interpreter::logic_kleene::{self, Ternary};
 use crate::interpreter::tensor_ops::{
-    apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics, FlatTensor,
+    apply_binary_broadcast_with_metrics, apply_unary_flat_with_metrics,
 };
 use crate::interpreter::value_extraction_helpers::extract_integer_from_value;
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
-use crate::types::{Value, ValueData};
+use crate::types::Value;
 
-fn check_value_has_truthy(val: &Value) -> bool {
-    match &val.data {
-        ValueData::Nil => false,
-        ValueData::Scalar(f) => !f.is_zero(),
-        // ExactScalar values are always non-zero irrationals → truthy
-        ValueData::ExactScalar(_) => true,
-        ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => true,
-        ValueData::Vector(_) | ValueData::Record { .. } => {
-            if let Ok(tensor) = FlatTensor::from_value(val) {
-                tensor.data.iter().any(|f| !f.is_zero())
-            } else {
-                false
-            }
-        }
-        ValueData::Tensor { data, .. } => data.iter().any(|f| !f.is_zero()),
-    }
+/// Whether an operand forces the scalar three-valued (K3) path rather
+/// than element-wise tensor broadcast: an operational NIL or the logical
+/// `Unknown` (U). When neither operand is special, `AND`/`OR` keep their
+/// existing vector/tensor broadcast semantics.
+fn forces_k3_path(value: &Value) -> bool {
+    value.is_nil() || value.is_unknown()
 }
 
 fn compute_inverted_fraction(f: &Fraction) -> Fraction {
@@ -38,8 +29,12 @@ fn compute_inverted_value(
     val: &Value,
     metrics: Option<&mut RuntimeMetrics>,
 ) -> Result<Value> {
-    if val.is_nil() {
-        return Ok(Value::nil());
+    // The logical Unknown (¬U = U) and operational NIL (¬NIL = NIL) cases
+    // route through the canonical K3 NOT table (SPEC §7.5). Checked before
+    // the scalar path because U is represented as a NIL node; a plain
+    // numeric/boolean scalar keeps its existing 0↔1 inversion below.
+    if val.is_unknown() || val.is_nil() {
+        return Ok(logic_kleene::not(Ternary::classify(val)).into_value());
     }
     if let Some(f) = val.as_scalar() {
         return Ok(Value::from_fraction(compute_inverted_fraction(f)));
@@ -79,7 +74,10 @@ pub fn op_not(interp: &mut Interpreter) -> Result<()> {
             let source: Vec<Value> = interp.stack.to_vec();
             let mut results: Vec<Value> = Vec::with_capacity(source.len());
             for value in &source {
-                results.push(compute_inverted_value(value, Some(&mut interp.runtime_metrics))?);
+                results.push(compute_inverted_value(
+                    value,
+                    Some(&mut interp.runtime_metrics),
+                )?);
             }
 
             if is_keep_mode {
@@ -113,25 +111,12 @@ pub fn op_and(interp: &mut Interpreter) -> Result<()> {
                 (a_val, b_val)
             };
 
-            let a_is_nil: bool = a_val.is_nil();
-            let b_is_nil: bool = b_val.is_nil();
-
-            if a_is_nil && b_is_nil {
-                interp.stack.push(Value::nil());
-                return Ok(());
-            } else if a_is_nil {
-                if check_value_has_truthy(&b_val) {
-                    interp.stack.push(Value::nil());
-                } else {
-                    interp.stack.push(Value::from_bool(false));
-                }
-                return Ok(());
-            } else if b_is_nil {
-                if check_value_has_truthy(&a_val) {
-                    interp.stack.push(Value::nil());
-                } else {
-                    interp.stack.push(Value::from_bool(false));
-                }
+            // K3 (SPEC §7.5) when either operand is an operational NIL or
+            // the logical Unknown (U); otherwise keep element-wise broadcast.
+            if forces_k3_path(&a_val) || forces_k3_path(&b_val) {
+                let result =
+                    logic_kleene::and(Ternary::classify(&a_val), Ternary::classify(&b_val));
+                interp.stack.push(result.into_value());
                 return Ok(());
             }
 
@@ -170,19 +155,16 @@ pub fn op_and(interp: &mut Interpreter) -> Result<()> {
                 interp.stack.drain(interp.stack.len() - count..).collect()
             };
 
-            let has_nil: bool = items.iter().any(|v| v.is_nil());
-            let has_falsy_non_nil: bool = items.iter().any(|v| !v.is_nil() && !v.is_truthy());
-            let all_truthy: bool = items.iter().all(|v| v.is_truthy());
-
-            if has_falsy_non_nil {
-                interp.stack.push(Value::from_bool(false));
-            } else if has_nil {
-                interp.stack.push(Value::nil());
-            } else if all_truthy {
-                interp.stack.push(Value::from_bool(true));
-            } else {
-                interp.stack.push(Value::from_bool(false));
+            // STAK-mode K3 fold (SPEC §7.5): F absorbs, then NIL takes
+            // priority over U (SPEC §4.5.2), then U propagates, else T.
+            let mut acc = Ternary::True;
+            for v in &items {
+                acc = logic_kleene::and(acc, Ternary::classify(v));
+                if acc == Ternary::False {
+                    break;
+                }
             }
+            interp.stack.push(acc.into_value());
             Ok(())
         }
     }
@@ -209,25 +191,11 @@ pub fn op_or(interp: &mut Interpreter) -> Result<()> {
                 (a_val, b_val)
             };
 
-            let a_is_nil: bool = a_val.is_nil();
-            let b_is_nil: bool = b_val.is_nil();
-
-            if a_is_nil && b_is_nil {
-                interp.stack.push(Value::nil());
-                return Ok(());
-            } else if a_is_nil {
-                if check_value_has_truthy(&b_val) {
-                    interp.stack.push(Value::from_bool(true));
-                } else {
-                    interp.stack.push(Value::nil());
-                }
-                return Ok(());
-            } else if b_is_nil {
-                if check_value_has_truthy(&a_val) {
-                    interp.stack.push(Value::from_bool(true));
-                } else {
-                    interp.stack.push(Value::nil());
-                }
+            // K3 (SPEC §7.5) when either operand is an operational NIL or
+            // the logical Unknown (U); otherwise keep element-wise broadcast.
+            if forces_k3_path(&a_val) || forces_k3_path(&b_val) {
+                let result = logic_kleene::or(Ternary::classify(&a_val), Ternary::classify(&b_val));
+                interp.stack.push(result.into_value());
                 return Ok(());
             }
 
@@ -266,16 +234,16 @@ pub fn op_or(interp: &mut Interpreter) -> Result<()> {
                 interp.stack.drain(interp.stack.len() - count..).collect()
             };
 
-            let has_nil: bool = items.iter().any(|v| v.is_nil());
-            let has_truthy: bool = items.iter().any(|v| v.is_truthy());
-
-            if has_truthy {
-                interp.stack.push(Value::from_bool(true));
-            } else if has_nil {
-                interp.stack.push(Value::nil());
-            } else {
-                interp.stack.push(Value::from_bool(false));
+            // STAK-mode K3 fold (SPEC §7.5): T absorbs, then NIL takes
+            // priority over U (SPEC §4.5.2), then U propagates, else F.
+            let mut acc = Ternary::False;
+            for v in &items {
+                acc = logic_kleene::or(acc, Ternary::classify(v));
+                if acc == Ternary::True {
+                    break;
+                }
             }
+            interp.stack.push(acc.into_value());
             Ok(())
         }
     }

--- a/rust/src/interpreter/logic_kleene.rs
+++ b/rust/src/interpreter/logic_kleene.rs
@@ -1,0 +1,209 @@
+//! Strong Kleene three-valued logic (K3) for `AND` / `OR` / `NOT`
+//! (SPEC §7.5), with the NIL/Unknown interaction rules of SPEC §4.5.2.
+//!
+//! This is the single canonical implementation of the K3 truth tables;
+//! both the `StackTop` and `STAK` paths in [`super::logic`] route through
+//! it so the comparison-word `Unknown` (U) and the logic words never
+//! drift apart (SPEC §14.1). The truth domain is {T, F, U}; operational
+//! NIL is tracked as a fourth input category so that the absorbing rules
+//! (`F` for `AND`, `T` for `OR`) and the NIL-over-U priority rule
+//! (SPEC §4.5.2) can be expressed uniformly.
+
+use crate::types::Value;
+
+/// An operand of a logic word, classified into the logical truth domain
+/// {True, False, Unknown} plus the operational `Nil` category.
+///
+/// `Unknown` is the logical U (SPEC §7.5); `Nil` is an operational
+/// absence (a reasoned Bubble/NIL, SPEC §4.5) that is *not* U. A
+/// non-NIL, non-U operand is collapsed to `True`/`False` by its
+/// truthiness, which is how a vector/scalar operand participates when
+/// the *other* operand forces the scalar K3 path.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Ternary {
+    True,
+    False,
+    Unknown,
+    Nil,
+}
+
+impl Ternary {
+    /// Classify a value for K3 combination. U is detected via the
+    /// canonical [`Value::is_unknown`] predicate (never by matching the
+    /// underlying NIL representation) so U is always separated from an
+    /// operational NIL.
+    pub(crate) fn classify(value: &Value) -> Ternary {
+        if value.is_unknown() {
+            Ternary::Unknown
+        } else if value.is_nil() {
+            Ternary::Nil
+        } else if value.is_truthy() {
+            Ternary::True
+        } else {
+            Ternary::False
+        }
+    }
+
+    /// Materialize the combination result as a stack value: T/F become
+    /// `TruthValue`-role booleans, U becomes [`Value::unknown`], and an
+    /// operational NIL becomes a plain NIL (matching the historical
+    /// reasonless NIL the logic words produced for NIL combinations).
+    pub(crate) fn into_value(self) -> Value {
+        match self {
+            Ternary::True => truth_bool(true),
+            Ternary::False => truth_bool(false),
+            Ternary::Unknown => Value::unknown(),
+            Ternary::Nil => Value::nil(),
+        }
+    }
+}
+
+/// A definite `true`/`false` carrying the `TruthValue` interpretation
+/// role so it displays as `TRUE`/`FALSE` and serializes through the
+/// `truthValue` axis.
+fn truth_bool(b: bool) -> Value {
+    let mut v = Value::from_bool(b);
+    v.hint = crate::types::Interpretation::TruthValue;
+    v
+}
+
+/// K3 `AND`: `F` absorbs (even over U and NIL); otherwise NIL takes
+/// priority over U (SPEC §4.5.2); otherwise U propagates; else T.
+pub(crate) fn and(a: Ternary, b: Ternary) -> Ternary {
+    if a == Ternary::False || b == Ternary::False {
+        Ternary::False
+    } else if a == Ternary::Nil || b == Ternary::Nil {
+        Ternary::Nil
+    } else if a == Ternary::Unknown || b == Ternary::Unknown {
+        Ternary::Unknown
+    } else {
+        Ternary::True
+    }
+}
+
+/// K3 `OR`: `T` absorbs (even over U and NIL); otherwise NIL takes
+/// priority over U (SPEC §4.5.2); otherwise U propagates; else F.
+pub(crate) fn or(a: Ternary, b: Ternary) -> Ternary {
+    if a == Ternary::True || b == Ternary::True {
+        Ternary::True
+    } else if a == Ternary::Nil || b == Ternary::Nil {
+        Ternary::Nil
+    } else if a == Ternary::Unknown || b == Ternary::Unknown {
+        Ternary::Unknown
+    } else {
+        Ternary::False
+    }
+}
+
+/// K3 `NOT`: `¬T=F`, `¬F=T`, `¬U=U`; NIL passes through as NIL.
+pub(crate) fn not(a: Ternary) -> Ternary {
+    match a {
+        Ternary::True => Ternary::False,
+        Ternary::False => Ternary::True,
+        Ternary::Unknown => Ternary::Unknown,
+        Ternary::Nil => Ternary::Nil,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t() -> Value {
+        let mut v = Value::from_bool(true);
+        v.hint = crate::types::Interpretation::TruthValue;
+        v
+    }
+    fn f() -> Value {
+        let mut v = Value::from_bool(false);
+        v.hint = crate::types::Interpretation::TruthValue;
+        v
+    }
+    fn u() -> Value {
+        Value::unknown()
+    }
+    fn n() -> Value {
+        Value::nil()
+    }
+
+    #[test]
+    fn classify_separates_unknown_from_nil() {
+        assert_eq!(Ternary::classify(&t()), Ternary::True);
+        assert_eq!(Ternary::classify(&f()), Ternary::False);
+        assert_eq!(Ternary::classify(&u()), Ternary::Unknown);
+        assert_eq!(Ternary::classify(&n()), Ternary::Nil);
+    }
+
+    // SPEC §7.5 AND truth table, all nine {T,F,U}^2 cells.
+    #[test]
+    fn k3_and_truth_table() {
+        use Ternary::*;
+        assert_eq!(and(True, True), True);
+        assert_eq!(and(True, Unknown), Unknown);
+        assert_eq!(and(True, False), False);
+        assert_eq!(and(Unknown, True), Unknown);
+        assert_eq!(and(Unknown, Unknown), Unknown);
+        assert_eq!(and(Unknown, False), False);
+        assert_eq!(and(False, True), False);
+        assert_eq!(and(False, Unknown), False);
+        assert_eq!(and(False, False), False);
+    }
+
+    // SPEC §7.5 OR truth table, all nine {T,F,U}^2 cells.
+    #[test]
+    fn k3_or_truth_table() {
+        use Ternary::*;
+        assert_eq!(or(False, False), False);
+        assert_eq!(or(False, Unknown), Unknown);
+        assert_eq!(or(False, True), True);
+        assert_eq!(or(Unknown, False), Unknown);
+        assert_eq!(or(Unknown, Unknown), Unknown);
+        assert_eq!(or(Unknown, True), True);
+        assert_eq!(or(True, False), True);
+        assert_eq!(or(True, Unknown), True);
+        assert_eq!(or(True, True), True);
+    }
+
+    // SPEC §7.5 NOT truth table.
+    #[test]
+    fn k3_not_truth_table() {
+        use Ternary::*;
+        assert_eq!(not(True), False);
+        assert_eq!(not(Unknown), Unknown);
+        assert_eq!(not(False), True);
+    }
+
+    // SPEC §4.5.2: NIL takes priority over U when neither is absorbed.
+    #[test]
+    fn nil_takes_priority_over_unknown() {
+        use Ternary::*;
+        assert_eq!(and(Nil, Unknown), Nil);
+        assert_eq!(and(Unknown, Nil), Nil);
+        assert_eq!(or(Nil, Unknown), Nil);
+        assert_eq!(or(Unknown, Nil), Nil);
+        // but an absorbing definite still wins over NIL
+        assert_eq!(and(False, Nil), False);
+        assert_eq!(or(True, Nil), True);
+    }
+
+    // Existing NIL semantics (SPEC §7.12) are unchanged by the U addition.
+    #[test]
+    fn nil_semantics_preserved() {
+        use Ternary::*;
+        assert_eq!(and(Nil, True), Nil);
+        assert_eq!(and(Nil, False), False);
+        assert_eq!(and(Nil, Nil), Nil);
+        assert_eq!(or(Nil, False), Nil);
+        assert_eq!(or(Nil, True), True);
+        assert_eq!(or(Nil, Nil), Nil);
+        assert_eq!(not(Nil), Nil);
+    }
+
+    #[test]
+    fn into_value_roundtrips_truth_value() {
+        assert!(Ternary::Unknown.into_value().is_unknown());
+        assert!(Ternary::Nil.into_value().is_nil() && !Ternary::Nil.into_value().is_unknown());
+        assert!(Ternary::True.into_value().is_truth_value());
+        assert!(Ternary::False.into_value().is_truth_value());
+    }
+}

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -23,6 +23,7 @@ pub mod interval_ops;
 pub mod io;
 pub mod json;
 pub mod logic;
+pub mod logic_kleene;
 pub mod math_ops;
 pub mod modules;
 pub(crate) mod naming_convention_checker;

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -70,13 +70,20 @@ const CORE_PASSTHROUGH: &[(&str, NilClass)] = &[
     ("MUL", NilClass::BinaryBlanket),
     // MOD/FLOOR/CEIL/ROUND are Projecting/CreatesNil: on ExactScalar (CF)
     // operands the partial-quotient budget can exhaust, yielding an
-    // Undecidable NIL (SPEC §7.4.1) — the same treatment as comparison
-    // words. They are covered by projecting_word_set_matches_registry and
-    // the arithmetic NIL-input probes below.
-    // Comparison words (EQ/NEQ/LT/LTE/GT/GTE) are Projecting/CreatesNil
-    // per SPEC §7.14 (comparison-budget exhaustion can produce Undecidable
-    // NIL). They are covered by the projecting_word_set_matches_registry
-    // and bubble_creation_comparison_nil_input probes below.
+    // Undecidable NIL (SPEC §7.4.1). They are covered by
+    // projecting_word_set_matches_registry and the arithmetic NIL-input
+    // probes below.
+    // Comparison words (EQ/NEQ/LT/LTE/GT/GTE) are Projecting/Passthrough
+    // per SPEC §7.14 (revised): budget exhaustion now yields the logical
+    // truth value Unknown (U), not a reasoned NIL, so they no longer create
+    // NIL — but they still pass NIL operands through (§7.12), which is the
+    // BinaryBlanket behavior verified here.
+    ("EQ", NilClass::BinaryBlanket),
+    ("NEQ", NilClass::BinaryBlanket),
+    ("LT", NilClass::BinaryBlanket),
+    ("LTE", NilClass::BinaryBlanket),
+    ("GT", NilClass::BinaryBlanket),
+    ("GTE", NilClass::BinaryBlanket),
     ("NOT", NilClass::UnaryNil),
     ("AND", NilClass::ThreeValAnd),
     ("OR", NilClass::ThreeValOr),
@@ -188,6 +195,76 @@ async fn three_valued_or() {
     }
 }
 
+// --- Three-valued logic with the logical Unknown (SPEC §7.5, §4.5.2) ------
+
+/// Ajisai source that leaves the logical Unknown (U) on the stack: the
+/// comparison of two equal irrationals exhausts the partial-quotient
+/// budget (SPEC §7.4.1).
+const PRODUCE_U: &str = "'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ";
+
+fn is_unknown(v: &Value) -> bool {
+    v.is_unknown()
+}
+
+#[tokio::test]
+async fn unknown_is_produced_by_undecidable_comparison() {
+    let stack = run_ok(PRODUCE_U).await;
+    assert_eq!(stack.len(), 1);
+    assert!(is_unknown(&stack[0]), "undecidable EQ must yield Unknown");
+    assert_eq!(stack[0].truth_value(), Some("unknown"));
+}
+
+#[tokio::test]
+async fn k3_and_or_not_with_unknown() {
+    // U AND TRUE = U ; U AND FALSE = FALSE (F absorbs).
+    let s = run_ok(&format!("{PRODUCE_U} TRUE AND")).await;
+    assert!(is_unknown(&s[0]), "U AND TRUE must be Unknown");
+    let s = run_ok(&format!("{PRODUCE_U} FALSE AND")).await;
+    assert!(is_false(&s[0]), "U AND FALSE must be FALSE");
+
+    // U OR FALSE = U ; U OR TRUE = TRUE (T absorbs).
+    let s = run_ok(&format!("{PRODUCE_U} FALSE OR")).await;
+    assert!(is_unknown(&s[0]), "U OR FALSE must be Unknown");
+    let s = run_ok(&format!("{PRODUCE_U} TRUE OR")).await;
+    assert!(is_true(&s[0]), "U OR TRUE must be TRUE");
+
+    // NOT U = U.
+    let s = run_ok(&format!("{PRODUCE_U} NOT")).await;
+    assert!(is_unknown(&s[0]), "NOT U must be Unknown");
+}
+
+#[tokio::test]
+async fn nil_takes_priority_over_unknown_in_logic() {
+    // SPEC §4.5.2: when NIL and U meet with no absorbing definite, NIL wins
+    // (it carries a diagnostic reason that must be preserved). The result is
+    // an operational NIL, not U.
+    let s = run_ok(&format!("{PRODUCE_U} NIL AND")).await;
+    assert!(
+        is_nil(&s[0]) && !is_unknown(&s[0]),
+        "U AND NIL must be NIL, not Unknown"
+    );
+    let s = run_ok(&format!("{PRODUCE_U} NIL OR")).await;
+    assert!(
+        is_nil(&s[0]) && !is_unknown(&s[0]),
+        "U OR NIL must be NIL, not Unknown"
+    );
+
+    // But an absorbing definite still decides over both.
+    let s = run_ok(&format!("{PRODUCE_U} FALSE AND")).await;
+    assert!(
+        is_false(&s[0]),
+        "U AND FALSE must be FALSE even though U is present"
+    );
+}
+
+#[tokio::test]
+async fn unknown_passes_through_pipeline_distinct_from_nil() {
+    // U flowing through a logic pipeline stays U (not collapsed to NIL) until
+    // an absorbing element or a real NIL intervenes.
+    let s = run_ok(&format!("{PRODUCE_U} NOT NOT")).await;
+    assert!(is_unknown(&s[0]), "NOT NOT U must remain Unknown");
+}
+
 // --- Bubble creation: Projecting / CreatesNil words (SPEC §11.2) ----------
 
 /// Projecting words: a well-formed domain miss yields Bubble/NIL with a
@@ -197,16 +274,10 @@ const PROJECTING_WORDS: &[&str] = &[
     "CEIL",
     "CHR",
     "DIV",
-    "EQ",
     "FLOOR",
     "GET",
-    "GT",
-    "GTE",
     "INDEX-OF",
-    "LT",
-    "LTE",
     "MOD",
-    "NEQ",
     "NUM",
     "PARSE-ISO",
     "POW",
@@ -284,8 +355,10 @@ async fn bubble_creation_well_formed_domain_miss() {
 
 #[tokio::test]
 async fn bubble_creation_comparison_nil_input() {
-    // Comparison words are Projecting/CreatesNil (SPEC §7.14). A NIL operand
-    // propagates as NIL output via the Bubble Rule (SPEC §4.5.1, §11.2).
+    // Comparison words are Projecting/Passthrough (SPEC §7.14, revised). A
+    // NIL operand propagates as NIL output via the passthrough rule
+    // (SPEC §4.5.1, §7.12). (Budget exhaustion instead yields Unknown, not
+    // a NIL — covered by the comparison Unknown tests.)
     for name in &["EQ", "NEQ", "LT", "LTE", "GT", "GTE"] {
         for code in [
             format!("NIL 1 {name}"),

--- a/rust/src/semantic/capability.rs
+++ b/rust/src/semantic/capability.rs
@@ -14,4 +14,7 @@ pub enum Capability {
     ModuleOwned,
     CoreOwned,
     AiExplainable,
+    /// The value is a three-valued truth value (true / false / unknown,
+    /// SPEC §7.5). Signals consumers to read the `truthValue` axis.
+    TruthValued,
 }

--- a/rust/src/semantic/protocol.rs
+++ b/rust/src/semantic/protocol.rs
@@ -47,6 +47,7 @@ impl Capability {
             Capability::ModuleOwned => "moduleOwned",
             Capability::CoreOwned => "coreOwned",
             Capability::AiExplainable => "aiExplainable",
+            Capability::TruthValued => "truthValued",
         }
     }
 }

--- a/rust/src/semantic/protocol_string_tests.rs
+++ b/rust/src/semantic/protocol_string_tests.rs
@@ -57,6 +57,48 @@ fn comparison_budget_undecidable_protocol_strings() {
 }
 
 #[test]
+fn logically_unknown_protocol_strings() {
+    // SPEC §7.5 / §2.3: the logical Unknown (U) carries the
+    // `logicallyUnknown` reason internally and the `truthValued`
+    // capability; it is observed through the `truthValue` axis as
+    // `unknown`.
+    assert_eq!(
+        NilReason::LogicallyUnknown.as_protocol_str(),
+        "logicallyUnknown"
+    );
+    assert_eq!(Capability::TruthValued.as_protocol_str(), "truthValued");
+}
+
+#[test]
+fn unknown_value_exposes_truth_value_axis_and_capability() {
+    use crate::types::Value;
+    let u = Value::unknown();
+    assert!(u.is_unknown());
+    assert_eq!(u.truth_value(), Some("unknown"));
+    assert!(u.has_capability(Capability::TruthValued));
+    // The internal NIL representation carries the LogicallyUnknown reason,
+    // but consumers must read the truthValue axis, not this reason.
+    let absence = u.absence_metadata().expect("U carries absence metadata");
+    assert_eq!(absence.reason, Some(NilReason::LogicallyUnknown));
+    assert_eq!(absence.origin, AbsenceOrigin::ComparisonBudget);
+}
+
+#[test]
+fn definite_truth_values_expose_truth_value_axis() {
+    use crate::types::{Interpretation, Value};
+    let mut t = Value::from_bool(true);
+    t.hint = Interpretation::TruthValue;
+    let mut f = Value::from_bool(false);
+    f.hint = Interpretation::TruthValue;
+    assert_eq!(t.truth_value(), Some("true"));
+    assert_eq!(f.truth_value(), Some("false"));
+    assert!(t.has_capability(Capability::TruthValued));
+    // A plain number is not truth-valued.
+    assert_eq!(Value::from_int(1).truth_value(), None);
+    assert!(!Value::from_int(1).has_capability(Capability::TruthValued));
+}
+
+#[test]
 fn nil_with_reason_undecidable_routes_to_comparison_budget_origin() {
     // `nil_with_reason` is the runtime's primary entry point for
     // building reasoned NIL values. Verify the §7.4.1 reason/origin

--- a/rust/src/types/arena.rs
+++ b/rust/src/types/arena.rs
@@ -283,6 +283,12 @@ pub fn json_to_arena_node(arena: &mut ValueArena, json: JsonValue) -> Result<Nod
 
 pub fn arena_node_to_json(arena: &ValueArena, root: NodeId) -> JsonValue {
     match arena.kind(root) {
+        // The logical Unknown (U, SPEC §7.5) is a TruthValue-role NIL node;
+        // it serializes to the string `"unknown"` (display-only surface,
+        // SPEC §12.2) rather than JSON null.
+        NodeKind::Nil if arena.hint(root) == Interpretation::TruthValue => {
+            JsonValue::String("unknown".to_string())
+        }
         NodeKind::Nil => JsonValue::Null,
         NodeKind::Scalar(frac) => {
             if arena.hint(root) == Interpretation::TruthValue {

--- a/rust/src/types/display.rs
+++ b/rust/src/types/display.rs
@@ -11,6 +11,12 @@ impl fmt::Display for Value {
 }
 
 pub fn format_with_hint(value: &Value, hint: Interpretation) -> String {
+    // The logical Unknown (U, SPEC §7.5) always renders as `UNKNOWN`,
+    // regardless of the effective hint, so it is never shown as `NIL`.
+    // Display-only and non-canonical (SPEC §12.2).
+    if value.is_unknown() {
+        return "UNKNOWN".to_string();
+    }
     match hint {
         Interpretation::Nil => {
             if matches!(value.data, ValueData::Nil) {
@@ -26,7 +32,7 @@ pub fn format_with_hint(value: &Value, hint: Interpretation) -> String {
         Interpretation::RawNumber => format_value_recursive(&value.data, 0),
         Interpretation::Interval => format_as_interval(value),
         Interpretation::Text => format_as_string(&value.data),
-        Interpretation::TruthValue => format_as_boolean(&value.data),
+        Interpretation::TruthValue => format_as_boolean(value),
         Interpretation::Timestamp => format_as_datetime(&value.data),
         Interpretation::ContinuedFraction => format_as_continued_fraction(value),
     }
@@ -348,8 +354,51 @@ fn format_as_string(data: &ValueData) -> String {
     }
 }
 
-fn format_as_boolean(data: &ValueData) -> String {
-    match data {
+/// Boolean label for a single element of a truth-valued vector/tensor.
+/// The logical Unknown (U, SPEC §7.5) renders as `UNKNOWN`; an
+/// operational NIL stays `NIL`.
+fn boolean_element_label(child: &Value) -> &'static str {
+    if child.is_unknown() {
+        return "UNKNOWN";
+    }
+    match &child.data {
+        ValueData::Nil => "NIL",
+        ValueData::Scalar(f) => {
+            if f.is_nil() {
+                "NIL"
+            } else if f.is_zero() {
+                "FALSE"
+            } else {
+                "TRUE"
+            }
+        }
+        ValueData::Vector(v) | ValueData::Record { pairs: v, .. } => {
+            if v.is_empty() {
+                "FALSE"
+            } else {
+                "TRUE"
+            }
+        }
+        ValueData::Tensor { data, .. } => {
+            if data.is_empty() {
+                "FALSE"
+            } else {
+                "TRUE"
+            }
+        }
+        ValueData::ExactScalar(_) => "TRUE",
+        ValueData::CodeBlock(_) => "TRUE",
+        ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => "TRUE",
+    }
+}
+
+fn format_as_boolean(value: &Value) -> String {
+    // The logical Unknown is handled by `format_with_hint`, but guard
+    // here too so the function is correct in isolation.
+    if value.is_unknown() {
+        return "UNKNOWN".to_string();
+    }
+    match &value.data {
         ValueData::Nil => "NIL".to_string(),
         // ExactScalar values are always non-zero positive irrationals → TRUE
         ValueData::ExactScalar(_) => "TRUE".to_string(),
@@ -367,43 +416,7 @@ fn format_as_boolean(data: &ValueData) -> String {
                 return "FALSE".to_string();
             }
 
-            let inner: Vec<&str> = v
-                .iter()
-                .map(|child| match &child.data {
-                    ValueData::Nil => "NIL",
-                    ValueData::Scalar(f) => {
-                        if f.is_nil() {
-                            "NIL"
-                        } else if f.is_zero() {
-                            "FALSE"
-                        } else {
-                            "TRUE"
-                        }
-                    }
-                    ValueData::Vector(_) | ValueData::Record { .. } => {
-                        let cv = match &child.data {
-                            ValueData::Vector(v) => v,
-                            ValueData::Record { pairs, .. } => pairs,
-                            _ => unreachable!(),
-                        };
-                        if cv.is_empty() {
-                            "FALSE"
-                        } else {
-                            "TRUE"
-                        }
-                    }
-                    ValueData::Tensor { data, .. } => {
-                        if data.is_empty() {
-                            "FALSE"
-                        } else {
-                            "TRUE"
-                        }
-                    }
-                    ValueData::ExactScalar(_) => "TRUE",
-                    ValueData::CodeBlock(_) => "TRUE",
-                    ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => "TRUE",
-                })
-                .collect();
+            let inner: Vec<&str> = v.iter().map(boolean_element_label).collect();
             format!("{{ {} }}", inner.join(" "))
         }
         ValueData::Tensor { data, .. } => {

--- a/rust/src/types/value_operations.rs
+++ b/rust/src/types/value_operations.rs
@@ -20,6 +20,7 @@ fn absence_origin_for_reason(reason: &NilReason) -> AbsenceOrigin {
         NilReason::UnknownWord => AbsenceOrigin::UnknownWord,
         NilReason::ExecutionFailure => AbsenceOrigin::ExecutionFailure,
         NilReason::Undecidable => AbsenceOrigin::ComparisonBudget,
+        NilReason::LogicallyUnknown => AbsenceOrigin::ComparisonBudget,
         NilReason::NoData => AbsenceOrigin::HostEnvironment,
         NilReason::PortDisconnected => AbsenceOrigin::HostEnvironment,
         NilReason::SafeCaught(_) => AbsenceOrigin::SafeProjection,
@@ -59,6 +60,80 @@ impl Value {
             origin,
             Recoverability::Unknown,
         ))
+    }
+
+    /// Construct the logical truth value `Unknown` (U), SPEC §7.5 / §7.4.1.
+    ///
+    /// U is represented as a NIL node carrying `NilReason::LogicallyUnknown`
+    /// and the `Interpretation::TruthValue` role. This reuses the existing
+    /// NIL plumbing (passthrough, diagnosis, arena) while remaining a
+    /// *logical* value rather than an operational absence. Never branch on
+    /// the underlying `ValueData::Nil` to detect U — use [`is_unknown`].
+    #[inline]
+    pub fn unknown() -> Self {
+        Self {
+            data: ValueData::Nil,
+            hint: Interpretation::TruthValue,
+            absence: Some(AbsenceMetadata::with_reason(
+                NilReason::LogicallyUnknown,
+                AbsenceOrigin::ComparisonBudget,
+                Recoverability::Unknown,
+            )),
+        }
+    }
+
+    /// Whether this value is the logical truth value `Unknown` (U).
+    ///
+    /// This is the single canonical predicate for U. It keys off the
+    /// `LogicallyUnknown` reason, which is attached exclusively to U, so it
+    /// is robust regardless of how the `TruthValue` hint propagates. All
+    /// call sites must use this instead of matching `ValueData::Nil`.
+    #[inline]
+    pub fn is_unknown(&self) -> bool {
+        matches!(self.nil_reason(), Some(NilReason::LogicallyUnknown))
+    }
+
+    /// Whether this value carries the `TruthValue` interpretation role
+    /// (true, false, or unknown). Used at observation boundaries to attach
+    /// the `truthValue` axis and the `truthValued` capability.
+    #[inline]
+    pub fn is_truth_value(&self) -> bool {
+        self.hint == Interpretation::TruthValue
+    }
+
+    /// The observable `truthValue` axis (SPEC §2.3) under a given effective
+    /// interpretation role: `Some("true")`, `Some("false")`, or
+    /// `Some("unknown")` for truth-valued values, and `None` otherwise.
+    ///
+    /// The role is taken as a parameter because a definite boolean produced
+    /// by a comparison/logic word carries its `TruthValue` role in the
+    /// semantic plane (SPEC §12.2), not on the value's own `hint`. The
+    /// logical Unknown (U) is always `unknown` regardless of the role, since
+    /// it is detected from its reason. This is the single canonical mapping
+    /// from a value to its three-valued logical surface; external consumers
+    /// must read this axis rather than the internal NIL representation or
+    /// display text.
+    pub fn truth_value_for_role(&self, effective: Interpretation) -> Option<&'static str> {
+        if self.is_unknown() {
+            return Some("unknown");
+        }
+        if effective != Interpretation::TruthValue {
+            return None;
+        }
+        match &self.data {
+            ValueData::Nil => Some("unknown"),
+            ValueData::Scalar(f) => Some(if f.is_zero() { "false" } else { "true" }),
+            ValueData::ExactScalar(_) => Some("true"),
+            _ => Some(if self.is_truthy() { "true" } else { "false" }),
+        }
+    }
+
+    /// The `truthValue` axis using the value's own `hint` as the role.
+    /// Convenience for values that carry the `TruthValue` role on the value
+    /// itself (notably U); the boundary uses
+    /// [`truth_value_for_role`] with the effective role.
+    pub fn truth_value(&self) -> Option<&'static str> {
+        self.truth_value_for_role(self.hint)
     }
 
     #[inline]
@@ -320,6 +395,13 @@ impl Value {
             }
             ValueData::CodeBlock(_) => capabilities.push(Capability::Callable),
             ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => {}
+        }
+        // Truth-valued values (true / false / unknown) advertise the
+        // `truthValued` capability so consumers know to read the
+        // `truthValue` axis (SPEC §2.3, §12.2). This covers definite
+        // booleans (Scalar + TruthValue role) and the logical U.
+        if self.is_truth_value() {
+            capabilities.push(Capability::TruthValued);
         }
         capabilities
     }

--- a/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
@@ -213,7 +213,7 @@ fn absence_to_protocol_js(absence: &crate::semantic::AbsenceMetadata) -> JsValue
     obj.into()
 }
 
-fn value_semantics_to_js(value: &Value) -> JsValue {
+fn value_semantics_to_js(value: &Value, effective: Interpretation) -> JsValue {
     let obj = js_sys::Object::new();
     set_prop(
         &obj,
@@ -221,9 +221,30 @@ fn value_semantics_to_js(value: &Value) -> JsValue {
         &value.semantic_kind().as_protocol_str().into(),
     );
     set_prop(&obj, "shape", &value.shape_kind().as_protocol_str().into());
+    // The `truthValue` axis (SPEC §2.3) is the only observable surface for
+    // the three-valued logic: `true` / `false` / `unknown`. It is derived
+    // from the *effective* interpretation role, because a definite boolean
+    // carries the `TruthValue` role in the semantic plane rather than on the
+    // value's own hint (SPEC §12.2). Present only on truth-valued values.
+    let truth = value.truth_value_for_role(effective);
+    if let Some(truth) = truth {
+        set_prop(&obj, "truthValue", &truth.into());
+    }
     let capabilities = js_sys::Array::new();
+    let mut has_truth_valued = false;
     for capability in value.capabilities() {
+        if capability == crate::semantic::Capability::TruthValued {
+            has_truth_valued = true;
+        }
         capabilities.push(&JsValue::from_str(capability.as_protocol_str()));
+    }
+    // A value rendered under the TruthValue role advertises `truthValued`
+    // even when the role lives in the semantic plane (comparison/logic
+    // booleans), not on the value's own hint.
+    if truth.is_some() && !has_truth_valued {
+        capabilities.push(&JsValue::from_str(
+            crate::semantic::Capability::TruthValued.as_protocol_str(),
+        ));
     }
     set_prop(&obj, "capabilities", &capabilities.into());
     set_prop(&obj, "origin", &value.origin().as_protocol_str().into());
@@ -394,6 +415,18 @@ pub(crate) fn value_to_protocol(
             semantics: None,
         };
     }
+    // The logical Unknown (U, SPEC §7.5) is observed through the
+    // `truthValue` axis as `unknown`, never as a NIL. Detected via the
+    // canonical `is_unknown()` predicate (SPEC §2.3 firewall: the internal
+    // NIL representation is not observable).
+    if value.is_unknown() {
+        return ProtocolNode {
+            type_str: "truthValue",
+            value: ProtocolValue::Text("unknown".to_string()),
+            display_hint: Interpretation::TruthValue,
+            semantics: Some(value.clone()),
+        };
+    }
     let (type_str, protocol_value) = match &value.data {
         ValueData::Nil => ("nil", ProtocolValue::Null),
         ValueData::ExactScalar(er) => {
@@ -463,7 +496,11 @@ fn protocol_to_js(node: &ProtocolNode) -> JsValue {
         &interpretation_protocol_str(node.display_hint).into(),
     );
     if let Some(source) = &node.semantics {
-        set_prop(&obj, "semantics", &value_semantics_to_js(source));
+        set_prop(
+            &obj,
+            "semantics",
+            &value_semantics_to_js(source, node.display_hint),
+        );
     }
     set_prop(&obj, "type", &node.type_str.into());
     match &node.value {
@@ -532,10 +569,15 @@ fn tensor_data_to_js_array(
                 js_sys::Reflect::set(&elem, &"displayHint".into(), &"rawNumber".into()).unwrap();
             }
             let element_value = Value::from_fraction(f.clone());
+            let leaf_role = if leaves_are_bool {
+                Interpretation::TruthValue
+            } else {
+                Interpretation::RawNumber
+            };
             js_sys::Reflect::set(
                 &elem,
                 &"semantics".into(),
-                &value_semantics_to_js(&element_value),
+                &value_semantics_to_js(&element_value, leaf_role),
             )
             .unwrap();
             arr.push(&elem);
@@ -953,6 +995,57 @@ mod protocol_mcdc_tests {
             ProtocolValue::Children(kids) => kids,
             other => panic!("expected Children, got {:?}", other),
         }
+    }
+
+    // --- logical Unknown (U) serialization (SPEC §7.5, §2.3) ---
+
+    #[test]
+    fn unknown_serializes_as_truth_value_unknown() {
+        let node = value_to_protocol(&Value::unknown(), None);
+        assert_eq!(node.type_str, "truthValue");
+        assert_eq!(node.value, ProtocolValue::Text("unknown".to_string()));
+        assert_eq!(node.display_hint, Interpretation::TruthValue);
+    }
+
+    #[test]
+    fn unknown_serializes_as_truth_value_even_under_external_hint() {
+        // Detection is reason-based, so U is observed as `unknown` regardless
+        // of any external hint override (SPEC §2.3 firewall).
+        let node = value_to_protocol(&Value::unknown(), Some(Interpretation::Nil));
+        assert_eq!(node.type_str, "truthValue");
+        assert_eq!(node.value, ProtocolValue::Text("unknown".to_string()));
+    }
+
+    #[test]
+    fn plain_nil_is_still_nil_not_unknown() {
+        let node = value_to_protocol(&Value::nil(), None);
+        assert_eq!(node.type_str, "nil");
+        assert_eq!(node.value, ProtocolValue::Null);
+    }
+
+    #[test]
+    fn truth_value_axis_uses_effective_role_for_definite_booleans() {
+        // A comparison/logic boolean carries the TruthValue role in the
+        // semantic plane (here passed as the external hint), not on the
+        // value's own RawNumber hint. The truthValue axis must still resolve.
+        assert_eq!(
+            scalar(1).truth_value_for_role(Interpretation::TruthValue),
+            Some("true")
+        );
+        assert_eq!(
+            scalar(0).truth_value_for_role(Interpretation::TruthValue),
+            Some("false")
+        );
+        // Without the TruthValue role it is a plain number, not a truth value.
+        assert_eq!(
+            scalar(1).truth_value_for_role(Interpretation::RawNumber),
+            None
+        );
+        // U is `unknown` regardless of the role.
+        assert_eq!(
+            Value::unknown().truth_value_for_role(Interpretation::RawNumber),
+            Some("unknown")
+        );
     }
 
     // --- scalar interpretation arms (MC/DC on the 4-way match) ---

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -272,6 +272,10 @@ const formatValue = (item: Value, depth: number): string => {
             return String(item.value);
         case 'boolean':
             return item.value ? 'TRUE' : 'FALSE';
+        case 'truthValue':
+            // Three-valued logic Unknown (SPEC §7.5). The wire value is the
+            // protocol string 'unknown'; render it as UNKNOWN (display-only).
+            return item.value === 'unknown' ? 'UNKNOWN' : String(item.value).toUpperCase();
         case 'vector':
             return formatVector(item.value, depth);
         case 'nil':

--- a/src/wasm-interpreter-types.ts
+++ b/src/wasm-interpreter-types.ts
@@ -91,6 +91,13 @@ export interface ProtocolAbsence {
 export interface ProtocolValueSemantics {
     semanticKind: string;
     shape: string;
+    /**
+     * Three-valued logic surface (SPEC §2.3, §7.5). Present only on
+     * truth-valued values; `'true'` / `'false'` / `'unknown'`. This is the
+     * only observable surface for the third value — do not infer it from
+     * `semanticKind` or the internal NIL representation.
+     */
+    truthValue?: 'true' | 'false' | 'unknown';
     capabilities: string[];
     origin: string;
     absence?: ProtocolAbsence;


### PR DESCRIPTION
## Phase 1 — Rust core + WASM/TS implementation of `Unknown` (U)

Implements the semantics settled in **Phase 0** (spec PR #993, merged). Introduces the logical truth value **`Unknown` (U)** as a first-class state of the `TruthValue` role, so the epistemic undecidability of continued-fraction (CF) comparison is modeled as a *logical* value rather than an *operational* NIL.

### Behavior at a glance
| Ajisai | before | after |
|---|---|---|
| `2 SQRT 2 SQRT SUB 0 EQ` (equal irrationals) | `undecidable` NIL | **`UNKNOWN`** (`truthValue: "unknown"`) |
| `2 SQRT 3 SQRT EQ` (distinct irrationals) | `FALSE` | `FALSE` (decides at finite prefix) |
| `1 1 EQ` (finite CFs) | `TRUE` | `TRUE` |
| `U TRUE AND` / `U FALSE AND` | — | `U` / `FALSE` (K3) |
| `U NIL AND` | — | `NIL` (NIL-over-U priority, §4.5.2) |

### Rust core
- **`error.rs`** — `NilReason::LogicallyUnknown` (+ `logicallyUnknown` protocol string): the reason that tags U internally.
- **`value_operations.rs`** — `Value::unknown()`, `is_unknown()` (the single canonical, reason-based U predicate — no call site branches on `ValueData::Nil` to detect U), `is_truth_value()`, and `truth_value_for_role()` / `truth_value()` for the observable `truthValue` axis. Adds the `truthValued` capability.
- **`comparison.rs`** — budget exhaustion now pushes U (`push_unknown`) instead of an `undecidable` NIL, across StackTop, STAK, and the interval path.
- **`logic_kleene.rs` (new)** — the single canonical strong-Kleene (K3) truth table for `AND`/`OR`/`NOT` over {T,F,U}, with the **NIL-over-U priority** rule (§4.5.2). `logic.rs` routes both StackTop and STAK through it.
- **`display.rs` / `wasm_value_conversion.rs` / `arena.rs`** — render/serialize U as `UNKNOWN` / `truthValue: "unknown"`. The `truthValue` axis derives from the *effective* role so definite comparison/logic booleans expose it too. All detection via `is_unknown()` (SPEC §2.3 firewall — internal NIL representation stays unobservable).
- **`coreword_registry` / builtin specs** — comparison words reclassified `Projecting`/`Passthrough` (no longer `CreatesNil` for the undecidable case).

### TS shell
- **`wasm-interpreter-types.ts`** — optional `truthValue` axis on `ProtocolValueSemantics`.
- **`output-display-renderer.ts`** — render the `truthValue` node type as `UNKNOWN`.

### Tests
- K3 MC/DC truth tables (all nine AND/OR cells, NOT, NIL/U interaction).
- Comparison decidability: finite CFs decide; equal irrationals → U; distinct irrationals decide at a finite prefix.
- NIL-over-U priority and U passthrough through logic pipelines.
- Protocol strings (`logicallyUnknown`, `truthValued`, `unknown`) and WASM serialization of U.
- Existing Bubble/NIL semantics regression-green.

### Verification
- `cargo test --all-targets`: **1230 passed**.
- `cargo check --target wasm32-unknown-unknown`: clean.
- `npm run check` (tsc), `npm run lint` (eslint), `npm test` (vitest 29): clean.
- No sweeping reformatting — the diff is limited to the 18 feature files + the new module.

### Notes on scope
- Existing Bubble/NIL rules (division by zero, out-of-range `GET`, parse failure) are unchanged. `NilReason::Undecidable` is retained for the `DIV`/rounding operational-NIL path (not the comparison path).
- Phase 2 (publish CF `agreed_prefix` / `COMPARE-WITHIN`) is intentionally deferred to a later PR.

https://claude.ai/code/session_011s5Xe5cybmSceEinTJz1ei

---
_Generated by [Claude Code](https://claude.ai/code/session_011s5Xe5cybmSceEinTJz1ei)_