### PR TITLE
Strengthen HostEffect isolation and tighten conformance payload matching

### DIFF
--- a/rust/src/conformance_tests.rs
+++ b/rust/src/conformance_tests.rs
@@ -63,7 +63,7 @@ fn decode_entities(s: &str) -> String {
 }
 
 /// Collapse inter-token whitespace to single spaces and trim. This is the only
-/// normalization applied to results (and to effect payloads).
+/// normalization applied to results. Host-effect payload strings are exact.
 fn normalize_ws(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
@@ -319,7 +319,7 @@ async fn run_case(case: &Case) -> std::result::Result<(), String> {
                 act.kind()
             ));
         }
-        if normalize_ws(&exp.payload) != normalize_ws(act.payload()) {
+        if exp.payload != act.payload() {
             return Err(format!(
                 "effect[{i}] payload mismatch:\n  expected: {:?}\n  actual:   {:?}",
                 exp.payload,

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -212,11 +212,13 @@ impl Interpreter {
                             if resolved {
                                 let stack_backup = std::mem::take(&mut self.stack);
                                 let output_backup = std::mem::take(&mut self.output_buffer);
+                                let host_effects_backup = std::mem::take(&mut self.host_effects);
                                 match self.execute_word_core(upper.as_ref()) {
                                     Ok(()) => {
                                         let results =
                                             std::mem::replace(&mut self.stack, stack_backup);
                                         self.output_buffer = output_backup;
+                                        self.host_effects = host_effects_backup;
                                         if results.is_empty() {
                                             values.push(Value::from_string(s));
                                             has_other = true;
@@ -228,6 +230,7 @@ impl Interpreter {
                                     Err(_) => {
                                         self.stack = stack_backup;
                                         self.output_buffer = output_backup;
+                                        self.host_effects = host_effects_backup;
                                         values.push(Value::from_string(s));
                                         has_other = true;
                                     }

--- a/rust/src/interpreter/shadow_validation.rs
+++ b/rust/src/interpreter/shadow_validation.rs
@@ -48,12 +48,14 @@ impl Interpreter {
         let saved_consumption = self.consumption_mode;
         let saved_output = std::mem::take(&mut self.output_buffer);
         let saved_io_output = std::mem::take(&mut self.io_output_buffer);
+        let saved_host_effects = std::mem::take(&mut self.host_effects);
 
         let fast_result = execute_compiled_plan(self, compiled);
         let fast_stack = self.stack.clone();
         let fast_hints = self.semantic_registry.stack_hints.clone();
         let fast_output = std::mem::take(&mut self.output_buffer);
         let fast_io_output = std::mem::take(&mut self.io_output_buffer);
+        let fast_host_effects = std::mem::take(&mut self.host_effects);
 
         self.stack = saved_stack;
         self.semantic_registry.stack_hints = saved_hints;
@@ -65,9 +67,11 @@ impl Interpreter {
         let plain_hints = self.semantic_registry.stack_hints.clone();
         let plain_output = std::mem::take(&mut self.output_buffer);
         let plain_io_output = std::mem::take(&mut self.io_output_buffer);
+        let plain_host_effects = std::mem::take(&mut self.host_effects);
 
         self.output_buffer = saved_output;
         self.io_output_buffer = saved_io_output;
+        self.host_effects = saved_host_effects;
 
         match (&fast_result, &plain_result) {
             (Ok(()), Ok(())) if fast_stack == plain_stack => {
@@ -76,6 +80,7 @@ impl Interpreter {
                 self.semantic_registry.stack_hints = fast_hints;
                 self.output_buffer.push_str(&fast_output);
                 self.io_output_buffer.push_str(&fast_io_output);
+                self.host_effects.extend(fast_host_effects.clone());
                 ValidationOutcome {
                     result: Ok(()),
                     used_plain_fallback: false,
@@ -88,6 +93,7 @@ impl Interpreter {
                 self.semantic_registry.stack_hints = plain_hints;
                 self.output_buffer.push_str(&plain_output);
                 self.io_output_buffer.push_str(&plain_io_output);
+                self.host_effects.extend(plain_host_effects);
                 ValidationOutcome {
                     result: Ok(()),
                     used_plain_fallback: true,
@@ -102,6 +108,7 @@ impl Interpreter {
                 self.semantic_registry.stack_hints = fast_hints;
                 self.output_buffer.push_str(&fast_output);
                 self.io_output_buffer.push_str(&fast_io_output);
+                self.host_effects.extend(fast_host_effects);
                 ValidationOutcome {
                     result: Ok(()),
                     used_plain_fallback: false,

--- a/rust/wasm-tests/Cargo.lock
+++ b/rust/wasm-tests/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "ajisai-core"
 version = "0.1.0"
 dependencies = [
- "chrono",
+ "console_error_panic_hook",
  "getrandom",
  "js-sys",
  "lazy_static",
@@ -30,15 +30,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-test",
-]
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -87,23 +78,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
+name = "console_error_panic_hook"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
+ "cfg-if",
  "wasm-bindgen",
- "windows-link",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "find-msvc-tools"
@@ -149,30 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,12 +165,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "log"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -541,63 +493,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"


### PR DESCRIPTION
### Motivation
- Move the reference Rust implementation toward a host‑independent Ajisai core by making Host Effects a structured observation channel and preventing speculative/internal checks from leaking effects.
- Make the conformance contract precise by treating effect payloads as exact strings rather than applying inter‑token whitespace normalization to them.
- Prepare the codebase for eventual HostEnv injection and clearer Core/Hosted separation while keeping existing human‑readable output protocols working in parallel.

### Description
- Change the conformance runner to require exact matches for `data-payload` on `ajisai-effect` elements (removed whitespace normalization for effect payloads). (`rust/src/conformance_tests.rs`).
- Prevent speculative/user‑word probe evaluation in vector parsing from leaking observable effects by saving and restoring `host_effects` alongside `stack`/`output_buffer` during the probe path. (`rust/src/interpreter/execution_loop.rs`).
- Extend shadow validation to save/restore and then replay only the chosen branch's `host_effects` so the compiled-vs-plain double execution does not duplicate or leak effects. (`rust/src/interpreter/shadow_validation.rs`).
- Refresh the wasm test lockfile to reflect the updated optional dependency graph (removed `chrono` from the core wasm path and updated wasm test dependencies). (`rust/wasm-tests/Cargo.lock`).

### Testing
- Ran `cd rust && cargo fmt` which completed successfully.  
- Ran `cd rust && cargo test` and all Rust tests passed locally (1233 passed, 0 failed).  
- Ran `cd rust && cargo check` which completed successfully.  
- Attempted `cd rust && cargo check --features wasm --target wasm32-unknown-unknown` but the environment could not install the `wasm32-unknown-unknown` target (network/target download error), so the wasm target check could not be completed here.  
- Ran `npm run check` and `npm run build` which both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b41974c48326acd3534a7c9b49f7)