### PR TITLE
style: apply cargo fmt across ajisai-core and wasm-tests crates

### DIFF
--- a/rust/benches/interpreter-performance-benchmarks.rs
+++ b/rust/benches/interpreter-performance-benchmarks.rs
@@ -1,31 +1,93 @@
-use criterion::{criterion_group, criterion_main, Criterion, black_box};
-use std::collections::HashMap;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use num_bigint::BigInt;
 use num_traits::One;
+use std::collections::HashMap;
 
-use ajisai_core::types::fraction::Fraction;
 use ajisai_core::elastic::ElasticMode;
 use ajisai_core::interpreter::Interpreter;
-
+use ajisai_core::types::fraction::Fraction;
 
 fn build_ajisai_dictionary() -> HashMap<String, String> {
     let words = vec![
-        "GET", "INSERT", "REPLACE", "REMOVE", "LENGTH", "TAKE", "SPLIT",
-        "CONCAT", "REVERSE", "RANGE", "REORDER", "COLLECT", "SORT",
-        "SHAPE", "RANK", "RESHAPE", "TRANSPOSE", "FILL",
-        "FLOOR", "CEIL", "ROUND", "MOD",
-        "+", "-", "*", "/", "=", "<", "<=",
-        "AND", "OR", "NOT",
-        "PRINT", "DEF", "DEL", "?",
-        "MAP", "FILTER", "FOLD", "TIMES", "EXEC", "EVAL",
-        "TRUE", "FALSE", "NIL",
-        "STR", "NUM", "BOOL", "CHR", "CHARS", "JOIN",
-        "NOW", "DATETIME", "TIMESTAMP", "CSPRNG", "HASH",
-        "SEQ", "SIM", "SLOT", "GAIN", "GAIN-RESET",
-        "PAN", "PAN-RESET", "FX-RESET", "PLAY", "CHORD", "ADSR",
-        "SINE", "SQUARE", "SAW", "TRI",
-        "PARSE", "STRINGIFY", "INPUT", "OUTPUT",
-        "JSON-GET", "JSON-KEYS", "JSON-SET", "JSON-EXPORT",
+        "GET",
+        "INSERT",
+        "REPLACE",
+        "REMOVE",
+        "LENGTH",
+        "TAKE",
+        "SPLIT",
+        "CONCAT",
+        "REVERSE",
+        "RANGE",
+        "REORDER",
+        "COLLECT",
+        "SORT",
+        "SHAPE",
+        "RANK",
+        "RESHAPE",
+        "TRANSPOSE",
+        "FILL",
+        "FLOOR",
+        "CEIL",
+        "ROUND",
+        "MOD",
+        "+",
+        "-",
+        "*",
+        "/",
+        "=",
+        "<",
+        "<=",
+        "AND",
+        "OR",
+        "NOT",
+        "PRINT",
+        "DEF",
+        "DEL",
+        "?",
+        "MAP",
+        "FILTER",
+        "FOLD",
+        "TIMES",
+        "EXEC",
+        "EVAL",
+        "TRUE",
+        "FALSE",
+        "NIL",
+        "STR",
+        "NUM",
+        "BOOL",
+        "CHR",
+        "CHARS",
+        "JOIN",
+        "NOW",
+        "DATETIME",
+        "TIMESTAMP",
+        "CSPRNG",
+        "HASH",
+        "SEQ",
+        "SIM",
+        "SLOT",
+        "GAIN",
+        "GAIN-RESET",
+        "PAN",
+        "PAN-RESET",
+        "FX-RESET",
+        "PLAY",
+        "CHORD",
+        "ADSR",
+        "SINE",
+        "SQUARE",
+        "SAW",
+        "TRI",
+        "PARSE",
+        "STRINGIFY",
+        "INPUT",
+        "OUTPUT",
+        "JSON-GET",
+        "JSON-KEYS",
+        "JSON-SET",
+        "JSON-EXPORT",
         "!",
     ];
     let mut map = HashMap::new();
@@ -61,7 +123,6 @@ fn bench_hashmap_lookup_miss(c: &mut Criterion) {
     });
 }
 
-
 fn bench_fraction_new_small_integers(c: &mut Criterion) {
     c.bench_function("fraction_new_small_integers", |b| {
         b.iter(|| {
@@ -87,7 +148,6 @@ fn bench_fraction_new_large_gcd(c: &mut Criterion) {
         })
     });
 }
-
 
 fn bench_fraction_add_i64_path(c: &mut Criterion) {
     let a = Fraction::new(BigInt::from(3), BigInt::from(7));
@@ -201,14 +261,14 @@ fn bench_fraction_eq_fraction(c: &mut Criterion) {
     });
 }
 
-
 fn bench_interpreter_simple_arithmetic(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     c.bench_function("interp_simple_arithmetic", |b| {
         b.iter(|| {
             let mut interp = Interpreter::new();
-            rt.block_on(interp.execute("[ 1 2 3 ] [ 4 5 6 ] +")).unwrap();
+            rt.block_on(interp.execute("[ 1 2 3 ] [ 4 5 6 ] +"))
+                .unwrap();
             black_box(&interp);
         })
     });
@@ -276,7 +336,8 @@ fn bench_interpreter_sort(c: &mut Criterion) {
     c.bench_function("interp_sort", |b| {
         b.iter(|| {
             let mut interp = Interpreter::new();
-            rt.block_on(interp.execute("'algo' IMPORT [ 5 3 8 1 9 2 7 4 10 6 ] SORT")).unwrap();
+            rt.block_on(interp.execute("'algo' IMPORT [ 5 3 8 1 9 2 7 4 10 6 ] SORT"))
+                .unwrap();
             black_box(&interp);
         })
     });
@@ -288,9 +349,8 @@ fn bench_interpreter_word_lookup_overhead(c: &mut Criterion) {
     c.bench_function("interp_many_word_lookups", |b| {
         b.iter(|| {
             let mut interp = Interpreter::new();
-            rt.block_on(interp.execute(
-                "'algo' IMPORT [ 3 1 2 ] SORT == ,, LENGTH"
-            )).unwrap();
+            rt.block_on(interp.execute("'algo' IMPORT [ 3 1 2 ] SORT == ,, LENGTH"))
+                .unwrap();
             black_box(&interp);
         })
     });
@@ -330,7 +390,8 @@ fn bench_interpreter_vector_construction(c: &mut Criterion) {
     c.bench_function("interp_vector_construction", |b| {
         b.iter(|| {
             let mut interp = Interpreter::new();
-            rt.block_on(interp.execute("[ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ]")).unwrap();
+            rt.block_on(interp.execute("[ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ]"))
+                .unwrap();
             black_box(&interp);
         })
     });
@@ -342,9 +403,8 @@ fn bench_interpreter_fraction_heavy(c: &mut Criterion) {
     c.bench_function("interp_fraction_heavy", |b| {
         b.iter(|| {
             let mut interp = Interpreter::new();
-            rt.block_on(interp.execute(
-                "[ 1/3 2/7 5/11 3/13 7/17 ] [ 1/2 3/5 4/9 2/3 1/7 ] *"
-            )).unwrap();
+            rt.block_on(interp.execute("[ 1/3 2/7 5/11 3/13 7/17 ] [ 1/2 3/5 4/9 2/3 1/7 ] *"))
+                .unwrap();
             black_box(&interp);
         })
     });
@@ -365,7 +425,8 @@ fn bench_interpreter_reuse(c: &mut Criterion) {
     c.bench_function("interp_reuse_add", |b| {
         b.iter(|| {
             interp.update_stack(Vec::new());
-            rt.block_on(interp.execute("[ 1 2 3 ] [ 4 5 6 ] +")).unwrap();
+            rt.block_on(interp.execute("[ 1 2 3 ] [ 4 5 6 ] +"))
+                .unwrap();
             black_box(&interp);
         })
     });
@@ -374,19 +435,71 @@ fn bench_interpreter_reuse(c: &mut Criterion) {
 fn bench_interpreter_hof_mode_matrix(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let scenarios: [(&str, &str, ElasticMode); 13] = [
-        ("map_arith_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP", ElasticMode::Greedy),
-        ("map_arith_hedged", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP", ElasticMode::HedgedSafe),
-        ("map_arith_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP", ElasticMode::FastGuarded),
-        ("map_predicate_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] < } MAP", ElasticMode::Greedy),
-        ("map_predicate_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] < } MAP", ElasticMode::FastGuarded),
-        ("filter_greedy", "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER", ElasticMode::Greedy),
-        ("filter_fast_guarded", "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER", ElasticMode::FastGuarded),
-        ("fold_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD", ElasticMode::Greedy),
-        ("fold_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD", ElasticMode::FastGuarded),
-        ("scan_greedy", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } SCAN", ElasticMode::Greedy),
-        ("scan_fast_guarded", "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } SCAN", ElasticMode::FastGuarded),
-        ("epoch_change_hedged", "{ [2] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP { [3] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP", ElasticMode::HedgedSafe),
-        ("epoch_change_fast_guarded", "{ [2] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP { [3] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP", ElasticMode::FastGuarded),
+        (
+            "map_arith_greedy",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP",
+            ElasticMode::Greedy,
+        ),
+        (
+            "map_arith_hedged",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP",
+            ElasticMode::HedgedSafe,
+        ),
+        (
+            "map_arith_fast_guarded",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 2 ] * } MAP",
+            ElasticMode::FastGuarded,
+        ),
+        (
+            "map_predicate_greedy",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] < } MAP",
+            ElasticMode::Greedy,
+        ),
+        (
+            "map_predicate_fast_guarded",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 5 ] < } MAP",
+            ElasticMode::FastGuarded,
+        ),
+        (
+            "filter_greedy",
+            "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER",
+            ElasticMode::Greedy,
+        ),
+        (
+            "filter_fast_guarded",
+            "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER",
+            ElasticMode::FastGuarded,
+        ),
+        (
+            "fold_greedy",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD",
+            ElasticMode::Greedy,
+        ),
+        (
+            "fold_fast_guarded",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD",
+            ElasticMode::FastGuarded,
+        ),
+        (
+            "scan_greedy",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } SCAN",
+            ElasticMode::Greedy,
+        ),
+        (
+            "scan_fast_guarded",
+            "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } SCAN",
+            ElasticMode::FastGuarded,
+        ),
+        (
+            "epoch_change_hedged",
+            "{ [2] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP { [3] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP",
+            ElasticMode::HedgedSafe,
+        ),
+        (
+            "epoch_change_fast_guarded",
+            "{ [2] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP { [3] * } 'DBL' DEF [1 2 3 4] 'DBL' MAP",
+            ElasticMode::FastGuarded,
+        ),
     ];
 
     c.bench_function("interp_hof_mode_matrix", |b| {
@@ -417,7 +530,6 @@ fn bench_interpreter_hof_mode_matrix(c: &mut Criterion) {
         })
     });
 }
-
 
 const TRIE_ALPHABET_SIZE: usize = 40;
 
@@ -485,22 +597,82 @@ impl Default for TrieNode {
 
 fn build_trie_dictionary() -> TrieNode {
     let words = vec![
-        "GET", "INSERT", "REPLACE", "REMOVE", "LENGTH", "TAKE", "SPLIT",
-        "CONCAT", "REVERSE", "RANGE", "REORDER", "COLLECT", "SORT",
-        "SHAPE", "RANK", "RESHAPE", "TRANSPOSE", "FILL",
-        "FLOOR", "CEIL", "ROUND", "MOD",
-        "+", "-", "*", "/", "=", "<", "<=",
-        "AND", "OR", "NOT",
-        "PRINT", "DEF", "DEL", "?",
-        "MAP", "FILTER", "FOLD", "TIMES", "EXEC", "EVAL",
-        "TRUE", "FALSE", "NIL",
-        "STR", "NUM", "BOOL", "CHR", "CHARS", "JOIN",
-        "CSPRNG", "HASH",
-        "SEQ", "SIM", "SLOT", "GAIN", "GAIN-RESET",
-        "PAN", "PAN-RESET", "FX-RESET", "PLAY", "CHORD", "ADSR",
-        "SINE", "SQUARE", "SAW", "TRI",
-        "PARSE", "STRINGIFY", "INPUT", "OUTPUT",
-        "JSON-GET", "JSON-KEYS", "JSON-SET", "JSON-EXPORT",
+        "GET",
+        "INSERT",
+        "REPLACE",
+        "REMOVE",
+        "LENGTH",
+        "TAKE",
+        "SPLIT",
+        "CONCAT",
+        "REVERSE",
+        "RANGE",
+        "REORDER",
+        "COLLECT",
+        "SORT",
+        "SHAPE",
+        "RANK",
+        "RESHAPE",
+        "TRANSPOSE",
+        "FILL",
+        "FLOOR",
+        "CEIL",
+        "ROUND",
+        "MOD",
+        "+",
+        "-",
+        "*",
+        "/",
+        "=",
+        "<",
+        "<=",
+        "AND",
+        "OR",
+        "NOT",
+        "PRINT",
+        "DEF",
+        "DEL",
+        "?",
+        "MAP",
+        "FILTER",
+        "FOLD",
+        "TIMES",
+        "EXEC",
+        "EVAL",
+        "TRUE",
+        "FALSE",
+        "NIL",
+        "STR",
+        "NUM",
+        "BOOL",
+        "CHR",
+        "CHARS",
+        "JOIN",
+        "CSPRNG",
+        "HASH",
+        "SEQ",
+        "SIM",
+        "SLOT",
+        "GAIN",
+        "GAIN-RESET",
+        "PAN",
+        "PAN-RESET",
+        "FX-RESET",
+        "PLAY",
+        "CHORD",
+        "ADSR",
+        "SINE",
+        "SQUARE",
+        "SAW",
+        "TRI",
+        "PARSE",
+        "STRINGIFY",
+        "INPUT",
+        "OUTPUT",
+        "JSON-GET",
+        "JSON-KEYS",
+        "JSON-SET",
+        "JSON-EXPORT",
         "!",
     ];
     let mut trie = TrieNode::new();
@@ -535,7 +707,6 @@ fn bench_trie_lookup_miss(c: &mut Criterion) {
         })
     });
 }
-
 
 criterion_group!(
     dictionary_benches,

--- a/rust/src/arithmetic_operation_tests.rs
+++ b/rust/src/arithmetic_operation_tests.rs
@@ -746,7 +746,6 @@ mod ai_first_comparison_tests {
         let stack = interp.get_stack();
         assert_eq!(stack.len(), 3, "KEEP must retain both operands plus result");
     }
-
 }
 
 #[cfg(test)]

--- a/rust/src/dimension_limit_tests.rs
+++ b/rust/src/dimension_limit_tests.rs
@@ -109,7 +109,11 @@ mod dimension_limit_tests {
             "2D outermost should be [ ], got: {}",
             result
         );
-        assert!(result.contains("[ 1/1 2/1 ]"), "2D inner should use [ ], got: {}", result);
+        assert!(
+            result.contains("[ 1/1 2/1 ]"),
+            "2D inner should use [ ], got: {}",
+            result
+        );
     }
 
     #[tokio::test]

--- a/rust/src/elastic/elastic_engine_tests.rs
+++ b/rust/src/elastic/elastic_engine_tests.rs
@@ -52,7 +52,9 @@ mod tests {
         // HOF / Cond / Exec dispatchers are themselves pure (Phase 1-B).
         // Callback purity is propagated separately via the PushCodeBlock
         // recursion in `analyze_compiled_plan_with_context`.
-        for word in &["MAP", "FILTER", "FOLD", "SCAN", "ANY", "ALL", "COUNT", "UNFOLD", "COND", "EXEC"] {
+        for word in &[
+            "MAP", "FILTER", "FOLD", "SCAN", "ANY", "ALL", "COUNT", "UNFOLD", "COND", "EXEC",
+        ] {
             let info = purity_by_name(word)
                 .unwrap_or_else(|| panic!("missing purity entry for '{}'", word));
             assert_eq!(info.purity, Purity::Pure, "{}: expected Pure", word);
@@ -510,7 +512,8 @@ mod tests {
 
     #[tokio::test]
     async fn semantics_fast_guarded_hof_kernels() {
-        let code = "[1 2 3 4] { [1] + } MAP [1 2 3 4] { [2] MOD [0] = } FILTER [1 2 3 4] [0] { + } FOLD";
+        let code =
+            "[1 2 3 4] { [1] + } MAP [1 2 3 4] { [2] MOD [0] = } FILTER [1 2 3 4] [0] { + } FOLD";
         let greedy = run_greedy(code).await;
         let fast_guarded = run_fast_guarded(code).await;
         assert_eq!(

--- a/rust/src/elastic/tracer.rs
+++ b/rust/src/elastic/tracer.rs
@@ -17,7 +17,6 @@
 /// === Elastic Tracer Report ===
 ///   +                    calls=42  avg=0.011ms  total=0.5ms
 /// ```
-
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -52,7 +51,10 @@ lazy_static::lazy_static! {
 pub fn init_from_env() {
     #[cfg(not(target_arch = "wasm32"))]
     {
-        if std::env::var("AJISAI_TRACE").map(|v| v == "1").unwrap_or(false) {
+        if std::env::var("AJISAI_TRACE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+        {
             TRACE_ENABLED.store(true, Ordering::Relaxed);
         }
     }
@@ -97,14 +99,17 @@ pub fn report() {
     let data = TRACE_DATA.lock().unwrap();
     eprintln!("\n=== Elastic Tracer Report ===");
 
-    let mut entries: Vec<(&String, u64)> =
-        data.call_counts.iter().map(|(k, &v)| (k, v)).collect();
+    let mut entries: Vec<(&String, u64)> = data.call_counts.iter().map(|(k, &v)| (k, v)).collect();
     entries.sort_by(|a, b| b.1.cmp(&a.1));
 
     for (word, count) in entries.iter().take(20) {
-        let total_ns  = data.total_nanos.get(*word).copied().unwrap_or(0);
-        let avg_ms    = if *count > 0 { total_ns as f64 / *count as f64 / 1_000_000.0 } else { 0.0 };
-        let total_ms  = total_ns as f64 / 1_000_000.0;
+        let total_ns = data.total_nanos.get(*word).copied().unwrap_or(0);
+        let avg_ms = if *count > 0 {
+            total_ns as f64 / *count as f64 / 1_000_000.0
+        } else {
+            0.0
+        };
+        let total_ms = total_ns as f64 / 1_000_000.0;
         eprintln!(
             "  {:<20} calls={:<6} avg={:.3}ms  total={:.1}ms",
             word, count, avg_ms, total_ms

--- a/rust/src/interpreter/arithmetic.rs
+++ b/rust/src/interpreter/arithmetic.rs
@@ -471,7 +471,8 @@ pub fn op_div(interp: &mut Interpreter) -> Result<()> {
         if stack_len >= 2 {
             let left_hint = interp.semantic_registry.lookup_hint_at(stack_len - 2);
             let right_hint = interp.semantic_registry.lookup_hint_at(stack_len - 1);
-            if matches!(left_hint, Interpretation::Text) || matches!(right_hint, Interpretation::Text)
+            if matches!(left_hint, Interpretation::Text)
+                || matches!(right_hint, Interpretation::Text)
             {
                 return Err(AjisaiError::create_structure_error("number", "string"));
             }

--- a/rust/src/interpreter/audio/audio_integration_tests.rs
+++ b/rust/src/interpreter/audio/audio_integration_tests.rs
@@ -11,7 +11,6 @@ async fn test_play_integration() {
 
     let output = interp.collect_output();
 
-
     assert!(
         output.contains("AUDIO:"),
         "Output should contain AUDIO command: {}",
@@ -27,9 +26,7 @@ async fn test_play_integration() {
 async fn test_seq_play_integration() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
-    let result = interp
-        .execute("[ 440 550 660 ] MUSIC@SEQ MUSIC@PLAY")
-        .await;
+    let result = interp.execute("[ 440 550 660 ] MUSIC@SEQ MUSIC@PLAY").await;
     assert!(
         result.is_ok(),
         "SEQ MUSIC@PLAY should succeed: {:?}",
@@ -47,9 +44,7 @@ async fn test_seq_play_integration() {
 async fn test_sim_play_integration() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
-    let result = interp
-        .execute("[ 440 550 660 ] MUSIC@SIM MUSIC@PLAY")
-        .await;
+    let result = interp.execute("[ 440 550 660 ] MUSIC@SIM MUSIC@PLAY").await;
     assert!(
         result.is_ok(),
         "SIM MUSIC@PLAY should succeed: {:?}",
@@ -58,11 +53,7 @@ async fn test_sim_play_integration() {
 
     let output = interp.collect_output();
 
-
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
@@ -83,7 +74,6 @@ async fn test_multitrack_play() {
         output.contains("\"type\":\"sim\""),
         "Should contain sim structure for multitrack"
     );
-
 
     assert!(
         interp.get_stack().is_empty(),
@@ -111,7 +101,6 @@ async fn test_multitrack_seq_play() {
         "Should contain seq structure for multitrack"
     );
 
-
     assert!(
         interp.get_stack().is_empty(),
         "Stack should be empty after .. MUSIC@SEQ MUSIC@PLAY"
@@ -120,7 +109,6 @@ async fn test_multitrack_seq_play() {
 
 #[tokio::test]
 async fn test_multitrack_play_consumes_all() {
-
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
     let result = interp
@@ -132,7 +120,6 @@ async fn test_multitrack_play_consumes_all() {
         result
     );
 
-
     assert!(
         interp.get_stack().is_empty(),
         "Stack should be completely empty after playing 3 tracks"
@@ -141,8 +128,6 @@ async fn test_multitrack_play_consumes_all() {
 
 #[tokio::test]
 async fn test_play_with_duration() {
-
-
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
     let result = interp.execute("[ 440/3 550/1 660/7 ] MUSIC@PLAY").await;
@@ -153,16 +138,11 @@ async fn test_play_with_duration() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
 async fn test_play_with_zero_rest() {
-
-
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
     let result = interp.execute("[ 440 0/2 550 ] MUSIC@PLAY").await;
@@ -173,18 +153,13 @@ async fn test_play_with_zero_rest() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
-
 
 #[tokio::test]
 async fn test_chord_marks_as_simultaneous() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
-
 
     let result = interp
         .execute("[ 440 550 660 ] MUSIC@CHORD MUSIC@PLAY")
@@ -196,10 +171,7 @@ async fn test_chord_marks_as_simultaneous() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
@@ -215,7 +187,6 @@ async fn test_adsr_sets_envelope() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
 
-
     let result = interp
         .execute("[ 440 ] [ 0.05 0.1 0.8 0.2 ] MUSIC@ADSR MUSIC@PLAY")
         .await;
@@ -227,10 +198,7 @@ async fn test_adsr_sets_envelope() {
 
     let output = interp.collect_output();
 
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
@@ -244,7 +212,6 @@ async fn test_adsr_requires_4_elements() {
 
 #[tokio::test]
 async fn test_adsr_sustain_validation() {
-
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
     let result = interp
@@ -266,10 +233,7 @@ async fn test_square_waveform() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
@@ -285,10 +249,7 @@ async fn test_saw_waveform() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
@@ -304,15 +265,11 @@ async fn test_tri_waveform() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
 async fn test_sine_is_default_not_serialized() {
-
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
     let result = interp.execute("[ 440 ] MUSIC@SINE MUSIC@PLAY").await;
@@ -512,8 +469,11 @@ async fn test_combined_chord_adsr_waveform() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
 
-
-    let result = interp.execute("[ 440 550 660 ] MUSIC@CHORD [ 0.01 0.1 0.7 0.3 ] MUSIC@ADSR MUSIC@SQUARE MUSIC@PLAY").await;
+    let result = interp
+        .execute(
+            "[ 440 550 660 ] MUSIC@CHORD [ 0.01 0.1 0.7 0.3 ] MUSIC@ADSR MUSIC@SQUARE MUSIC@PLAY",
+        )
+        .await;
     assert!(
         result.is_ok(),
         "Combined CHORD ADSR SQUARE PLAY should succeed: {:?}",
@@ -521,10 +481,7 @@ async fn test_combined_chord_adsr_waveform() {
     );
 
     let output = interp.collect_output();
-    assert!(
-        output.contains("AUDIO:"),
-        "Should contain AUDIO command"
-    );
+    assert!(output.contains("AUDIO:"), "Should contain AUDIO command");
 }
 
 #[tokio::test]
@@ -579,9 +536,7 @@ async fn test_rest_plays_as_rest() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
 
-    let result = interp
-        .execute("1 MUSIC@DUR MUSIC@REST MUSIC@PLAY")
-        .await;
+    let result = interp.execute("1 MUSIC@DUR MUSIC@REST MUSIC@PLAY").await;
     assert!(result.is_ok(), "REST/PLAY should succeed: {:?}", result);
 
     let output = interp.collect_output();
@@ -669,7 +624,11 @@ async fn test_hz_respects_keep_mode() {
 
     // ,, is the KEEP modifier: the operand must remain on the stack.
     let result = interp.execute("440 ,, MUSIC@HZ").await;
-    assert!(result.is_ok(), "HZ in KEEP mode should succeed: {:?}", result);
+    assert!(
+        result.is_ok(),
+        "HZ in KEEP mode should succeed: {:?}",
+        result
+    );
 
     assert_eq!(
         interp.get_stack().len(),
@@ -721,10 +680,7 @@ async fn test_explain_describes_pitch_and_note() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
 
-    interp
-        .execute("440 MUSIC@HZ MUSIC@EXPLAIN")
-        .await
-        .unwrap();
+    interp.execute("440 MUSIC@HZ MUSIC@EXPLAIN").await.unwrap();
     let pitch_output = interp.collect_output();
     assert!(
         pitch_output.contains("Pitch:"),
@@ -752,7 +708,11 @@ async fn test_raw_tensor_vector_plays_all_children() {
     interp.execute("'music' IMPORT").await.unwrap();
 
     let result = interp.execute("[ 440 550 660 ] MUSIC@PLAY").await;
-    assert!(result.is_ok(), "Raw vector PLAY should succeed: {:?}", result);
+    assert!(
+        result.is_ok(),
+        "Raw vector PLAY should succeed: {:?}",
+        result
+    );
 
     let output = interp.collect_output();
     assert!(
@@ -769,9 +729,7 @@ async fn test_voice_group_explains_as_voice() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
 
-    let result = interp
-        .execute("[ 440 550 ] MUSIC@VOICE MUSIC@PLAY")
-        .await;
+    let result = interp.execute("[ 440 550 ] MUSIC@VOICE MUSIC@PLAY").await;
     assert!(result.is_ok(), "VOICE PLAY should succeed: {:?}", result);
     let output = interp.collect_output();
     assert!(
@@ -876,7 +834,9 @@ async fn test_with_tuning_rejects_non_tuning_operand() {
     let mut interp = Interpreter::new();
     interp.execute("'music' IMPORT").await.unwrap();
 
-    let result = interp.execute("[ 0 2 4 ] [ 0 2 4 ] MUSIC@WITH-TUNING").await;
+    let result = interp
+        .execute("[ 0 2 4 ] [ 0 2 4 ] MUSIC@WITH-TUNING")
+        .await;
     assert!(
         result.is_err(),
         "WITH-TUNING without a music.tuning operand should fail"

--- a/rust/src/interpreter/audio/audio_types.rs
+++ b/rust/src/interpreter/audio/audio_types.rs
@@ -1,9 +1,6 @@
-
-
 use super::super::Interpreter;
 use crate::types::ValueExt;
 use serde::Serialize;
-
 
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -53,7 +50,6 @@ impl ValueExt for AudioHint {
     }
 }
 
-
 pub(crate) struct MusicState {
     pub play_mode: PlayMode,
 }
@@ -80,14 +76,12 @@ pub(crate) fn update_play_mode(interp: &mut Interpreter, mode: PlayMode) {
     );
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum PlayMode {
     #[default]
     Sequential,
     Simultaneous,
 }
-
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
@@ -121,11 +115,9 @@ pub enum AudioStructure {
     },
 }
 
-
 pub(crate) fn is_default_waveform(wf: &WaveformType) -> bool {
     *wf == WaveformType::Sine
 }
-
 
 #[derive(Debug, Serialize)]
 pub(crate) struct PlayCommand {

--- a/rust/src/interpreter/audio/audio_unit_tests.rs
+++ b/rust/src/interpreter/audio/audio_unit_tests.rs
@@ -1,7 +1,7 @@
 //! Unit test suite for `crate::interpreter::audio`.
 
-use super::build_audio_structure::build_audio_structure;
 use super::audio_types::{AudioStructure, PlayMode};
+use super::build_audio_structure::build_audio_structure;
 use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_bigint::BigInt;
@@ -27,7 +27,6 @@ fn create_vector(elements: Vec<Value>) -> Value {
 
 #[test]
 fn test_tone_from_integer() {
-
     let val = create_number(440);
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Sequential, &mut output).unwrap();
@@ -47,7 +46,6 @@ fn test_tone_from_integer() {
 
 #[test]
 fn test_tone_from_fraction() {
-
     let val = create_fraction(440, 3);
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Sequential, &mut output).unwrap();
@@ -67,8 +65,6 @@ fn test_tone_from_fraction() {
 
 #[test]
 fn test_tone_from_fraction_unreduced() {
-
-
     let val = create_fraction(440, 2);
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Sequential, &mut output).unwrap();
@@ -88,7 +84,6 @@ fn test_tone_from_fraction_unreduced() {
 
 #[test]
 fn test_rest_from_zero() {
-
     let val = create_fraction(0, 4);
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Sequential, &mut output).unwrap();
@@ -103,7 +98,6 @@ fn test_rest_from_zero() {
 
 #[test]
 fn test_rest_from_zero_coprime() {
-
     let val = create_fraction(0, 3);
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Sequential, &mut output).unwrap();
@@ -118,7 +112,6 @@ fn test_rest_from_zero_coprime() {
 
 #[test]
 fn test_rest_from_nil() {
-
     let val = create_nil();
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Sequential, &mut output).unwrap();
@@ -133,11 +126,9 @@ fn test_rest_from_nil() {
 
 #[test]
 fn test_nil_becomes_rest() {
-
     let val = Value::nil();
     let mut output = String::new();
     let result = build_audio_structure(&val, PlayMode::Sequential, &mut output);
-
 
     match result {
         Ok(AudioStructure::Rest { duration }) => {
@@ -150,8 +141,6 @@ fn test_nil_becomes_rest() {
 
 #[test]
 fn test_seq_structure() {
-
-
     let elements = vec![create_number(440), create_number(550)];
     let val = create_vector(elements);
     let mut output = String::new();
@@ -167,13 +156,10 @@ fn test_seq_structure() {
 
 #[test]
 fn test_sim_structure() {
-
-
     let elements = vec![create_number(440), create_number(550)];
     let val = create_vector(elements);
     let mut output = String::new();
     let structure = build_audio_structure(&val, PlayMode::Simultaneous, &mut output).unwrap();
-
 
     match structure {
         AudioStructure::Seq { children, .. } => {

--- a/rust/src/interpreter/audio/build_audio_structure.rs
+++ b/rust/src/interpreter/audio/build_audio_structure.rs
@@ -1,14 +1,11 @@
-
-
+use super::super::{Interpreter, OperationTargetMode};
 use super::audio_types::{
     update_play_mode, AudioStructure, Envelope, PlayCommand, PlayMode, WaveformType,
 };
-use super::super::{Interpreter, OperationTargetMode};
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::{is_string_value, value_as_string};
 use crate::types::{Value, ValueData};
 use num_traits::ToPrimitive;
-
 
 pub fn op_play(interp: &mut Interpreter) -> Result<()> {
     let mode = super::lookup_play_mode(interp);
@@ -16,24 +13,20 @@ pub fn op_play(interp: &mut Interpreter) -> Result<()> {
 
     match target {
         OperationTargetMode::StackTop => {
-
             let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
             let structure = build_audio_structure(&val, mode, &mut interp.output_buffer)?;
             emit_play_command(&structure, &mut interp.output_buffer);
         }
         OperationTargetMode::Stack => {
-
             let values: Vec<Value> = interp.stack.drain(..).collect();
             if values.is_empty() {
                 return Err(AjisaiError::StackUnderflow);
             }
 
-
             let structures: Vec<AudioStructure> = values
                 .iter()
                 .map(|v| build_audio_structure(v, PlayMode::Sequential, &mut interp.output_buffer))
                 .collect::<Result<Vec<_>>>()?;
-
 
             let combined = match mode {
                 PlayMode::Sequential => AudioStructure::Seq {
@@ -52,13 +45,11 @@ pub fn op_play(interp: &mut Interpreter) -> Result<()> {
         }
     }
 
-
     update_play_mode(interp, PlayMode::Sequential);
     interp.operation_target_mode = OperationTargetMode::StackTop;
 
     Ok(())
 }
-
 
 pub(crate) fn build_audio_structure(
     value: &Value,
@@ -67,7 +58,6 @@ pub(crate) fn build_audio_structure(
 ) -> Result<AudioStructure> {
     build_audio_structure_ctx(value, mode, output, None)
 }
-
 
 /// `tuning`, when set, marks an active `MUSIC@WITH-TUNING` scope: bare scalars
 /// are read as steps of that tuning (numerator = step, denominator = duration)
@@ -132,9 +122,7 @@ fn build_audio_structure_ctx(
             .map(|e| build_audio_structure_ctx(e, PlayMode::Sequential, output, tuning))
             .collect::<Result<Vec<_>>>()?
             .into_iter()
-            .filter(
-                |s| !matches!(s, AudioStructure::Seq { children, .. } if children.is_empty()),
-            )
+            .filter(|s| !matches!(s, AudioStructure::Seq { children, .. } if children.is_empty()))
             .collect();
 
         return match group.mode {
@@ -143,12 +131,13 @@ fn build_audio_structure_ctx(
                 envelope,
                 waveform,
             }),
-            super::music_group::GroupMode::Simultaneous
-            | super::music_group::GroupMode::Chord => Ok(AudioStructure::Sim {
-                children: group_children,
-                envelope,
-                waveform,
-            }),
+            super::music_group::GroupMode::Simultaneous | super::music_group::GroupMode::Chord => {
+                Ok(AudioStructure::Sim {
+                    children: group_children,
+                    envelope,
+                    waveform,
+                })
+            }
         };
     }
 
@@ -222,7 +211,6 @@ fn build_audio_structure_ctx(
     })
 }
 
-
 fn tone_or_rest(
     frequency: f64,
     duration: f64,
@@ -248,7 +236,6 @@ fn tone_or_rest(
     })
 }
 
-
 fn note_to_structure(
     note: &Value,
     envelope: Option<Envelope>,
@@ -264,7 +251,6 @@ fn note_to_structure(
         .ok_or_else(|| AjisaiError::from("Invalid music.note: unresolvable duration"))?;
     tone_or_rest(frequency, duration, envelope, waveform, output)
 }
-
 
 fn check_audible_range(freq: f64, output: &mut String) {
     const MIN_AUDIBLE: f64 = 20.0;
@@ -283,7 +269,6 @@ fn check_audible_range(freq: f64, output: &mut String) {
     }
 }
 
-
 fn emit_play_command(structure: &AudioStructure, output: &mut String) {
     let command = PlayCommand {
         command_type: "play".to_string(),
@@ -291,7 +276,6 @@ fn emit_play_command(structure: &AudioStructure, output: &mut String) {
     };
 
     if let Ok(json) = serde_json::to_string(&command) {
-
         if !output.is_empty() && !output.ends_with('\n') {
             output.push('\n');
         }

--- a/rust/src/interpreter/audio/execute_audio_commands.rs
+++ b/rust/src/interpreter/audio/execute_audio_commands.rs
@@ -1,12 +1,10 @@
-
-
+use super::super::Interpreter;
 use super::audio_types::{update_play_mode, PlayMode, WaveformType};
 use super::music_group::{explain_value, make_group, operand_children, GroupMode};
 use super::music_values::{
     make_duration, make_edo_pitch, make_hz_pitch, make_note, make_rest, make_scope, make_tuning,
     parse_ratio, record_kind, tuning_components, DURATION_KIND, PITCH_KIND, TUNING_KIND,
 };
-use super::super::Interpreter;
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::extract_integer_from_value;
 use crate::interpreter::{ConsumptionMode, OperationTargetMode};
@@ -14,18 +12,15 @@ use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_traits::ToPrimitive;
 
-
 pub fn op_seq(interp: &mut Interpreter) -> Result<()> {
     update_play_mode(interp, PlayMode::Sequential);
     Ok(())
 }
 
-
 pub fn op_sim(interp: &mut Interpreter) -> Result<()> {
     update_play_mode(interp, PlayMode::Simultaneous);
     Ok(())
 }
-
 
 fn extract_scalar_from_value(val: &Value) -> Option<Fraction> {
     if let Some(f) = val.as_scalar() {
@@ -38,24 +33,19 @@ fn extract_scalar_from_value(val: &Value) -> Option<Fraction> {
     None
 }
 
-
 pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-
-    let frac =
-        extract_scalar_from_value(&val).ok_or_else(|| AjisaiError::from("SLOT requires a single number"))?;
-
+    let frac = extract_scalar_from_value(&val)
+        .ok_or_else(|| AjisaiError::from("SLOT requires a single number"))?;
 
     let seconds = frac
         .to_f64()
         .ok_or_else(|| AjisaiError::from("SLOT value too large"))?;
 
-
     if seconds <= 0.0 {
         return Err(AjisaiError::from("SLOT duration must be positive"));
     }
-
 
     if seconds < 0.01 {
         interp.output_buffer.push_str(&format!(
@@ -70,7 +60,6 @@ pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
-
     interp
         .output_buffer
         .push_str(&format!("CONFIG:{{\"slot_duration\":{}}}\n", seconds));
@@ -78,16 +67,15 @@ pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let frac = extract_scalar_from_value(&val).ok_or_else(|| AjisaiError::from("GAIN requires a number"))?;
+    let frac = extract_scalar_from_value(&val)
+        .ok_or_else(|| AjisaiError::from("GAIN requires a number"))?;
 
     let gain = frac
         .to_f64()
         .ok_or_else(|| AjisaiError::from("GAIN value too large"))?;
-
 
     let clamped = gain.clamp(0.0, 1.0);
 
@@ -98,7 +86,6 @@ pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
-
     interp
         .output_buffer
         .push_str(&format!("EFFECT:{{\"gain\":{}}}\n", clamped));
@@ -106,22 +93,20 @@ pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 pub fn op_gain_reset(interp: &mut Interpreter) -> Result<()> {
     interp.output_buffer.push_str("EFFECT:{\"gain\":1.0}\n");
     Ok(())
 }
 
-
 pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let frac = extract_scalar_from_value(&val).ok_or_else(|| AjisaiError::from("PAN requires a number"))?;
+    let frac = extract_scalar_from_value(&val)
+        .ok_or_else(|| AjisaiError::from("PAN requires a number"))?;
 
     let pan = frac
         .to_f64()
         .ok_or_else(|| AjisaiError::from("PAN value too large"))?;
-
 
     let clamped = pan.clamp(-1.0, 1.0);
 
@@ -132,7 +117,6 @@ pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
-
     interp
         .output_buffer
         .push_str(&format!("EFFECT:{{\"pan\":{}}}\n", clamped));
@@ -140,12 +124,10 @@ pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 pub fn op_pan_reset(interp: &mut Interpreter) -> Result<()> {
     interp.output_buffer.push_str("EFFECT:{\"pan\":0.0}\n");
     Ok(())
 }
-
 
 pub fn op_fx_reset(interp: &mut Interpreter) -> Result<()> {
     interp
@@ -153,7 +135,6 @@ pub fn op_fx_reset(interp: &mut Interpreter) -> Result<()> {
         .push_str("EFFECT:{\"gain\":1.0,\"pan\":0.0}\n");
     Ok(())
 }
-
 
 /// Reject the whole-stack operation target mode for value constructors, which
 /// only have a well-defined effect on a fixed number of stack-top operands.
@@ -167,7 +148,6 @@ fn reject_stack_mode(interp: &Interpreter, word: &str) -> Result<()> {
     Ok(())
 }
 
-
 /// Clone the top `count` operands (stack order) without consuming them, so a
 /// constructor can validate before committing.
 fn peek_operands(interp: &Interpreter, count: usize) -> Result<Vec<Value>> {
@@ -178,7 +158,6 @@ fn peek_operands(interp: &Interpreter, count: usize) -> Result<Vec<Value>> {
     Ok(interp.stack[len - count..].to_vec())
 }
 
-
 /// Consume the operands (only in `Consume` mode) and push the constructed value.
 fn consume_and_push(interp: &mut Interpreter, count: usize, result: Value) {
     if interp.consumption_mode == ConsumptionMode::Consume {
@@ -188,14 +167,12 @@ fn consume_and_push(interp: &mut Interpreter, count: usize, result: Value) {
     interp.stack.push(result);
 }
 
-
 fn require_scalar(value: &Value, message: &str) -> Result<Fraction> {
     value
         .as_scalar()
         .cloned()
         .ok_or_else(|| AjisaiError::from(message))
 }
-
 
 fn require_positive_divisions(value: &Value, word: &str) -> Result<i64> {
     let divisions = extract_integer_from_value(value).map_err(|_| {
@@ -213,55 +190,42 @@ fn require_positive_divisions(value: &Value, word: &str) -> Result<i64> {
     Ok(divisions)
 }
 
-
 /// Build an explicit sequential music group from a vector.
 pub fn op_seq_group(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Sequential, "generic", "SEQ-GROUP")
 }
-
 
 /// Build an explicit simultaneous music group from a vector.
 pub fn op_sim_group(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Simultaneous, "generic", "SIM-GROUP")
 }
 
-
 /// Build an explicit chord group (simultaneous playback) from a vector.
 pub fn op_chord(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Chord, "chord", "CHORD")
 }
-
 
 /// Build a music group with the role of a single melodic voice.
 pub fn op_voice(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Sequential, "voice", "VOICE")
 }
 
-
 /// Build a music group with the role of an instrument track.
 pub fn op_track(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Sequential, "track", "TRACK")
 }
-
 
 /// Build a music group with the role of a measure (bar).
 pub fn op_measure(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Sequential, "measure", "MEASURE")
 }
 
-
 /// Build a music group with the role of a phrase.
 pub fn op_phrase(interp: &mut Interpreter) -> Result<()> {
     build_group(interp, GroupMode::Sequential, "phrase", "PHRASE")
 }
 
-
-fn build_group(
-    interp: &mut Interpreter,
-    mode: GroupMode,
-    role: &str,
-    word: &str,
-) -> Result<()> {
+fn build_group(interp: &mut Interpreter, mode: GroupMode, role: &str, word: &str) -> Result<()> {
     reject_stack_mode(interp, word)?;
     let operands = peek_operands(interp, 1)?;
     let children = operand_children(&operands[0], word)?;
@@ -270,30 +234,23 @@ fn build_group(
     Ok(())
 }
 
-
 /// Build a `music.pitch` from a direct frequency in Hz. The frequency is kept
 /// as an exact rational, so just-intonation ratios survive losslessly.
 pub fn op_hz(interp: &mut Interpreter) -> Result<()> {
     reject_stack_mode(interp, "HZ")?;
     let operands = peek_operands(interp, 1)?;
 
-    let hz = require_scalar(
-        &operands[0],
-        "MUSIC@HZ requires a number (frequency in Hz)",
-    )?;
+    let hz = require_scalar(&operands[0], "MUSIC@HZ requires a number (frequency in Hz)")?;
     let approx = hz
         .to_f64()
         .ok_or_else(|| AjisaiError::from("MUSIC@HZ frequency is too large"))?;
     if approx < 0.0 {
-        return Err(AjisaiError::from(
-            "MUSIC@HZ frequency must be non-negative",
-        ));
+        return Err(AjisaiError::from("MUSIC@HZ frequency must be non-negative"));
     }
 
     consume_and_push(interp, 1, make_hz_pitch(hz, "explicit:MUSIC@HZ"));
     Ok(())
 }
-
 
 /// Build a `music.duration` from a number of seconds.
 pub fn op_dur(interp: &mut Interpreter) -> Result<()> {
@@ -314,7 +271,6 @@ pub fn op_dur(interp: &mut Interpreter) -> Result<()> {
     consume_and_push(interp, 1, make_duration(seconds, "explicit:MUSIC@DUR"));
     Ok(())
 }
-
 
 /// Combine a `music.pitch` and a `music.duration` into a `music.note`.
 pub fn op_note(interp: &mut Interpreter) -> Result<()> {
@@ -341,7 +297,6 @@ pub fn op_note(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 /// Build a `music.rest` from a `music.duration`.
 pub fn op_rest(interp: &mut Interpreter) -> Result<()> {
     reject_stack_mode(interp, "REST")?;
@@ -357,7 +312,6 @@ pub fn op_rest(interp: &mut Interpreter) -> Result<()> {
     consume_and_push(interp, 1, rest);
     Ok(())
 }
-
 
 /// Build a `music.tuning` for equal division of the octave (EDO).
 pub fn op_edo(interp: &mut Interpreter) -> Result<()> {
@@ -389,7 +343,6 @@ pub fn op_edo(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 /// Build a `music.tuning` for equal division of an arbitrary ratio (EDR),
 /// supporting non-octave tunings such as the Bohlen-Pierce tritave (3/1).
 pub fn op_edr(interp: &mut Interpreter) -> Result<()> {
@@ -410,9 +363,7 @@ pub fn op_edr(interp: &mut Interpreter) -> Result<()> {
     }
 
     let (num, den) = parse_ratio(&operands[1]).ok_or_else(|| {
-        AjisaiError::from(
-            "MUSIC@EDR equave must be a ratio: a number or a [ num den ] vector",
-        )
+        AjisaiError::from("MUSIC@EDR equave must be a ratio: a number or a [ num den ] vector")
     })?;
     let num_f = num
         .to_f64()
@@ -433,7 +384,6 @@ pub fn op_edr(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 /// Resolve a step within a `music.tuning` into a `music.pitch`.
 pub fn op_step(interp: &mut Interpreter) -> Result<()> {
     reject_stack_mode(interp, "STEP")?;
@@ -452,7 +402,6 @@ pub fn op_step(interp: &mut Interpreter) -> Result<()> {
     consume_and_push(interp, 2, pitch);
     Ok(())
 }
-
 
 /// Bind a tuning over a body of musical content. Inside the resulting scope
 /// bare integers are interpreted as steps of the tuning at MUSIC@PLAY time.
@@ -480,7 +429,6 @@ pub fn op_with_tuning(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 /// Explain how a value would be interpreted by MUSIC@PLAY. Diagnostic only:
 /// the inspected value is always left on the stack.
 pub fn op_explain(interp: &mut Interpreter) -> Result<()> {
@@ -497,18 +445,13 @@ pub fn op_explain(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 pub fn op_adsr(interp: &mut Interpreter) -> Result<()> {
-
     let params = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-
     let target = interp.stack.pop().ok_or_else(|| {
-
         interp.stack.push(params.clone());
         AjisaiError::StackUnderflow
     })?;
-
 
     if !params.is_vector() {
         interp.stack.push(target);
@@ -524,13 +467,11 @@ pub fn op_adsr(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
-
     if !target.is_vector() {
         interp.stack.push(target);
         interp.stack.push(params);
         return Err(AjisaiError::from("ADSR target must be a vector"));
     }
-
 
     let param_at = |i: usize, label: &str| -> Result<f64> {
         params
@@ -542,7 +483,6 @@ pub fn op_adsr(interp: &mut Interpreter) -> Result<()> {
     let decay = param_at(1, "decay")?;
     let sustain = param_at(2, "sustain")?;
     let release = param_at(3, "release")?;
-
 
     if attack < 0.0 || decay < 0.0 || release < 0.0 {
         interp.stack.push(target);
@@ -557,40 +497,32 @@ pub fn op_adsr(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
-
     interp.stack.push(target);
     Ok(())
 }
-
 
 pub fn op_sine(interp: &mut Interpreter) -> Result<()> {
     apply_waveform(interp, WaveformType::Sine)
 }
 
-
 pub fn op_square(interp: &mut Interpreter) -> Result<()> {
     apply_waveform(interp, WaveformType::Square)
 }
-
 
 pub fn op_saw(interp: &mut Interpreter) -> Result<()> {
     apply_waveform(interp, WaveformType::Sawtooth)
 }
 
-
 pub fn op_tri(interp: &mut Interpreter) -> Result<()> {
     apply_waveform(interp, WaveformType::Triangle)
 }
 
-
 fn apply_waveform(interp: &mut Interpreter, _waveform: WaveformType) -> Result<()> {
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-
 
     if !val.is_vector() {
         return Err(AjisaiError::from("Waveform word requires a vector"));
     }
-
 
     interp.stack.push(val);
     Ok(())

--- a/rust/src/interpreter/audio/mod.rs
+++ b/rust/src/interpreter/audio/mod.rs
@@ -1,14 +1,10 @@
-
-
 mod audio_types;
-mod execute_audio_commands;
 mod build_audio_structure;
+mod execute_audio_commands;
 mod music_group;
 mod music_values;
 
-pub use audio_types::{
-    AudioHint, AudioStructure, Envelope, PlayMode, WaveformType,
-};
+pub use audio_types::{AudioHint, AudioStructure, Envelope, PlayMode, WaveformType};
 pub use build_audio_structure::op_play;
 pub use execute_audio_commands::{
     op_adsr, op_chord, op_dur, op_edo, op_edr, op_explain, op_fx_reset, op_gain, op_gain_reset,
@@ -20,6 +16,6 @@ pub use execute_audio_commands::{
 pub(crate) use audio_types::lookup_play_mode;
 
 #[cfg(test)]
-mod audio_unit_tests;
-#[cfg(test)]
 mod audio_integration_tests;
+#[cfg(test)]
+mod audio_unit_tests;

--- a/rust/src/interpreter/cast/cast_chars_join.rs
+++ b/rust/src/interpreter/cast/cast_chars_join.rs
@@ -34,16 +34,12 @@ pub fn op_chars(interp: &mut Interpreter) -> Result<()> {
 
             if is_number_value(&val) {
                 interp.stack.push(val);
-                return Err(AjisaiError::from(
-                    "CHARS: expected String, got Number",
-                ));
+                return Err(AjisaiError::from("CHARS: expected String, got Number"));
             }
 
             if is_boolean_value(&val) {
                 interp.stack.push(val);
-                return Err(AjisaiError::from(
-                    "CHARS: expected String, got Boolean",
-                ));
+                return Err(AjisaiError::from("CHARS: expected String, got Boolean"));
             }
 
             interp.stack.push(val);
@@ -83,17 +79,13 @@ pub fn op_chars(interp: &mut Interpreter) -> Result<()> {
                 if is_number_value(&elem) {
                     interp.stack = results;
                     interp.stack.push(elem);
-                    return Err(AjisaiError::from(
-                        "CHARS: expected String, got Number",
-                    ));
+                    return Err(AjisaiError::from("CHARS: expected String, got Number"));
                 }
 
                 if is_boolean_value(&elem) {
                     interp.stack = results;
                     interp.stack.push(elem);
-                    return Err(AjisaiError::from(
-                        "CHARS: expected String, got Boolean",
-                    ));
+                    return Err(AjisaiError::from("CHARS: expected String, got Boolean"));
                 }
 
                 interp.stack = results;
@@ -120,9 +112,7 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
             if let Some(children) = val.as_vector_view() {
                 if children.is_empty() {
                     interp.stack.push(val);
-                    return Err(AjisaiError::from(
-                        "JOIN: expected non-empty Vector",
-                    ));
+                    return Err(AjisaiError::from("JOIN: expected non-empty Vector"));
                 }
 
                 let mut result = String::new();
@@ -136,7 +126,10 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
 
                     if is_number_value(elem) {
                         match try_char_from_value(elem) {
-                            Some(c) => { result.push(c); continue; }
+                            Some(c) => {
+                                result.push(c);
+                                continue;
+                            }
                             None => {
                                 interp.stack.push(val);
                                 return Err(AjisaiError::from(format!(
@@ -183,7 +176,6 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
             )))
         }
         OperationTargetMode::Stack => {
-
             let stack_len = interp.stack.len();
             if stack_len == 0 {
                 return Err(AjisaiError::StackUnderflow);
@@ -193,13 +185,11 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
             let elements: Vec<Value> = interp.stack.drain(..).collect();
 
             for elem in elements {
-
                 if elem.is_nil() {
                     interp.stack = results;
                     interp.stack.push(elem);
                     return Err(AjisaiError::from("JOIN: requires vector format, got Nil"));
                 }
-
 
                 if let Some(children) = elem.as_vector_view() {
                     if children.is_empty() {
@@ -212,14 +202,12 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
 
                     let mut result_str = String::new();
                     for (i, v) in children.iter().enumerate() {
-
                         if is_string_value(v) {
                             if let Some(s) = value_as_string(v) {
                                 result_str.push_str(&s);
                                 continue;
                             }
                         }
-
 
                         if is_number_value(v) {
                             if let Some(f) = v.as_scalar() {
@@ -240,7 +228,6 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
                             )));
                         }
 
-
                         let type_name = if v.is_nil() {
                             "nil"
                         } else if is_boolean_value(v) {
@@ -259,7 +246,6 @@ pub fn op_join(interp: &mut Interpreter) -> Result<()> {
                     results.push(Value::from_string(&result_str));
                     continue;
                 }
-
 
                 let type_name = if is_string_value(&elem) {
                     "String"
@@ -308,8 +294,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_chars_structure_error() {
-
-
         let mut interp = Interpreter::new();
         let result = interp.execute("[ 42 ] CHARS").await;
         assert!(result.is_ok());
@@ -366,7 +350,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_nil_pushes_constant() {
-
         let mut interp = Interpreter::new();
         let result = interp.execute("NIL").await;
         assert!(result.is_ok());
@@ -379,7 +362,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_nil_multiple() {
-
         let mut interp = Interpreter::new();
         let result = interp.execute("NIL NIL NIL").await;
         assert!(result.is_ok());

--- a/rust/src/interpreter/cast/cast_conversion_tests.rs
+++ b/rust/src/interpreter/cast/cast_conversion_tests.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::interpreter::cast::cast_conversions::{op_str, op_num, op_bool, op_chr};
+    use crate::interpreter::cast::cast_conversions::{op_bool, op_chr, op_num, op_str};
     use crate::interpreter::cast::cast_value_helpers::{
         format_value_to_string_repr, is_number_value, is_string_value,
     };
@@ -15,14 +15,11 @@ mod tests {
 
     #[test]
     fn test_format_value_to_string_repr() {
-
         let num = Value::from_fraction(Fraction::new(BigInt::from(42), BigInt::one()));
         assert_eq!(format_value_to_string_repr(&num), "42");
 
-
         let bool_val = Value::from_bool(true);
         assert_eq!(format_value_to_string_repr(&bool_val), "1");
-
 
         let nil = Value::nil();
         assert_eq!(format_value_to_string_repr(&nil), "NIL");
@@ -32,10 +29,10 @@ mod tests {
     fn test_str_conversion() {
         let mut interp = Interpreter::new();
 
-
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(42), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(42),
+            BigInt::one(),
+        )));
         op_str(&mut interp).unwrap();
 
         if let Some(val) = interp.stack.last() {
@@ -49,7 +46,6 @@ mod tests {
     fn test_num_conversion() {
         let mut interp = Interpreter::new();
 
-
         interp.stack.push(Value::from_string("42"));
         op_num(&mut interp).unwrap();
 
@@ -59,7 +55,6 @@ mod tests {
                 assert_eq!(f.numerator(), BigInt::from(42));
             }
         }
-
 
         interp.stack.clear();
         interp.stack.push(Value::from_string("1/3"));
@@ -73,7 +68,6 @@ mod tests {
             }
         }
 
-
         interp.stack.clear();
         interp.stack.push(Value::from_string("ABC"));
         let result = op_num(&mut interp);
@@ -82,17 +76,16 @@ mod tests {
             assert!(val.is_nil());
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(123), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(123),
+            BigInt::one(),
+        )));
         let result = op_num(&mut interp);
         assert!(result.is_ok());
         if let Some(val) = interp.stack.last() {
             assert!(is_number_value(val));
         }
-
 
         interp.stack.clear();
         interp.stack.push(Value::from_bool(true));
@@ -104,7 +97,6 @@ mod tests {
     fn test_bool_conversion() {
         let mut interp = Interpreter::new();
 
-
         interp.stack.push(Value::from_string("TRUE"));
         op_bool(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
@@ -113,7 +105,6 @@ mod tests {
                 assert!(!f.is_zero());
             }
         }
-
 
         interp.stack.clear();
         interp.stack.push(Value::from_string("true"));
@@ -125,7 +116,6 @@ mod tests {
             }
         }
 
-
         interp.stack.clear();
         interp.stack.push(Value::from_string("false"));
         op_bool(&mut interp).unwrap();
@@ -136,14 +126,12 @@ mod tests {
             }
         }
 
-
         interp.stack.clear();
         interp.stack.push(Value::from_string("1"));
         op_bool(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(val.is_nil());
         }
-
 
         interp.stack.clear();
         interp.stack.push(Value::from_string("other"));
@@ -152,11 +140,11 @@ mod tests {
             assert!(val.is_nil());
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(100), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(100),
+            BigInt::one(),
+        )));
         op_bool(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(val.is_scalar());
@@ -165,11 +153,11 @@ mod tests {
             }
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(0), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(0),
+            BigInt::one(),
+        )));
         op_bool(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(val.is_scalar());
@@ -178,11 +166,11 @@ mod tests {
             }
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(1), BigInt::from(2))));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(1),
+            BigInt::from(2),
+        )));
         op_bool(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(val.is_scalar());
@@ -191,22 +179,20 @@ mod tests {
             }
         }
 
-
         interp.stack.clear();
         interp.stack.push(Value::from_bool(true));
         let result = op_bool(&mut interp);
         assert!(result.is_ok());
     }
 
-
     #[test]
     fn test_chr_basic() {
         let mut interp = Interpreter::new();
 
-
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(65), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(65),
+            BigInt::one(),
+        )));
         op_chr(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(is_string_value(val));
@@ -214,11 +200,11 @@ mod tests {
             assert_eq!(s, "A");
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(97), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(97),
+            BigInt::one(),
+        )));
         op_chr(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(is_string_value(val));
@@ -226,11 +212,11 @@ mod tests {
             assert_eq!(s, "a");
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(10), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(10),
+            BigInt::one(),
+        )));
         op_chr(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(is_string_value(val));
@@ -238,46 +224,42 @@ mod tests {
             assert_eq!(s, "\n");
         }
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(48), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(48),
+            BigInt::one(),
+        )));
         op_chr(&mut interp).unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(is_string_value(val));
             let s = value_as_string(val).unwrap();
             assert_eq!(s, "0");
         }
-
-
     }
 
     #[test]
     fn test_chr_errors() {
         let mut interp = Interpreter::new();
 
-
         interp.stack.push(Value::from_string("A"));
         let result = op_chr(&mut interp);
         assert!(result.is_err());
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(1), BigInt::from(2))));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(1),
+            BigInt::from(2),
+        )));
         let result = op_chr(&mut interp);
         assert!(result.is_err());
 
-
         interp.stack.clear();
-        interp
-            .stack
-            .push(create_number_value(Fraction::new(BigInt::from(-1), BigInt::one())));
+        interp.stack.push(create_number_value(Fraction::new(
+            BigInt::from(-1),
+            BigInt::one(),
+        )));
         op_chr(&mut interp).unwrap();
         assert!(interp.stack.last().unwrap().is_nil());
-
 
         interp.stack.clear();
         interp.stack.push(create_number_value(Fraction::new(
@@ -292,7 +274,6 @@ mod tests {
     async fn test_chr_integration() {
         let mut interp = Interpreter::new();
 
-
         interp.execute("65 CHR").await.unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(is_string_value(val));
@@ -301,11 +282,9 @@ mod tests {
         }
     }
 
-
     #[tokio::test]
     async fn test_num_str_roundtrip() {
         let mut interp = Interpreter::new();
-
 
         interp.execute("'123' NUM STR").await.unwrap();
         if let Some(val) = interp.stack.last() {
@@ -313,7 +292,6 @@ mod tests {
             let s = value_as_string(val).unwrap();
             assert_eq!(s, "123");
         }
-
 
         interp.stack.clear();
         interp.execute("'1/3' NUM STR").await.unwrap();
@@ -328,7 +306,6 @@ mod tests {
     async fn test_str_num_parse_fail() {
         let mut interp = Interpreter::new();
 
-
         interp.execute("'ABC' NUM").await.unwrap();
         assert_eq!(interp.stack.len(), 1);
         if let Some(val) = interp.stack.last() {
@@ -340,13 +317,11 @@ mod tests {
     async fn test_bool_string_parsing() {
         let mut interp = Interpreter::new();
 
-
         interp.execute("'true' BOOL").await.unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(val.is_scalar());
             assert!(val.is_truthy());
         }
-
 
         interp.stack.clear();
         interp.execute("'FALSE' BOOL").await.unwrap();
@@ -354,7 +329,6 @@ mod tests {
             assert!(val.is_scalar());
             assert!(!val.is_truthy());
         }
-
 
         interp.stack.clear();
         interp.execute("'other' BOOL").await.unwrap();
@@ -367,13 +341,11 @@ mod tests {
     async fn test_bool_number_truthiness() {
         let mut interp = Interpreter::new();
 
-
         interp.execute("100 BOOL").await.unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(val.is_scalar());
             assert!(val.is_truthy());
         }
-
 
         interp.stack.clear();
         interp.execute("0 BOOL").await.unwrap();
@@ -381,7 +353,6 @@ mod tests {
             assert!(val.is_scalar());
             assert!(!val.is_truthy());
         }
-
 
         interp.stack.clear();
         interp.execute("-1 BOOL").await.unwrap();
@@ -395,14 +366,12 @@ mod tests {
     async fn test_str_boolean() {
         let mut interp = Interpreter::new();
 
-
         interp.execute("TRUE STR").await.unwrap();
         if let Some(val) = interp.stack.last() {
             assert!(is_string_value(val));
             let s = value_as_string(val).unwrap();
             assert_eq!(s, "1");
         }
-
 
         interp.stack.clear();
         interp.execute("FALSE STR").await.unwrap();
@@ -416,7 +385,6 @@ mod tests {
     #[tokio::test]
     async fn test_str_nil() {
         let mut interp = Interpreter::new();
-
 
         interp.execute("NIL STR").await.unwrap();
         if let Some(val) = interp.stack.last() {

--- a/rust/src/interpreter/cast/cast_text_ops.rs
+++ b/rust/src/interpreter/cast/cast_text_ops.rs
@@ -58,7 +58,9 @@ fn op_trim_generic(interp: &mut Interpreter, word: &str, side: TrimSide) -> Resu
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
             let s = pop_string(interp, word)?;
-            interp.stack.push(Value::from_string(&apply_trim(&side, &s)));
+            interp
+                .stack
+                .push(Value::from_string(&apply_trim(&side, &s)));
             Ok(())
         }
         OperationTargetMode::Stack => {
@@ -107,9 +109,10 @@ pub fn op_trim_right(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_tokenize(interp: &mut Interpreter) -> Result<()> {
     let sep_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let src_val = interp.stack.pop().ok_or_else(|| {
-        AjisaiError::StackUnderflow
-    });
+    let src_val = interp
+        .stack
+        .pop()
+        .ok_or_else(|| AjisaiError::StackUnderflow);
     let src_val = match src_val {
         Ok(v) => v,
         Err(e) => {
@@ -141,10 +144,7 @@ pub fn op_tokenize(interp: &mut Interpreter) -> Result<()> {
     }
     if !is_string_value(&sep_val) {
         let tn = type_name_of(&sep_val);
-        let err = AjisaiError::from(format!(
-            "TOKENIZE: expected separator String, got {}",
-            tn
-        ));
+        let err = AjisaiError::from(format!("TOKENIZE: expected separator String, got {}", tn));
         restore(interp, src_val, sep_val);
         return Err(err);
     }
@@ -158,10 +158,7 @@ pub fn op_tokenize(interp: &mut Interpreter) -> Result<()> {
         return Err(err);
     }
 
-    let parts: Vec<Value> = src
-        .split(sep.as_str())
-        .map(Value::from_string)
-        .collect();
+    let parts: Vec<Value> = src.split(sep.as_str()).map(Value::from_string).collect();
     interp.stack.push(Value::from_vector(parts));
     Ok(())
 }

--- a/rust/src/interpreter/cast/mod.rs
+++ b/rust/src/interpreter/cast/mod.rs
@@ -1,12 +1,11 @@
-pub(crate) mod cast_value_helpers;
-pub(crate) mod cast_conversions;
 mod cast_chars_join;
 mod cast_conversion_tests;
+pub(crate) mod cast_conversions;
 mod cast_text_ops;
+pub(crate) mod cast_value_helpers;
 
-pub use cast_conversions::{op_str, op_num, op_bool, op_nil, op_chr};
 pub use cast_chars_join::{op_chars, op_join};
+pub use cast_conversions::{op_bool, op_chr, op_nil, op_num, op_str};
 pub use cast_text_ops::{
-    op_ends_with, op_starts_with, op_substitute, op_tokenize, op_trim, op_trim_left,
-    op_trim_right,
+    op_ends_with, op_starts_with, op_substitute, op_tokenize, op_trim, op_trim_left, op_trim_right,
 };

--- a/rust/src/interpreter/child_runtime.rs
+++ b/rust/src/interpreter/child_runtime.rs
@@ -1,9 +1,7 @@
 use crate::error::AjisaiError;
 use crate::types::{Interpretation, Value};
 
-use super::interpreter_core::{
-    ChildRuntime, ChildState, ExitReason, RuntimeDictionarySnapshot,
-};
+use super::interpreter_core::{ChildRuntime, ChildState, ExitReason, RuntimeDictionarySnapshot};
 use super::value_extraction_helpers::extract_integer_from_value;
 use super::Interpreter;
 
@@ -126,8 +124,10 @@ impl Interpreter {
         child_interpreter.module_vocabulary = child.dictionary_snapshot.module_vocabulary.clone();
         child_interpreter.dictionary_dependencies =
             child.dictionary_snapshot.dictionary_dependencies.clone();
-        child_interpreter.next_registration_order = child.dictionary_snapshot.next_registration_order;
-        child_interpreter.active_user_dictionary = child.dictionary_snapshot.active_user_dictionary.clone();
+        child_interpreter.next_registration_order =
+            child.dictionary_snapshot.next_registration_order;
+        child_interpreter.active_user_dictionary =
+            child.dictionary_snapshot.active_user_dictionary.clone();
         child_interpreter.max_execution_steps = self.max_execution_steps;
 
         let lines = vec![crate::types::ExecutionLine {
@@ -139,7 +139,8 @@ impl Interpreter {
                 child.state = ChildState::Completed;
                 child.exit_reason = Some(ExitReason::Normal);
                 let stack = child_interpreter.stack.clone();
-                child.result_snapshot = Some(Self::build_exit_result(ExitReason::Normal, Some(stack)));
+                child.result_snapshot =
+                    Some(Self::build_exit_result(ExitReason::Normal, Some(stack)));
             }
             Err(err) => {
                 let exit_reason = Self::map_error_to_exit_reason(err);
@@ -212,8 +213,8 @@ impl Interpreter {
         let mut attempt = 0usize;
         loop {
             self.bump_execution_epoch();
-        let spawn_epoch = self.current_epoch_snapshot();
-        let id = self.next_child_id;
+            let spawn_epoch = self.current_epoch_snapshot();
+            let id = self.next_child_id;
             self.next_child_id += 1;
             let mut child = ChildRuntime {
                 code_block: code_block.clone(),

--- a/rust/src/interpreter/child_runtime_tests.rs
+++ b/rust/src/interpreter/child_runtime_tests.rs
@@ -40,7 +40,9 @@ mod tests {
     #[tokio::test]
     async fn monitor_registration() {
         let mut interp = Interpreter::new();
-        let result = interp.execute("{ [ 1 ] [ 0 ] / } SPAWN MONITOR AWAIT").await;
+        let result = interp
+            .execute("{ [ 1 ] [ 0 ] / } SPAWN MONITOR AWAIT")
+            .await;
         assert!(result.is_ok());
         assert_eq!(interp.monitor_notifications.len(), 1);
     }

--- a/rust/src/interpreter/comptime/sandbox.rs
+++ b/rust/src/interpreter/comptime/sandbox.rs
@@ -4,7 +4,10 @@ use crate::types::{Token, Value};
 
 pub(crate) const PRECOMPUTE_STEP_LIMIT: usize = 20_000;
 
-pub(crate) fn run_precompute_block(interp: &Interpreter, block_body_tokens: &[Token]) -> Result<Vec<Value>> {
+pub(crate) fn run_precompute_block(
+    interp: &Interpreter,
+    block_body_tokens: &[Token],
+) -> Result<Vec<Value>> {
     let mut sandbox = Interpreter::new();
     sandbox.core_vocabulary = interp.core_vocabulary.clone();
     sandbox.user_words = interp.user_words.clone();

--- a/rust/src/interpreter/control.rs
+++ b/rust/src/interpreter/control.rs
@@ -33,15 +33,20 @@ pub(crate) fn op_eval(interp: &mut Interpreter) -> Result<()> {
                 ));
             }
             let temp_vec: Value = Value::from_vector(all_elements);
-            value_as_string(&temp_vec)
-                .ok_or_else(|| AjisaiError::from("EVAL: expected convertible stack, got non-string data"))?
+            value_as_string(&temp_vec).ok_or_else(|| {
+                AjisaiError::from("EVAL: expected convertible stack, got non-string data")
+            })?
         }
     };
 
     interp.operation_target_mode = OperationTargetMode::StackTop;
 
-    let tokens: Vec<Token> = crate::tokenizer::tokenize(&source_code)
-        .map_err(|e| AjisaiError::from(format!("EVAL: expected valid syntax, got tokenization error: {}", e)))?;
+    let tokens: Vec<Token> = crate::tokenizer::tokenize(&source_code).map_err(|e| {
+        AjisaiError::from(format!(
+            "EVAL: expected valid syntax, got tokenization error: {}",
+            e
+        ))
+    })?;
 
     interp.execute_section_core(&tokens, 0)?;
 

--- a/rust/src/interpreter/control_exec_eval_tests.rs
+++ b/rust/src/interpreter/control_exec_eval_tests.rs
@@ -4,7 +4,6 @@
 mod tests {
     use crate::interpreter::Interpreter;
 
-
     #[tokio::test]
     async fn test_exec_stack_top_simple() {
         let mut interp = Interpreter::new();
@@ -99,7 +98,6 @@ mod tests {
             }
         }
     }
-
 
     #[tokio::test]
     async fn test_eval_stack_top_simple() {

--- a/rust/src/interpreter/dictionary_resolution_tests.rs
+++ b/rust/src/interpreter/dictionary_resolution_tests.rs
@@ -27,7 +27,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_short_name_no_collision() {
-
         let mut interp = Interpreter::new();
         let sample_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
         restore_sample_words(&mut interp, &sample_words);
@@ -44,7 +43,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_dict_at_word() {
-
         let mut interp = Interpreter::new();
         let sample_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
         restore_sample_words(&mut interp, &sample_words);
@@ -61,7 +59,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_user_dict_word() {
-
         let mut interp = Interpreter::new();
         let sample_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
         restore_sample_words(&mut interp, &sample_words);
@@ -78,7 +75,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_fully_qualified_user() {
-
         let mut interp = Interpreter::new();
         let sample_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
         restore_sample_words(&mut interp, &sample_words);
@@ -95,7 +91,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_module_at_word() {
-
         let mut interp = Interpreter::new();
         interp.execute("'music' IMPORT").await.unwrap();
         let _ = interp.collect_output();
@@ -110,7 +105,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_dict_module_word() {
-
         let mut interp = Interpreter::new();
         interp.execute("'music' IMPORT").await.unwrap();
         let _ = interp.collect_output();
@@ -125,7 +119,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_core_at_word() {
-
         let mut interp = Interpreter::new();
         interp.execute("[ 10 20 30 ]").await.unwrap();
 
@@ -139,7 +132,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_dict_core_word() {
-
         let mut interp = Interpreter::new();
         interp.execute("[ 10 20 30 ]").await.unwrap();
 
@@ -153,7 +145,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_case_insensitive() {
-
         let mut interp = Interpreter::new();
         interp.execute("'music' IMPORT").await.unwrap();
         let _ = interp.collect_output();
@@ -168,7 +159,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_path_case_insensitive_user() {
-
         let mut interp = Interpreter::new();
         let sample_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
         restore_sample_words(&mut interp, &sample_words);
@@ -185,14 +175,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_user_word_short_name_wins_without_music_sample_collision() {
-
         let mut interp = Interpreter::new();
         interp.execute("{ [ 999 ] } 'SEQ' DEF").await.unwrap();
         let _ = interp.collect_output();
 
         interp.execute("'music' IMPORT").await.unwrap();
         let _ = interp.collect_output();
-
 
         let result = interp.execute("SEQ").await;
         assert!(
@@ -201,9 +189,10 @@ mod tests {
             result.err()
         );
         if let Some(val) = interp.stack.last() {
-            let scalar_owned = val.as_scalar().cloned().or_else(|| {
-                val.child(0).and_then(|c| c.as_scalar().cloned())
-            });
+            let scalar_owned = val
+                .as_scalar()
+                .cloned()
+                .or_else(|| val.child(0).and_then(|c| c.as_scalar().cloned()));
             let scalar = scalar_owned.expect("SEQ should resolve to a numeric user word");
             assert_eq!(scalar.to_i64().unwrap(), 999);
         }
@@ -211,14 +200,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_qualified_module_and_user_paths_resolve_after_sample_reset() {
-
         let mut interp = Interpreter::new();
         interp.execute("{ [ 999 ] } 'SEQ' DEF").await.unwrap();
         let _ = interp.collect_output();
 
         interp.execute("'music' IMPORT").await.unwrap();
         let _ = interp.collect_output();
-
 
         let result = interp.execute("MUSIC@SEQ").await;
         assert!(
@@ -227,13 +214,17 @@ mod tests {
             result.err()
         );
 
-
         let result = interp.execute("DEMO@SEQ").await;
-        assert!(result.is_ok(), "DEMO@SEQ should resolve: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "DEMO@SEQ should resolve: {:?}",
+            result.err()
+        );
         if let Some(val) = interp.stack.last() {
-            let scalar_owned = val.as_scalar().cloned().or_else(|| {
-                val.child(0).and_then(|c| c.as_scalar().cloned())
-            });
+            let scalar_owned = val
+                .as_scalar()
+                .cloned()
+                .or_else(|| val.child(0).and_then(|c| c.as_scalar().cloned()));
             let scalar = scalar_owned.expect("DEMO@SEQ should be numeric");
             assert_eq!(scalar.to_i64().unwrap(), 999);
         }
@@ -241,9 +232,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_builtin_not_ambiguous() {
-
         let mut interp = Interpreter::new();
-
 
         let result = interp.execute("[ 10 20 30 ] [ 0 ] GET").await;
         assert!(
@@ -255,11 +244,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_module_builtin_word_via_qualified_path() {
-
         let mut interp = Interpreter::new();
         interp.execute("'music' IMPORT").await.unwrap();
         let _ = interp.collect_output();
-
 
         let result = interp.execute("[ 440 ] MUSIC@SEQ MUSIC@PLAY").await;
         assert!(
@@ -301,7 +288,6 @@ mod tests {
     async fn test_split_path_unit() {
         use crate::interpreter::Interpreter;
 
-
         let (layers, word) = Interpreter::split_path("MUSIC@PLAY");
         assert_eq!(layers, vec!["MUSIC"]);
         assert_eq!(word, "PLAY");
@@ -317,7 +303,6 @@ mod tests {
         let (layers, word) = Interpreter::split_path("SAY-HELLO");
         assert!(layers.is_empty());
         assert_eq!(word, "SAY-HELLO");
-
 
         let (layers, word) = Interpreter::split_path("music@play");
         assert_eq!(layers, vec!["MUSIC"]);

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -68,9 +68,11 @@ fn is_string_like(val: &Value) -> bool {
             | ValueData::Record {
                 pairs: children, ..
             } => children.iter().all(check_codepoints),
-            ValueData::Tensor { data, .. } => data
-                .iter()
-                .all(|f| f.to_i64().map(|n| (0..=0x10FFFF).contains(&n)).unwrap_or(false)),
+            ValueData::Tensor { data, .. } => data.iter().all(|f| {
+                f.to_i64()
+                    .map(|n| (0..=0x10FFFF).contains(&n))
+                    .unwrap_or(false)
+            }),
             ValueData::ExactScalar(_) => false,
             ValueData::CodeBlock(_)
             | ValueData::ProcessHandle(_)

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -1,6 +1,6 @@
 use crate::error::{AjisaiError, ErrorCategory, NilReason, Result};
 use crate::types::fraction::Fraction;
-use crate::types::{Interpretation, ExecutionLine, Token, Value};
+use crate::types::{ExecutionLine, Interpretation, Token, Value};
 
 use super::debug_diagnosis::{DebugDiagnosis, ErrorPhase};
 use super::error_flow_trace::{ErrorFlowEvent, ErrorFlowEventKind};
@@ -366,10 +366,7 @@ impl Interpreter {
                                         absence: None,
                                         stack_len_before,
                                         stack_len_after: self.stack.len(),
-                                        message: format!(
-                                            "word error word={} error={}",
-                                            upper, err
-                                        ),
+                                        message: format!("word error word={} error={}", upper, err),
                                         diagnosis: Some(diagnosis),
                                     });
                                     return Err(err);

--- a/rust/src/interpreter/hash.rs
+++ b/rust/src/interpreter/hash.rs
@@ -1,5 +1,3 @@
-
-
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::tensor_ops::FlatTensor;
 use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
@@ -8,9 +6,7 @@ use crate::types::{Value, ValueData};
 use num_bigint::BigInt;
 use num_traits::{One, ToPrimitive, Zero};
 
-
 const DEFAULT_HASH_BITS: u32 = 256;
-
 
 const PRIME_BITS: u32 = 127;
 
@@ -34,7 +30,6 @@ lazy_static::lazy_static! {
     static ref HASH_BASE: BigInt = BigInt::from(257u32);
 }
 
-
 fn serialize_value_for_hash(value: &Value) -> Vec<u8> {
     let mut bytes = Vec::new();
     serialize_value_inner_for_hash(value, &mut bytes);
@@ -42,16 +37,13 @@ fn serialize_value_for_hash(value: &Value) -> Vec<u8> {
 }
 
 fn serialize_value_inner_for_hash(val: &Value, bytes: &mut Vec<u8>) {
-
     if val.is_nil() {
         bytes.push(0x06);
         return;
     }
 
-
     if val.is_scalar() {
         if let Some(frac) = val.as_scalar() {
-
             let canonical = Fraction::new(frac.numerator(), frac.denominator());
             let (can_num, can_den) = canonical.to_bigint_pair();
             bytes.push(0x01);
@@ -73,7 +65,6 @@ fn serialize_value_inner_for_hash(val: &Value, bytes: &mut Vec<u8>) {
             return;
         }
     }
-
 
     if let ValueData::Vector(children) = &val.data {
         bytes.push(0x04);
@@ -97,13 +88,11 @@ fn serialize_value_inner_for_hash(val: &Value, bytes: &mut Vec<u8>) {
     }
 }
 
-
 fn compute_polynomial_hash(bytes: &[u8], prime: &BigInt) -> BigInt {
     let mut hash = BigInt::zero();
     let mut power = BigInt::one();
 
     for &byte in bytes {
-
         hash = (&hash + &power * BigInt::from(byte)) % prime;
 
         power = (&power * &*HASH_BASE) % prime;
@@ -112,31 +101,24 @@ fn compute_polynomial_hash(bytes: &[u8], prime: &BigInt) -> BigInt {
     hash
 }
 
-
 fn compute_multi_prime_hash(bytes: &[u8], output_bits: u32) -> BigInt {
     let h1 = compute_polynomial_hash(bytes, &PRIME1);
     let h2 = compute_polynomial_hash(bytes, &PRIME2);
     let h3 = compute_polynomial_hash(bytes, &PRIME3);
 
-
     let combined = &h1 + (&h2 << PRIME_BITS as usize) + (&h3 << (2 * PRIME_BITS) as usize);
-
 
     let output_modulus = BigInt::one() << output_bits as usize;
 
-
     let mut result = combined.clone();
-
 
     let shift1 = output_bits / 3;
     let shift2 = output_bits * 2 / 3;
     result = &result ^ (&result >> shift1 as usize);
     result = &result ^ (&result >> shift2 as usize);
 
-
     result % output_modulus
 }
-
 
 fn extract_positive_integer_from_value(val: &Value) -> Option<u32> {
     let tensor = FlatTensor::from_value(val).ok()?;
@@ -158,7 +140,9 @@ fn parse_hash_args_in_keep_mode(interp: &Interpreter) -> Result<(u32, Value)> {
         .ok_or_else(|| AjisaiError::from("HASH requires a value to hash"))?;
 
     if interp.stack.len() >= 2 {
-        if let Some(bits) = extract_positive_integer_from_value(&interp.stack[interp.stack.len() - 2]) {
+        if let Some(bits) =
+            extract_positive_integer_from_value(&interp.stack[interp.stack.len() - 2])
+        {
             return Ok((bits, target));
         }
     }
@@ -166,9 +150,7 @@ fn parse_hash_args_in_keep_mode(interp: &Interpreter) -> Result<(u32, Value)> {
     Ok((DEFAULT_HASH_BITS, target))
 }
 
-
 pub fn op_hash(interp: &mut Interpreter) -> Result<()> {
-
     if interp.operation_target_mode != OperationTargetMode::StackTop {
         return Err(AjisaiError::ModeUnsupported {
             word: "HASH".into(),
@@ -187,23 +169,18 @@ pub fn op_hash(interp: &mut Interpreter) -> Result<()> {
         parse_hash_args(interp)?
     };
 
-
     if output_bits < 32 || output_bits > 1024 {
         return Err(AjisaiError::from(
             "HASH: output bits must be between 32 and 1024",
         ));
     }
 
-
     let bytes = serialize_value_for_hash(&target_value);
-
 
     let hash_value = compute_multi_prime_hash(&bytes, output_bits);
 
-
     let denominator = BigInt::one() << output_bits as usize;
     let result_fraction = Fraction::new(hash_value, denominator);
-
 
     interp
         .stack
@@ -213,7 +190,6 @@ pub fn op_hash(interp: &mut Interpreter) -> Result<()> {
 
     Ok(())
 }
-
 
 fn parse_hash_args(interp: &mut Interpreter) -> Result<(u32, Value)> {
     let target = interp

--- a/rust/src/interpreter/hash_tests.rs
+++ b/rust/src/interpreter/hash_tests.rs
@@ -114,9 +114,7 @@ mod tests {
     async fn test_hash_with_bit_specification() {
         let mut interp = Interpreter::new();
 
-        let result = interp
-            .execute("'crypto' IMPORT [ 128 ] 'hello' HASH")
-            .await;
+        let result = interp.execute("'crypto' IMPORT [ 128 ] 'hello' HASH").await;
         assert!(
             result.is_ok(),
             "HASH with bit spec should succeed: {:?}",
@@ -232,9 +230,7 @@ mod tests {
     async fn test_hash_invalid_bits() {
         let mut interp = Interpreter::new();
 
-        let result = interp
-            .execute("'crypto' IMPORT [ 16 ] 'hello' HASH")
-            .await;
+        let result = interp.execute("'crypto' IMPORT [ 16 ] 'hello' HASH").await;
         assert!(result.is_err(), "Bits < 32 should error");
 
         let result = interp

--- a/rust/src/interpreter/higher_order/hedged.rs
+++ b/rust/src/interpreter/higher_order/hedged.rs
@@ -70,8 +70,7 @@ pub(crate) fn execute_hedged_map_kernel(
     };
     if fast_guarded_mode(interp.elastic_mode()) {
         if is_quantized_block_guard_valid(interp, qb) {
-            return execute_quantized_map_kernel(interp, qb, elem)
-                .map(normalize_map_kernel_result);
+            return execute_quantized_map_kernel(interp, qb, elem).map(normalize_map_kernel_result);
         }
         interp.runtime_metrics.hedged_race_fallback_count += 1;
         interp.push_hedged_trace(format!(

--- a/rust/src/interpreter/higher_order/map.rs
+++ b/rust/src/interpreter/higher_order/map.rs
@@ -66,28 +66,27 @@ pub fn op_map(interp: &mut Interpreter) -> Result<()> {
             // quantized/plain race still observes per-element kernel events.
             if let ExecutableCode::QuantizedBlock(qb) = &executable {
                 if !super::hedged::hedged_mode(interp.elastic_mode()) {
-                if let Some(bulk) = super::fast_kernels::try_bulk_quantized_map(
-                    interp, qb, &target_val,
-                ) {
-                    match bulk {
-                        Ok(out) => {
-                            let result =
-                                Value::from_tensor(out.data, vec![n_elements]);
-                            if is_keep_mode {
-                                interp.stack.push(target_val);
+                    if let Some(bulk) =
+                        super::fast_kernels::try_bulk_quantized_map(interp, qb, &target_val)
+                    {
+                        match bulk {
+                            Ok(out) => {
+                                let result = Value::from_tensor(out.data, vec![n_elements]);
+                                if is_keep_mode {
+                                    interp.stack.push(target_val);
+                                }
+                                interp.stack.push(result);
+                                return Ok(());
                             }
-                            interp.stack.push(result);
-                            return Ok(());
-                        }
-                        Err(e) => {
-                            if !is_keep_mode {
-                                interp.stack.push(target_val);
+                            Err(e) => {
+                                if !is_keep_mode {
+                                    interp.stack.push(target_val);
+                                }
+                                interp.stack.push(code_val);
+                                return Err(e);
                             }
-                            interp.stack.push(code_val);
-                            return Err(e);
                         }
                     }
-                }
                 }
             }
 

--- a/rust/src/interpreter/higher_order/mod.rs
+++ b/rust/src/interpreter/higher_order/mod.rs
@@ -51,4 +51,3 @@ pub(crate) fn try_bulk_quantized_predicate_pub(
 ) -> Option<fast_kernels::BulkPredicateResult> {
     fast_kernels::try_bulk_quantized_predicate(interp, qb, target)
 }
-

--- a/rust/src/interpreter/higher_order_fold.rs
+++ b/rust/src/interpreter/higher_order_fold.rs
@@ -8,7 +8,8 @@ use crate::types::Value;
 
 pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let plain_tokens: Option<Vec<crate::types::Token>> = code_val.as_code_block().map(|t| t.to_vec());
+    let plain_tokens: Option<Vec<crate::types::Token>> =
+        code_val.as_code_block().map(|t| t.to_vec());
 
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
@@ -200,16 +201,14 @@ pub fn op_fold(interp: &mut Interpreter) -> Result<()> {
 
             for item in targets {
                 let fold_res = match &executable {
-                    ExecutableCode::QuantizedBlock(qb) => {
-                        execute_hedged_fold_kernel(
-                            interp,
-                            "FOLD",
-                            qb,
-                            plain_tokens.as_deref(),
-                            accumulator,
-                            item,
-                        )
-                    }
+                    ExecutableCode::QuantizedBlock(qb) => execute_hedged_fold_kernel(
+                        interp,
+                        "FOLD",
+                        qb,
+                        plain_tokens.as_deref(),
+                        accumulator,
+                        item,
+                    ),
                     _ => {
                         interp.stack.clear();
                         interp.stack.push(accumulator);
@@ -322,14 +321,10 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
                 }
 
                 if is_vector_value(&unwrapped) && unwrapped.len() == 2 {
-                    let yielded = unwrapped
-                        .child(0)
-                        .expect("len==2 implies child(0) exists");
+                    let yielded = unwrapped.child(0).expect("len==2 implies child(0) exists");
                     results.push(yielded);
 
-                    let next_state = unwrapped
-                        .child(1)
-                        .expect("len==2 implies child(1) exists");
+                    let next_state = unwrapped.child(1).expect("len==2 implies child(1) exists");
                     if next_state.is_nil() {
                         break;
                     }
@@ -406,14 +401,12 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
                         }
 
                         if is_vector_value(&unwrapped) && unwrapped.len() == 2 {
-                            let yielded = unwrapped
-                                .child(0)
-                                .expect("len==2 implies child(0) exists");
+                            let yielded =
+                                unwrapped.child(0).expect("len==2 implies child(0) exists");
                             results.push(yielded);
 
-                            let next_state = unwrapped
-                                .child(1)
-                                .expect("len==2 implies child(1) exists");
+                            let next_state =
+                                unwrapped.child(1).expect("len==2 implies child(1) exists");
                             if next_state.is_nil() {
                                 break;
                             }
@@ -453,7 +446,8 @@ pub fn op_unfold(interp: &mut Interpreter) -> Result<()> {
 
 pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
     let code_val: Value = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-    let plain_tokens: Option<Vec<crate::types::Token>> = code_val.as_code_block().map(|t| t.to_vec());
+    let plain_tokens: Option<Vec<crate::types::Token>> =
+        code_val.as_code_block().map(|t| t.to_vec());
 
     let executable: ExecutableCode = match extract_executable_code(interp, &code_val) {
         Ok(exec) => exec,
@@ -623,16 +617,14 @@ pub fn op_scan(interp: &mut Interpreter) -> Result<()> {
 
             for item in targets {
                 let fold_res = match &executable {
-                    ExecutableCode::QuantizedBlock(qb) => {
-                        execute_hedged_fold_kernel(
-                            interp,
-                            "SCAN",
-                            qb,
-                            plain_tokens.as_deref(),
-                            accumulator,
-                            item,
-                        )
-                    }
+                    ExecutableCode::QuantizedBlock(qb) => execute_hedged_fold_kernel(
+                        interp,
+                        "SCAN",
+                        qb,
+                        plain_tokens.as_deref(),
+                        accumulator,
+                        item,
+                    ),
                     _ => {
                         interp.stack.clear();
                         interp.stack.push(accumulator);

--- a/rust/src/interpreter/higher_order_fold_tests.rs
+++ b/rust/src/interpreter/higher_order_fold_tests.rs
@@ -32,7 +32,11 @@ mod tests {
     async fn test_fold_nil_returns_initial() {
         let mut interp = Interpreter::new();
         let result = interp.execute("NIL [ 42 ] '+' FOLD").await;
-        assert!(result.is_ok(), "FOLD on NIL should return initial: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "FOLD on NIL should return initial: {:?}",
+            result
+        );
         assert_eq!(top_scalar_i64(&interp), 42);
     }
 
@@ -50,7 +54,11 @@ mod tests {
     async fn test_unfold_immediate_nil() {
         let mut interp = Interpreter::new();
         let result = interp.execute("[ 1 ] { NIL } UNFOLD").await;
-        assert!(result.is_ok(), "UNFOLD immediate NIL should succeed: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "UNFOLD immediate NIL should succeed: {:?}",
+            result
+        );
         assert!(top_is_nil(&interp));
     }
 
@@ -76,17 +84,18 @@ mod tests {
             .await
             .unwrap();
         let result = interp.execute("[ 99 ] [ 1 ] 'NEXT' UNFOLD").await;
-        assert!(result.is_ok(), "UNFOLD user word should succeed: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "UNFOLD user word should succeed: {:?}",
+            result
+        );
         assert_eq!(interp.stack.len(), 2);
         let below = &interp.stack[0];
-        let below_num = below
-            .as_scalar()
-            .and_then(|f| f.to_i64())
-            .or_else(|| {
-                below
-                    .child(0)
-                    .and_then(|v| v.as_scalar().and_then(|f| f.to_i64()))
-            });
+        let below_num = below.as_scalar().and_then(|f| f.to_i64()).or_else(|| {
+            below
+                .child(0)
+                .and_then(|v| v.as_scalar().and_then(|f| f.to_i64()))
+        });
         assert_eq!(below_num, Some(99));
     }
 
@@ -117,8 +126,14 @@ mod tests {
     #[tokio::test]
     async fn test_any_short_circuit() {
         let mut interp = Interpreter::new();
-        let result = interp.execute("[ 1 2 3 ] { { [ 1 ] = } { TRUE } { IDLE } { [ 1 ] [ 0 ] / } COND } ANY").await;
-        assert!(result.is_ok(), "ANY should short-circuit before divide-by-zero: {:?}", result);
+        let result = interp
+            .execute("[ 1 2 3 ] { { [ 1 ] = } { TRUE } { IDLE } { [ 1 ] [ 0 ] / } COND } ANY")
+            .await;
+        assert!(
+            result.is_ok(),
+            "ANY should short-circuit before divide-by-zero: {:?}",
+            result
+        );
         assert_eq!(top_scalar_i64(&interp), 1);
     }
 
@@ -140,7 +155,11 @@ mod tests {
         let ok3 = interp3
             .execute("[ 2 3 4 ] { { [ 2 ] = } { FALSE } { IDLE } { [ 1 ] [ 0 ] / } COND } ALL")
             .await;
-        assert!(ok3.is_ok(), "ALL should short-circuit on first FALSE: {:?}", ok3);
+        assert!(
+            ok3.is_ok(),
+            "ALL should short-circuit on first FALSE: {:?}",
+            ok3
+        );
         assert_eq!(top_scalar_i64(&interp3), 0);
 
         let mut interp4 = Interpreter::new();
@@ -177,7 +196,10 @@ mod tests {
         assert_eq!(top_scalar_i64(&interp3), 0);
 
         let mut interp4 = Interpreter::new();
-        assert!(interp4.execute("NIL { [ 2 ] MOD [ 0 ] = } COUNT").await.is_ok());
+        assert!(interp4
+            .execute("NIL { [ 2 ] MOD [ 0 ] = } COUNT")
+            .await
+            .is_ok());
         assert_eq!(top_scalar_i64(&interp4), 0);
 
         let mut interp5 = Interpreter::new();
@@ -189,14 +211,17 @@ mod tests {
         assert_eq!(top_scalar_i64(&interp5), 2);
     }
 
-
     #[tokio::test]
     async fn test_count_percent_alias_matches_mod() {
         let mut mod_interp = Interpreter::new();
         let mod_result = mod_interp
             .execute("[ 1 2 3 4 5 6 ] { [ 2 ] MOD [ 0 ] = } COUNT")
             .await;
-        assert!(mod_result.is_ok(), "COUNT with MOD failed: {:?}", mod_result);
+        assert!(
+            mod_result.is_ok(),
+            "COUNT with MOD failed: {:?}",
+            mod_result
+        );
         let mod_count = top_scalar_i64(&mod_interp);
 
         let mut alias_interp = Interpreter::new();
@@ -219,7 +244,11 @@ mod tests {
         let and_result = and_interp
             .execute("[ [ TRUE TRUE ] [ TRUE FALSE ] [ FALSE TRUE ] ] { [ 0 ] [ 1 ] AND } FILTER")
             .await;
-        assert!(and_result.is_ok(), "FILTER with AND failed: {:?}", and_result);
+        assert!(
+            and_result.is_ok(),
+            "FILTER with AND failed: {:?}",
+            and_result
+        );
 
         let mut alias_interp = Interpreter::new();
         let alias_result = alias_interp
@@ -250,7 +279,10 @@ mod tests {
 
         let mut interp4 = Interpreter::new();
         interp4.execute("{ + } 'MYSUM' DEF").await.unwrap();
-        assert!(interp4.execute("[ 1 2 3 ] [ 0 ] 'MYSUM' SCAN").await.is_ok());
+        assert!(interp4
+            .execute("[ 1 2 3 ] [ 0 ] 'MYSUM' SCAN")
+            .await
+            .is_ok());
         assert_eq!(interp4.stack.last().expect("result").len(), 3);
 
         let mut interp5 = Interpreter::new();

--- a/rust/src/interpreter/interpreter_definition_tests.rs
+++ b/rust/src/interpreter/interpreter_definition_tests.rs
@@ -5,7 +5,6 @@ mod tests {
     use crate::interpreter::Interpreter;
     use crate::types::ValueData;
 
-
     #[tokio::test]
     async fn test_map_with_increment() {
         let mut interp = Interpreter::new();
@@ -68,7 +67,6 @@ mod tests {
         assert!(result.is_err(), "Empty brackets should be an error");
         assert!(result.unwrap_err().to_string().contains("Empty vector"));
     }
-
 
     #[tokio::test]
     async fn test_force_flag_del_without_dependents() {
@@ -158,7 +156,6 @@ mod tests {
         let result = interp.execute("'DOUBLE' DEL").await;
         assert!(result.is_err());
     }
-
 
     #[tokio::test]
     async fn test_nil_keyword_works() {
@@ -292,7 +289,6 @@ mod tests {
         assert!(val.is_truthy(), "TRUE OR NIL should be truthy");
     }
 
-
     #[tokio::test]
     async fn test_nested_call_chain_4_levels_ok() {
         let mut interp = Interpreter::new();
@@ -302,7 +298,11 @@ mod tests {
         interp.execute("{ [ 1 ] } 'D' DEF").await.unwrap();
 
         let result = interp.execute("A").await;
-        assert!(result.is_ok(), "4-level nested call chain should succeed: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "4-level nested call chain should succeed: {:?}",
+            result
+        );
         assert_eq!(interp.stack.len(), 1);
     }
 
@@ -316,7 +316,11 @@ mod tests {
         interp.execute("{ [ 1 ] } 'E' DEF").await.unwrap();
 
         let result = interp.execute("A").await;
-        assert!(result.is_ok(), "Deep call chain should succeed: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Deep call chain should succeed: {:?}",
+            result
+        );
     }
 
     #[tokio::test]
@@ -326,7 +330,10 @@ mod tests {
         interp.execute("{ REC } 'REC' DEF").await.unwrap();
 
         let result = interp.execute("REC").await;
-        assert!(result.is_err(), "Direct recursion should hit execution limit");
+        assert!(
+            result.is_err(),
+            "Direct recursion should hit execution limit"
+        );
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Execution step limit"),
@@ -375,7 +382,10 @@ mod tests {
             result
         );
         // call_depth must be back to 0 after a successful run.
-        assert_eq!(interp.call_depth, 0, "call_depth should reset to 0 on success");
+        assert_eq!(
+            interp.call_depth, 0,
+            "call_depth should reset to 0 on success"
+        );
     }
 
     // Task 6: after a recursion-limit error, call_depth must reset to 0 so
@@ -456,7 +466,10 @@ mod tests {
             .execute("{ { 1 2 } PRECOMPUTE ADD } 'THREE' DEF")
             .await
             .expect("multi-value PRECOMPUTE should succeed");
-        interp.execute("THREE").await.expect("THREE should evaluate");
+        interp
+            .execute("THREE")
+            .await
+            .expect("THREE should evaluate");
         let val = interp.stack.last().unwrap();
         assert_eq!(
             val.as_scalar().expect("scalar").numerator().to_string(),
@@ -492,10 +505,11 @@ mod tests {
     #[tokio::test]
     async fn test_precompute_runtime_error_is_wrapped() {
         let mut interp = Interpreter::new();
-        let result = interp
-            .execute("{ { 1 0 DIV } PRECOMPUTE } 'BAD' DEF")
-            .await;
-        assert!(result.is_err(), "division by zero in PRECOMPUTE should fail DEF");
+        let result = interp.execute("{ { 1 0 DIV } PRECOMPUTE } 'BAD' DEF").await;
+        assert!(
+            result.is_err(),
+            "division by zero in PRECOMPUTE should fail DEF"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("PRECOMPUTE"),

--- a/rust/src/interpreter/interpreter_execution_tests.rs
+++ b/rust/src/interpreter/interpreter_execution_tests.rs
@@ -31,8 +31,7 @@ mod tests {
         let val = &interp.stack[3];
 
         assert!(
-            !val
-                .as_scalar()
+            !val.as_scalar()
                 .expect("Expected scalar boolean result")
                 .is_zero(),
             "Expected TRUE from comparison"
@@ -92,8 +91,7 @@ ADDTEST
             let only = val.child(0).expect("len==1 implies child(0) exists");
             {
                 assert_eq!(
-                    only
-                        .as_scalar()
+                    only.as_scalar()
                         .expect("Expected scalar")
                         .numerator()
                         .to_string(),
@@ -150,8 +148,7 @@ ADDTEST
             let only = val.child(0).expect("len==1 implies child(0) exists");
             {
                 assert_eq!(
-                    only
-                        .as_scalar()
+                    only.as_scalar()
                         .expect("Expected scalar")
                         .numerator()
                         .to_string(),
@@ -185,8 +182,7 @@ ADDTEST
             let only = val.child(0).expect("len==1 implies child(0) exists");
             {
                 assert_eq!(
-                    only
-                        .as_scalar()
+                    only.as_scalar()
                         .expect("Expected scalar")
                         .numerator()
                         .to_string(),
@@ -196,7 +192,6 @@ ADDTEST
             }
         }
     }
-
 }
 
 #[tokio::test]
@@ -228,12 +223,20 @@ async fn numbers_render_as_canonical_fractions_on_stack() {
 
 #[tokio::test]
 async fn comparison_words_return_scalar_booleans() {
-    let cases = [("1 2 LT", true), ("2 2 LTE", true), ("2 1 LT", false), ("1 1 EQ", true), ("1 2 EQ", false)];
+    let cases = [
+        ("1 2 LT", true),
+        ("2 2 LTE", true),
+        ("2 1 LT", false),
+        ("1 1 EQ", true),
+        ("1 2 EQ", false),
+    ];
     for (program, expected) in cases {
         let mut interp = crate::interpreter::Interpreter::new();
         interp.execute(program).await.unwrap();
         assert_eq!(interp.stack.len(), 1, "program: {program}");
-        let scalar = interp.stack[0].as_scalar().expect("comparison should return scalar boolean");
+        let scalar = interp.stack[0]
+            .as_scalar()
+            .expect("comparison should return scalar boolean");
         assert_eq!(scalar.is_zero(), !expected, "program: {program}");
     }
 }

--- a/rust/src/interpreter/interpreter_mode_tests.rs
+++ b/rust/src/interpreter/interpreter_mode_tests.rs
@@ -150,5 +150,4 @@ mod tests {
             "Stack should have 3 elements after keep mode division"
         );
     }
-
 }

--- a/rust/src/interpreter/interval_ops.rs
+++ b/rust/src/interpreter/interval_ops.rs
@@ -105,7 +105,9 @@ pub(crate) fn op_is_exact(interp: &mut Interpreter) -> Result<()> {
     let interval = value_to_interval(&value)
         .ok_or_else(|| AjisaiError::from("IS_EXACT: expected Number or Interval"))?;
     interp.stack.push(Value::from_bool(interval.is_exact()));
-    interp.semantic_registry.push_hint(Interpretation::TruthValue);
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::TruthValue);
     Ok(())
 }
 
@@ -130,7 +132,9 @@ where
     let interval = value_to_interval(&value)
         .ok_or_else(|| AjisaiError::from("interval accessor: expected Number or Interval"))?;
     interp.stack.push(Value::from_fraction(f(interval)));
-    interp.semantic_registry.push_hint(Interpretation::RawNumber);
+    interp
+        .semantic_registry
+        .push_hint(Interpretation::RawNumber);
     Ok(())
 }
 
@@ -154,11 +158,15 @@ pub(crate) fn op_sqrt(interp: &mut Interpreter) -> Result<()> {
             Some(er) => {
                 // from_exact_real already collapses Rational variants to Scalar(Fraction)
                 interp.stack.push(Value::from_exact_real(er));
-                interp.semantic_registry.push_hint(Interpretation::RawNumber);
+                interp
+                    .semantic_registry
+                    .push_hint(Interpretation::RawNumber);
             }
             None => {
                 // Negative input → NIL
-                interp.stack.push(Value::nil_with_reason(NilReason::DivisionByZero));
+                interp
+                    .stack
+                    .push(Value::nil_with_reason(NilReason::DivisionByZero));
                 interp.semantic_registry.push_hint(Interpretation::Nil);
             }
         }

--- a/rust/src/interpreter/io.rs
+++ b/rust/src/interpreter/io.rs
@@ -1,5 +1,3 @@
-
-
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::{ConsumptionMode, Interpreter};
 use crate::types::Value;
@@ -15,7 +13,6 @@ fn extract_value_for_print(interp: &mut Interpreter, keep_mode: bool) -> Result<
     }
     interp.stack.pop().ok_or(AjisaiError::StackUnderflow)
 }
-
 
 pub fn op_print(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;

--- a/rust/src/interpreter/logic.rs
+++ b/rust/src/interpreter/logic.rs
@@ -25,10 +25,7 @@ fn compute_inverted_fraction(f: &Fraction) -> Fraction {
     }
 }
 
-fn compute_inverted_value(
-    val: &Value,
-    metrics: Option<&mut RuntimeMetrics>,
-) -> Result<Value> {
+fn compute_inverted_value(val: &Value, metrics: Option<&mut RuntimeMetrics>) -> Result<Value> {
     // The logical Unknown (¬U = U) and operational NIL (¬NIL = NIL) cases
     // route through the canonical K3 NOT table (SPEC §7.5). Checked before
     // the scalar path because U is represented as a NIL node; a plain

--- a/rust/src/interpreter/logic_kleene.rs
+++ b/rust/src/interpreter/logic_kleene.rs
@@ -310,14 +310,18 @@ mod tests {
         let u_k = u_with_prefix(4);
         let ff = f();
         // U(k) AND FALSE = FALSE (F absorbs); no agreedPrefix carried.
-        let result =
-            into_value_with_diagnosis(and(Ternary::classify(&u_k), Ternary::classify(&ff)), &[&u_k, &ff]);
+        let result = into_value_with_diagnosis(
+            and(Ternary::classify(&u_k), Ternary::classify(&ff)),
+            &[&u_k, &ff],
+        );
         assert_eq!(result.truth_value(), Some("false"));
         assert_eq!(agreed_prefix_of(&result), None);
         // U(k) AND NIL = NIL (NIL priority, SPEC §4.5.2); stays operational NIL.
         let nn = n();
-        let result =
-            into_value_with_diagnosis(and(Ternary::classify(&u_k), Ternary::classify(&nn)), &[&u_k, &nn]);
+        let result = into_value_with_diagnosis(
+            and(Ternary::classify(&u_k), Ternary::classify(&nn)),
+            &[&u_k, &nn],
+        );
         assert!(result.is_nil() && !result.is_unknown());
     }
 

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -32,8 +32,8 @@ pub mod quantized_block;
 pub mod random;
 pub mod redundancy_layer;
 mod resolve_cache;
-mod shadow_validation;
 pub mod serial;
+mod shadow_validation;
 pub(crate) mod simd_ops;
 pub mod sort;
 pub mod tensor_cmds;
@@ -53,6 +53,10 @@ mod execution_loop;
 mod execute_builtin;
 
 #[cfg(test)]
+mod algo_ops_tests;
+#[cfg(test)]
+mod arithmetic_exact_div_tests;
+#[cfg(test)]
 mod child_runtime_tests;
 #[cfg(test)]
 mod control_cond_tests;
@@ -69,17 +73,7 @@ mod dictionary_tier_tests;
 #[cfg(test)]
 mod error_flow_trace_tests;
 #[cfg(test)]
-mod algo_ops_tests;
-#[cfg(test)]
 mod hash_tests;
-#[cfg(test)]
-mod math_ops_tests;
-#[cfg(test)]
-mod arithmetic_exact_div_tests;
-#[cfg(test)]
-mod nil_unknown_firewall_tests;
-#[cfg(test)]
-mod nil_conformance_tests;
 #[cfg(test)]
 mod higher_order_fold_tests;
 #[cfg(test)]
@@ -91,11 +85,17 @@ mod interpreter_execution_tests;
 #[cfg(test)]
 mod interpreter_mode_tests;
 #[cfg(test)]
-mod module_unimport_tests;
+mod math_ops_tests;
 #[cfg(test)]
 mod module_catalog_tests;
 #[cfg(test)]
+mod module_unimport_tests;
+#[cfg(test)]
+mod nil_conformance_tests;
+#[cfg(test)]
 mod nil_reason_tests;
+#[cfg(test)]
+mod nil_unknown_firewall_tests;
 
 pub use interpreter_core::*;
 

--- a/rust/src/interpreter/module_catalog_tests.rs
+++ b/rust/src/interpreter/module_catalog_tests.rs
@@ -11,7 +11,9 @@ mod tests {
     #[test]
     fn available_modules_cover_all_specced_modules() {
         let names = available_module_names();
-        for expected in ["MUSIC", "JSON", "IO", "TIME", "CRYPTO", "ALGO", "MATH", "SERIAL"] {
+        for expected in [
+            "MUSIC", "JSON", "IO", "TIME", "CRYPTO", "ALGO", "MATH", "SERIAL",
+        ] {
             assert!(
                 names.contains(&expected),
                 "available module list should include {}",
@@ -27,7 +29,9 @@ mod tests {
         let names: Vec<&str> = catalog.iter().map(|w| w.short_name).collect();
         assert!(names.contains(&"PARSE"));
         assert!(names.contains(&"STRINGIFY"));
-        assert!(!catalog.iter().any(|w| w.is_sample && w.short_name == "PARSE"));
+        assert!(!catalog
+            .iter()
+            .any(|w| w.is_sample && w.short_name == "PARSE"));
     }
 
     #[test]
@@ -75,6 +79,12 @@ mod tests {
     #[test]
     fn restore_import_entry_unknown_module_returns_false() {
         let mut interp = Interpreter::new();
-        assert!(!restore_import_entry(&mut interp, "NOPE", true, vec![], vec![]));
+        assert!(!restore_import_entry(
+            &mut interp,
+            "NOPE",
+            true,
+            vec![],
+            vec![]
+        ));
     }
 }

--- a/rust/src/interpreter/module_unimport_tests.rs
+++ b/rust/src/interpreter/module_unimport_tests.rs
@@ -93,13 +93,14 @@ mod tests {
     async fn del_cannot_destroy_module_dictionary_or_words_even_forced() {
         let mut interp = Interpreter::new();
         let before_import = interp.execute("'JSON' DEL").await;
-        assert!(before_import.is_err(), "known modules cannot be deleted before import");
         assert!(
-            before_import
-                .unwrap_err()
-                .to_string()
-                .contains("Cannot delete module dictionary JSON")
+            before_import.is_err(),
+            "known modules cannot be deleted before import"
         );
+        assert!(before_import
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot delete module dictionary JSON"));
 
         interp.execute("'music' IMPORT").await.unwrap();
 

--- a/rust/src/interpreter/modules/module_word_docs.rs
+++ b/rust/src/interpreter/modules/module_word_docs.rs
@@ -13,10 +13,7 @@ pub(super) struct ModuleWordDoc {
     pub stack_effect: &'static str,
 }
 
-pub(super) fn lookup_module_word_doc(
-    module: &str,
-    word: &str,
-) -> Option<&'static ModuleWordDoc> {
+pub(super) fn lookup_module_word_doc(module: &str, word: &str) -> Option<&'static ModuleWordDoc> {
     MODULE_WORD_DOCS
         .iter()
         .find(|d| d.module == module && d.word == word)
@@ -44,10 +41,7 @@ pub(super) fn assert_every_word_has_doc(specs: &[ModuleSpec]) -> Result<(), Stri
                         return Err(format!("{}@{} has empty role", d.module, d.word));
                     }
                     if d.stack_effect.is_empty() {
-                        return Err(format!(
-                            "{}@{} has empty stack_effect",
-                            d.module, d.word
-                        ));
+                        return Err(format!("{}@{} has empty stack_effect", d.module, d.word));
                     }
                 }
             }

--- a/rust/src/interpreter/perf_regression_tests.rs
+++ b/rust/src/interpreter/perf_regression_tests.rs
@@ -108,16 +108,14 @@ fn run_loop(
         ..Default::default()
     };
 
-    let plan_total =
-        delta.compiled_plan_cache_hit_count + delta.compiled_plan_cache_miss_count;
+    let plan_total = delta.compiled_plan_cache_hit_count + delta.compiled_plan_cache_miss_count;
     let hit_rate = if plan_total > 0 {
         (delta.compiled_plan_cache_hit_count as f64 / plan_total as f64) * 100.0
     } else {
         0.0
     };
     let expected_total_quant = (iterations as u64) * expected_quant_calls_per_iter.max(1);
-    let quant_rate = (delta.quantized_block_use_count as f64 / expected_total_quant as f64)
-        * 100.0;
+    let quant_rate = (delta.quantized_block_use_count as f64 / expected_total_quant as f64) * 100.0;
     append_perf_jsonl(&PerfJsonLine {
         label: label.to_string(),
         iterations,
@@ -150,8 +148,7 @@ fn run_loop(
     #[cfg(feature = "trace-compile")]
     eprintln!(
         "[metrics] quant_build={} quant_use={}",
-        delta.quantized_block_build_count,
-        delta.quantized_block_use_count
+        delta.quantized_block_build_count, delta.quantized_block_use_count
     );
 
     (elapsed, delta)
@@ -165,18 +162,10 @@ fn perf_filter_map_fold_reports_metrics() {
         11,
         "[ -5 -4 -3 -2 -1 0 1 2 3 4 5 ] { [ 0 ] <= NOT } FILTER",
     );
-    let (map_elapsed, map_metrics) = run_loop(
-        "MAP",
-        1000,
-        10,
-        "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 1 ] + } MAP",
-    );
-    let (fold_elapsed, fold_metrics) = run_loop(
-        "FOLD",
-        500,
-        10,
-        "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD",
-    );
+    let (map_elapsed, map_metrics) =
+        run_loop("MAP", 1000, 10, "[ 1 2 3 4 5 6 7 8 9 10 ] { [ 1 ] + } MAP");
+    let (fold_elapsed, fold_metrics) =
+        run_loop("FOLD", 500, 10, "[ 1 2 3 4 5 6 7 8 9 10 ] [ 0 ] { + } FOLD");
 
     assert!(filter_elapsed < PERF_LOOP_SOFT_LIMIT);
     assert!(map_elapsed < PERF_LOOP_SOFT_LIMIT);
@@ -198,7 +187,8 @@ fn perf_filter_map_fold_reports_metrics() {
 fn perf_scan_any_all_count_reports_quantized_usage() {
     let (_scan_elapsed, scan_metrics) = run_loop("SCAN", 500, 5, "[ 1 2 3 4 5 ] [ 0 ] { + } SCAN");
     let (_any_elapsed, any_metrics) = run_loop("ANY", 1000, 3, "[ 1 2 3 4 5 ] { [ 3 ] = } ANY");
-    let (_all_elapsed, all_metrics) = run_loop("ALL", 1000, 5, "[ 1 2 3 4 5 ] { [ 0 ] <= NOT } ALL");
+    let (_all_elapsed, all_metrics) =
+        run_loop("ALL", 1000, 5, "[ 1 2 3 4 5 ] { [ 0 ] <= NOT } ALL");
     let (_count_elapsed, count_metrics) = run_loop(
         "COUNT",
         1000,

--- a/rust/src/interpreter/quantized_block.rs
+++ b/rust/src/interpreter/quantized_block.rs
@@ -413,9 +413,7 @@ fn try_user_word_is_pure(
 /// rather than caught later in the analyzer.
 pub fn is_quantizable_block(tokens: &[Token]) -> bool {
     !tokens.is_empty()
-        && !tokens
-            .iter()
-            .any(|t| matches!(t, Token::LineBreak))
+        && !tokens.iter().any(|t| matches!(t, Token::LineBreak))
         && !tokens.iter().any(token_is_impure_builtin)
 }
 

--- a/rust/src/interpreter/random.rs
+++ b/rust/src/interpreter/random.rs
@@ -230,9 +230,7 @@ mod tests {
     async fn test_csprng_small_denominator_efficiency() {
         let mut interp = Interpreter::new();
 
-        let result = interp
-            .execute("'crypto' IMPORT [ 2 ] [ 50 ] CSPRNG")
-            .await;
+        let result = interp.execute("'crypto' IMPORT [ 2 ] [ 50 ] CSPRNG").await;
         assert!(result.is_ok());
 
         let val = &interp.stack[0];

--- a/rust/src/interpreter/shadow_validation.rs
+++ b/rust/src/interpreter/shadow_validation.rs
@@ -36,7 +36,10 @@ impl Interpreter {
         self.runtime_metrics.shadow_validation_started_count += 1;
         if self.is_hedged_mode() {
             self.runtime_metrics.hedged_race_started_count += 1;
-            self.push_hedged_trace(format!("race:start compiled-vs-plain word={}", resolved_name));
+            self.push_hedged_trace(format!(
+                "race:start compiled-vs-plain word={}",
+                resolved_name
+            ));
         }
 
         let saved_stack = self.stack.clone();

--- a/rust/src/interpreter/simd_ops.rs
+++ b/rust/src/interpreter/simd_ops.rs
@@ -25,7 +25,9 @@ pub fn extract_integer_vector(val: &Value) -> Option<Vec<i64>> {
         | ValueData::ExactScalar(_)
         | ValueData::Record { .. }
         | ValueData::Nil
-        | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
+        | ValueData::CodeBlock(_)
+        | ValueData::ProcessHandle(_)
+        | ValueData::SupervisorHandle(_) => return None,
     };
 
     if children.len() < SIMD_THRESHOLD {
@@ -45,7 +47,9 @@ pub fn extract_integer_vector(val: &Value) -> Option<Vec<i64>> {
             | ValueData::Tensor { .. }
             | ValueData::Record { .. }
             | ValueData::Nil
-            | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => return None,
+            | ValueData::CodeBlock(_)
+            | ValueData::ProcessHandle(_)
+            | ValueData::SupervisorHandle(_) => return None,
         }
     }
     Some(result)
@@ -65,7 +69,9 @@ fn extract_integer_scalar(value: &Value) -> Option<i64> {
         | ValueData::Tensor { .. }
         | ValueData::Record { .. }
         | ValueData::Nil
-        | ValueData::CodeBlock(_) | ValueData::ProcessHandle(_) | ValueData::SupervisorHandle(_) => None,
+        | ValueData::CodeBlock(_)
+        | ValueData::ProcessHandle(_)
+        | ValueData::SupervisorHandle(_) => None,
     }
 }
 
@@ -215,17 +221,26 @@ mod wasm_impl {
 mod wasm_impl {
     #[inline]
     pub fn simd_add(a: &[i64], b: &[i64]) -> Vec<i64> {
-        a.iter().zip(b.iter()).map(|(x, y)| x + y).collect::<Vec<i64>>()
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| x + y)
+            .collect::<Vec<i64>>()
     }
 
     #[inline]
     pub fn simd_sub(a: &[i64], b: &[i64]) -> Vec<i64> {
-        a.iter().zip(b.iter()).map(|(x, y)| x - y).collect::<Vec<i64>>()
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| x - y)
+            .collect::<Vec<i64>>()
     }
 
     #[inline]
     pub fn simd_mul(a: &[i64], b: &[i64]) -> Vec<i64> {
-        a.iter().zip(b.iter()).map(|(x, y)| x * y).collect::<Vec<i64>>()
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| x * y)
+            .collect::<Vec<i64>>()
     }
 
     #[inline]
@@ -254,17 +269,17 @@ pub fn apply_simd_mul(a: &Value, b: &Value) -> Option<Value> {
 pub fn apply_simd_scalar_add(vec_val: &Value, scalar_val: &Value) -> Option<Value> {
     let va: Vec<i64> = extract_integer_vector(vec_val)?;
     let scalar: i64 = extract_integer_scalar(scalar_val)?;
-    Some(create_value_from_integer_vector(wasm_impl::simd_scalar_add(
-        &va, scalar,
-    )))
+    Some(create_value_from_integer_vector(
+        wasm_impl::simd_scalar_add(&va, scalar),
+    ))
 }
 
 pub fn apply_simd_scalar_mul(vec_val: &Value, scalar_val: &Value) -> Option<Value> {
     let va: Vec<i64> = extract_integer_vector(vec_val)?;
     let scalar: i64 = extract_integer_scalar(scalar_val)?;
-    Some(create_value_from_integer_vector(wasm_impl::simd_scalar_mul(
-        &va, scalar,
-    )))
+    Some(create_value_from_integer_vector(
+        wasm_impl::simd_scalar_mul(&va, scalar),
+    ))
 }
 
 #[cfg(test)]
@@ -272,7 +287,10 @@ mod tests {
     use super::*;
 
     fn create_int_vector(values: &[i64]) -> Value {
-        let children: Vec<Value> = values.iter().map(|&v| Value::from_int(v)).collect::<Vec<Value>>();
+        let children: Vec<Value> = values
+            .iter()
+            .map(|&v| Value::from_int(v))
+            .collect::<Vec<Value>>();
         Value::from_children(children)
     }
 

--- a/rust/src/interpreter/tensor_cmds.rs
+++ b/rust/src/interpreter/tensor_cmds.rs
@@ -330,9 +330,7 @@ pub fn op_mod(interp: &mut Interpreter) -> Result<()> {
     }
 
     // ExactScalar path: a mod b = a - b * floor(a/b) via CF (SPEC §4.2.2)
-    if interp.operation_target_mode == OperationTargetMode::StackTop
-        && interp.stack.len() >= 2
-    {
+    if interp.operation_target_mode == OperationTargetMode::StackTop && interp.stack.len() >= 2 {
         let stack_len = interp.stack.len();
         let a_ref = &interp.stack[stack_len - 2];
         let b_ref = &interp.stack[stack_len - 1];
@@ -361,7 +359,10 @@ pub fn op_mod(interp: &mut Interpreter) -> Result<()> {
                 // zero check) means the CF division/floor exhausted its
                 // budget, so the result is undecidable: project to a
                 // Bubble NIL (SPEC §7.4.1) rather than erroring.
-                let modulo = a.div(&b).and_then(|q| q.floor()).map(|fl| a.sub(&b.mul(&fl)));
+                let modulo = a
+                    .div(&b)
+                    .and_then(|q| q.floor())
+                    .map(|fl| a.sub(&b.mul(&fl)));
                 if interp.consumption_mode != ConsumptionMode::Keep {
                     interp.stack.pop();
                     interp.stack.pop();

--- a/rust/src/interpreter/vector_ops/mod.rs
+++ b/rust/src/interpreter/vector_ops/mod.rs
@@ -1,5 +1,3 @@
-
-
 pub mod position;
 pub mod quantity;
 pub mod structure;
@@ -10,9 +8,9 @@ mod tests;
 #[cfg(test)]
 mod tests_modes;
 
-pub use position::{op_get, op_insert, op_replace, op_remove};
-pub use quantity::{op_length, op_take, op_split};
-pub use structure::{op_concat, op_reverse, op_range, op_reorder, op_collect};
+pub use position::{op_get, op_insert, op_remove, op_replace};
+pub use quantity::{op_length, op_split, op_take};
+pub use structure::{op_collect, op_concat, op_range, op_reorder, op_reverse};
 
 use crate::types::Value;
 

--- a/rust/src/interpreter/vector_ops/quantity.rs
+++ b/rust/src/interpreter/vector_ops/quantity.rs
@@ -1,5 +1,3 @@
-
-
 use super::extract_vector_elements;
 use super::targeting::with_stacktop_vector_target_with_arg;
 use crate::error::{AjisaiError, Result};
@@ -33,13 +31,11 @@ fn compute_take_bounds(len: usize, count: i64, target: &str) -> Result<(usize, u
     Ok((0, take))
 }
 
-
 pub fn op_length(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
     let len = match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-
             let target_val = interp.stack.last().ok_or(AjisaiError::StackUnderflow)?;
 
             if target_val.is_nil() {
@@ -54,7 +50,6 @@ pub fn op_length(interp: &mut Interpreter) -> Result<()> {
             }
         }
         OperationTargetMode::Stack => {
-
             if is_keep_mode {
                 interp.stack.len()
             } else {
@@ -68,7 +63,6 @@ pub fn op_length(interp: &mut Interpreter) -> Result<()> {
     interp.stack.push(create_number_value(len_frac));
     Ok(())
 }
-
 
 pub fn op_take(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
@@ -127,13 +121,10 @@ pub fn op_take(interp: &mut Interpreter) -> Result<()> {
     }
 }
 
-
 pub fn op_split(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
-
     let args_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-
 
     let sizes: Vec<usize> = if args_val.is_vector() {
         let n = args_val.len();
@@ -209,7 +200,6 @@ pub fn op_split(interp: &mut Interpreter) -> Result<()> {
             }
 
             if is_keep_mode {
-
                 let original_elements: Vec<Value> = interp.stack.iter().cloned().collect();
                 let mut result_stack = Vec::new();
                 let mut pos = 0;

--- a/rust/src/interpreter/vector_ops/structure.rs
+++ b/rust/src/interpreter/vector_ops/structure.rs
@@ -1,5 +1,3 @@
-
-
 use super::extract_vector_elements;
 use super::targeting::{with_stacktop_vector_target_no_arg, with_stacktop_vector_target_with_arg};
 use crate::error::{AjisaiError, Result};
@@ -115,7 +113,6 @@ fn parse_reorder_indices(indices_val: &Value) -> Result<Vec<i64>> {
     Ok(vec![single])
 }
 
-
 pub fn op_concat(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
@@ -153,7 +150,6 @@ pub fn op_concat(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 pub fn op_reverse(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
@@ -181,11 +177,8 @@ pub fn op_reverse(interp: &mut Interpreter) -> Result<()> {
     }
 }
 
-
 pub fn op_range(interp: &mut Interpreter) -> Result<()> {
-
     let args_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-
 
     let (start, end, step) = match parse_range_args(&args_val) {
         Ok(values) => values,
@@ -227,13 +220,10 @@ pub fn op_range(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-
 pub fn op_reorder(interp: &mut Interpreter) -> Result<()> {
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
 
-
     let indices_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
-
 
     let indices = match parse_reorder_indices(&indices_val) {
         Ok(values) => values,
@@ -245,8 +235,11 @@ pub fn op_reorder(interp: &mut Interpreter) -> Result<()> {
 
     match interp.operation_target_mode {
         OperationTargetMode::StackTop => {
-            let reordered =
-                with_stacktop_vector_target_with_arg(interp, &indices_val, is_keep_mode, |target_val| {
+            let reordered = with_stacktop_vector_target_with_arg(
+                interp,
+                &indices_val,
+                is_keep_mode,
+                |target_val| {
                     let len = target_val.len();
                     if len == 0 {
                         return Err(AjisaiError::from("REORDER: target vector is empty"));
@@ -272,7 +265,8 @@ pub fn op_reorder(interp: &mut Interpreter) -> Result<()> {
                     } else {
                         Ok(Value::from_vector(result))
                     }
-                })?;
+                },
+            )?;
 
             if is_keep_mode {
                 interp.stack.push(indices_val);
@@ -311,7 +305,6 @@ pub fn op_reorder(interp: &mut Interpreter) -> Result<()> {
         }
     }
 }
-
 
 pub fn op_collect(interp: &mut Interpreter) -> Result<()> {
     let count_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;

--- a/rust/src/interpreter/vector_ops/targeting.rs
+++ b/rust/src/interpreter/vector_ops/targeting.rs
@@ -28,7 +28,10 @@ where
             interp.stack.push(target_val);
         }
         interp.stack.push(arg_to_restore.clone());
-        return Err(AjisaiError::create_structure_error("vector", "other format"));
+        return Err(AjisaiError::create_structure_error(
+            "vector",
+            "other format",
+        ));
     }
 
     match action(&target_val) {
@@ -52,7 +55,11 @@ where
     F: FnOnce(&Value) -> Result<R>,
 {
     let target_val = if preserve_source {
-        interp.stack.last().cloned().ok_or(AjisaiError::StackUnderflow)?
+        interp
+            .stack
+            .last()
+            .cloned()
+            .ok_or(AjisaiError::StackUnderflow)?
     } else {
         interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?
     };
@@ -61,7 +68,10 @@ where
         if !preserve_source {
             interp.stack.push(target_val);
         }
-        return Err(AjisaiError::create_structure_error("vector", "other format"));
+        return Err(AjisaiError::create_structure_error(
+            "vector",
+            "other format",
+        ));
     }
 
     match action(&target_val) {

--- a/rust/src/interpreter/vector_ops/tests.rs
+++ b/rust/src/interpreter/vector_ops/tests.rs
@@ -107,7 +107,6 @@ async fn test_range_error_infinite_restores_stack() {
     );
 }
 
-
 #[tokio::test]
 async fn test_reorder_basic_stacktop() {
     let mut interp = Interpreter::new();

--- a/rust/src/interpreter/vector_ops/tests_modes.rs
+++ b/rust/src/interpreter/vector_ops/tests_modes.rs
@@ -2,7 +2,6 @@
 
 use crate::interpreter::Interpreter;
 
-
 #[tokio::test]
 async fn test_collect_basic() {
     let mut interp = Interpreter::new();
@@ -78,7 +77,6 @@ async fn test_collect_error_negative_count() {
     let result = interp.execute("1 2 3 -2 COLLECT").await;
     assert!(result.is_err(), "COLLECT with negative count should fail");
 }
-
 
 #[tokio::test]
 async fn test_get_consume_mode() {
@@ -174,7 +172,6 @@ async fn test_take_keep_mode() {
     );
 }
 
-
 #[tokio::test]
 async fn test_get_keep_mode_preserves_all_operands() {
     let mut interp = Interpreter::new();
@@ -267,7 +264,6 @@ async fn test_mod_keep_mode() {
     );
 }
 
-
 #[tokio::test]
 async fn test_percent_alias_keep_mode() {
     let mut interp = Interpreter::new();
@@ -300,8 +296,14 @@ async fn test_modifier_order_independence() {
 #[tokio::test]
 async fn test_insert_stack_consume_modifies_in_place() {
     let mut interp = Interpreter::new();
-    let result = interp.execute("[ 10 ] [ 20 ] [ 30 ] [ 0 99 ] .. INSERT").await;
-    assert!(result.is_ok(), "Stack+Consume INSERT should succeed: {:?}", result);
+    let result = interp
+        .execute("[ 10 ] [ 20 ] [ 30 ] [ 0 99 ] .. INSERT")
+        .await;
+    assert!(
+        result.is_ok(),
+        "Stack+Consume INSERT should succeed: {:?}",
+        result
+    );
     assert_eq!(
         interp.stack.len(),
         4,
@@ -310,14 +312,24 @@ async fn test_insert_stack_consume_modifies_in_place() {
     let first = interp.stack[0]
         .as_scalar()
         .expect("inserted element should be scalar");
-    assert_eq!(first.to_i64(), Some(99), "inserted element should be at index 0");
+    assert_eq!(
+        first.to_i64(),
+        Some(99),
+        "inserted element should be at index 0"
+    );
 }
 
 #[tokio::test]
 async fn test_insert_stack_keep_preserves_original_and_appends_modified() {
     let mut interp = Interpreter::new();
-    let result = interp.execute("[ 10 ] [ 20 ] [ 30 ] [ 0 99 ] ,, .. INSERT").await;
-    assert!(result.is_ok(), "Stack+Keep INSERT should succeed: {:?}", result);
+    let result = interp
+        .execute("[ 10 ] [ 20 ] [ 30 ] [ 0 99 ] ,, .. INSERT")
+        .await;
+    assert!(
+        result.is_ok(),
+        "Stack+Keep INSERT should succeed: {:?}",
+        result
+    );
     assert_eq!(
         interp.stack.len(),
         7,
@@ -328,14 +340,22 @@ async fn test_insert_stack_keep_preserves_original_and_appends_modified() {
     let inserted = interp.stack[3]
         .as_scalar()
         .expect("inserted element should be scalar");
-    assert_eq!(inserted.to_i64(), Some(99), "modified copy head should be the inserted element");
+    assert_eq!(
+        inserted.to_i64(),
+        Some(99),
+        "modified copy head should be the inserted element"
+    );
 }
 
 #[tokio::test]
 async fn test_remove_stack_consume_modifies_in_place() {
     let mut interp = Interpreter::new();
     let result = interp.execute("[ 10 ] [ 20 ] [ 30 ] [ 1 ] .. REMOVE").await;
-    assert!(result.is_ok(), "Stack+Consume REMOVE should succeed: {:?}", result);
+    assert!(
+        result.is_ok(),
+        "Stack+Consume REMOVE should succeed: {:?}",
+        result
+    );
     assert_eq!(
         interp.stack.len(),
         2,
@@ -346,8 +366,14 @@ async fn test_remove_stack_consume_modifies_in_place() {
 #[tokio::test]
 async fn test_remove_stack_keep_preserves_original_and_appends_modified() {
     let mut interp = Interpreter::new();
-    let result = interp.execute("[ 10 ] [ 20 ] [ 30 ] [ 1 ] ,, .. REMOVE").await;
-    assert!(result.is_ok(), "Stack+Keep REMOVE should succeed: {:?}", result);
+    let result = interp
+        .execute("[ 10 ] [ 20 ] [ 30 ] [ 1 ] ,, .. REMOVE")
+        .await;
+    assert!(
+        result.is_ok(),
+        "Stack+Keep REMOVE should succeed: {:?}",
+        result
+    );
     assert_eq!(
         interp.stack.len(),
         5,
@@ -358,8 +384,14 @@ async fn test_remove_stack_keep_preserves_original_and_appends_modified() {
 #[tokio::test]
 async fn test_replace_stack_consume_modifies_in_place() {
     let mut interp = Interpreter::new();
-    let result = interp.execute("[ 10 ] [ 20 ] [ 30 ] [ 1 99 ] .. REPLACE").await;
-    assert!(result.is_ok(), "Stack+Consume REPLACE should succeed: {:?}", result);
+    let result = interp
+        .execute("[ 10 ] [ 20 ] [ 30 ] [ 1 99 ] .. REPLACE")
+        .await;
+    assert!(
+        result.is_ok(),
+        "Stack+Consume REPLACE should succeed: {:?}",
+        result
+    );
     assert_eq!(
         interp.stack.len(),
         3,
@@ -374,8 +406,14 @@ async fn test_replace_stack_consume_modifies_in_place() {
 #[tokio::test]
 async fn test_replace_stack_keep_preserves_original_and_appends_modified() {
     let mut interp = Interpreter::new();
-    let result = interp.execute("[ 10 ] [ 20 ] [ 30 ] [ 1 99 ] ,, .. REPLACE").await;
-    assert!(result.is_ok(), "Stack+Keep REPLACE should succeed: {:?}", result);
+    let result = interp
+        .execute("[ 10 ] [ 20 ] [ 30 ] [ 1 99 ] ,, .. REPLACE")
+        .await;
+    assert!(
+        result.is_ok(),
+        "Stack+Keep REPLACE should succeed: {:?}",
+        result
+    );
     assert_eq!(
         interp.stack.len(),
         6,

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -108,10 +108,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             if i + 1 < chars.len() && chars[i + 1].is_ascii_alphabetic() {
                 let start = i;
                 i += 1;
-                while i < chars.len()
-                    && !chars[i].is_whitespace()
-                    && !is_special_char(chars[i])
-                {
+                while i < chars.len() && !chars[i].is_whitespace() && !is_special_char(chars[i]) {
                     i += 1;
                 }
                 let token_str: String = chars[start..i].iter().collect();

--- a/rust/src/types/arena.rs
+++ b/rust/src/types/arena.rs
@@ -74,7 +74,8 @@ impl ValueArena {
     pub fn alloc_string(&mut self, value: &str) -> NodeId {
         let mut children = Vec::with_capacity(value.chars().count());
         for ch in value.chars() {
-            let scalar = self.alloc_scalar(Fraction::from(ch as u32 as i64), Interpretation::RawNumber);
+            let scalar =
+                self.alloc_scalar(Fraction::from(ch as u32 as i64), Interpretation::RawNumber);
             children.push(scalar);
         }
         if children.is_empty() {
@@ -273,7 +274,8 @@ pub fn json_to_arena_node(arena: &mut ValueArena, json: JsonValue) -> Result<Nod
                 index.insert(key.clone(), pairs.len());
                 let key_id = arena.alloc_string(&key);
                 let value_id = json_to_arena_node(arena, value)?;
-                let pair_id = arena.alloc_vector(vec![key_id, value_id], Interpretation::Unassigned);
+                let pair_id =
+                    arena.alloc_vector(vec![key_id, value_id], Interpretation::Unassigned);
                 pairs.push(pair_id);
             }
             Ok(arena.alloc_record(pairs, index, Interpretation::Unassigned))

--- a/rust/src/types/fraction.rs
+++ b/rust/src/types/fraction.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigInt;
-use num_traits::{Zero, One, ToPrimitive, Signed};
 use num_integer::Integer;
+use num_traits::{One, Signed, ToPrimitive, Zero};
 use std::str::FromStr;
 
 #[inline]
@@ -29,15 +29,21 @@ pub(crate) fn create_bigint_from_i128(n: i128) -> BigInt {
         } else {
             BigInt::from(high) * BigInt::from(1u128 << 64) + BigInt::from(low)
         };
-        if sign < 0 { -result } else { result }
+        if sign < 0 {
+            -result
+        } else {
+            result
+        }
     }
 }
-
 
 #[derive(Debug, Clone)]
 pub(crate) enum FractionRepr {
     Small(i64, i64),
-    Big { numerator: BigInt, denominator: BigInt },
+    Big {
+        numerator: BigInt,
+        denominator: BigInt,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -60,7 +66,9 @@ impl PartialEq for Fraction {
         }
         match (&self.repr, &other.repr) {
             (FractionRepr::Small(a, b), FractionRepr::Small(c, d)) => {
-                if b == d { return a == c; }
+                if b == d {
+                    return a == c;
+                }
                 (*a as i128) * (*d as i128) == (*c as i128) * (*b as i128)
             }
             (FractionRepr::Small(..), FractionRepr::Big { .. })
@@ -68,7 +76,9 @@ impl PartialEq for Fraction {
             | (FractionRepr::Big { .. }, FractionRepr::Big { .. }) => {
                 let (an, ad): (BigInt, BigInt) = self.to_bigint_pair();
                 let (bn, bd): (BigInt, BigInt) = other.to_bigint_pair();
-                if ad == bd { return an == bn; }
+                if ad == bd {
+                    return an == bn;
+                }
                 an * &bd == bn * &ad
             }
         }
@@ -80,7 +90,9 @@ impl Eq for Fraction {}
 impl Fraction {
     #[inline]
     pub fn nil() -> Self {
-        Fraction { repr: FractionRepr::Small(0, 0) }
+        Fraction {
+            repr: FractionRepr::Small(0, 0),
+        }
     }
 
     #[inline]
@@ -91,17 +103,20 @@ impl Fraction {
         }
     }
 
-
     #[inline]
     pub fn is_small(&self) -> bool {
         matches!(self.repr, FractionRepr::Small(..))
     }
 
     pub fn new(numerator: BigInt, denominator: BigInt) -> Self {
-        if denominator.is_zero() { panic!("Division by zero"); }
+        if denominator.is_zero() {
+            panic!("Division by zero");
+        }
 
         if numerator.is_zero() {
-            return Fraction { repr: FractionRepr::Small(0, 1) };
+            return Fraction {
+                repr: FractionRepr::Small(0, 1),
+            };
         }
 
         if let (Some(n), Some(d)) = (numerator.to_i64(), denominator.to_i64()) {
@@ -112,7 +127,9 @@ impl Fraction {
                 num = -num;
                 den = -den;
             }
-            return Fraction { repr: FractionRepr::Small(num, den) };
+            return Fraction {
+                repr: FractionRepr::Small(num, den),
+            };
         }
 
         let common: BigInt = numerator.gcd(&denominator);
@@ -127,7 +144,9 @@ impl Fraction {
 
     #[inline]
     pub fn create_unreduced(mut numerator: BigInt, mut denominator: BigInt) -> Self {
-        if denominator.is_zero() { panic!("Division by zero"); }
+        if denominator.is_zero() {
+            panic!("Division by zero");
+        }
         if denominator < BigInt::zero() {
             numerator = -numerator;
             denominator = -denominator;
@@ -148,9 +167,16 @@ impl Fraction {
     #[inline]
     pub(crate) fn from_bigint_pair(numerator: BigInt, denominator: BigInt) -> Self {
         if let (Some(n), Some(d)) = (numerator.to_i64(), denominator.to_i64()) {
-            return Fraction { repr: FractionRepr::Small(n, d) };
+            return Fraction {
+                repr: FractionRepr::Small(n, d),
+            };
         }
-        Fraction { repr: FractionRepr::Big { numerator, denominator } }
+        Fraction {
+            repr: FractionRepr::Big {
+                numerator,
+                denominator,
+            },
+        }
     }
 
     #[inline]
@@ -173,9 +199,10 @@ impl Fraction {
     pub fn to_bigint_pair(&self) -> (BigInt, BigInt) {
         match &self.repr {
             FractionRepr::Small(n, d) => (BigInt::from(*n), BigInt::from(*d)),
-            FractionRepr::Big { numerator, denominator } => {
-                (numerator.clone(), denominator.clone())
-            }
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => (numerator.clone(), denominator.clone()),
         }
     }
 
@@ -204,7 +231,10 @@ impl Fraction {
     pub(crate) fn extract_i64_pair(&self) -> Option<(i64, i64)> {
         match &self.repr {
             FractionRepr::Small(n, d) => Some((*n, *d)),
-            FractionRepr::Big { numerator, denominator } => {
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
                 let n = numerator.to_i64()?;
                 let d = denominator.to_i64()?;
                 Some((n, d))
@@ -216,10 +246,19 @@ impl Fraction {
     pub fn to_i64(&self) -> Option<i64> {
         match &self.repr {
             FractionRepr::Small(n, d) => {
-                if *d == 1 { Some(*n) } else { None }
+                if *d == 1 {
+                    Some(*n)
+                } else {
+                    None
+                }
             }
-            FractionRepr::Big { numerator, denominator } => {
-                if !denominator.is_one() { return None; }
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
+                if !denominator.is_one() {
+                    return None;
+                }
                 numerator.to_i64()
             }
         }
@@ -235,8 +274,13 @@ impl Fraction {
                     None
                 }
             }
-            FractionRepr::Big { numerator, denominator } => {
-                if !denominator.is_one() || *numerator < BigInt::zero() { return None; }
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
+                if !denominator.is_one() || *numerator < BigInt::zero() {
+                    return None;
+                }
                 numerator.to_usize()
             }
         }
@@ -263,10 +307,10 @@ impl Fraction {
             d = -d;
         }
 
-        if n >= i64::MIN as i128 && n <= i64::MAX as i128
-            && d >= 0 && d <= i64::MAX as i128
-        {
-            return Fraction { repr: FractionRepr::Small(n as i64, d as i64) };
+        if n >= i64::MIN as i128 && n <= i64::MAX as i128 && d >= 0 && d <= i64::MAX as i128 {
+            return Fraction {
+                repr: FractionRepr::Small(n as i64, d as i64),
+            };
         }
         Fraction {
             repr: FractionRepr::Big {
@@ -277,11 +321,13 @@ impl Fraction {
     }
 
     pub fn from_str(s: &str) -> std::result::Result<Self, String> {
-        if s.is_empty() { return Err("Empty string".to_string()); }
+        if s.is_empty() {
+            return Err("Empty string".to_string());
+        }
 
         if let Some(e_pos) = s.find(|c| char::is_ascii(&c) && (c == 'e' || c == 'E')) {
             let mantissa_str = &s[..e_pos];
-            let exponent_str = &s[e_pos+1..];
+            let exponent_str = &s[e_pos + 1..];
 
             let mantissa: Fraction = Self::from_str(mantissa_str)?;
             let exponent: i32 = exponent_str.parse::<i32>().map_err(|e| e.to_string())?;
@@ -297,27 +343,46 @@ impl Fraction {
         }
         if let Some(pos) = s.find('/') {
             let num: BigInt = BigInt::from_str(&s[..pos]).map_err(|e| e.to_string())?;
-            let den: BigInt = BigInt::from_str(&s[pos+1..]).map_err(|e| e.to_string())?;
+            let den: BigInt = BigInt::from_str(&s[pos + 1..]).map_err(|e| e.to_string())?;
             Ok(Fraction::new(num, den))
         } else if let Some(dot_pos) = s.find('.') {
-            let int_part_str = if s.starts_with('.') { "0" } else { &s[..dot_pos] };
-            let frac_part_str = &s[dot_pos+1..];
-            if frac_part_str.is_empty() { return Self::from_str(int_part_str); }
+            let int_part_str = if s.starts_with('.') {
+                "0"
+            } else {
+                &s[..dot_pos]
+            };
+            let frac_part_str = &s[dot_pos + 1..];
+            if frac_part_str.is_empty() {
+                return Self::from_str(int_part_str);
+            }
             let int_part: BigInt = BigInt::from_str(int_part_str).map_err(|e| e.to_string())?;
             let frac_num: BigInt = BigInt::from_str(frac_part_str).map_err(|e| e.to_string())?;
             let frac_den: BigInt = BigInt::from(10).pow(frac_part_str.len() as u32);
             let total_num: BigInt = int_part.abs() * &frac_den + frac_num;
-            Ok(Fraction::new(if int_part < BigInt::zero() { -total_num } else { total_num }, frac_den))
+            Ok(Fraction::new(
+                if int_part < BigInt::zero() {
+                    -total_num
+                } else {
+                    total_num
+                },
+                frac_den,
+            ))
         } else {
             let num: BigInt = BigInt::from_str(s).map_err(|e| e.to_string())?;
 
             if let Some(n) = num.to_i64() {
-                return Ok(Fraction { repr: FractionRepr::Small(n, 1) });
+                return Ok(Fraction {
+                    repr: FractionRepr::Small(n, 1),
+                });
             }
-            Ok(Fraction { repr: FractionRepr::Big { numerator: num, denominator: BigInt::one() } })
+            Ok(Fraction {
+                repr: FractionRepr::Big {
+                    numerator: num,
+                    denominator: BigInt::one(),
+                },
+            })
         }
     }
-
 
     #[inline]
     pub fn lt(&self, other: &Fraction) -> bool {
@@ -373,23 +438,33 @@ impl ToPrimitive for Fraction {
     fn to_i64(&self) -> Option<i64> {
         match &self.repr {
             FractionRepr::Small(n, d) => {
-                if *d == 0 { return None; }
+                if *d == 0 {
+                    return None;
+                }
                 Some(n / d)
             }
-            FractionRepr::Big { numerator, denominator } => {
-                (numerator / denominator).to_i64()
-            }
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => (numerator / denominator).to_i64(),
         }
     }
 
     fn to_u64(&self) -> Option<u64> {
         match &self.repr {
             FractionRepr::Small(n, d) => {
-                if *d == 0 || *n < 0 { return None; }
+                if *d == 0 || *n < 0 {
+                    return None;
+                }
                 Some((*n / *d) as u64)
             }
-            FractionRepr::Big { numerator, denominator } => {
-                if *numerator < BigInt::zero() { return None; }
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
+                if *numerator < BigInt::zero() {
+                    return None;
+                }
                 (numerator / denominator).to_u64()
             }
         }
@@ -398,13 +473,22 @@ impl ToPrimitive for Fraction {
     fn to_f64(&self) -> Option<f64> {
         match &self.repr {
             FractionRepr::Small(n, d) => {
-                if *d == 0 { return None; }
+                if *d == 0 {
+                    return None;
+                }
                 Some(*n as f64 / *d as f64)
             }
-            FractionRepr::Big { numerator, denominator } => {
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
                 let num_f64: f64 = numerator.to_f64()?;
                 let den_f64: f64 = denominator.to_f64()?;
-                if den_f64 == 0.0 { None } else { Some(num_f64 / den_f64) }
+                if den_f64 == 0.0 {
+                    None
+                } else {
+                    Some(num_f64 / den_f64)
+                }
             }
         }
     }
@@ -413,14 +497,18 @@ impl ToPrimitive for Fraction {
 impl From<i64> for Fraction {
     #[inline]
     fn from(n: i64) -> Self {
-        Fraction { repr: FractionRepr::Small(n, 1) }
+        Fraction {
+            repr: FractionRepr::Small(n, 1),
+        }
     }
 }
 
 impl From<i32> for Fraction {
     #[inline]
     fn from(n: i32) -> Self {
-        Fraction { repr: FractionRepr::Small(n as i64, 1) }
+        Fraction {
+            repr: FractionRepr::Small(n as i64, 1),
+        }
     }
 }
 
@@ -428,10 +516,16 @@ impl std::fmt::Display for Fraction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.repr {
             FractionRepr::Small(n, d) => {
-                if *d == 1 { write!(f, "{}", n) }
-                else { write!(f, "{}/{}", n, d) }
+                if *d == 1 {
+                    write!(f, "{}", n)
+                } else {
+                    write!(f, "{}/{}", n, d)
+                }
             }
-            FractionRepr::Big { numerator, denominator } => {
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
                 if denominator.is_one() {
                     write!(f, "{}", numerator)
                 } else {
@@ -442,7 +536,6 @@ impl std::fmt::Display for Fraction {
     }
 }
 
-
 #[cfg(test)]
 mod literal_parsing_tests {
     use super::Fraction;
@@ -451,9 +544,18 @@ mod literal_parsing_tests {
     fn literals_parse_to_reduced_canonical_fractions() {
         // Surface forms are convenience syntax; all reduce to the same
         // canonical exact-real value. No surface style is retained.
-        assert_eq!(Fraction::from_str("0.5").unwrap(), Fraction::from_str("1/2").unwrap());
-        assert_eq!(Fraction::from_str("2/1").unwrap(), Fraction::from_str("2").unwrap());
-        assert_eq!(Fraction::from_str("4/2").unwrap(), Fraction::from_str("2").unwrap());
+        assert_eq!(
+            Fraction::from_str("0.5").unwrap(),
+            Fraction::from_str("1/2").unwrap()
+        );
+        assert_eq!(
+            Fraction::from_str("2/1").unwrap(),
+            Fraction::from_str("2").unwrap()
+        );
+        assert_eq!(
+            Fraction::from_str("4/2").unwrap(),
+            Fraction::from_str("2").unwrap()
+        );
         assert!(Fraction::from_str("2/1").unwrap().is_integer());
     }
 

--- a/rust/src/types/fraction_arithmetic.rs
+++ b/rust/src/types/fraction_arithmetic.rs
@@ -57,10 +57,11 @@ impl Fraction {
             if b == d {
                 return Self::create_from_i128((a as i128) + (c as i128), b as i128);
             }
-            if let Some(num) = (a as i128).checked_mul(d as i128)
-                .and_then(|ad| (c as i128).checked_mul(b as i128)
-                    .and_then(|cb| ad.checked_add(cb)))
-            {
+            if let Some(num) = (a as i128).checked_mul(d as i128).and_then(|ad| {
+                (c as i128)
+                    .checked_mul(b as i128)
+                    .and_then(|cb| ad.checked_add(cb))
+            }) {
                 return Self::create_from_i128(num, (b as i128) * (d as i128));
             }
         }
@@ -80,10 +81,7 @@ impl Fraction {
             return Self::create_already_reduced(&sum / &g, &ad / &g);
         }
 
-        Fraction::new(
-            &an * &bd + &bn * &ad,
-            &ad * &bd,
-        )
+        Fraction::new(&an * &bd + &bn * &ad, &ad * &bd)
     }
 
     pub fn sub(&self, other: &Fraction) -> Fraction {
@@ -98,10 +96,11 @@ impl Fraction {
             if b == d {
                 return Self::create_from_i128((a as i128) - (c as i128), b as i128);
             }
-            if let Some(num) = (a as i128).checked_mul(d as i128)
-                .and_then(|ad| (c as i128).checked_mul(b as i128)
-                    .and_then(|cb| ad.checked_sub(cb)))
-            {
+            if let Some(num) = (a as i128).checked_mul(d as i128).and_then(|ad| {
+                (c as i128)
+                    .checked_mul(b as i128)
+                    .and_then(|cb| ad.checked_sub(cb))
+            }) {
                 return Self::create_from_i128(num, (b as i128) * (d as i128));
             }
         }
@@ -121,10 +120,7 @@ impl Fraction {
             return Self::create_already_reduced(&diff / &g, &ad / &g);
         }
 
-        Fraction::new(
-            &an * &bd - &bn * &ad,
-            &ad * &bd,
-        )
+        Fraction::new(&an * &bd - &bn * &ad, &ad * &bd)
     }
 
     pub fn mul(&self, other: &Fraction) -> Fraction {
@@ -173,10 +169,7 @@ impl Fraction {
         let c_reduced: BigInt = &bn / &g2;
         let b_reduced: BigInt = &ad / &g2;
 
-        Self::create_already_reduced(
-            a_reduced * c_reduced,
-            b_reduced * d_reduced,
-        )
+        Self::create_already_reduced(a_reduced * c_reduced, b_reduced * d_reduced)
     }
 
     pub fn div(&self, other: &Fraction) -> Fraction {
@@ -228,10 +221,7 @@ impl Fraction {
         let d_reduced: BigInt = &bd / &g2;
         let b_reduced: BigInt = &ad / &g2;
 
-        Self::create_already_reduced(
-            a_reduced * d_reduced,
-            b_reduced * c_reduced,
-        )
+        Self::create_already_reduced(a_reduced * d_reduced, b_reduced * c_reduced)
     }
 
     #[inline]
@@ -240,19 +230,18 @@ impl Fraction {
             return self.clone();
         }
         match &self.repr {
-            FractionRepr::Small(n, d) => {
-                Fraction::from_repr(FractionRepr::Small(n.abs(), *d))
-            }
-            FractionRepr::Big { numerator, denominator } => {
-                Fraction::from_repr(FractionRepr::Big {
-                    numerator: if *numerator < BigInt::zero() {
-                        -numerator.clone()
-                    } else {
-                        numerator.clone()
-                    },
-                    denominator: denominator.clone(),
-                })
-            }
+            FractionRepr::Small(n, d) => Fraction::from_repr(FractionRepr::Small(n.abs(), *d)),
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => Fraction::from_repr(FractionRepr::Big {
+                numerator: if *numerator < BigInt::zero() {
+                    -numerator.clone()
+                } else {
+                    numerator.clone()
+                },
+                denominator: denominator.clone(),
+            }),
         }
     }
 
@@ -268,7 +257,10 @@ impl Fraction {
                 let floored = if *n < 0 && r != 0 { q - 1 } else { q };
                 Fraction::from_repr(FractionRepr::Small(floored, 1))
             }
-            FractionRepr::Big { numerator, denominator } => {
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
                 let q = numerator / denominator;
                 let r = numerator % denominator;
                 let floored = if *numerator < BigInt::zero() && !r.is_zero() {
@@ -293,7 +285,10 @@ impl Fraction {
                 let ceiled = if *n > 0 && r != 0 { q + 1 } else { q };
                 Fraction::from_repr(FractionRepr::Small(ceiled, 1))
             }
-            FractionRepr::Big { numerator, denominator } => {
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
                 let q = numerator / denominator;
                 let r = numerator % denominator;
                 let ceiled = if *numerator > BigInt::zero() && !r.is_zero() {
@@ -305,7 +300,6 @@ impl Fraction {
             }
         }
     }
-
 
     pub fn round(&self) -> Fraction {
         if self.is_integer() {
@@ -322,9 +316,15 @@ impl Fraction {
                 let abs_n = n.abs() as i128;
                 let d128 = *d as i128;
                 let result = ((2 * abs_n + d128) / (2 * d128)) as i64;
-                Fraction::from_repr(FractionRepr::Small(if is_negative { -result } else { result }, 1))
+                Fraction::from_repr(FractionRepr::Small(
+                    if is_negative { -result } else { result },
+                    1,
+                ))
             }
-            FractionRepr::Big { numerator, denominator } => {
+            FractionRepr::Big {
+                numerator,
+                denominator,
+            } => {
                 let is_negative = *numerator < BigInt::zero();
                 let abs_num = if is_negative {
                     -numerator.clone()
@@ -334,14 +334,10 @@ impl Fraction {
                 let two = BigInt::from(2);
                 let two_abs_num = &abs_num * &two;
                 let result = (&two_abs_num + denominator) / (&two * denominator);
-                Self::from_bigint_pair(
-                    if is_negative { -result } else { result },
-                    BigInt::one(),
-                )
+                Self::from_bigint_pair(if is_negative { -result } else { result }, BigInt::one())
             }
         }
     }
-
 
     pub fn modulo(&self, other: &Fraction) -> Fraction {
         if other.is_zero() {
@@ -352,7 +348,11 @@ impl Fraction {
             if b == 1 && d == 1 {
                 let rem = a % c;
                 let result = if rem < 0 {
-                    if c > 0 { rem + c } else { rem - c }
+                    if c > 0 {
+                        rem + c
+                    } else {
+                        rem - c
+                    }
                 } else {
                     rem
                 };
@@ -368,7 +368,11 @@ impl Fraction {
             let den = b * d;
             let rem = num % mod_by;
             let result_num = if rem < 0 {
-                if mod_by > 0 { rem + mod_by } else { rem - mod_by }
+                if mod_by > 0 {
+                    rem + mod_by
+                } else {
+                    rem - mod_by
+                }
             } else {
                 rem
             };

--- a/rust/src/types/fraction_mcdc_tests.rs
+++ b/rust/src/types/fraction_mcdc_tests.rs
@@ -183,7 +183,11 @@ mod as_usize_small {
     #[test]
     fn aq_ver_001_c_row2_integer_negative_returns_none() {
         let f = small(-1, 1);
-        assert_eq!(f.as_usize(), None, "negative integer must not coerce to usize");
+        assert_eq!(
+            f.as_usize(),
+            None,
+            "negative integer must not coerce to usize"
+        );
     }
 
     #[test]
@@ -466,7 +470,10 @@ mod create_from_i128_small_big_boundary {
         // before line 267 evaluates `d >= 0`. The result still depends on
         // A,B,D. Here d = -3 is normalized to d = +3 with sign flipped onto n.
         let f = Fraction::create_from_i128(5, -3);
-        assert!(f.is_small(), "after normalization both n,d fit i64 -> Small");
+        assert!(
+            f.is_small(),
+            "after normalization both n,d fit i64 -> Small"
+        );
         assert_eq!(f, small(-5, 3));
     }
 }
@@ -523,7 +530,10 @@ mod add_small_fast_path_entry_guard {
         // Expected: 2*i64::MAX + 1
         let expected_num = BigInt::from(i64::MAX) * BigInt::from(2i64) + BigInt::from(1i64);
         assert_eq!(result, Fraction::new(expected_num, BigInt::from(1)));
-        assert!(!result.is_small(), "Big + Small with overflow must stay Big");
+        assert!(
+            !result.is_small(),
+            "Big + Small with overflow must stay Big"
+        );
     }
 
     #[test]
@@ -535,7 +545,10 @@ mod add_small_fast_path_entry_guard {
         let result = small_one.add(&big);
         let expected_num = BigInt::from(i64::MAX) * BigInt::from(2i64) + BigInt::from(1i64);
         assert_eq!(result, Fraction::new(expected_num, BigInt::from(1)));
-        assert!(!result.is_small(), "Small + Big with overflow must stay Big");
+        assert!(
+            !result.is_small(),
+            "Small + Big with overflow must stay Big"
+        );
     }
 }
 
@@ -600,7 +613,11 @@ mod add_checked_chain_defensive {
         let lhs = small(i64::MAX, i64::MAX);
         let rhs = small(i64::MAX, i64::MAX);
         let result = lhs.add(&rhs);
-        assert_eq!(result, small(2, 1), "i64::MAX/i64::MAX + i64::MAX/i64::MAX = 2");
+        assert_eq!(
+            result,
+            small(2, 1),
+            "i64::MAX/i64::MAX + i64::MAX/i64::MAX = 2"
+        );
     }
 
     #[test]

--- a/rust/src/wasm_interpreter_bindings/mod.rs
+++ b/rust/src/wasm_interpreter_bindings/mod.rs
@@ -2,9 +2,9 @@ use crate::interpreter::Interpreter;
 use crate::types::Token;
 use wasm_bindgen::prelude::*;
 
-pub(crate) mod wasm_value_conversion;
 mod wasm_interpreter_execution;
 mod wasm_interpreter_state;
+pub(crate) mod wasm_value_conversion;
 
 /// Install console_error_panic_hook so any panic on the WASM side
 /// surfaces in the browser console with a JS-friendly stack trace

--- a/rust/tests/nicf_feasibility.rs
+++ b/rust/tests/nicf_feasibility.rs
@@ -230,7 +230,9 @@ fn nicf_vs_rcf_agreed_prefix() {
     // Deterministic LCG so the corpus is reproducible without an rng dep.
     let mut seed: u64 = 0x9E3779B97F4A7C15;
     let mut next = || {
-        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        seed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         seed
     };
 

--- a/rust/wasm-tests/tests/boundary.rs
+++ b/rust/wasm-tests/tests/boundary.rs
@@ -103,7 +103,11 @@ async fn exact_scalar_rawnumber_marks_approximate_at_boundary() {
     let stack = stack_of("'math' IMPORT 2 SQRT").await;
     assert_eq!(stack.length(), 1);
     let node = stack.get(0);
-    assert_eq!(type_of(&node), "number", "√2 (RawNumber) serializes as number");
+    assert_eq!(
+        type_of(&node),
+        "number",
+        "√2 (RawNumber) serializes as number"
+    );
     // The numeric value is present (the rational approximation).
     let value = field(&node, "value");
     assert!(field(&value, "numerator").as_string().is_some());


### PR DESCRIPTION
## Summary

Mechanical reformatting only. Ran `cargo fmt` over both independent Rust crates so that `cargo fmt --check` is clean (exit 0):

- `rust/` (`ajisai-core`) — 62 files / ~999 insertions, 843 deletions
- `rust/wasm-tests/` (`ajisai-wasm-tests`) — `tests/boundary.rs`

These are two separate crates (not a workspace), so `cargo fmt` was run in each independently.

## Nature of changes

- **Logic changes: none.** This is purely `cargo fmt` output (rustfmt 1.8.0-stable, default config, edition 2021) with no manual edits.
- Changes are limited to whitespace, line wrapping, import ordering, and spacing.
- Only `.rs` files are touched.

## Verification

- `cd rust && cargo fmt --check` → exit 0
- `cd rust/wasm-tests && cargo fmt --check` → exit 0
- `cd rust && cargo build` → success (pre-existing warnings unchanged)
- `cd rust && cargo test --all-targets` → exit 0, 1264 tests pass, 0 failures (behavior unchanged)

## Notes

- The 435+ formatting hunks may conflict with other in-flight PRs; merging while few other PRs are open is advisable.
- Out of scope (intentionally separate): switching the repo variable `AJISAI_STRICT_QUALITY=true` to make the Quality Gate blocking. That would also block on the ~124 outstanding `cargo clippy` warnings, which need separate cleanup first.

https://claude.ai/code/session_01JEmPyYkcT755fAfGauDgmb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEmPyYkcT755fAfGauDgmb)_