### PR TITLE
feat(Phase 3): propagate the logical Unknown (U) through MIN/MAX/SORT…

### DIFF
--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -1551,3 +1551,153 @@ mod continued_fraction_role_tests {
         );
     }
 }
+
+/// SPEC §7.4.3 — propagation of the logical `Unknown` (U) through the
+/// comparison-dependent words `MIN`, `MAX`, `SORT`, and `COND`. The
+/// U-producing idiom is `2 SQRT 2 SQRT SUB 0 <cmp>`: √2−√2 is a Gosper node
+/// the budget cannot distinguish from 0, so any comparison against 0 yields U.
+#[cfg(test)]
+mod u_propagation_tests {
+    use crate::interpreter::Interpreter;
+
+    async fn run(source: &str) -> Interpreter {
+        let mut interp = Interpreter::new();
+        interp.execute(source).await.unwrap();
+        interp
+    }
+
+    fn top(interp: &Interpreter) -> &crate::types::Value {
+        interp.get_stack().last().expect("non-empty stack")
+    }
+
+    // ── MIN / MAX ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn min_selects_smaller_when_decided() {
+        let interp = run("'math' IMPORT 3 5 MIN").await;
+        assert_eq!(format!("{}", top(&interp)), "3/1");
+    }
+
+    #[tokio::test]
+    async fn max_selects_larger_when_decided() {
+        let interp = run("'math' IMPORT 3 5 MAX").await;
+        assert_eq!(format!("{}", top(&interp)), "5/1");
+    }
+
+    #[tokio::test]
+    async fn min_on_undecidable_yields_unknown_with_prefix() {
+        let interp = run("'math' IMPORT 2 SQRT 2 SQRT SUB 0 MIN").await;
+        let v = top(&interp);
+        assert!(
+            v.is_unknown(),
+            "MIN of an undecidable pair must be U, got {v}"
+        );
+        assert_eq!(v.truth_value(), Some("unknown"));
+        let absence = v.absence_metadata().expect("U carries absence");
+        let diag = absence.diagnosis.as_ref().expect("U carries a diagnosis");
+        assert!(
+            diag.agreed_prefix.is_some(),
+            "MIN U must carry agreedPrefix"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_on_undecidable_yields_unknown() {
+        let interp = run("'math' IMPORT 2 SQRT 2 SQRT SUB 0 MAX").await;
+        assert!(top(&interp).is_unknown());
+    }
+
+    #[tokio::test]
+    async fn min_with_nil_operand_passes_nil_through() {
+        let interp = run("'math' IMPORT NIL 3 MIN").await;
+        assert!(top(&interp).is_nil() && !top(&interp).is_unknown());
+    }
+
+    // ── SORT ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn sort_orders_rationals_ascending() {
+        let interp = run("'algo' IMPORT [ 3 1 2 ] SORT").await;
+        assert_eq!(format!("{}", top(&interp)), "[ 1/1 2/1 3/1 ]");
+    }
+
+    #[tokio::test]
+    async fn sort_stack_mode_orders_ascending() {
+        let interp = run("'algo' IMPORT 3 1 2 .. SORT").await;
+        let s: Vec<String> = interp
+            .get_stack()
+            .iter()
+            .map(|v| format!("{}", v))
+            .collect();
+        assert_eq!(s, vec!["1/1", "2/1", "3/1"]);
+    }
+
+    #[tokio::test]
+    async fn sort_with_undecidable_pair_yields_unknown_not_partial() {
+        // Build a runtime vector containing √2−√2 and 0 via stack-mode SORT;
+        // the undecidable pair makes the whole order unestablished ⇒ U.
+        let interp = run("'algo' IMPORT 'math' IMPORT 2 SQRT 2 SQRT SUB 0 .. SORT").await;
+        let v = top(&interp);
+        assert!(
+            v.is_unknown(),
+            "SORT with an undecidable pair must be U, got {v}"
+        );
+        let absence = v.absence_metadata().expect("U carries absence");
+        let diag = absence.diagnosis.as_ref().expect("U carries a diagnosis");
+        assert!(
+            diag.agreed_prefix.is_some(),
+            "SORT U must carry agreedPrefix"
+        );
+    }
+
+    // ── COND ─────────────────────────────────────────────────────────────
+    //
+    // Syntax: `[ value ] { guard $ body } { IDLE $ body } COND`. The guard is
+    // evaluated with `value` on the stack; `[ 0 ] =` tests `value == 0`. The
+    // value `2 SQRT 2 SQRT SUB` (≈ √2−√2) compares Unknown against 0.
+
+    #[tokio::test]
+    async fn cond_fires_clause_with_definite_true_guard() {
+        let interp = run("[ 0 ]\n{ [ 0 ] = $ 'zero' }\n{ IDLE $ 'other' }\nCOND").await;
+        assert_eq!(format!("{}", top(&interp)), "'zero'");
+    }
+
+    #[tokio::test]
+    async fn cond_u_guard_does_not_fire_falls_through_to_next_clause() {
+        // First clause guard reduces to U (√2−√2 == 0 is Unknown — and √2−√2
+        // is in fact Unknown against every rational); it must NOT fire. The
+        // second guard `TRUE` is value-independent and definitely fires.
+        let interp = run(
+            "'math' IMPORT 2 SQRT 2 SQRT SUB\n{ [ 0 ] = $ 'fired-on-U' }\n{ TRUE $ 'second' }\n{ IDLE $ 'else' }\nCOND",
+        )
+        .await;
+        assert_eq!(
+            format!("{}", top(&interp)),
+            "'second'",
+            "U guard must fall through to the next clause, not fire or error"
+        );
+    }
+
+    #[tokio::test]
+    async fn cond_u_guard_then_else_clause() {
+        // The only non-else guard is U ⇒ does not fire ⇒ IDLE/else runs.
+        let interp = run(
+            "'math' IMPORT 2 SQRT 2 SQRT SUB\n{ [ 0 ] = $ 'fired-on-U' }\n{ IDLE $ 'else' }\nCOND",
+        )
+        .await;
+        assert_eq!(format!("{}", top(&interp)), "'else'");
+    }
+
+    #[tokio::test]
+    async fn cond_u_guard_with_no_match_is_cond_exhausted() {
+        // U guard does not fire and there is no else clause ⇒ CondExhausted.
+        let mut interp = Interpreter::new();
+        let result = interp
+            .execute("'math' IMPORT 2 SQRT 2 SQRT SUB\n{ [ 0 ] = $ 'fired-on-U' }\nCOND")
+            .await;
+        assert!(
+            result.is_err(),
+            "a U-only COND with no else clause must raise CondExhausted"
+        );
+    }
+}

--- a/rust/src/interpreter/comparison.rs
+++ b/rust/src/interpreter/comparison.rs
@@ -105,6 +105,43 @@ fn compare_scalar_pair(a_val: &Value, b_val: &Value, kind: OrderingKind) -> Resu
     })
 }
 
+/// Outcome of a budgeted three-way order comparison shared by the
+/// comparison-dependent words of SPEC §7.4.3 (`MIN`, `MAX`, `SORT`).
+/// `Decided` carries the exact `a` vs `b` ordering. `Undecided` carries the
+/// agreed-prefix length of the budget-exhausted continued-fraction
+/// comparison; the caller projects it to the logical `Unknown` (U) with
+/// `diagnosis.agreedPrefix`.
+pub(crate) enum OrderOutcome {
+    Decided(std::cmp::Ordering),
+    Undecided(usize),
+}
+
+/// Three-way order of two scalar values under the SPEC §7.4.1 comparison
+/// budget. Returns `Err(_)` for structurally non-comparable operands (the
+/// malformed-use path). Both-`Rational` operands take the exact `Fraction`
+/// fast path; any non-`Rational` `ExactReal` routes through the budgeted CF
+/// comparison and may yield `Undecided`.
+
+pub(crate) fn three_way_compare(a_val: &Value, b_val: &Value) -> Result<OrderOutcome> {
+    let a = extract_exact_real_for_comparison(a_val)?;
+    let b = extract_exact_real_for_comparison(b_val)?;
+    Ok(match (a.as_rational(), b.as_rational()) {
+        (Some(af), Some(bf)) => OrderOutcome::Decided(af.cmp(bf)),
+        _ => match a.cmp_with_budget_tracked(&b, DEFAULT_COMPARISON_BUDGET) {
+            CmpOutcome::Decided(o) => OrderOutcome::Decided(o),
+            CmpOutcome::Undecided { agreed_prefix } => OrderOutcome::Undecided(agreed_prefix),
+        },
+    })
+}
+
+/// Push the logical `Unknown` (U) carrying an agreed-prefix diagnosis, for
+/// the comparison-dependent words of SPEC §7.4.3. Mirrors the relations'
+/// own U production: a `TruthValue`-role value observed as
+/// `truthValue = unknown` with `diagnosis.agreedPrefix`.
+pub(crate) fn push_comparison_unknown(interp: &mut Interpreter, agreed_prefix: usize) {
+    push_unknown(interp, Some(agreed_prefix));
+}
+
 /// Extract an `ExactReal` view of a value's scalar content for
 /// comparison. Scalar (`Fraction`-backed) values lift to
 /// `ExactReal::Rational`; singleton Vector / Tensor values also

--- a/rust/src/interpreter/control_cond.rs
+++ b/rust/src/interpreter/control_cond.rs
@@ -152,7 +152,9 @@ fn evaluate_guard_isolated(
     let saved_epoch: EpochSnapshot = interp.current_epoch_snapshot();
 
     interp.stack.push(value.clone());
-    interp.semantic_registry.push_hint(Interpretation::Unassigned);
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::Unassigned);
     interp.operation_target_mode = OperationTargetMode::StackTop;
     interp.consumption_mode = ConsumptionMode::Consume;
     interp.safe_mode = false;
@@ -175,6 +177,13 @@ fn evaluate_guard_isolated(
     let result_value: Value = guard_result_value.ok_or_else(|| {
         AjisaiError::from("COND: guard must return TRUE or FALSE, got empty stack")
     })?;
+    // SPEC §7.4.3: a guard that reduces to the logical `Unknown` (U) — e.g.
+    // an undecidable continued-fraction comparison — is not a definite
+    // `true`, so its clause does not fire. Fall through to the next clause
+    // exactly as for a `false` guard. U is neither an error nor a match.
+    if result_value.is_unknown() {
+        return Ok(false);
+    }
     let unwrapped: &Value = if result_value.as_scalar().is_none() {
         if result_value.len() == 1 {
             result_value.get_child(0).ok_or_else(|| {

--- a/rust/src/interpreter/math_ops.rs
+++ b/rust/src/interpreter/math_ops.rs
@@ -109,12 +109,57 @@ pub(crate) fn op_sign(interp: &mut Interpreter) -> Result<()> {
     })
 }
 
+/// `MIN` / `MAX` select one of two numeric operands by the order relation
+/// (SPEC §7.4.3). They accept the full numeric domain, including lazy
+/// continued-fraction operands, and decide the order through the same
+/// budgeted comparison as the relations. When the comparison decides, the
+/// selected operand is returned unchanged (preserving its exact
+/// representation). When it does not decide within the budget, the result is
+/// the logical `Unknown` (U) carrying `diagnosis.agreedPrefix` — the program
+/// cannot be told which operand is the min/max when their order is unknown.
+/// NIL-passthrough, with NIL taking priority over a U-producing comparison.
+fn apply_selecting<F>(interp: &mut Interpreter, word: &str, pick_left: F) -> Result<()>
+where
+    // Given the order of `a` (left) vs `b` (right), return true to keep `a`.
+    F: Fn(std::cmp::Ordering) -> bool,
+{
+    require_stack_top(interp, word)?;
+    if nil_passthrough_binary(interp) {
+        return Ok(());
+    }
+    let operands = extract_operands(interp, 2)?;
+    match crate::interpreter::comparison::three_way_compare(&operands[0], &operands[1]) {
+        Ok(crate::interpreter::comparison::OrderOutcome::Decided(ord)) => {
+            let chosen = if pick_left(ord) {
+                operands[0].clone()
+            } else {
+                operands[1].clone()
+            };
+            push_result(interp, chosen);
+            interp
+                .semantic_registry
+                .push_hint(Interpretation::RawNumber);
+            Ok(())
+        }
+        Ok(crate::interpreter::comparison::OrderOutcome::Undecided(agreed_prefix)) => {
+            crate::interpreter::comparison::push_comparison_unknown(interp, agreed_prefix);
+            Ok(())
+        }
+        Err(e) => {
+            restore_operands(interp, operands);
+            Err(e)
+        }
+    }
+}
+
 pub(crate) fn op_min(interp: &mut Interpreter) -> Result<()> {
-    apply_binary(interp, "MIN", |a, b| if a.le(&b) { a } else { b })
+    // Keep the left operand when it is less-or-equal to the right.
+    apply_selecting(interp, "MIN", |ord| ord != std::cmp::Ordering::Greater)
 }
 
 pub(crate) fn op_max(interp: &mut Interpreter) -> Result<()> {
-    apply_binary(interp, "MAX", |a, b| if a.ge(&b) { a } else { b })
+    // Keep the left operand when it is greater-or-equal to the right.
+    apply_selecting(interp, "MAX", |ord| ord != std::cmp::Ordering::Less)
 }
 
 fn restore_operands(interp: &mut Interpreter, operands: Vec<Value>) {

--- a/rust/src/interpreter/sort.rs
+++ b/rust/src/interpreter/sort.rs
@@ -1,16 +1,70 @@
 use crate::error::{AjisaiError, Result};
+use crate::interpreter::comparison::{three_way_compare, OrderOutcome};
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
-use crate::types::fraction::Fraction;
 use crate::types::Value;
-
-fn sort_fractions_by_introsort(values: &mut [(usize, Fraction)]) {
-    values.sort_unstable_by(|a, b| a.1.cmp(&b.1));
-}
+use std::cell::RefCell;
 
 fn reorder_values_by_permutation(source: &[Value], perm: &[usize]) -> Vec<Value> {
     perm.iter()
         .map(|&orig_idx| source[orig_idx].clone())
         .collect::<Vec<Value>>()
+}
+
+/// Outcome of attempting to sort a slice of values under the SPEC §7.4.3
+/// budgeted comparison.
+enum SortAttempt {
+    /// Every required comparison decided; `perm` is the ascending permutation
+    /// of the original indices.
+    Ordered(Vec<usize>),
+    /// At least one required comparison was undecidable within the budget; the
+    /// sorted order as a whole is not established (SPEC §7.4.3: a partial order
+    /// is not a sort). Carries the agreed-prefix of the first undecidable pair.
+    Undecided(usize),
+    /// An element was structurally non-comparable (non-numeric) — malformed use
+    /// (SPEC §11.2), distinct from the logical Unknown.
+    Malformed(AjisaiError),
+}
+
+/// Sort the indices `0..items.len()` by the values' ascending order under the
+/// budgeted continued-fraction comparison (SPEC §7.4.1). A single undecidable
+/// pair makes the whole order unestablished — reported as `Undecided` with the
+/// first such pair's agreed-prefix — and `SORT` then yields the logical
+/// `Unknown` rather than a partially-sorted vector. A non-comparable element
+/// is reported as `Malformed`.
+fn try_sort_indices(items: &[Value]) -> SortAttempt {
+    // Captured by the comparator: the first malformed error and the first
+    // undecidable agreed-prefix. When either is set the produced permutation
+    // is discarded, so returning `Equal` from the comparator in those cases is
+    // harmless to correctness.
+    let malformed: RefCell<Option<AjisaiError>> = RefCell::new(None);
+    let undecided: RefCell<Option<usize>> = RefCell::new(None);
+
+    let mut perm: Vec<usize> = (0..items.len()).collect();
+    perm.sort_by(|&i, &j| match three_way_compare(&items[i], &items[j]) {
+        Ok(OrderOutcome::Decided(ord)) => ord,
+        Ok(OrderOutcome::Undecided(prefix)) => {
+            let mut slot = undecided.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(prefix);
+            }
+            std::cmp::Ordering::Equal
+        }
+        Err(e) => {
+            let mut slot = malformed.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(e);
+            }
+            std::cmp::Ordering::Equal
+        }
+    });
+
+    if let Some(e) = malformed.into_inner() {
+        return SortAttempt::Malformed(e);
+    }
+    if let Some(prefix) = undecided.into_inner() {
+        return SortAttempt::Undecided(prefix);
+    }
+    SortAttempt::Ordered(perm)
 }
 
 pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
@@ -49,61 +103,51 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
                 return Ok(());
             }
 
-            let mut indexed_fractions: Vec<(usize, Fraction)> = Vec::with_capacity(children.len());
-            for (i, elem) in children.iter().enumerate() {
-                match elem.as_scalar() {
-                    Some(f) => indexed_fractions.push((i, f.clone())),
-                    None => {
-                        if !is_keep_mode {
-                            interp.stack.push(val);
-                        }
-                        return Err(AjisaiError::from(
-                            "SORT: expected all elements to be numbers, got non-number element",
-                        ));
+            match try_sort_indices(&children) {
+                SortAttempt::Ordered(perm) => {
+                    let sorted_v: Vec<Value> = reorder_values_by_permutation(&children, &perm);
+                    interp.stack.push(Value::from_vector(sorted_v));
+                    Ok(())
+                }
+                SortAttempt::Undecided(agreed_prefix) => {
+                    // SPEC §7.4.3: a single undecidable pair makes the whole
+                    // order unestablished — yield the logical Unknown (U),
+                    // never a partially-sorted vector.
+                    crate::interpreter::comparison::push_comparison_unknown(interp, agreed_prefix);
+                    Ok(())
+                }
+                SortAttempt::Malformed(e) => {
+                    if !is_keep_mode {
+                        interp.stack.push(val);
                     }
+                    Err(e)
                 }
             }
-
-            sort_fractions_by_introsort(&mut indexed_fractions);
-
-            let perm: Vec<usize> = indexed_fractions
-                .iter()
-                .map(|(orig_idx, _)| *orig_idx)
-                .collect::<Vec<usize>>();
-            let sorted_v: Vec<Value> = reorder_values_by_permutation(&children, &perm);
-            interp.stack.push(Value::from_vector(sorted_v));
-            Ok(())
         }
         OperationTargetMode::Stack => {
             if interp.stack.is_empty() {
                 return Ok(());
             }
 
-            let mut indexed_fractions: Vec<(usize, Fraction)> =
-                Vec::with_capacity(interp.stack.len());
-            for (i, elem) in interp.stack.iter().enumerate() {
-                match elem.as_scalar() {
-                    Some(f) => indexed_fractions.push((i, f.clone())),
-                    None => {
-                        return Err(AjisaiError::from(
-                            "SORT: expected all stack elements to be numbers, got non-number element",
-                        ));
+            let items: Vec<Value> = interp.stack.clone();
+            match try_sort_indices(&items) {
+                SortAttempt::Ordered(perm) => {
+                    let sorted_stack: Vec<Value> = reorder_values_by_permutation(&items, &perm);
+                    if is_keep_mode {
+                        interp.stack.extend(sorted_stack);
+                    } else {
+                        interp.stack = sorted_stack;
                     }
+                    Ok(())
                 }
+                SortAttempt::Undecided(agreed_prefix) => {
+                    // SPEC §7.4.3: the whole sorted order is unestablished;
+                    // leave the operands in place and push the logical Unknown.
+                    crate::interpreter::comparison::push_comparison_unknown(interp, agreed_prefix);
+                    Ok(())
+                }
+                SortAttempt::Malformed(e) => Err(e),
             }
-
-            sort_fractions_by_introsort(&mut indexed_fractions);
-            let perm: Vec<usize> = indexed_fractions
-                .iter()
-                .map(|(orig, _)| *orig)
-                .collect::<Vec<usize>>();
-            let sorted_stack: Vec<Value> = reorder_values_by_permutation(&interp.stack, &perm);
-            if is_keep_mode {
-                interp.stack.extend(sorted_stack);
-            } else {
-                interp.stack = sorted_stack;
-            }
-            Ok(())
         }
     }
 }
@@ -111,65 +155,46 @@ pub fn op_sort(interp: &mut Interpreter) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::fraction::Fraction;
     use num_bigint::BigInt;
 
-    fn create_fraction(num: i64, den: i64) -> Fraction {
-        Fraction::new(BigInt::from(num), BigInt::from(den))
+    fn scalar(num: i64, den: i64) -> Value {
+        Value::from_fraction(Fraction::new(BigInt::from(num), BigInt::from(den)))
+    }
+
+    fn ordered(items: &[Value]) -> Vec<usize> {
+        match try_sort_indices(items) {
+            SortAttempt::Ordered(perm) => perm,
+            SortAttempt::Undecided(_) => panic!("expected decidable sort"),
+            SortAttempt::Malformed(e) => panic!("unexpected malformed: {e}"),
+        }
     }
 
     #[test]
-    fn test_fraction_comparison() {
-        let half: Fraction = create_fraction(1, 2);
-        let third: Fraction = create_fraction(1, 3);
-        assert!(half > third);
-
-        let two_thirds: Fraction = create_fraction(2, 3);
-        assert!(two_thirds > half);
+    fn try_sort_orders_integers_ascending() {
+        let items = vec![scalar(32, 1), scalar(8, 1), scalar(2, 1), scalar(18, 1)];
+        let perm = ordered(&items);
+        // ascending: 2(idx2), 8(idx1), 18(idx3), 32(idx0)
+        assert_eq!(perm, vec![2, 1, 3, 0]);
     }
 
     #[test]
-    fn test_introsort_integers() {
-        let mut values: Vec<(usize, Fraction)> = vec![
-            (0, create_fraction(32, 1)),
-            (1, create_fraction(8, 1)),
-            (2, create_fraction(2, 1)),
-            (3, create_fraction(18, 1)),
-        ];
-        sort_fractions_by_introsort(&mut values);
-
-        assert_eq!(values[0].1, create_fraction(2, 1));
-        assert_eq!(values[1].1, create_fraction(8, 1));
-        assert_eq!(values[2].1, create_fraction(18, 1));
-        assert_eq!(values[3].1, create_fraction(32, 1));
+    fn try_sort_orders_fractions_ascending() {
+        let items = vec![scalar(1, 2), scalar(1, 3), scalar(2, 3)];
+        let perm = ordered(&items);
+        // ascending: 1/3(idx1), 1/2(idx0), 2/3(idx2)
+        assert_eq!(perm, vec![1, 0, 2]);
     }
 
     #[test]
-    fn test_sort_fractions_by_introsort() {
-        let mut values: Vec<(usize, Fraction)> = vec![
-            (0, create_fraction(1, 2)),
-            (1, create_fraction(1, 3)),
-            (2, create_fraction(2, 3)),
-        ];
-        sort_fractions_by_introsort(&mut values);
-
-        assert_eq!(values[0].1, create_fraction(1, 3));
-        assert_eq!(values[1].1, create_fraction(1, 2));
-        assert_eq!(values[2].1, create_fraction(2, 3));
-    }
-
-    #[test]
-    fn test_introsort_mixed() {
-        let mut values: Vec<(usize, Fraction)> = vec![
-            (0, create_fraction(3, 1)),
-            (1, create_fraction(1, 2)),
-            (2, create_fraction(2, 1)),
-            (3, create_fraction(1, 4)),
-        ];
-        sort_fractions_by_introsort(&mut values);
-
-        assert_eq!(values[0].1, create_fraction(1, 4));
-        assert_eq!(values[1].1, create_fraction(1, 2));
-        assert_eq!(values[2].1, create_fraction(2, 1));
-        assert_eq!(values[3].1, create_fraction(3, 1));
+    fn try_sort_reports_malformed_on_non_numeric() {
+        // A multi-element vector is not a comparable scalar (a singleton
+        // vector would project to its sole scalar, so use two elements).
+        let non_numeric = Value::from_vector(vec![scalar(1, 1), scalar(2, 1)]);
+        let items = vec![scalar(1, 1), non_numeric];
+        assert!(matches!(
+            try_sort_indices(&items),
+            SortAttempt::Malformed(_)
+        ));
     }
 }


### PR DESCRIPTION
…/COND

Implements SPEC §7.4.3 (specified in #997): the comparison-dependent words now surface an undecidable comparison as U (or, for COND, as a non-firing clause) instead of rejecting the operands or fabricating a decision.

- comparison.rs: expose a shared `three_way_compare` (decided Ordering or Undecided{agreed_prefix}) reusing the same extraction + budgeted-CF path as the relations, plus `push_comparison_unknown`. MIN/MAX/SORT route through it.
- math_ops.rs (MIN/MAX): replace the Fraction-only `apply_binary` path with a selecting form that accepts the full numeric domain (incl. lazy CF / ExactScalar), returns the chosen operand unchanged when the order decides, and yields U with diagnosis.agreedPrefix when it does not. NIL-passthrough with NIL over U.
- sort.rs (SORT): accept ExactScalar; sort indices via the budgeted comparison. A single undecidable pair makes the whole order unestablished ⇒ yield U (never a partially-sorted vector), carrying the first undecidable pair's agreedPrefix. Non-numeric element ⇒ malformed-use error (unchanged). Both StackTop and Stack modes.
- control_cond.rs (COND): a guard that reduces to U does NOT fire — fall through to the next clause / IDLE / CondExhausted, exactly as for false. Fixes the prior §7.4.3 violation where a U guard raised "must return TRUE or FALSE". One check covers the greedy and hedged-prefetch guard paths (both route through evaluate_guard_isolated).

Tests (§15.3): new u_propagation_tests module — MIN/MAX decided selection, undecidable→U with agreedPrefix, NIL passthrough; SORT ascending (vector and stack mode), undecidable→U-not-partial; COND definite-true fires, U guard falls through to the next clause, U→else, U-only→CondExhausted. Plus sort.rs unit tests for try_sort_indices. All 1259 lib tests pass; clippy + rustfmt clean.

https://claude.ai/code/session_011s5Xe5cybmSceEinTJz1ei

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
