### PR TITLE
Portability foundation: conformance suite, HostEffect, optional wasm feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,10 @@ jobs:
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Rust native check (Core build, no wasm deps)
+        working-directory: rust
+        run: cargo check
+
       - name: Run all Rust tests
         working-directory: rust
         run: cargo test --verbose
@@ -112,7 +116,7 @@ jobs:
         working-directory: rust
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo check --target wasm32-unknown-unknown
+          cargo check --features wasm --target wasm32-unknown-unknown
 
       - name: Detect stale committed wasm bundle (advisory)
         # Build the wasm bundle the same way the deploy workflow does and

--- a/PORTABILITY.md
+++ b/PORTABILITY.md
@@ -1,0 +1,41 @@
+# Ajisai Portability Policy
+
+Ajisai の移植性とは、Rust/WASM/Tauri/Web に依存せず、Ajisai Core の意味論を
+別の実装言語・別の実行環境・別の UI 上で再現できる性質である。Ajisai の同一性は
+特定実装ではなく conformance suite が定義する入出力の対応関係によって与えられる。
+
+## Principles
+1. Ajisai の正典は特定実装ではなく、仕様と conformance suite である。
+2. Rust/WASM 実装は参照実装のひとつであり、唯一の正統実装ではない。
+3. Ajisai Core はホスト非依存でなければならない。
+4. 外部効果は Host Capability として扱い、Host Effect として構造化する。
+5. Host Capability の不足は仕様化された方法で失敗する。
+6. Core 語彙は決定的でなければならない。
+7. Hosted 語彙は要求する Capability を明示しなければならない。
+8. 新機能は Core か Hosted かを明示して追加する。
+9. Platform 固有 API を Core へ直接持ち込まない。
+10. ある実装が Ajisai であることは conformance suite を通すことで証明される。
+11. conformance が固定する対応が現象であり、それ以外は実装の裁量である。
+12. 正規化は最小限とし、緩める方向にのみ明示的に変更する。
+
+## Lineage
+Ajisai は FORTH から辞書システムを継承した遠縁である。ただし FORTH が
+スタックベースなのに対し Ajisai は Vector ベースであり、実行モデルの根幹が
+異なる。FORTH の移植性（小さなスタック VM の再実装）をそのまま継承せず、
+Ajisai の移植性は conformance suite が定義する現象の再現そのものである。
+
+## Portability Layers
+| Layer | Description | Examples |
+| --- | --- | --- |
+| Core | ホスト非依存の意味論的核 | vector evaluation, arithmetic, blocks, map/form/fold, NIL/UNKNOWN |
+| Hosted | 外部能力を要求する語彙 | NOW, CSPRNG, SERIAL, AUDIO, JSONEXPORT |
+| Platform | 具体的な宿主 | Web, WASM, Tauri, CLI, WASI, Native |
+
+## Conformance
+Ajisai の現象は tests/conformance/ 配下の HTML スイートが定義する。各ケースは
+Ajisai ソースと、期待される結果および Host Effect の列を構造化して持つ。
+実装はこのスイートを通すことで適合性を示す。
+
+判定規則・正規化規則の詳細は `tests/conformance/index.html` の冒頭に記述され、
+参照実装側のランナーは `rust/src/conformance_tests.rs` にある。効果の観測対象は
+構造化された Host Effect の列であり、人間可読な出力文字列ではない。

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1100,3 +1100,24 @@ refusal or a step-budget exhaustion is an operational or environment condition,
 whereas an exhausted comparison budget is a *logical* `Unknown`, never an
 operational absence.
 
+
+## Portability Profiles
+
+### Core Profile
+Host-independent semantics only: tokenization, vector evaluation, exact
+arithmetic, vectors, blocks, map/form/fold, NIL/UNKNOWN, user definitions.
+
+### Hosted Profile
+Words requiring host capabilities: NOW, CSPRNG, SERIAL, AUDIO, JSONEXPORT,
+persistence, file I/O.
+
+### Platform Profile
+Concrete runtime bindings: Web/WASM, Tauri, CLI, WASI, Native desktop.
+
+## Conformance and Identity
+An implementation is an Ajisai implementation if and only if it passes the
+conformance suite (tests/conformance/). The suite defines, language-
+independently, the correspondence between Ajisai source programs and their
+observable results, including the ordered sequence of host effects. This
+correspondence is the phenomenon of Ajisai; everything not fixed by the
+suite is implementation freedom.

--- a/docs/dev/current-test-status.md
+++ b/docs/dev/current-test-status.md
@@ -4,3 +4,17 @@ This file is an operational note only.
 It does not define language semantics.
 
 Canonical semantics are defined only in `SPECIFICATION.md`.
+
+## CI build matrix
+
+Current CI (`.github/workflows/test.yml`) runs on `ubuntu-latest` only:
+
+- `cargo check` (native Core build, no wasm deps)
+- `cargo check --features wasm --target wasm32-unknown-unknown`
+- `cargo test` / `cargo test --all-targets`
+
+TODO(portability): add a native OS matrix (ubuntu / macos / windows) so the
+host-clock (`SystemTime`) and OS-CSPRNG (`getrandom`) boundaries are exercised
+on every supported native host, not just Linux. This is a future goal; the
+single-OS gate above is the current baseline.
+

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,11 @@
-[target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+simd128"]
+# Baseline wasm build does NOT force SIMD. WASM SIMD (`simd128`) was previously
+# enabled globally here, which made every wasm build assume a SIMD-capable host
+# and required the intrinsics kernel in interpreter/simd_ops.rs to compile.
+# Baseline portability comes first: simd_ops.rs falls back to a scalar kernel
+# unless `simd128` is enabled, so the default wasm build is host-agnostic.
+#
+# TODO(portability): add an explicit optimized build path (e.g. npm
+# `build:wasm:simd`) that re-enables SIMD with:
+#   [target.wasm32-unknown-unknown]
+#   rustflags = ["-C", "target-feature=+simd128"]
+# selecting the intrinsics kernel in simd_ops.rs.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,26 +7,46 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
-js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.6"
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 num-integer = "0.1"
 serde_json = "1.0"
-wasm-bindgen-futures = "0.4"
-chrono = { version = "0.4", features = ["wasmbind"] }
-getrandom = { version = "0.2", features = ["js"] }
 lazy_static = "1.4"
 smallvec = "1"
-console_error_panic_hook = "0.1"
+# chrono was previously declared but is unused: NOW reads the host clock
+# directly (js Date.now / std SystemTime, see interpreter/datetime.rs) and all
+# civil <-> instant conversion is host-independent exact-rational arithmetic in
+# time_ops/time_calendar. Removed to keep Core dependency-light.
+
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
+js-sys = { version = "0.3", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+getrandom = { version = "0.2", optional = true }
 
 [dependencies.web-sys]
 version = "0.3"
+optional = true
 features = ["console", "Window", "CustomEvent", "EventTarget", "Event"]
 
 [features]
+# default keeps the native std + hosted build. hosted is included so that
+# CSPRNG (a Hosted capability) and the existing native test suite still build
+# and run under a plain `cargo test`. The portability template's bare
+# default=["std"] would drop `getrandom` and fail to compile interpreter/random.rs.
+default = ["std", "hosted"]
+std = []
+# hosted: ネイティブ std 環境では getrandom は OS バックエンドで動作する。
+# wasm 環境では getrandom/js を使う（wasm feature 側で指定）。
+hosted = ["std", "dep:getrandom"]
+wasm = [
+  "std", "hosted",
+  "dep:wasm-bindgen", "dep:js-sys", "dep:serde-wasm-bindgen",
+  "dep:wasm-bindgen-futures", "dep:console_error_panic_hook", "dep:web-sys",
+  "getrandom/js",
+]
 trace-compile = []
 trace-epoch = []
 trace-quant = []

--- a/rust/src/conformance_tests.rs
+++ b/rust/src/conformance_tests.rs
@@ -1,0 +1,357 @@
+//! Conformance runner.
+//!
+//! Ajisai's identity is defined language-independently by the HTML conformance
+//! suite at `tests/conformance/`, not by this Rust implementation. Each
+//! `<section class="ajisai-case">` pairs an Ajisai source program with its
+//! expected final result and the expected ordered sequence of host effects.
+//!
+//! Contract (see `tests/conformance/index.html` and `PORTABILITY.md`):
+//!   1. The `ajisai-source` is executed as an Ajisai program.
+//!   2. The observed final result (the whole stack, rendered value-by-value)
+//!      must equal `ajisai-expect-result` after normalization.
+//!   3. The fired `HostEffect`s must equal the `ajisai-effect` elements in
+//!      order — both `data-kind` and `data-payload`.
+//!
+//! Observation target for effects is `Interpreter::host_effects()` — the
+//! structured channel — NOT the human-readable `output_buffer`.
+//!
+//! Normalization (deliberately minimal, §"正規化規則"): only whitespace
+//! BETWEEN tokens (spaces / tabs / newlines) is normalized, because whitespace
+//! is a separator in the value model, not a value. Everything else — numeric
+//! notation (`n/d`), element order, nesting, the spelling of `NIL`/`UNKNOWN` —
+//! is matched exactly. If this line ever conflates phenomenon with notation it
+//! must only be loosened, with a comment recording the reason.
+//!
+//! The parser is strict: a case missing a required element, or an
+//! `ajisai-effect` missing `data-kind`/`data-payload`, aborts with a panic. We
+//! never silently skip a malformed case.
+
+use crate::interpreter::Interpreter;
+
+const SUITE: &str = include_str!("../../tests/conformance/index.html");
+
+#[derive(Debug)]
+struct ExpectedEffect {
+    kind: String,
+    payload: String,
+}
+
+#[derive(Debug)]
+struct Case {
+    id: String,
+    #[allow(dead_code)]
+    category: String,
+    source: String,
+    expect_result: String,
+    effects: Vec<ExpectedEffect>,
+}
+
+// ── tiny strict HTML extraction ───────────────────────────────────────────
+// A targeted scanner for the fixed `class`/`data-*` structure of the suite.
+// Not a general HTML parser; it assumes the suite is well-formed and well
+// quoted, and fails loudly when a required piece is absent.
+
+/// Decode the small set of HTML entities the suite may contain.
+fn decode_entities(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        // `&amp;` must be last so it does not re-trigger the others.
+        .replace("&amp;", "&")
+}
+
+/// Collapse inter-token whitespace to single spaces and trim. This is the only
+/// normalization applied to results (and to effect payloads).
+fn normalize_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+struct StartTag {
+    name: String,
+    attrs: String,
+    /// Byte index just past the closing `>` of this start tag.
+    content_start: usize,
+}
+
+/// Parse a start tag beginning at `lt` (which must index a `<`).
+fn parse_start_tag(html: &str, lt: usize) -> Option<StartTag> {
+    let bytes = html.as_bytes();
+    debug_assert_eq!(bytes[lt], b'<');
+    let mut i = lt + 1;
+    let name_start = i;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-') {
+        i += 1;
+    }
+    if i == name_start {
+        return None; // `</...`, `<!--`, etc. — not a start tag.
+    }
+    let name = html[name_start..i].to_string();
+    let attrs_start = i;
+    // Walk to the closing `>`, skipping over quoted attribute values so a `>`
+    // inside an attribute does not end the tag prematurely.
+    let mut quote: Option<u8> = None;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                }
+            }
+            None => {
+                if c == b'"' || c == b'\'' {
+                    quote = Some(c);
+                } else if c == b'>' {
+                    let attrs = html[attrs_start..i]
+                        .trim()
+                        .trim_end_matches('/')
+                        .to_string();
+                    return Some(StartTag {
+                        name,
+                        attrs,
+                        content_start: i + 1,
+                    });
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find the matching close tag for `name`, accounting for nested same-name
+/// tags. Returns `(inner_html, outer_end)` where `outer_end` is just past the
+/// closing `</name>`.
+fn find_matching_close(html: &str, content_start: usize, name: &str) -> Option<(String, usize)> {
+    let bytes = html.as_bytes();
+    let mut i = content_start;
+    let mut depth = 1usize;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+                // Possible close tag.
+                let after = &html[i + 2..];
+                if after
+                    .strip_prefix(name)
+                    .map(|rest| rest.trim_start().starts_with('>'))
+                    .unwrap_or(false)
+                {
+                    depth -= 1;
+                    let gt = i + 2 + html[i + 2..].find('>').unwrap();
+                    if depth == 0 {
+                        return Some((html[content_start..i].to_string(), gt + 1));
+                    }
+                    i = gt + 1;
+                    continue;
+                }
+            } else if let Some(st) = parse_start_tag(html, i) {
+                if st.name == name {
+                    depth += 1;
+                }
+                i = st.content_start;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+struct Element {
+    attrs: String,
+    inner: String,
+    /// Byte index just past this element's close tag.
+    outer_end: usize,
+}
+
+/// Find the next element (any tag) whose `class` attribute contains `class`,
+/// searching `html[from..]`.
+fn find_element_by_class(html: &str, from: usize, class: &str) -> Option<Element> {
+    let mut i = from;
+    let bytes = html.as_bytes();
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if let Some(st) = parse_start_tag(html, i) {
+                if class_attr_contains(&st.attrs, class) {
+                    let (inner, outer_end) = find_matching_close(html, st.content_start, &st.name)?;
+                    return Some(Element {
+                        attrs: st.attrs,
+                        inner,
+                        outer_end,
+                    });
+                }
+                i = st.content_start;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Read the value of attribute `name` from a start-tag attribute string.
+fn attr_value(attrs: &str, name: &str) -> Option<String> {
+    let mut search = 0;
+    let bytes = attrs.as_bytes();
+    while let Some(rel) = attrs[search..].find(name) {
+        let at = search + rel;
+        // Must be a whole attribute name: preceded by start/space, followed by `=`.
+        let before_ok = at == 0 || attrs.as_bytes()[at - 1].is_ascii_whitespace();
+        let mut j = at + name.len();
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if before_ok && j < bytes.len() && bytes[j] == b'=' {
+            j += 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && (bytes[j] == b'"' || bytes[j] == b'\'') {
+                let q = bytes[j];
+                let val_start = j + 1;
+                let end = attrs[val_start..].find(q as char)? + val_start;
+                return Some(decode_entities(&attrs[val_start..end]));
+            }
+        }
+        search = at + name.len();
+    }
+    None
+}
+
+fn class_attr_contains(attrs: &str, class: &str) -> bool {
+    match attr_value(attrs, "class") {
+        Some(v) => v.split_whitespace().any(|c| c == class),
+        None => false,
+    }
+}
+
+fn parse_cases() -> Vec<Case> {
+    let html = SUITE;
+    let mut cases = Vec::new();
+    let mut from = 0;
+    while let Some(section) = find_element_by_class(html, from, "ajisai-case") {
+        let next_from = section.outer_end;
+
+        let id = attr_value(&section.attrs, "id")
+            .expect("ajisai-case section is missing required `id` attribute");
+        let category = attr_value(&section.attrs, "data-category").unwrap_or_else(|| {
+            panic!("ajisai-case `{id}` is missing required `data-category` attribute")
+        });
+
+        let inner = &section.inner;
+
+        let source_el = find_element_by_class(inner, 0, "ajisai-source")
+            .unwrap_or_else(|| panic!("case `{id}` is missing `ajisai-source`"));
+        let result_el = find_element_by_class(inner, 0, "ajisai-expect-result")
+            .unwrap_or_else(|| panic!("case `{id}` is missing `ajisai-expect-result`"));
+        let effects_el = find_element_by_class(inner, 0, "ajisai-expect-effects")
+            .unwrap_or_else(|| panic!("case `{id}` is missing `ajisai-expect-effects`"));
+
+        // Source: decode entities, trim outer whitespace. Internal whitespace
+        // (including newlines, which are significant Ajisai tokens) is kept.
+        let source = decode_entities(&source_el.inner).trim().to_string();
+        let expect_result = decode_entities(&result_el.inner);
+
+        // Effects: every `ajisai-effect` inside `ajisai-expect-effects`, in order.
+        let mut effects = Vec::new();
+        let mut eff_from = 0;
+        while let Some(eff) = find_element_by_class(&effects_el.inner, eff_from, "ajisai-effect") {
+            eff_from = eff.outer_end;
+            let kind = attr_value(&eff.attrs, "data-kind").unwrap_or_else(|| {
+                panic!("case `{id}` has an `ajisai-effect` missing `data-kind`")
+            });
+            let payload = attr_value(&eff.attrs, "data-payload")
+                .unwrap_or_else(|| panic!("case `{id}` effect `{kind}` is missing `data-payload`"));
+            effects.push(ExpectedEffect { kind, payload });
+        }
+
+        cases.push(Case {
+            id,
+            category,
+            source,
+            expect_result,
+            effects,
+        });
+        from = next_from;
+    }
+    cases
+}
+
+async fn run_case(case: &Case) -> std::result::Result<(), String> {
+    let mut interp = Interpreter::new();
+    interp
+        .execute(&case.source)
+        .await
+        .map_err(|e| format!("execution failed: {e}"))?;
+
+    // Final result = the whole stack, each value rendered via Display.
+    let actual_result = interp
+        .get_stack()
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let expected_norm = normalize_ws(&case.expect_result);
+    let actual_norm = normalize_ws(&actual_result);
+    if expected_norm != actual_norm {
+        return Err(format!(
+            "result mismatch:\n  expected: {expected_norm:?}\n  actual:   {actual_norm:?}"
+        ));
+    }
+
+    // Host effects in order.
+    let actual_effects = interp.host_effects();
+    if actual_effects.len() != case.effects.len() {
+        return Err(format!(
+            "effect count mismatch: expected {}, got {} ({:?})",
+            case.effects.len(),
+            actual_effects.len(),
+            actual_effects
+        ));
+    }
+    for (i, (exp, act)) in case.effects.iter().zip(actual_effects.iter()).enumerate() {
+        if exp.kind != act.kind() {
+            return Err(format!(
+                "effect[{i}] kind mismatch: expected {:?}, got {:?}",
+                exp.kind,
+                act.kind()
+            ));
+        }
+        if normalize_ws(&exp.payload) != normalize_ws(act.payload()) {
+            return Err(format!(
+                "effect[{i}] payload mismatch:\n  expected: {:?}\n  actual:   {:?}",
+                exp.payload,
+                act.payload()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn conformance_suite_passes() {
+    let cases = parse_cases();
+    assert!(
+        !cases.is_empty(),
+        "conformance suite parsed zero cases — the suite file is empty or malformed"
+    );
+
+    let mut failures = Vec::new();
+    for case in &cases {
+        if let Err(e) = run_case(case).await {
+            failures.push(format!("[{}] {}", case.id, e));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} of {} conformance case(s) failed:\n\n{}",
+            failures.len(),
+            cases.len(),
+            failures.join("\n\n")
+        );
+    }
+    eprintln!("conformance: {} case(s) passed", cases.len());
+}

--- a/rust/src/interpreter/audio/build_audio_structure.rs
+++ b/rust/src/interpreter/audio/build_audio_structure.rs
@@ -15,7 +15,11 @@ pub fn op_play(interp: &mut Interpreter) -> Result<()> {
         OperationTargetMode::StackTop => {
             let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
             let structure = build_audio_structure(&val, mode, &mut interp.output_buffer)?;
-            emit_play_command(&structure, &mut interp.output_buffer);
+            if let Some(json) = emit_play_command(&structure, &mut interp.output_buffer) {
+                interp
+                    .host_effects
+                    .push(crate::interpreter::HostEffect::Audio(json));
+            }
         }
         OperationTargetMode::Stack => {
             let values: Vec<Value> = interp.stack.drain(..).collect();
@@ -41,7 +45,11 @@ pub fn op_play(interp: &mut Interpreter) -> Result<()> {
                 },
             };
 
-            emit_play_command(&combined, &mut interp.output_buffer);
+            if let Some(json) = emit_play_command(&combined, &mut interp.output_buffer) {
+                interp
+                    .host_effects
+                    .push(crate::interpreter::HostEffect::Audio(json));
+            }
         }
     }
 
@@ -269,18 +277,25 @@ fn check_audible_range(freq: f64, output: &mut String) {
     }
 }
 
-fn emit_play_command(structure: &AudioStructure, output: &mut String) {
+/// Emit the `play` command. Writes the legacy `AUDIO:{json}` protocol line into
+/// `output` and returns the JSON payload so the caller can also record a
+/// structured `HostEffect::Audio` (the conformance observation channel).
+fn emit_play_command(structure: &AudioStructure, output: &mut String) -> Option<String> {
     let command = PlayCommand {
         command_type: "play".to_string(),
         structure: structure.clone(),
     };
 
-    if let Ok(json) = serde_json::to_string(&command) {
-        if !output.is_empty() && !output.ends_with('\n') {
+    match serde_json::to_string(&command) {
+        Ok(json) => {
+            if !output.is_empty() && !output.ends_with('\n') {
+                output.push('\n');
+            }
+            output.push_str("AUDIO:");
+            output.push_str(&json);
             output.push('\n');
+            Some(json)
         }
-        output.push_str("AUDIO:");
-        output.push_str(&json);
-        output.push('\n');
+        Err(_) => None,
     }
 }

--- a/rust/src/interpreter/audio/execute_audio_commands.rs
+++ b/rust/src/interpreter/audio/execute_audio_commands.rs
@@ -60,9 +60,13 @@ pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
+    let payload = format!("{{\"slot_duration\":{}}}", seconds);
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Config(payload.clone()));
     interp
         .output_buffer
-        .push_str(&format!("CONFIG:{{\"slot_duration\":{}}}\n", seconds));
+        .push_str(&format!("CONFIG:{}\n", payload));
 
     Ok(())
 }
@@ -86,14 +90,23 @@ pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
+    let payload = format!("{{\"gain\":{}}}", clamped);
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Effect(payload.clone()));
     interp
         .output_buffer
-        .push_str(&format!("EFFECT:{{\"gain\":{}}}\n", clamped));
+        .push_str(&format!("EFFECT:{}\n", payload));
 
     Ok(())
 }
 
 pub fn op_gain_reset(interp: &mut Interpreter) -> Result<()> {
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Effect(
+            "{\"gain\":1.0}".to_string(),
+        ));
     interp.output_buffer.push_str("EFFECT:{\"gain\":1.0}\n");
     Ok(())
 }
@@ -117,19 +130,33 @@ pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
         ));
     }
 
+    let payload = format!("{{\"pan\":{}}}", clamped);
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Effect(payload.clone()));
     interp
         .output_buffer
-        .push_str(&format!("EFFECT:{{\"pan\":{}}}\n", clamped));
+        .push_str(&format!("EFFECT:{}\n", payload));
 
     Ok(())
 }
 
 pub fn op_pan_reset(interp: &mut Interpreter) -> Result<()> {
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Effect(
+            "{\"pan\":0.0}".to_string(),
+        ));
     interp.output_buffer.push_str("EFFECT:{\"pan\":0.0}\n");
     Ok(())
 }
 
 pub fn op_fx_reset(interp: &mut Interpreter) -> Result<()> {
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Effect(
+            "{\"gain\":1.0,\"pan\":0.0}".to_string(),
+        ));
     interp
         .output_buffer
         .push_str("EFFECT:{\"gain\":1.0,\"pan\":0.0}\n");

--- a/rust/src/interpreter/datetime.rs
+++ b/rust/src/interpreter/datetime.rs
@@ -11,12 +11,44 @@ use crate::interpreter::value_extraction_helpers::create_datetime_value;
 use crate::interpreter::{Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use num_bigint::BigInt;
-use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = Date, js_name = now)]
-    fn date_now() -> f64;
+// TODO(portability): Route NOW through HostEnv instead of the default clock.
+// A deterministic clock is required for time-dependent conformance cases
+// (e.g. a DeterministicHost { now_millis, random_bytes }).
+
+/// The single host-clock boundary. Returns wall-clock milliseconds since the
+/// Unix epoch from whichever host the current build targets. WASM-specific
+/// access to `Date.now()` is isolated behind the `wasm` feature so the Core
+/// (native std) build never references wasm-bindgen.
+pub(crate) fn default_now_millis() -> i64 {
+    #[cfg(feature = "wasm")]
+    {
+        wasm_now_millis()
+    }
+    #[cfg(all(not(feature = "wasm"), feature = "std"))]
+    {
+        std_now_millis()
+    }
+}
+
+#[cfg(feature = "wasm")]
+fn wasm_now_millis() -> i64 {
+    use wasm_bindgen::prelude::*;
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = Date, js_name = now)]
+        fn date_now() -> f64;
+    }
+    date_now() as i64
+}
+
+#[cfg(all(not(feature = "wasm"), feature = "std"))]
+fn std_now_millis() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 pub fn op_now(interp: &mut Interpreter) -> Result<()> {
@@ -27,8 +59,8 @@ pub fn op_now(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
-    let now_ms = date_now();
-    let ms_bigint = BigInt::from(now_ms as i64);
+    let now_ms = default_now_millis();
+    let ms_bigint = BigInt::from(now_ms);
     let timestamp = Fraction::new(ms_bigint, BigInt::from(1000));
 
     interp.stack.push(create_datetime_value(timestamp));

--- a/rust/src/interpreter/host.rs
+++ b/rust/src/interpreter/host.rs
@@ -1,0 +1,77 @@
+//! Host abstraction scaffolding (portability first step).
+//!
+//! Ajisai Core is host-independent; anything that reaches outside the pure
+//! value model (the wall clock, a CSPRNG, a serial port, audio, JSON export)
+//! is a *host capability*. When such a word runs it produces a structured
+//! `HostEffect` rather than only appending a string to `output_buffer`.
+//!
+//! The conformance suite (`tests/conformance/`) observes the ordered sequence
+//! of `HostEffect`s, not the human-readable `output_buffer`. Structuring the
+//! effects this way lets two independent implementations be compared
+//! language-independently: they agree iff they emit the same effect列.
+//!
+//! This is a first scaffold. Payloads are kept as `String` for now and the
+//! legacy `output_buffer` string protocol (`SERIAL:`, `AUDIO:`, ...) is still
+//! emitted in parallel so the Web/Tauri front-ends keep working unchanged.
+
+/// A capability the host must provide for a Hosted-profile word to run.
+///
+/// Core-profile words never require a `HostCapability`. Hosted-profile words
+/// declare exactly one. This enum is the vocabulary used to describe those
+/// requirements; routing words through it (and failing in a specified way when
+/// a capability is absent) is future work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HostCapability {
+    Clock,
+    SecureRandom,
+    Serial,
+    Audio,
+    JsonExport,
+    Config,
+    Effect,
+}
+
+/// A structured, observable side effect produced by a Hosted-profile word.
+///
+/// Each variant corresponds to a conformance `data-kind` (see `kind`). The
+/// payload is the same text that is (for now) also written to the legacy
+/// `output_buffer` protocol line, so the two observation channels stay in sync.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HostEffect {
+    Print(String),
+    Audio(String),
+    Config(String),
+    Effect(String),
+    Serial(String),
+    JsonExport(String),
+    Diagnostic(String),
+}
+
+impl HostEffect {
+    /// Stable, language-independent kind tag. This is the string the
+    /// conformance suite carries in `data-kind` on each `ajisai-effect`.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            HostEffect::Print(_) => "print",
+            HostEffect::Audio(_) => "audio",
+            HostEffect::Config(_) => "config",
+            HostEffect::Effect(_) => "effect",
+            HostEffect::Serial(_) => "serial",
+            HostEffect::JsonExport(_) => "json_export",
+            HostEffect::Diagnostic(_) => "diagnostic",
+        }
+    }
+
+    /// The effect payload. Conformance carries this in `data-payload`.
+    pub fn payload(&self) -> &str {
+        match self {
+            HostEffect::Print(s)
+            | HostEffect::Audio(s)
+            | HostEffect::Config(s)
+            | HostEffect::Effect(s)
+            | HostEffect::Serial(s)
+            | HostEffect::JsonExport(s)
+            | HostEffect::Diagnostic(s) => s,
+        }
+    }
+}

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -213,6 +213,19 @@ pub struct Interpreter {
     pub(crate) user_dictionaries: HashMap<String, UserDictionary>,
     pub(crate) dependents: HashMap<String, HashSet<String>>,
     pub(crate) output_buffer: String,
+    /// Structured, ordered host effects produced during execution. This is the
+    /// language-independent observation channel for the conformance suite
+    /// (`tests/conformance/`): two implementations agree iff they emit the same
+    /// effect列. The legacy `output_buffer` string protocol is still emitted in
+    /// parallel so existing front-ends keep working.
+    ///
+    // TODO(portability): tag each coreword with its portability profile so that
+    // Core vs Hosted membership is machine-checkable. Sketch:
+    //   pub enum WordProfile { Core, Hosted(HostCapability), PlatformSpecific }
+    // A Hosted word would then declare the single capability it requires, and a
+    // missing capability would fail in a specified way rather than at the call
+    // site.
+    pub(crate) host_effects: Vec<super::HostEffect>,
     pub(crate) definition_to_load: Option<String>,
     pub(crate) operation_target_mode: OperationTargetMode,
     pub(crate) consumption_mode: ConsumptionMode,
@@ -280,6 +293,7 @@ impl Interpreter {
             user_dictionaries: HashMap::new(),
             dependents: HashMap::new(),
             output_buffer: String::new(),
+            host_effects: Vec::new(),
             definition_to_load: None,
             operation_target_mode: OperationTargetMode::StackTop,
             consumption_mode: ConsumptionMode::Consume,
@@ -484,6 +498,7 @@ impl Interpreter {
         self.user_dictionaries.clear();
         self.dependents.clear();
         self.output_buffer.clear();
+        self.host_effects.clear();
         self.definition_to_load = None;
         self.reset_execution_modes();
         self.force_flag = false;
@@ -511,6 +526,13 @@ impl Interpreter {
 
     pub fn collect_output(&mut self) -> String {
         std::mem::take(&mut self.output_buffer)
+    }
+
+    /// The ordered sequence of structured host effects produced so far. This is
+    /// the language-independent observation channel used by the conformance
+    /// suite, distinct from the human-readable `output_buffer`.
+    pub fn host_effects(&self) -> &[super::HostEffect] {
+        &self.host_effects
     }
 
     pub fn get_stack(&self) -> &Stack {

--- a/rust/src/interpreter/json.rs
+++ b/rust/src/interpreter/json.rs
@@ -294,6 +294,11 @@ pub fn op_json_export(interp: &mut Interpreter) -> Result<()> {
     let json_val = arena_node_to_json(&arena, root_id);
     let json_compact = serde_json::to_string(&json_val).unwrap_or_else(|_| "null".to_string());
     interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::JsonExport(
+            json_compact.clone(),
+        ));
+    interp
         .output_buffer
         .push_str(&format!("JSONEXPORT:{}\n", json_compact));
     Ok(())

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -19,6 +19,7 @@ pub mod execution_plan_set;
 pub mod hash;
 pub mod higher_order;
 pub mod higher_order_fold;
+pub mod host;
 pub mod interval_ops;
 pub mod io;
 pub mod json;
@@ -98,6 +99,8 @@ mod nil_reason_tests;
 mod nil_unknown_firewall_tests;
 
 pub use interpreter_core::*;
+
+pub use host::{HostCapability, HostEffect};
 
 pub use crate::types::WordDefinition;
 

--- a/rust/src/interpreter/random.rs
+++ b/rust/src/interpreter/random.rs
@@ -8,6 +8,15 @@ use num_traits::{One, ToPrimitive};
 
 const DEFAULT_DENOMINATOR_BITS: u32 = 32;
 
+// TODO(portability): Allow CSPRNG to be provided by HostEnv for deterministic
+// conformance tests (e.g. a DeterministicHost { now_millis, random_bytes }).
+
+/// The single secure-random boundary. On native std this uses the OS entropy
+/// source; on wasm it uses `getrandom/js` (selected by the `wasm` feature).
+pub(crate) fn default_fill_random(buf: &mut [u8]) -> std::result::Result<(), String> {
+    getrandom::getrandom(buf).map_err(|e| format!("random generation failed: {}", e))
+}
+
 fn compute_uniform_random(denominator: &BigInt) -> Result<BigInt> {
     if *denominator <= BigInt::one() {
         return Ok(BigInt::from(0));
@@ -18,7 +27,7 @@ fn compute_uniform_random(denominator: &BigInt) -> Result<BigInt> {
     let bytes = total_bits.div_ceil(8);
 
     let mut buf = vec![0u8; bytes];
-    getrandom::getrandom(&mut buf).map_err(|e| {
+    default_fill_random(&mut buf).map_err(|e| {
         AjisaiError::from(format!("CSPRNG: failed to generate random bytes: {}", e))
     })?;
 

--- a/rust/src/interpreter/serial/execute_serial_commands.rs
+++ b/rust/src/interpreter/serial/execute_serial_commands.rs
@@ -66,11 +66,17 @@ fn extract_bytes(val: &Value) -> Result<Vec<u8>> {
 }
 
 fn emit(interp: &mut Interpreter, command: serde_json::Value) {
+    let line = command.to_string();
+    // Structured observation channel (conformance suite, kind = "serial").
+    interp
+        .host_effects
+        .push(crate::interpreter::HostEffect::Serial(line.clone()));
+    // Legacy string protocol kept in parallel for the Web/Tauri adapters.
     if !interp.output_buffer.is_empty() && !interp.output_buffer.ends_with('\n') {
         interp.output_buffer.push('\n');
     }
     interp.output_buffer.push_str("SERIAL:");
-    interp.output_buffer.push_str(&command.to_string());
+    interp.output_buffer.push_str(&line);
     interp.output_buffer.push('\n');
 }
 

--- a/rust/src/interpreter/simd_ops.rs
+++ b/rust/src/interpreter/simd_ops.rs
@@ -84,7 +84,16 @@ fn apply_simd_binary(a: &Value, b: &Value, op: fn(&[i64], &[i64]) -> Vec<i64>) -
     Some(create_value_from_integer_vector(op(&va, &vb)))
 }
 
-#[cfg(target_arch = "wasm32")]
+// SIMD intrinsics path: only when wasm32 is built with the `simd128` target
+// feature enabled. This is no longer the baseline default (see
+// `.cargo/config.toml`); a future `build:wasm:simd` path can opt in with
+// `-C target-feature=+simd128` to take this kernel. Without simd128 the scalar
+// fallback below is used so the baseline wasm build always compiles.
+//
+// TODO(portability): expose this as an explicit optimized build target
+// (e.g. npm `build:wasm:simd`) and/or runtime feature detection, rather than a
+// global compile-time flag.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 mod wasm_impl {
     use std::arch::wasm32::*;
 
@@ -217,7 +226,9 @@ mod wasm_impl {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+// Scalar fallback: native builds, and any wasm build without `simd128`
+// (now the baseline). Same observable result as the intrinsics path.
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
 mod wasm_impl {
     #[inline]
     pub fn simd_add(a: &[i64], b: &[i64]) -> Vec<i64> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,8 +8,11 @@ pub mod semantic;
 pub mod surface_forms;
 mod tokenizer;
 pub mod types;
+
+#[cfg(feature = "wasm")]
 mod wasm_interpreter_bindings;
 
+#[cfg(feature = "wasm")]
 pub use wasm_interpreter_bindings::AjisaiInterpreter;
 
 #[cfg(test)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,3 +32,6 @@ mod tensor_operation_tests;
 
 #[cfg(test)]
 mod json_io_tests;
+
+#[cfg(test)]
+mod conformance_tests;

--- a/rust/wasm-tests/Cargo.toml
+++ b/rust/wasm-tests/Cargo.toml
@@ -15,8 +15,10 @@ publish = false
 [lib]
 path = "lib.rs"
 
+# The WASM/JS bindings (AjisaiInterpreter) are gated behind ajisai-core's
+# `wasm` feature, so enable it here — this crate exists to drive that boundary.
 [dependencies]
-ajisai-core = { path = ".." }
+ajisai-core = { path = "..", features = ["wasm"] }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 

--- a/scripts/rebuild-wasm.sh
+++ b/scripts/rebuild-wasm.sh
@@ -27,7 +27,10 @@ if ! command -v wasm-pack >/dev/null 2>&1; then
 fi
 
 cd "${repo_root}/rust"
-wasm-pack build --target web --out-dir "${scratch_dir}" --no-opt
+# The WASM/JS bindings are gated behind the `wasm` Cargo feature so the native
+# Core build never pulls in wasm-bindgen. wasm-pack passes args after `--`
+# straight to cargo.
+wasm-pack build --target web --out-dir "${scratch_dir}" --no-opt -- --features wasm
 
 mkdir -p "${out_dir}"
 for f in ajisai_core.js ajisai_core.d.ts ajisai_core_bg.wasm ajisai_core_bg.wasm.d.ts; do

--- a/tests/conformance/index.html
+++ b/tests/conformance/index.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Ajisai Conformance Suite</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 60rem; margin: 2rem auto; line-height: 1.5; }
+    .ajisai-case { border: 1px solid #ccc; border-radius: 6px; padding: 1rem; margin: 1rem 0; }
+    .ajisai-case h3 { margin-top: 0; }
+    .ajisai-source, .ajisai-expect-result { background: #f6f6f6; padding: .5rem; border-radius: 4px; white-space: pre-wrap; }
+    .label { font-weight: bold; color: #555; }
+    .ajisai-effect { display: inline-block; background: #eef; padding: .1rem .4rem; border-radius: 4px; margin: .1rem; font-family: monospace; }
+  </style>
+</head>
+<body>
+
+<h1>Ajisai Conformance Suite</h1>
+
+<p>
+  This file defines the <em>phenomenon</em> of Ajisai language-independently.
+  An implementation is an Ajisai implementation if and only if it reproduces
+  every case below (see <code>PORTABILITY.md</code> and
+  <code>SPECIFICATION.md</code> &sect; "Conformance and Identity").
+</p>
+
+<h2>Contract</h2>
+<ol>
+  <li>Each case is a <code>&lt;section class="ajisai-case"&gt;</code> with an
+      <code>id</code> and a <code>data-category</code>.</li>
+  <li><code>ajisai-source</code> is run as an Ajisai program.</li>
+  <li>The observed final result &mdash; the whole stack, each value rendered
+      value-by-value &mdash; must equal <code>ajisai-expect-result</code> after
+      normalization.</li>
+  <li>The fired host effects must equal the ordered list of
+      <code>ajisai-effect</code> elements inside
+      <code>ajisai-expect-effects</code>: both <code>data-kind</code> and
+      <code>data-payload</code>, in order. The observation target is the
+      structured host-effect channel, never the human-readable output buffer.
+      An empty <code>ajisai-expect-effects</code> means no effects.</li>
+</ol>
+
+<h2>Normalization (minimal, strict-leaning)</h2>
+<p>
+  Only whitespace <strong>between tokens</strong> (spaces, tabs, newlines) is
+  normalized, because whitespace is a separator in Ajisai's value model, not a
+  value. Everything else is matched exactly: numeric notation (every number is
+  a reduced <code>numerator/denominator</code>, integers included &mdash;
+  <code>3</code> renders as <code>3/1</code>), element order, nesting, and the
+  spellings <code>NIL</code> and <code>UNKNOWN</code>. This line may only be
+  <em>loosened</em> in future, never tightened, and any change must record why.
+</p>
+<p>
+  Note: Ajisai has no empty-vector literal &mdash; <code>[ ]</code> is rejected
+  by the value model ("Use NIL for empty values"). NIL is the canonical
+  absence, so there is no "empty vector vs NIL" case to encode here; the
+  distinction does not arise as an observable literal.
+</p>
+
+<!-- ============================ CORE ============================ -->
+
+<section class="ajisai-case" id="core-vector-self-evaluates" data-category="core">
+  <h3>A vector literal evaluates to itself</h3>
+  <div><span class="label">source</span></div>
+  <pre class="ajisai-source">[ 1 2 3 ]</pre>
+  <div><span class="label">expect result</span></div>
+  <pre class="ajisai-expect-result">[ 1/1 2/1 3/1 ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-nesting-preserved" data-category="core">
+  <h3>Nesting is preserved</h3>
+  <pre class="ajisai-source">[ [ 1 2 ] [ 3 4 ] ]</pre>
+  <pre class="ajisai-expect-result">[ [ 1/1 2/1 ] [ 3/1 4/1 ] ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-exact-addition" data-category="core">
+  <h3>Exact addition</h3>
+  <pre class="ajisai-source">3 4 +</pre>
+  <pre class="ajisai-expect-result">7/1</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-bignum-does-not-fall-to-float" data-category="core">
+  <h3>Arbitrary-precision integers do not fall back to float</h3>
+  <pre class="ajisai-source">1000000000000 1000000000000 *</pre>
+  <pre class="ajisai-expect-result">1000000000000000000000000/1</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-exact-division" data-category="core">
+  <h3>Exact division yields an exact rational</h3>
+  <pre class="ajisai-source">1 3 /</pre>
+  <pre class="ajisai-expect-result">1/3</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-division-by-zero-is-nil" data-category="core">
+  <h3>Division by zero is NIL (a specified absence, not a trap)</h3>
+  <pre class="ajisai-source">1 0 /</pre>
+  <pre class="ajisai-expect-result">NIL</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-map" data-category="core">
+  <h3>MAP applies a user block element-wise</h3>
+  <pre class="ajisai-source">{ [ 2 ] * } 'DBL' DEF [ 1 2 3 ] 'DBL' MAP</pre>
+  <pre class="ajisai-expect-result">[ 2/1 4/1 6/1 ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-fold" data-category="core">
+  <h3>FOLD reduces with an initial accumulator</h3>
+  <pre class="ajisai-source">[ 1 2 3 4 ] [ 0 ] '+' FOLD</pre>
+  <pre class="ajisai-expect-result">[ 10/1 ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-nil-spelling" data-category="core">
+  <h3>NIL spells as NIL</h3>
+  <pre class="ajisai-source">NIL</pre>
+  <pre class="ajisai-expect-result">NIL</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-nil-propagation" data-category="core">
+  <h3>NIL propagates through arithmetic</h3>
+  <pre class="ajisai-source">NIL 1 +</pre>
+  <pre class="ajisai-expect-result">NIL</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-unknown-spelling" data-category="core">
+  <h3>UNKNOWN spells as UNKNOWN (an undecidable comparison)</h3>
+  <pre class="ajisai-source">'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ</pre>
+  <pre class="ajisai-expect-result">UNKNOWN</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-unknown-propagation" data-category="core">
+  <h3>UNKNOWN propagates through Kleene AND</h3>
+  <pre class="ajisai-source">'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ TRUE AND</pre>
+  <pre class="ajisai-expect-result">UNKNOWN</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-user-definition-resolved" data-category="core">
+  <h3>A user-defined word resolves through the dictionary</h3>
+  <pre class="ajisai-source">{ [ 10 ] + } 'ADD10' DEF 5 ADD10</pre>
+  <pre class="ajisai-expect-result">[ 15/1 ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<!-- ============================ HOSTED ============================ -->
+
+<section class="ajisai-case" id="hosted-serial-list-ports" data-category="hosted">
+  <h3>SERIAL@LIST-PORTS fires one structured serial host effect</h3>
+  <pre class="ajisai-source">'serial' IMPORT SERIAL@LIST-PORTS</pre>
+  <pre class="ajisai-expect-result"></pre>
+  <div class="ajisai-expect-effects">
+    <span class="ajisai-effect" data-kind="serial" data-payload='{"op":"listPorts"}'></span>
+  </div>
+</section>
+
+<section class="ajisai-case" id="hosted-serial-open-then-write" data-category="hosted">
+  <h3>SERIAL open then write fires two serial effects in order</h3>
+  <pre class="ajisai-source">'serial' IMPORT 'COM1' SERIAL@OPEN [ 1 2 3 ] SERIAL@WRITE</pre>
+  <pre class="ajisai-expect-result">'COM1'</pre>
+  <div class="ajisai-expect-effects">
+    <span class="ajisai-effect" data-kind="serial" data-payload='{"op":"open","portId":"COM1"}'></span>
+    <span class="ajisai-effect" data-kind="serial" data-payload='{"bytes":[1,2,3],"op":"write","portId":"COM1"}'></span>
+  </div>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
First scaffold toward a host-independent Ajisai language core, where the language is defined by a language-independent conformance suite rather than the Rust/WASM implementation. Existing Web/Tauri string protocols are preserved.

## What changed, by phase

**Phase 0 — Conformance suite (the center of this change)**
- `tests/conformance/index.html`: 15 cases (`core` + `hosted`) defining Ajisai's phenomenon language-independently. Each `ajisai-case` pairs source with expected final result and an ordered list of structured `ajisai-effect`s.
- `rust/src/conformance_tests.rs`: a strict hand-written runner (no new deps). Observes the **whole stack** (rendered value-by-value) and `Interpreter::host_effects()` — never the human-readable output buffer. Normalizes only inter-token whitespace; errors (no silent skips) on malformed cases.
- Decisions (confirmed with maintainer): result = whole stack; value notation = canonical Display form (`n/d`, `[ … ]`, `NIL`/`UNKNOWN`); whitespace-only normalization. Note: `[ ]` is rejected by the value model, so there is no "empty-vector vs NIL" case.

**Phase 1 — Docs**
- `PORTABILITY.md` (policy, layers, lineage, conformance) and `SPECIFICATION.md` "Portability Profiles" + "Conformance and Identity".

**Phase 2 — Cargo features**
- `wasm-bindgen`/`js-sys`/`web-sys`/`serde-wasm-bindgen`/`wasm-bindgen-futures`/`console_error_panic_hook`/`getrandom` made optional behind a `wasm` feature.
- Removed `chrono` (it was declared but unused).
- `default = ["std", "hosted"]` — documented deviation from the template's `default=["std"]`, so CSPRNG (a Hosted capability) and the native test suite still build under plain `cargo test`.

**Phase 3 — WASM binding isolation**
- `wasm_interpreter_bindings` and `AjisaiInterpreter` gated behind `feature = "wasm"`; the native Core build no longer pulls in wasm-bindgen.

**Phase 4 — Host abstraction**
- New `interpreter/host.rs`: `HostCapability` and structured `HostEffect` (kind/payload). Added `Interpreter::host_effects` (cleared on reset) + accessor. Wired in parallel with the legacy `SERIAL:`/`AUDIO:`/`CONFIG:`/`EFFECT:`/`JSONEXPORT:` strings, so front-ends are unaffected. TODO left for machine-checkable Core/Hosted word profiles.

**Phase 5 — Time/random host boundary**
- `NOW` routes through `default_now_millis()` (`Date.now()` under wasm, `SystemTime` on native std). CSPRNG entropy wrapped in `default_fill_random()`. HostEnv injection TODOs left for deterministic conformance.

**Phase 6 — SIMD off the baseline**
- Removed the forced `-C target-feature=+simd128` from `.cargo/config.toml`. The wasm SIMD kernel in `simd_ops.rs` is gated behind `target_feature = "simd128"` with a scalar fallback, so the baseline wasm build is host-agnostic; a future `build:wasm:simd` can opt back in.

**Phase 7 — CI / build wiring**
- `rebuild-wasm.sh` and `wasm-tests` crate now enable `--features wasm`.
- `test.yml`: native `cargo check` + wasm-target check with `--features wasm`.
- `docs/dev/current-test-status.md`: TODO for a native ubuntu/macos/windows CI matrix.

## Verification
- `cargo fmt --check`, `cargo test` (1233 pass; the −32 vs. before are the wasm-binding unit tests, now correctly gated), `cargo check`, `cargo check --features wasm --target wasm32-unknown-unknown` (baseline and `+simd128`) all green.
- `npm run check` / `lint` / `build` / `build:web` green.
- `wasm-pack` could not be installed in this environment (network-restricted), so `build:wasm` was not run; the wasm-target compile is covered by the cargo check above.


---
_Generated by [Claude Code](https://claude.ai/code/session_016bJUbqzbgaTjNa8RoQWg2k)_