### PR TITLE
U/NIL 分離・ExactScalar 境界・診断引き継ぎ (P0-a/P0-b/P1/P2)

### DIFF
--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -435,6 +435,37 @@ pub fn op_div(interp: &mut Interpreter) -> Result<()> {
             return Ok(());
         }
     }
+    // ExactScalar path: at least one operand is an exact irrational. Placed
+    // before the generic broadcast block (which cannot convert ExactScalar to
+    // a FlatTensor and would hard-error first), matching op_add/op_sub/op_mul.
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
+        let stack_len = interp.stack.len();
+        let a = &interp.stack[stack_len - 2];
+        let b = &interp.stack[stack_len - 1];
+        if let Some(result) = try_exact_real_binary_op(a, b, |a, b| a.div(b)) {
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            interp.stack.push(result);
+            return Ok(());
+        } else if matches!(&a.data, ValueData::ExactScalar(_))
+            || matches!(&b.data, ValueData::ExactScalar(_))
+        {
+            // div returned None — structurally-zero divisor. DivisionByZero is a
+            // recoverable Bubble (NilReason::DivisionByZero), not a hard error.
+            if interp.consumption_mode != ConsumptionMode::Keep {
+                interp.stack.pop();
+                interp.stack.pop();
+            }
+            interp.stack.push(Value::bubble_with_reason(
+                NilReason::DivisionByZero,
+                AbsenceOrigin::ExecutionFailure,
+                Recoverability::Recoverable,
+            ));
+            return Ok(());
+        }
+    }
     if interp.operation_target_mode == OperationTargetMode::StackTop {
         let stack_len = interp.stack.len();
         if stack_len >= 2 {
@@ -485,36 +516,6 @@ pub fn op_div(interp: &mut Interpreter) -> Result<()> {
         }
     }
 
-    // ExactScalar path
-    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
-        let stack_len = interp.stack.len();
-        let a = &interp.stack[stack_len - 2];
-        let b = &interp.stack[stack_len - 1];
-        if let Some(result) =
-            try_exact_real_binary_op(a, b, |a, b| a.div(b))
-        {
-            if interp.consumption_mode != ConsumptionMode::Keep {
-                interp.stack.pop();
-                interp.stack.pop();
-            }
-            interp.stack.push(result);
-            return Ok(());
-        } else if matches!(&a.data, ValueData::ExactScalar(_))
-            || matches!(&b.data, ValueData::ExactScalar(_))
-        {
-            // div returned None — structurally-zero divisor
-            if interp.consumption_mode != ConsumptionMode::Keep {
-                interp.stack.pop();
-                interp.stack.pop();
-            }
-            interp.stack.push(Value::bubble_with_reason(
-                NilReason::DivisionByZero,
-                AbsenceOrigin::ExecutionFailure,
-                Recoverability::Recoverable,
-            ));
-            return Ok(());
-        }
-    }
     apply_binary_arithmetic(interp, |a, b| {
         if b.is_zero() {
             Err(AjisaiError::DivisionByZero)

--- a/rust/src/interpreter/arithmetic_exact_div_tests.rs
+++ b/rust/src/interpreter/arithmetic_exact_div_tests.rs
@@ -1,0 +1,86 @@
+//! Behavioral coverage for the ExactScalar path of `op_div` (SPEC §7.4.1).
+//!
+//! Regression guard for the ordering bug where the generic broadcast block
+//! (`apply_binary_broadcast_with_metrics`) ran *before* the ExactScalar
+//! block and unconditionally `return`ed on the `FlatTensor::from_value`
+//! error for exact irrationals, making the ExactScalar `DIV` path dead code.
+//! `op_add`/`op_sub`/`op_mul` place the ExactScalar block before broadcast;
+//! these tests pin `op_div` to the same, correct ordering.
+
+use crate::error::NilReason;
+use crate::interpreter::Interpreter;
+use crate::types::{Value, ValueData};
+
+async fn run_ok(code: &str) -> Vec<Value> {
+    let mut interp = Interpreter::new();
+    interp
+        .execute(code)
+        .await
+        .unwrap_or_else(|e| panic!("`{code}` unexpectedly errored: {e}"));
+    interp.get_stack().to_vec()
+}
+
+/// `√2 2 /` is evaluated as an exact value rather than hard-erroring on the
+/// (impossible) ExactScalar -> tensor conversion. This is the core P0-a
+/// guarantee: the ExactScalar block is now reachable before broadcast.
+#[tokio::test]
+async fn sqrt2_div_rational_is_exact_not_error() {
+    let stack = run_ok("'math' IMPORT 2 MATH@SQRT 2 /").await;
+    assert_eq!(stack.len(), 1);
+    let top = &stack[0];
+    assert!(
+        !top.is_nil(),
+        "√2 2 / must not collapse to NIL/error, got {top:?}"
+    );
+    assert!(
+        matches!(top.data, ValueData::ExactScalar(_) | ValueData::Scalar(_)),
+        "√2 2 / must stay an exact real, got {top:?}"
+    );
+}
+
+/// `√2 √2 /` is evaluated exactly (a recoverable exact real), not a hard
+/// error. NOTE: the current ExactReal engine represents this as a *lazy*
+/// `Gosper` (x/y) and does not structurally reduce it to the rational `1/1`;
+/// structural simplification is a CF-engine concern outside the P0-a
+/// ordering fix. The reachable-path guarantee (exact, not error) is what
+/// this test pins.
+#[tokio::test]
+async fn sqrt2_div_sqrt2_is_exact() {
+    let stack = run_ok("'math' IMPORT 2 MATH@SQRT 2 MATH@SQRT /").await;
+    assert_eq!(stack.len(), 1);
+    let top = &stack[0];
+    assert!(
+        !top.is_nil(),
+        "√2 √2 / must not collapse to NIL/error, got {top:?}"
+    );
+    assert!(
+        matches!(top.data, ValueData::ExactScalar(_) | ValueData::Scalar(_)),
+        "√2 √2 / must stay an exact real, got {top:?}"
+    );
+}
+
+/// `√2 0 /` is a recoverable DivisionByZero Bubble, not a hard error.
+#[tokio::test]
+async fn sqrt2_div_zero_is_division_by_zero_bubble() {
+    let stack = run_ok("'math' IMPORT 2 MATH@SQRT 0 /").await;
+    assert_eq!(stack.len(), 1);
+    let top = &stack[0];
+    assert!(top.is_nil(), "√2 0 / must be a Bubble/NIL, got {top:?}");
+    assert_eq!(
+        top.nil_reason().cloned(),
+        Some(NilReason::DivisionByZero),
+        "√2 0 / must carry NilReason::DivisionByZero, got {top:?}"
+    );
+}
+
+/// Ordinary rational division is unchanged (no regression): `6 3 /` -> `2`.
+#[tokio::test]
+async fn rational_division_unchanged() {
+    let stack = run_ok("6 3 /").await;
+    assert_eq!(stack.len(), 1);
+    let frac = stack[0]
+        .as_scalar()
+        .cloned()
+        .unwrap_or_else(|| panic!("6 3 / must be a rational, got {:?}", stack[0]));
+    assert_eq!(frac.to_i64(), Some(2), "6 3 / must equal 2");
+}

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -34,7 +34,12 @@ fn compute_inverted_value(
     // the scalar path because U is represented as a NIL node; a plain
     // numeric/boolean scalar keeps its existing 0↔1 inversion below.
     if val.is_unknown() || val.is_nil() {
-        return Ok(logic_kleene::not(Ternary::classify(val)).into_value());
+        // ¬U = U: carry the operand's comparison diagnosis (agreedPrefix)
+        // over to the result U (SPEC §4.5.0 / §7.4.1).
+        return Ok(logic_kleene::into_value_with_diagnosis(
+            logic_kleene::not(Ternary::classify(val)),
+            &[val],
+        ));
     }
     if let Some(f) = val.as_scalar() {
         return Ok(Value::from_fraction(compute_inverted_fraction(f)));
@@ -116,7 +121,10 @@ pub fn op_and(interp: &mut Interpreter) -> Result<()> {
             if forces_k3_path(&a_val) || forces_k3_path(&b_val) {
                 let result =
                     logic_kleene::and(Ternary::classify(&a_val), Ternary::classify(&b_val));
-                interp.stack.push(result.into_value());
+                interp.stack.push(logic_kleene::into_value_with_diagnosis(
+                    result,
+                    &[&a_val, &b_val],
+                ));
                 return Ok(());
             }
 
@@ -164,7 +172,10 @@ pub fn op_and(interp: &mut Interpreter) -> Result<()> {
                     break;
                 }
             }
-            interp.stack.push(acc.into_value());
+            let refs: Vec<&Value> = items.iter().collect();
+            interp
+                .stack
+                .push(logic_kleene::into_value_with_diagnosis(acc, &refs));
             Ok(())
         }
     }
@@ -195,7 +206,10 @@ pub fn op_or(interp: &mut Interpreter) -> Result<()> {
             // the logical Unknown (U); otherwise keep element-wise broadcast.
             if forces_k3_path(&a_val) || forces_k3_path(&b_val) {
                 let result = logic_kleene::or(Ternary::classify(&a_val), Ternary::classify(&b_val));
-                interp.stack.push(result.into_value());
+                interp.stack.push(logic_kleene::into_value_with_diagnosis(
+                    result,
+                    &[&a_val, &b_val],
+                ));
                 return Ok(());
             }
 
@@ -243,7 +257,10 @@ pub fn op_or(interp: &mut Interpreter) -> Result<()> {
                     break;
                 }
             }
-            interp.stack.push(acc.into_value());
+            let refs: Vec<&Value> = items.iter().collect();
+            interp
+                .stack
+                .push(logic_kleene::into_value_with_diagnosis(acc, &refs));
             Ok(())
         }
     }

--- a/rust/src/interpreter/logic_kleene.rs
+++ b/rust/src/interpreter/logic_kleene.rs
@@ -58,6 +58,34 @@ impl Ternary {
     }
 }
 
+/// Materialize a K3 combination result as a `Value`, re-attaching the
+/// comparison diagnosis (`agreedPrefix`, SPEC §4.5.0 / §7.4.1) when the
+/// result is the logical Unknown (U).
+///
+/// The truth tables (`and`/`or`/`not`) stay pure `Ternary -> Ternary`; the
+/// diagnosis is composed only here, at the `Value` layer, so the K3
+/// semantics are never polluted by metadata. Policy: when the result is U,
+/// the diagnosis of the **first U operand** (left-priority) is carried over
+/// by cloning that operand value; a bare `Value::unknown()` operand carries
+/// no diagnosis, so the result stays bare (diagnosis is never fabricated).
+/// This is diagnostic-only: the observable `truthValue` is identical to
+/// [`Ternary::into_value`] (both yield `unknown` for U), preserving the
+/// SPEC §2.3 firewall.
+pub(crate) fn into_value_with_diagnosis(result: Ternary, operands: &[&Value]) -> Value {
+    if result != Ternary::Unknown {
+        return result.into_value();
+    }
+    for op in operands {
+        if op.is_unknown() {
+            // The operand is itself a U value carrying (or lacking) the
+            // comparison diagnosis; cloning it faithfully preserves the
+            // agreedPrefix without inventing one.
+            return (*op).clone();
+        }
+    }
+    result.into_value()
+}
+
 /// A definite `true`/`false` carrying the `TruthValue` interpretation
 /// role so it displays as `TRUE`/`FALSE` and serializes through the
 /// `truthValue` axis.
@@ -205,5 +233,124 @@ mod tests {
         assert!(Ternary::Nil.into_value().is_nil() && !Ternary::Nil.into_value().is_unknown());
         assert!(Ternary::True.into_value().is_truth_value());
         assert!(Ternary::False.into_value().is_truth_value());
+    }
+
+    // --- P2: agreedPrefix diagnosis carry-over (SPEC §4.5.0 / §7.4.1) -------
+
+    /// A U carrying an `agreedPrefix=k` comparison diagnosis, as produced by
+    /// COMPARE-WITHIN / the comparison words via
+    /// `Value::unknown_with_agreed_prefix`.
+    fn u_with_prefix(k: usize) -> Value {
+        Value::unknown_with_agreed_prefix(Some("COMPARE-WITHIN"), k)
+    }
+
+    fn agreed_prefix_of(v: &Value) -> Option<usize> {
+        v.nil_diagnosis().and_then(|d| d.agreed_prefix)
+    }
+
+    /// `NOT` of a diagnosed U keeps the same `agreedPrefix`.
+    #[test]
+    fn not_preserves_agreed_prefix() {
+        let input = u_with_prefix(7);
+        let result = into_value_with_diagnosis(not(Ternary::classify(&input)), &[&input]);
+        assert!(result.is_unknown());
+        assert_eq!(result.truth_value(), Some("unknown"));
+        assert_eq!(agreed_prefix_of(&result), Some(7));
+    }
+
+    /// `U(k) AND TRUE` is U and keeps `agreedPrefix=k` (the lone U operand).
+    #[test]
+    fn and_unknown_true_preserves_agreed_prefix() {
+        let a = u_with_prefix(3);
+        let b = t();
+        let result =
+            into_value_with_diagnosis(and(Ternary::classify(&a), Ternary::classify(&b)), &[&a, &b]);
+        assert!(result.is_unknown());
+        assert_eq!(agreed_prefix_of(&result), Some(3));
+    }
+
+    /// `U(k1) AND U(k2)` is U and keeps the left operand's `agreedPrefix=k1`.
+    #[test]
+    fn and_two_unknowns_keeps_left_diagnosis() {
+        let a = u_with_prefix(11);
+        let b = u_with_prefix(99);
+        let result =
+            into_value_with_diagnosis(and(Ternary::classify(&a), Ternary::classify(&b)), &[&a, &b]);
+        assert!(result.is_unknown());
+        assert_eq!(agreed_prefix_of(&result), Some(11));
+    }
+
+    /// `OR` mirrors `AND`: left-priority diagnosis carry-over.
+    #[test]
+    fn or_two_unknowns_keeps_left_diagnosis() {
+        let a = u_with_prefix(5);
+        let b = u_with_prefix(8);
+        let result =
+            into_value_with_diagnosis(or(Ternary::classify(&a), Ternary::classify(&b)), &[&a, &b]);
+        assert!(result.is_unknown());
+        assert_eq!(agreed_prefix_of(&result), Some(5));
+    }
+
+    /// Bare U operands (no diagnosis) yield a bare U: the carry-over never
+    /// fabricates an `agreedPrefix`.
+    #[test]
+    fn bare_unknowns_stay_bare() {
+        let a = u();
+        let b = u();
+        let result =
+            into_value_with_diagnosis(and(Ternary::classify(&a), Ternary::classify(&b)), &[&a, &b]);
+        assert!(result.is_unknown());
+        assert_eq!(agreed_prefix_of(&result), None);
+    }
+
+    /// Definite and NIL results are unchanged by the diagnosis wrapper, and
+    /// no diagnosis leaks onto them: the observable `truthValue` is intact.
+    #[test]
+    fn definite_and_nil_results_unchanged() {
+        let u_k = u_with_prefix(4);
+        let ff = f();
+        // U(k) AND FALSE = FALSE (F absorbs); no agreedPrefix carried.
+        let result =
+            into_value_with_diagnosis(and(Ternary::classify(&u_k), Ternary::classify(&ff)), &[&u_k, &ff]);
+        assert_eq!(result.truth_value(), Some("false"));
+        assert_eq!(agreed_prefix_of(&result), None);
+        // U(k) AND NIL = NIL (NIL priority, SPEC §4.5.2); stays operational NIL.
+        let nn = n();
+        let result =
+            into_value_with_diagnosis(and(Ternary::classify(&u_k), Ternary::classify(&nn)), &[&u_k, &nn]);
+        assert!(result.is_nil() && !result.is_unknown());
+    }
+
+    /// End-to-end through the interpreter: an undecidable comparison emits a
+    /// U with an `agreedPrefix`; `NOT` must keep that diagnosis (this pins
+    /// the `logic.rs` wiring, not just the helper). `AND TRUE` likewise.
+    #[tokio::test]
+    async fn interpreter_not_and_preserve_agreed_prefix() {
+        use crate::interpreter::Interpreter;
+        async fn top(code: &str) -> Value {
+            let mut interp = Interpreter::new();
+            interp.execute(code).await.expect("executes");
+            interp.get_stack().last().expect("nonempty").clone()
+        }
+        // (√2 − √2) == 0 is undecidable within budget -> U with agreedPrefix.
+        const PRODUCE_U: &str = "'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ";
+        let base = top(PRODUCE_U).await;
+        let k = agreed_prefix_of(&base).expect("U carries an agreedPrefix");
+
+        let negated = top(&format!("{PRODUCE_U} NOT")).await;
+        assert!(negated.is_unknown());
+        assert_eq!(
+            agreed_prefix_of(&negated),
+            Some(k),
+            "NOT U must preserve agreedPrefix through op_not"
+        );
+
+        let anded = top(&format!("{PRODUCE_U} TRUE AND")).await;
+        assert!(anded.is_unknown());
+        assert_eq!(
+            agreed_prefix_of(&anded),
+            Some(k),
+            "U AND TRUE must preserve agreedPrefix through op_and"
+        );
     }
 }

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -75,6 +75,8 @@ mod hash_tests;
 #[cfg(test)]
 mod math_ops_tests;
 #[cfg(test)]
+mod arithmetic_exact_div_tests;
+#[cfg(test)]
 mod nil_conformance_tests;
 #[cfg(test)]
 mod higher_order_fold_tests;

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -77,6 +77,8 @@ mod math_ops_tests;
 #[cfg(test)]
 mod arithmetic_exact_div_tests;
 #[cfg(test)]
+mod nil_unknown_firewall_tests;
+#[cfg(test)]
 mod nil_conformance_tests;
 #[cfg(test)]
 mod higher_order_fold_tests;

--- a/rust/src/interpreter/nil_unknown_firewall_tests.rs
+++ b/rust/src/interpreter/nil_unknown_firewall_tests.rs
@@ -1,0 +1,107 @@
+//! Firewall between the logical Unknown (U) and operational NIL in the
+//! generic passthrough helpers (SPEC §7.5 / §2.3).
+//!
+//! `nil_passthrough_unary/value/binary` now key off `is_operational_nil()`
+//! rather than `is_nil()` (which is a storage predicate that also matches
+//! U). This stops U from being silently absorbed as an operational NIL when
+//! it reaches an arithmetic/generic Coreword that uses those helpers, while
+//! leaving genuine operational NIL passthrough intact.
+//!
+//! Observed behavior of `U 1 +` (recorded here per the task's request to
+//! observe and report what U does when it reaches an arithmetic broadcast):
+//!   - BEFORE the fix: `nil_passthrough_binary` matched U via `is_nil()` and
+//!     absorbed it into an operational NIL node (`Ok(Nil)`, hint demoted
+//!     `TruthValue` -> `Nil`). U was silently collapsed to an operational
+//!     absence even though it is a logical truth value.
+//!   - AFTER the fix: passthrough no longer matches U, so U reaches
+//!     `op_add`'s broadcast guard (`apply_binary_broadcast_with_metrics`,
+//!     left unchanged per task Step 3), which raises an explicit error
+//!     "Cannot broadcast NIL values". U is NOT collapsed into a reasonless
+//!     operational NIL.
+//! Either an explicit error or preserved-U is acceptable per the acceptance
+//! criteria; the firewall guarantee is that `NilReason::LogicallyUnknown`
+//! is never silently turned into a reasonless operational NIL.
+
+use crate::error::NilReason;
+use crate::interpreter::Interpreter;
+use crate::types::Value;
+
+/// Source that yields the logical Unknown (U): (√2 − √2) == 0 is undecidable
+/// within the comparison budget, so EQ emits U with an agreedPrefix.
+const PRODUCE_U: &str = "'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ";
+
+async fn run(code: &str) -> Result<Vec<Value>, String> {
+    let mut interp = Interpreter::new();
+    interp.execute(code).await.map_err(|e| e.to_string())?;
+    Ok(interp.get_stack().to_vec())
+}
+
+async fn run_ok(code: &str) -> Vec<Value> {
+    run(code)
+        .await
+        .unwrap_or_else(|e| panic!("`{code}` unexpectedly errored: {e}"))
+}
+
+/// Passing U to an arithmetic word must not silently collapse it into a
+/// reasonless operational NIL. The firewall holds if EITHER an explicit
+/// error is raised OR `is_unknown()` is preserved; what must never happen is
+/// a successful result that is an operational NIL with the
+/// `LogicallyUnknown` reason erased.
+#[tokio::test]
+async fn u_into_arithmetic_does_not_silently_collapse_to_reasonless_nil() {
+    let res = run(&format!("{PRODUCE_U} 1 +")).await;
+    match res {
+        Err(_) => {
+            // Acceptable: U reaches the broadcast guard and errors explicitly
+            // (the guard is intentionally left unchanged in this task).
+        }
+        Ok(stack) => {
+            assert_eq!(stack.len(), 1);
+            let top = &stack[0];
+            assert!(
+                top.is_unknown(),
+                "U passed to + must preserve is_unknown() if it does not \
+                 error; got {top:?}"
+            );
+            assert!(
+                !(top.is_nil() && !top.is_unknown()),
+                "U must never collapse to a reasonless operational NIL; got {top:?}"
+            );
+        }
+    }
+}
+
+/// A genuine operational NIL with a reason still passes through arithmetic
+/// unchanged (no regression): the reason is preserved and the result is an
+/// operational NIL (not U).
+#[tokio::test]
+async fn operational_nil_passthrough_preserves_reason() {
+    // `1 0 DIV` is a recoverable DivisionByZero Bubble (operational NIL).
+    let nil_src = "1 0 DIV";
+    let stack = run_ok(&format!("{nil_src} 1 +")).await;
+    assert_eq!(stack.len(), 1);
+    let top = &stack[0];
+    assert!(
+        top.is_operational_nil(),
+        "NIL 1 + must stay an operational NIL, got {top:?}"
+    );
+    assert_eq!(
+        top.nil_reason().cloned(),
+        Some(NilReason::DivisionByZero),
+        "operational NIL must keep its reason through arithmetic passthrough, got {top:?}"
+    );
+}
+
+/// The K3 logic path (`logic_kleene`) is unaffected: `U U AND` is U.
+/// (Ajisai has no `DUP`; two independently-produced U operands stand in for
+/// the task's `U DUP AND`, exercising the same `Unknown AND Unknown` cell.)
+#[tokio::test]
+async fn u_and_u_is_unknown() {
+    let stack = run_ok(&format!("{PRODUCE_U} {PRODUCE_U} AND")).await;
+    assert_eq!(stack.len(), 1);
+    assert!(
+        stack[0].is_unknown(),
+        "U U AND must remain Unknown, got {:?}",
+        stack[0]
+    );
+}

--- a/rust/src/interpreter/value_extraction_helpers.rs
+++ b/rust/src/interpreter/value_extraction_helpers.rs
@@ -200,7 +200,7 @@ pub(crate) fn nil_passthrough_unary(interp: &mut Interpreter) -> bool {
     if stack_len == 0 {
         return false;
     }
-    if !interp.stack[stack_len - 1].is_nil() {
+    if !interp.stack[stack_len - 1].is_operational_nil() {
         return false;
     }
     let inherited = Value::nil_inheriting_absence_from(&interp.stack[stack_len - 1]);
@@ -216,7 +216,7 @@ pub(crate) fn nil_passthrough_value<'a>(
 ) -> Option<Value> {
     items
         .into_iter()
-        .find(|v| v.is_nil())
+        .find(|v| v.is_operational_nil())
         .map(Value::nil_inheriting_absence_from)
 }
 
@@ -225,8 +225,8 @@ pub(crate) fn nil_passthrough_binary(interp: &mut Interpreter) -> bool {
     if stack_len < 2 {
         return false;
     }
-    let a_nil = interp.stack[stack_len - 2].is_nil();
-    let b_nil = interp.stack[stack_len - 1].is_nil();
+    let a_nil = interp.stack[stack_len - 2].is_operational_nil();
+    let b_nil = interp.stack[stack_len - 1].is_operational_nil();
     if !(a_nil || b_nil) {
         return false;
     }

--- a/rust/src/types/value_operations.rs
+++ b/rust/src/types/value_operations.rs
@@ -350,14 +350,42 @@ impl Value {
         }
     }
 
+    /// Storage-level NIL test: `true` for any `ValueData::Nil` node,
+    /// **including the logical Unknown (U)**, which is represented as a NIL
+    /// node (SPEC §7.5). This is a low-level storage predicate, not an
+    /// operational-absence test. If you need operational NIL only (U
+    /// excluded), use [`is_operational_nil`]. Kept with storage semantics to
+    /// avoid churning its ~164 call sites; see SPEC §7.5 / §2.3 firewall.
     #[inline]
     pub fn is_nil(&self) -> bool {
         matches!(self.data, ValueData::Nil)
     }
 
+    /// As [`is_nil`]: storage-level NIL test, **U included**. For
+    /// operational absence excluding the logical Unknown, use
+    /// [`is_operational_nil`].
     #[inline]
     pub fn is_absent(&self) -> bool {
         matches!(self.data, ValueData::Nil)
+    }
+
+    /// Low-level: whether the storage representation is a NIL node (U
+    /// included). Internal-detection only; equivalent to [`is_nil`] but
+    /// named to make the storage intent explicit at call sites that must
+    /// not be confused with operational absence.
+    #[inline]
+    pub fn is_nil_storage(&self) -> bool {
+        matches!(self.data, ValueData::Nil)
+    }
+
+    /// Operational NIL only: a NIL storage node that is **not** the logical
+    /// truth value Unknown (U). This is the firewall (SPEC §7.5 / §2.3)
+    /// between operational absence and the K3 logical Unknown: generic NIL
+    /// passthrough helpers use this so U is never silently absorbed as a
+    /// reasoned operational NIL.
+    #[inline]
+    pub fn is_operational_nil(&self) -> bool {
+        self.is_nil_storage() && !self.is_unknown()
     }
 
     #[inline]

--- a/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_value_conversion.rs
@@ -258,6 +258,19 @@ fn value_semantics_to_js(value: &Value, effective: Interpretation) -> JsValue {
     if let Some(absence) = value.normalized_absence_metadata() {
         set_prop(&obj, "absence", &absence_to_protocol_js(&absence));
     }
+    // Exact-irrational firewall marker (SPEC §2.3): an `ExactScalar` rendered
+    // under any role other than the lossless ContinuedFraction form is shown
+    // as a *best rational approximation* (see `value_to_protocol`). Without a
+    // marker its `number` value is indistinguishable from an exact rational,
+    // which contradicts Ajisai's "no hidden truncation" guarantee. This is an
+    // additive, optional field on the `semantics` metadata bag: existing
+    // consumers ignore it; the GUI can use it to prefix an `≈`. ContinuedFraction
+    // nodes carry no `semantics` block, so they never reach here.
+    if matches!(value.data, ValueData::ExactScalar(_))
+        && effective != Interpretation::ContinuedFraction
+    {
+        set_prop(&obj, "approximate", &JsValue::TRUE);
+    }
     obj.into()
 }
 
@@ -435,7 +448,12 @@ pub(crate) fn value_to_protocol(
     let (type_str, protocol_value) = match &value.data {
         ValueData::Nil => ("nil", ProtocolValue::Null),
         ValueData::ExactScalar(er) => {
-            // Serialize ExactScalar as best rational approximation with large denominator
+            // Serialize ExactScalar as best rational approximation with large
+            // denominator. The resulting node carries `semantics:
+            // Some(value.clone())` (the original exact real) plus an
+            // `approximate: true` marker in its semantics block (see
+            // `value_semantics_to_js`), so the approximation is observable and
+            // the GUI can reference the exact source (SPEC §2.3).
             use num_bigint::BigInt;
             let approx = er
                 .best_rational_approximation(&BigInt::from(1_000_000_000u64))
@@ -1026,6 +1044,63 @@ mod protocol_mcdc_tests {
         let node = value_to_protocol(&Value::nil(), None);
         assert_eq!(node.type_str, "nil");
         assert_eq!(node.value, ProtocolValue::Null);
+    }
+
+    // --- ExactScalar approximation marker (SPEC §2.3) ---
+
+    /// √2 as an exact irrational (AlgebraicSqrt), the canonical ExactScalar.
+    fn sqrt2() -> Value {
+        use crate::types::continued_fraction::ExactReal;
+        let er = ExactReal::from_sqrt_rational(frac(2)).expect("√2 is a valid exact real");
+        let v = Value::from_exact_real(er);
+        assert!(
+            matches!(v.data, ValueData::ExactScalar(_)),
+            "√2 must remain an ExactScalar, not collapse to a rational"
+        );
+        v
+    }
+
+    /// Under `RawNumber`, an ExactScalar serializes as a `number` (its best
+    /// rational approximation) but its `semantics` block must carry the
+    /// original exact value, so the GUI can reference the exact source rather
+    /// than a silent truncation (Option 1 / SPEC §2.3 firewall).
+    #[test]
+    fn exact_scalar_rawnumber_carries_exact_source_in_semantics() {
+        let node = value_to_protocol(&sqrt2(), Some(Interpretation::RawNumber));
+        assert_eq!(node.type_str, "number", "RawNumber ExactScalar -> number");
+        assert!(
+            matches!(node.value, ProtocolValue::Number { .. }),
+            "value is the rational approximation, got {:?}",
+            node.value
+        );
+        let semantics = node
+            .semantics
+            .as_ref()
+            .expect("ExactScalar node must carry a semantics source");
+        assert!(
+            matches!(semantics.data, ValueData::ExactScalar(_)),
+            "semantics must preserve the exact ExactScalar source, got {:?}",
+            semantics.data
+        );
+    }
+
+    /// Under the `ContinuedFraction` role the value is rendered losslessly as
+    /// the canonical nested-form string and carries no `semantics` block, so
+    /// it is never marked approximate (regression guard: unchanged behavior).
+    #[test]
+    fn exact_scalar_continued_fraction_role_is_lossless_nested_form() {
+        let node = value_to_protocol(&sqrt2(), Some(Interpretation::ContinuedFraction));
+        assert_eq!(node.type_str, "string", "CF role -> nested-form string");
+        assert!(
+            matches!(node.value, ProtocolValue::Text(_)),
+            "CF role yields the nested-form text, got {:?}",
+            node.value
+        );
+        assert_eq!(node.display_hint, Interpretation::ContinuedFraction);
+        assert!(
+            node.semantics.is_none(),
+            "CF nodes carry no semantics block (and thus no approximate marker)"
+        );
     }
 
     #[test]

--- a/rust/wasm-tests/tests/boundary.rs
+++ b/rust/wasm-tests/tests/boundary.rs
@@ -93,3 +93,42 @@ async fn bubble_nil_serializes_as_nil() {
     assert_eq!(stack.length(), 1);
     assert_eq!(type_of(&stack.get(0)), "nil");
 }
+
+/// An ExactScalar (√2) under the default `RawNumber` role crosses the boundary
+/// as a `number` (its best rational approximation) carrying an explicit
+/// `semantics.approximate === true` marker, so the GUI never mistakes the
+/// approximation for an exact rational (SPEC §2.3 firewall; P1).
+#[wasm_bindgen_test]
+async fn exact_scalar_rawnumber_marks_approximate_at_boundary() {
+    let stack = stack_of("'math' IMPORT 2 SQRT").await;
+    assert_eq!(stack.length(), 1);
+    let node = stack.get(0);
+    assert_eq!(type_of(&node), "number", "√2 (RawNumber) serializes as number");
+    // The numeric value is present (the rational approximation).
+    let value = field(&node, "value");
+    assert!(field(&value, "numerator").as_string().is_some());
+    assert!(field(&value, "denominator").as_string().is_some());
+    // The approximation marker rides on the semantics metadata bag.
+    let semantics = field(&node, "semantics");
+    assert_eq!(
+        field(&semantics, "approximate").as_bool(),
+        Some(true),
+        "ExactScalar rendered lossily must be marked approximate"
+    );
+}
+
+/// A genuinely exact rational (not an ExactScalar) is NOT marked approximate:
+/// the marker is specific to exact irrationals collapsed to an approximation.
+#[wasm_bindgen_test]
+async fn exact_rational_is_not_marked_approximate() {
+    let stack = stack_of("3 4 /").await;
+    assert_eq!(stack.length(), 1);
+    let node = stack.get(0);
+    assert_eq!(type_of(&node), "number");
+    let semantics = field(&node, "semantics");
+    // `approximate` is absent (undefined) for exact rationals.
+    assert!(
+        field(&semantics, "approximate").as_bool().is_none(),
+        "exact rational must not carry an approximate marker"
+    );
+}

--- a/src/wasm-interpreter-types.ts
+++ b/src/wasm-interpreter-types.ts
@@ -109,6 +109,16 @@ export interface ProtocolValueSemantics {
     capabilities: string[];
     origin: string;
     absence?: ProtocolAbsence;
+    /**
+     * Present and `true` only when this node's numeric `value` is a *best
+     * rational approximation* of an exact irrational (`ExactScalar`) rendered
+     * under a lossy role (e.g. `rawNumber`), rather than an exact rational
+     * (SPEC §2.3). The exact source is available via the node's `semantics`.
+     * Lossless `continuedFraction` rendering carries no `semantics` block and
+     * never sets this. The GUI may use it to prefix an `≈`; consumers that
+     * ignore it are unaffected (additive, optional).
+     */
+    approximate?: boolean;
 }
 
 export interface ErrorFlowTraceEvent {


### PR DESCRIPTION
作業指示書の 4 タスクを **P0-a → P0-b → P1 → P2** の順で、それぞれ独立コミットで実施。各タスクにテストを追加。

## ベースライン状態（重要）
- `cargo build`: ✅
- `cargo test --lib`: ✅ ベースライン 1259 → 本 PR 後 **1275 全パス**
- `cargo clippy --all-targets -- -D warnings`: ❌ **ベースラインで既に失敗**（lib 88 + lib-test 97 の既存 lint エラー: `module_inception`、未使用フィールド、`RangeInclusive::contains` 手動実装、`iter().cloned().collect()` 等、リポジトリ全域）。これらは本タスクと無関係なため指示書 §0 に従い**触れていない**。**本 PR で変更した各ファイルには新規の clippy 警告を一切追加していない**ことを行単位で確認済み。

---

## P0-a: `op_div` の ExactScalar 経路を到達可能に
`op_div` で汎用 broadcast ブロックが ExactScalar ブロックより前にあり、その `Err` アームが無条件 `return` するため、ExactScalar（FlatTensor 変換不可）を含む除算がハードエラーになっていた。`op_add/op_sub/op_mul` と同様、ExactScalar ブロックを interval 直後・broadcast 直前へ移動（ロジック不変・順序のみ）。

**テスト** (`arithmetic_exact_div_tests.rs`, 新規):
- `√2 2 /` が ExactScalar として厳密評価されエラーにならない
- `√2 0 /` が `NilReason::DivisionByZero` の回復可能 bubble
- `6 3 / → 2` 回帰なし
- ⚠️ **確定挙動の差異**: 指示書は `√2 √2 / = 1 (Rational 1/1)` を期待していたが、現 ExactReal エンジンはこれを **lazy `Gosper` (x/y)** として表現し構造的に `1/1` へ簡約しない（CF prefix も現状空）。これは CF 算術エンジンの別課題で、本タスク（順序入れ替え）の範囲外。テストは「厳密値であり**エラーにならない**」という P0-a 本来の保証に合わせて確定。

## P0-b: U と NIL の判定 API 分離（passthrough の U 漏れ停止）
`is_nil()` は storage 判定で論理値 U にも `true` を返すため、汎用 passthrough が U を operational NIL として吸収していた（SPEC §7.5/§2.3 firewall 違反）。
- `is_nil_storage()` / `is_operational_nil()` を追加（後者 = `is_nil_storage() && !is_unknown()`）。既存 `is_nil()/is_absent()` の意味は**不変**（波及 164 箇所を回避）、doc に storage 判定である旨を明記。
- `nil_passthrough_unary/value/binary` を `is_operational_nil()` ベースへ。
- broadcast ガード（`is_nil`）は指示書 §Step3 に従い**現状維持**し、U 到達時の挙動を観測。

**確定した観測挙動 (`U 1 +`)**:
- **修正前**: passthrough が U を吸収し `Ok(operational NIL)`（hint `TruthValue`→`Nil`）。U が無言で operational 不在へ潰れていた。
- **修正後**: passthrough が U を拾わず `op_add` の broadcast ガードに到達し**明示的エラー** `"Cannot broadcast NIL values"`。**operational NIL へは潰れない**（acceptance 充足）。

**テスト** (`nil_unknown_firewall_tests.rs`, 新規): U→算術で reasonless NIL に潰れない / 理由付き operational NIL の passthrough は理由保持（回帰なし）/ `U U AND = U`（logic_kleene 経路無傷。Ajisai に `DUP` が無いため U 2 個で代替）。既存 `logic_kleene`・`nil_conformance`・`nil_reason` 全パス。

## P1: WASM/GUI 境界で ExactScalar の近似表示を明示（**採用案: Option 1 を実体化、追加・非破壊**）
ExactScalar を非 `ContinuedFraction` role で serialize すると best rational approximation に潰れるが近似マーカーが無く、GUI 上で厳密 Rational と区別不能だった。protocol node は既に `semantics: Some(value.clone())` で元の ExactScalar を保持しているが、JS 境界では `semanticKind=Number` に平坦化され区別不能。→ `semantics` ブロックに **optional な `approximate: true`** を追加（`ExactScalar` かつ `effective != ContinuedFraction` のときのみ）。

**wire format への影響（確定・列挙）**:
- `semantics` メタバッグへの **additive・optional** フィールド追加のみ。top-level の `type`/`value`/`displayHint` の wire 形状は**不変**。既存 consumer は無視して影響なし（**非破壊**）。**Option 3（新 type / top-level `approx`）は採用せず提案にとどめる**。
- TS 型: `src/wasm-interpreter-types.ts` の `ProtocolValueSemantics` に `approximate?: boolean` を追記（任意フィールド、provably 非破壊）。GUI はこれで `≈` 接頭辞表示が可能（描画側対応は任意の後続作業）。`node_modules` 未導入のため `tsc` 実行は省略。
- `ContinuedFraction` role は従来どおり lossless な nested-form 文字列を返し `semantics` ブロック自体を持たないため `approximate` は付かない（回帰なし）。

**テスト**: native (`protocol_mcdc_tests`) で √2 RawNumber が `number` + `semantics` に元の ExactScalar 保持 / CF role は nested-form のまま semantics なし。`rust/wasm-tests/boundary.rs` で境界スナップショット（`semantics.approximate === true`、厳密 Rational `3 4 /` は非マーク）。**wasm32 target + wasm-bindgen-test-runner --node で 7/7 パスを実機確認済み**。

## P2: 論理演算で U の診断 (agreedPrefix) を引き継ぐ
`Ternary::into_value()` が U を `Value::unknown()` に潰し `diagnosis.agreedPrefix`（SPEC §4.5.0/§7.4.1）を捨てていた。真理表の純粋性を保つため、`Value` 層の薄いラッパ `into_value_with_diagnosis(result, operands)` を新設し、`logic.rs` の NOT / AND(scalar+fold) / OR(scalar+fold) の**全 6 系統**で適用。

**確定ポリシー**: 結果が U のとき**左側優先で最初の U operand**を clone して診断を引き継ぐ。両方 U なら左。診断無し U 同士は素の U（**捏造しない**）。真理表関数 `and/or/not`（`Ternary→Ternary`）は不変・純粋のまま。観測可能な `truthValue`（true/false/unknown）は**一切不変**（診断は diagnostic-only、SPEC §2.3 firewall 遵守）。

**テスト** (`logic_kleene` tests): NOT/AND/OR で agreedPrefix 保持・左優先・素の U 維持・定数/NIL 結果に診断漏れなし、さらに**インタプリタ経由**（COMPARE-WITHIN→NOT / AND TRUE）で実 wiring を検証。既存真理表テスト全パス。

---

## 検証サマリ
- `cargo build` ✅ / `cargo test --lib` ✅ **1275 全パス**
- `rust/wasm-tests`（wasm32 + node runner）✅ **7 全パス**
- 変更ファイルに新規 clippy 警告なし（既存ベースライン失敗は本タスク無関係・未対応）


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFNrp8m1FfjQHKhqh8EKGB)_