### PR TITLE
Name and classify symbolic surface forms as English-based concepts

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -129,7 +129,7 @@ Examples:
 
 A sequence of tokens enclosed in `{...}`. A code block must be written on a single line.
 
-`(` and `)` are not Ajisai syntactic characters. They are reserved at the lexical level to prevent accidental reuse and to keep the nested continued-fraction serialization form (Section 4.2) unambiguous; encountering `(` or `)` in source text is a tokenizer error.
+`(` and `)` are not Ajisai syntactic characters. They are reserved markers — `(` denotes the concept `RESERVED-BEGIN` and `)` denotes `RESERVED-END` (Section 3.9) — reserved at the lexical level to prevent accidental reuse and to keep the nested continued-fraction serialization form (Section 4.2) unambiguous; encountering `(` or `)` in source text is a tokenizer error.
 
 ### 3.5 Vectors
 
@@ -149,6 +149,46 @@ Inside a `COND` expression, clauses are separated by `$`. Each clause must occup
 ### 3.8 Word name normalization
 
 Word names are normalized to uppercase at runtime. `add` and `ADD` refer to the same word.
+
+### 3.9 Surface forms
+
+Ajisai source syntax is word-based. Every visible *symbolic* form is an alias or sugar for a named, English-based **canonical concept**.
+
+Not every surface form is a runtime word. A surface form is classified as one of the following kinds:
+
+| Kind | Meaning | Runtime word? |
+|------|---------|---------------|
+| Word alias | Symbol form of a runtime word (canonicalized at runtime) | yes |
+| Modifier sugar | Compound shorthand for stack modifiers | no |
+| Delimiter sugar | Parser-level structural delimiter | no |
+| Literal sugar | String-literal delimiter | no |
+| Source directive | Consumed lexically by the tokenizer | no |
+| Control directive | Meaningful only inside a specific construct | no |
+| Reserved marker | Never a runtime token; rejected in source | no |
+| Conversion word | `>` followed by letters; canonical home is a runtime word | yes |
+
+**Word aliases** are canonicalized to their English name at runtime (Section 7.0); the canonical name is the authoritative identifier. The remaining kinds denote concepts that are *not* runtime words: they are handled at the lexical or parser level and are never produced by `DEF`, never canonicalized to a runtime word, and (for reserved markers) never valid in source at all.
+
+| Surface | Canonical concept | Kind | Runtime word? |
+|---------|-------------------|------|---------------|
+| `+` `-` `*` `/` `%` | `ADD` `SUB` `MUL` `DIV` `MOD` | Word alias | yes |
+| `=` `<>` `<` `<=` `>` `>=` | `EQ` `NEQ` `LT` `LTE` `GT` `GTE` | Word alias | yes |
+| `&` `!` `?` | `AND` `FORC` `LOOKUP` | Word alias | yes |
+| `.` `..` `,` `,,` | `TOP` `STAK` `EAT` `KEEP` | Word alias | yes |
+| `==` `=>` | `PIPE` `OR-NIL` | Word alias | yes |
+| `;` | `TOP-EAT` (`. ,`) | Modifier sugar | no |
+| `;;` | `STAK-KEEP` (`.. ,,`) | Modifier sugar | no |
+| `[` `]` | `BEGIN-VECTOR` `END-VECTOR` | Delimiter sugar | no |
+| `{` `}` | `BEGIN-BLOCK` `END-BLOCK` | Delimiter sugar | no |
+| `'` | `STRING-QUOTE` | Literal sugar | no |
+| `#` | `COMMENT-LINE` | Source directive | no |
+| `$` | `COND-CLAUSE` | Control directive | no |
+| `(` `)` | `RESERVED-BEGIN` `RESERVED-END` | Reserved marker | no |
+| `>CF` | `>CF` (continued-fraction conversion) | Conversion word | yes |
+
+`;` and `;;` are pure shorthand: `; == . ,` and `;; == .. ,,`. The concept names `TOP-EAT` and `STAK-KEEP` name the compound forms; they are not stand-alone runtime words.
+
+`>` followed by an ASCII letter (e.g. `>CF`) is a single **conversion-word** token, not the `>` (`GT`) comparison alias followed by a word. Its canonical home is the runtime conversion word of the same name; `>` and `>=` remain the `GT` / `GTE` aliases.
 
 ---
 

--- a/rust/src/interpreter/core_word_canonicalization_tests.rs
+++ b/rust/src/interpreter/core_word_canonicalization_tests.rs
@@ -71,7 +71,27 @@ async fn symbol_aliases_and_canonical_core_words_are_reserved_for_user_definitio
 #[tokio::test]
 async fn lookup_alias_canonicalizes_to_english_word() {
     use crate::core_word_aliases::canonicalize_core_word_name;
+    assert_eq!(canonicalize_core_word_name("+"), "ADD");
     assert_eq!(canonicalize_core_word_name("?"), "LOOKUP");
     assert_eq!(canonicalize_core_word_name("=="), "PIPE");
     assert_eq!(canonicalize_core_word_name("=>"), "OR-NIL");
+}
+
+/// Lexical / structural surface forms are documented as named concepts but are
+/// never runtime words: `canonicalize_core_word_name` must not return their
+/// concept names. (See `crate::surface_forms`.)
+#[tokio::test]
+async fn surface_form_concepts_are_not_runtime_canonicalizations() {
+    use crate::core_word_aliases::canonicalize_core_word_name;
+    use crate::surface_forms::lookup_surface_form;
+
+    assert_eq!(lookup_surface_form("#").unwrap().concept, "COMMENT-LINE");
+    assert_eq!(lookup_surface_form("[").unwrap().concept, "BEGIN-VECTOR");
+    assert_eq!(lookup_surface_form(";").unwrap().concept, "TOP-EAT");
+
+    assert_ne!(canonicalize_core_word_name("#"), "COMMENT-LINE");
+    assert_ne!(canonicalize_core_word_name("["), "BEGIN-VECTOR");
+    assert_ne!(canonicalize_core_word_name("{"), "BEGIN-BLOCK");
+    assert_ne!(canonicalize_core_word_name("'"), "STRING-QUOTE");
+    assert_ne!(canonicalize_core_word_name(";"), "TOP-EAT");
 }

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -241,8 +241,10 @@ impl Interpreter {
                     i += 1;
                 }
                 Token::CondClauseSep => {
+                    // ControlDirective: '$' -> COND-CLAUSE (see surface_forms.rs).
                     return Err(AjisaiError::from(
-                        "Unexpected '$' separator outside COND clause parsing",
+                        "Unexpected '$' separator outside COND clause parsing. \
+                         '$' is control directive sugar for COND-CLAUSE and is meaningful only inside a COND expression.",
                     ));
                 }
                 _ => {
@@ -428,8 +430,10 @@ impl Interpreter {
                     }
                 }
                 Token::CondClauseSep => {
+                    // ControlDirective: '$' -> COND-CLAUSE (see surface_forms.rs).
                     return Err(AjisaiError::from(
-                        "Unexpected '$' separator outside COND clause parsing",
+                        "Unexpected '$' separator outside COND clause parsing. \
+                         '$' is control directive sugar for COND-CLAUSE and is meaningful only inside a COND expression.",
                     ));
                 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,6 +5,7 @@ pub mod elastic;
 mod error;
 pub mod interpreter;
 pub mod semantic;
+pub mod surface_forms;
 mod tokenizer;
 pub mod types;
 mod wasm_interpreter_bindings;

--- a/rust/src/surface_forms.rs
+++ b/rust/src/surface_forms.rs
@@ -1,0 +1,247 @@
+//! Surface-form metadata: the named, English-based concept behind every visible
+//! *symbolic* form in Ajisai source.
+//!
+//! Ajisai source is word-based. Visible symbols are **surface forms** — aliases
+//! or sugar for named, English-based canonical concepts. Crucially, not every
+//! surface form is a runtime word: some are purely lexical (resolved by the
+//! tokenizer), some are parser-level structural delimiters, and a few are
+//! reserved markers that never appear as runtime tokens at all.
+//!
+//! This module classifies the lexical / structural / reserved surface forms that
+//! are **not** runtime-canonicalizable words. The runtime *word* aliases
+//! (`+` -> `ADD`, `.` -> `TOP`, `==` -> `PIPE`, ...) live in
+//! [`crate::core_word_aliases`], which remains the single source of truth for
+//! runtime name canonicalization. The two tables are deliberately kept separate:
+//! [`crate::core_word_aliases::canonicalize_core_word_name`] must never map `#`,
+//! `[`, `{`, `'`, `;`, ... onto the concept names defined here, because these
+//! concepts are not runtime words.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SurfaceFormKind {
+    /// Parser-level structural delimiter, e.g. `[` `]` `{` `}`.
+    DelimiterSugar,
+    /// String-literal delimiter, e.g. `'`.
+    LiteralSugar,
+    /// Compound stack-modifier shorthand, e.g. `;` (`. ,`) and `;;` (`.. ,,`).
+    ModifierSugar,
+    /// Source-level directive consumed by the tokenizer, e.g. `#`.
+    SourceDirective,
+    /// Control-flow directive meaningful only inside a construct, e.g. `$`.
+    ControlDirective,
+    /// Reserved marker that is never a runtime token, e.g. `(` `)`.
+    ReservedMarker,
+    /// Conversion-word lexical pattern: `>` immediately followed by letters,
+    /// e.g. `>CF`. This is a *pattern*, not a fixed table entry, because the
+    /// canonical home is a runtime word of the same name (see
+    /// [`is_conversion_word_token`]).
+    ConversionWord,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SurfaceForm {
+    /// The visible symbol as written in source.
+    pub surface: &'static str,
+    /// The named, English-based concept this surface form denotes.
+    pub concept: &'static str,
+    pub kind: SurfaceFormKind,
+    /// Whether the concept is a runtime word. Every entry in [`SURFACE_FORMS`]
+    /// is `false`: these are lexical / structural / reserved forms only.
+    pub runtime_word: bool,
+    pub summary: &'static str,
+}
+
+/// The lexical / structural / reserved surface forms.
+///
+/// Runtime word aliases are intentionally absent here; see
+/// [`crate::core_word_aliases::CORE_WORD_ALIASES`]. The `>NAME` conversion-word
+/// form is also absent because it is a pattern (see [`is_conversion_word_token`])
+/// whose canonical home is a runtime word, not a fixed sugar entry.
+pub const SURFACE_FORMS: &[SurfaceForm] = &[
+    SurfaceForm {
+        surface: "#",
+        concept: "COMMENT-LINE",
+        kind: SurfaceFormKind::SourceDirective,
+        runtime_word: false,
+        summary: "Line comment: characters from `#` to end of line are ignored",
+    },
+    SurfaceForm {
+        surface: "$",
+        concept: "COND-CLAUSE",
+        kind: SurfaceFormKind::ControlDirective,
+        runtime_word: false,
+        summary: "COND clause separator (guard $ body)",
+    },
+    SurfaceForm {
+        surface: "[",
+        concept: "BEGIN-VECTOR",
+        kind: SurfaceFormKind::DelimiterSugar,
+        runtime_word: false,
+        summary: "Vector start",
+    },
+    SurfaceForm {
+        surface: "]",
+        concept: "END-VECTOR",
+        kind: SurfaceFormKind::DelimiterSugar,
+        runtime_word: false,
+        summary: "Vector end",
+    },
+    SurfaceForm {
+        surface: "{",
+        concept: "BEGIN-BLOCK",
+        kind: SurfaceFormKind::DelimiterSugar,
+        runtime_word: false,
+        summary: "Code block start",
+    },
+    SurfaceForm {
+        surface: "}",
+        concept: "END-BLOCK",
+        kind: SurfaceFormKind::DelimiterSugar,
+        runtime_word: false,
+        summary: "Code block end",
+    },
+    SurfaceForm {
+        surface: "'",
+        concept: "STRING-QUOTE",
+        kind: SurfaceFormKind::LiteralSugar,
+        runtime_word: false,
+        summary: "String literal delimiter (serves as both open and close)",
+    },
+    SurfaceForm {
+        surface: ";",
+        concept: "TOP-EAT",
+        kind: SurfaceFormKind::ModifierSugar,
+        runtime_word: false,
+        summary: "Shorthand for `. ,` (TOP EAT)",
+    },
+    SurfaceForm {
+        surface: ";;",
+        concept: "STAK-KEEP",
+        kind: SurfaceFormKind::ModifierSugar,
+        runtime_word: false,
+        summary: "Shorthand for `.. ,,` (STAK KEEP)",
+    },
+    SurfaceForm {
+        surface: "(",
+        concept: "RESERVED-BEGIN",
+        kind: SurfaceFormKind::ReservedMarker,
+        runtime_word: false,
+        summary: "Reserved (continued-fraction serialization); not valid in source",
+    },
+    SurfaceForm {
+        surface: ")",
+        concept: "RESERVED-END",
+        kind: SurfaceFormKind::ReservedMarker,
+        runtime_word: false,
+        summary: "Reserved (continued-fraction serialization); not valid in source",
+    },
+];
+
+/// Look up the surface-form metadata for a symbol.
+pub fn lookup_surface_form(surface: &str) -> Option<&'static SurfaceForm> {
+    SURFACE_FORMS.iter().find(|f| f.surface == surface)
+}
+
+/// Classify a `>NAME` conversion-word token (e.g. `>CF`).
+///
+/// `>` and `>=` are the `GT` / `GTE` comparison aliases (see
+/// [`crate::core_word_aliases`]); `>` immediately followed by an ASCII letter is
+/// instead a single conversion-word token whose canonical home is the runtime
+/// word of the same name (e.g. the `>CF` continued-fraction conversion word).
+pub fn is_conversion_word_token(token: &str) -> bool {
+    let mut chars = token.chars();
+    chars.next() == Some('>') && matches!(chars.next(), Some(c) if c.is_ascii_alphabetic())
+}
+
+/// Human-readable label for a surface-form kind, for diagnostics.
+pub fn surface_form_kind_label(kind: SurfaceFormKind) -> &'static str {
+    match kind {
+        SurfaceFormKind::DelimiterSugar => "delimiter sugar",
+        SurfaceFormKind::LiteralSugar => "literal sugar",
+        SurfaceFormKind::ModifierSugar => "modifier sugar",
+        SurfaceFormKind::SourceDirective => "a source directive",
+        SurfaceFormKind::ControlDirective => "control directive sugar",
+        SurfaceFormKind::ReservedMarker => "a reserved marker",
+        SurfaceFormKind::ConversionWord => "a conversion word",
+    }
+}
+
+/// One-line diagnostic describing a surface form, e.g.
+/// `'$' is control directive sugar for COND-CLAUSE.`
+pub fn describe_surface_form(surface: &str) -> Option<String> {
+    lookup_surface_form(surface).map(|f| {
+        format!(
+            "'{}' is {} for {}.",
+            f.surface,
+            surface_form_kind_label(f.kind),
+            f.concept
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core_word_aliases::canonicalize_core_word_name;
+
+    #[test]
+    fn lookup_returns_named_concepts() {
+        assert_eq!(lookup_surface_form("#").unwrap().concept, "COMMENT-LINE");
+        assert_eq!(lookup_surface_form("$").unwrap().concept, "COND-CLAUSE");
+        assert_eq!(lookup_surface_form("[").unwrap().concept, "BEGIN-VECTOR");
+        assert_eq!(lookup_surface_form("]").unwrap().concept, "END-VECTOR");
+        assert_eq!(lookup_surface_form("{").unwrap().concept, "BEGIN-BLOCK");
+        assert_eq!(lookup_surface_form("}").unwrap().concept, "END-BLOCK");
+        assert_eq!(lookup_surface_form("'").unwrap().concept, "STRING-QUOTE");
+        assert_eq!(lookup_surface_form(";").unwrap().concept, "TOP-EAT");
+        assert_eq!(lookup_surface_form(";;").unwrap().concept, "STAK-KEEP");
+        assert_eq!(lookup_surface_form("(").unwrap().concept, "RESERVED-BEGIN");
+        assert_eq!(lookup_surface_form(")").unwrap().concept, "RESERVED-END");
+    }
+
+    #[test]
+    fn unknown_surface_form_is_none() {
+        assert!(lookup_surface_form("+").is_none());
+        assert!(lookup_surface_form("ADD").is_none());
+        assert!(lookup_surface_form("COND").is_none());
+    }
+
+    #[test]
+    fn surface_forms_are_never_runtime_words() {
+        assert!(SURFACE_FORMS.iter().all(|f| !f.runtime_word));
+    }
+
+    /// The two tables must stay disjoint: a lexical/structural surface form must
+    /// never be canonicalized onto its concept name as if it were a runtime word.
+    #[test]
+    fn canonicalize_does_not_leak_surface_concepts() {
+        assert_ne!(canonicalize_core_word_name("#"), "COMMENT-LINE");
+        assert_ne!(canonicalize_core_word_name("["), "BEGIN-VECTOR");
+        assert_ne!(canonicalize_core_word_name("{"), "BEGIN-BLOCK");
+        assert_ne!(canonicalize_core_word_name("'"), "STRING-QUOTE");
+        assert_ne!(canonicalize_core_word_name(";"), "TOP-EAT");
+        assert_ne!(canonicalize_core_word_name(";;"), "STAK-KEEP");
+        assert_ne!(canonicalize_core_word_name("$"), "COND-CLAUSE");
+    }
+
+    #[test]
+    fn conversion_word_pattern() {
+        assert!(is_conversion_word_token(">CF"));
+        assert!(is_conversion_word_token(">Cf"));
+        // `>` and `>=` are comparison aliases, not conversion words.
+        assert!(!is_conversion_word_token(">"));
+        assert!(!is_conversion_word_token(">="));
+        assert!(!is_conversion_word_token(">2"));
+    }
+
+    #[test]
+    fn describe_is_diagnostic_friendly() {
+        assert_eq!(
+            describe_surface_form("$").unwrap(),
+            "'$' is control directive sugar for COND-CLAUSE."
+        );
+        assert_eq!(
+            describe_surface_form("]").unwrap(),
+            "']' is delimiter sugar for END-VECTOR."
+        );
+    }
+}

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -16,6 +16,8 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             continue;
         }
 
+        // SourceDirective: `#` -> COMMENT-LINE (see surface_forms.rs). Not a
+        // runtime word; consumed here at the lexical level to end of line.
         if chars[i] == '#' {
             let had_token_before = !tokens.is_empty() && tokens.last() != Some(&Token::LineBreak);
 
@@ -29,12 +31,21 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             continue;
         }
 
+        // ReservedMarker: `(` -> RESERVED-BEGIN, `)` -> RESERVED-END (see
+        // surface_forms.rs). These are never runtime tokens.
         if chars[i] == '(' || chars[i] == ')' {
+            let concept = if chars[i] == '(' {
+                "RESERVED-BEGIN"
+            } else {
+                "RESERVED-END"
+            };
             return Err(format!(
-                "'{}' is not a valid Ajisai source character (Section 3.4). The nested continued-fraction form is a display/serialization artifact only; use '{{' and '}}' for code blocks.",
-                chars[i]
+                "'{}' is a reserved marker ({}) and is not a valid Ajisai source character (Section 3.4). The nested continued-fraction form is a display/serialization artifact only; use '{{' and '}}' for code blocks.",
+                chars[i], concept
             ));
         }
+        // ModifierSugar: `;` -> TOP-EAT (`. ,`), `;;` -> STAK-KEEP (`.. ,,`)
+        // (see surface_forms.rs). Expanded here into the underlying modifiers.
         if chars[i] == ';' {
             if i + 1 < chars.len() && chars[i + 1] == ';' {
                 tokens.push(Token::Symbol("..".into()));
@@ -90,8 +101,10 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
         }
 
         if chars[i] == '>' {
-            // `>NAME` (e.g. `>CF`) is a single conversion-modifier identifier,
-            // not the `>` comparison operator followed by a word.
+            // ConversionWord: `>NAME` (e.g. `>CF`) is a single conversion-word
+            // token whose canonical home is the runtime word of the same name
+            // (see surface_forms::is_conversion_word_token). This is distinct
+            // from `>` -> GT and `>=` -> GTE (core_word_aliases.rs).
             if i + 1 < chars.len() && chars[i + 1].is_ascii_alphabetic() {
                 let start = i;
                 i += 1;
@@ -177,6 +190,9 @@ fn is_special_char(c: char) -> bool {
 }
 
 fn parse_token_from_single_char(c: char) -> Option<(Token, usize)> {
+    // DelimiterSugar / ControlDirective surface forms (see surface_forms.rs):
+    // `[` -> BEGIN-VECTOR, `]` -> END-VECTOR, `{` -> BEGIN-BLOCK,
+    // `}` -> END-BLOCK, `$` -> COND-CLAUSE. None of these are runtime words.
     match c {
         '[' => Some((Token::VectorStart, 1)),
         ']' => Some((Token::VectorEnd, 1)),
@@ -356,6 +372,8 @@ enum QuoteParseResult {
     NotQuote,
 }
 
+// LiteralSugar: `'` -> STRING-QUOTE (see surface_forms.rs). A single quote
+// serves as both the opening and closing string delimiter; not a runtime word.
 fn parse_string_from_quote(chars: &[char]) -> QuoteParseResult {
     if chars.is_empty() {
         return QuoteParseResult::NotQuote;


### PR DESCRIPTION
## 背景・指示書の妥当性判断

改修指示書の中心思想 —「Ajisai の可視記号はすべて英単語ベースの canonical concept に対応し、ただし必ずしも runtime word ではない」— は妥当と判断しました。現状 `#`, `$`, `[ ] { }`, `'`, `;`, `;;`, `( )` は tokenizer 内に意味名のないハードコード記号として散在しており、ここに名前と分類を与える価値があります。

一方、指示書のうち **2点は問題があると判断し、改善しました**:

1. **`>CF` → `AS-CF` リネームは採用しない。** `>CF` は sugar ではなく既に `builtin_word_definitions.rs` に登録された実在の canonical runtime word です。`AS-CF` という word は存在せず、リネームは指示書自身の非目標である「互換性破壊」に該当し、registry・テスト・仕様の変更を伴います。代わりに `>NAME`（`>` + 英字）を **conversion-word の字句規則** として文書化し、canonical 名は維持しました。
2. **lexical sugar を `CORE_WORD_ALIASES` / `canonicalize_core_word_name` に混ぜない。** 指示書推奨どおり**別テーブル**として実装し、runtime canonicalization には一切影響を与えていません（回帰リスクゼロ）。

## 変更内容

- **新規 `surface_forms` モジュール**: `SurfaceFormKind` / `SurfaceForm` と `SURFACE_FORMS` テーブル（`#`→`COMMENT-LINE`, `$`→`COND-CLAUSE`, `[`/`]`→`BEGIN-VECTOR`/`END-VECTOR`, `{`/`}`→`BEGIN-BLOCK`/`END-BLOCK`, `'`→`STRING-QUOTE`, `;`→`TOP-EAT`, `;;`→`STAK-KEEP`, `(`/`)`→`RESERVED-BEGIN`/`RESERVED-END`）、`lookup_surface_form` / `is_conversion_word_token` / 診断ヘルパー。
- **tokenizer**: 各特殊文字処理の近くに対応 concept 名コメントを追記（挙動は不変）。
- **エラーメッセージ改善**: 予約記号 `(`/`)`、COND 外 `$` に concept 名を表示。既存テストが検証する `"not a valid Ajisai source character"` 部分文字列は保持。
- **SPECIFICATION.md**（canonical）: 新節 **3.9 Surface forms**（分類表＋記号対応表）を追加し、3.4 から参照。
- **テスト**: lookup、conversion-word パターン、および「surface concept は決して runtime canonicalization にならない」不変条件を追加。

## 検証

- `cargo build` 成功（新規警告なし）
- `cargo test --lib` … **1264 passed / 0 failed**
- 自分の追加コードは fmt-clean（リポジトリ全体には既存の fmt 未整形が多数あるが、無関係なため触れていません）

## 非目標（指示書どおり）

`#` を runtime word 化しない / delimiter を実行可能にしない / tokenizer の大規模再設計をしない / 既存ソース互換を壊さない / `;` `;;` の挙動を変えない。

https://claude.ai/code/session_014kNeXuTByPdUmGngGvXu2K

---
_Generated by [Claude Code](https://claude.ai/code/session_014kNeXuTByPdUmGngGvXu2K)_