### PR TITLE
Introduce HostEnv trait and route hosted boundaries through injected host

### DIFF
--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -1,5 +1,6 @@
 use crate::builtins::builtin_specs;
 use crate::interpreter::modules::module_word_metadata_entries;
+use crate::interpreter::HostCapability;
 use serde::Serialize;
 #[cfg(test)]
 use std::collections::HashSet;
@@ -39,6 +40,17 @@ pub enum SafetyLevel {
     Quarantined,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WordProfile {
+    /// Host-independent, portable Ajisai semantics.
+    Core,
+    /// Requires an explicit host capability before execution.
+    Hosted,
+    /// Reserved for words whose behavior is intentionally platform-specific.
+    PlatformSpecific,
+}
+
 /// Canonical implementation home for a built-in word.
 ///
 /// Every built-in word has exactly one canonical home. `Core` means the word
@@ -64,6 +76,11 @@ pub struct CorewordMetadata {
     pub partiality: Partiality,
     pub nil_policy: NilPolicy,
     pub safety_level: SafetyLevel,
+    /// Portability profile used by conformance tooling to keep the Core
+    /// profile free of host-boundary words.
+    pub profile: WordProfile,
+    /// Capability required when `profile == Hosted`; absent for Core words.
+    pub required_capability: Option<HostCapability>,
     /// Where the canonical implementation lives (Core or a specific module).
     pub canonical_home: CanonicalHome,
     /// Whether the word appears in the Core word listing view.
@@ -268,6 +285,22 @@ pub fn get_words_by_purity(purity: WordPurity) -> Vec<CorewordMetadata> {
         .collect()
 }
 
+pub fn get_words_by_profile(profile: WordProfile) -> Vec<CorewordMetadata> {
+    get_builtin_word_registry()
+        .iter()
+        .filter(|word| word.profile == profile)
+        .cloned()
+        .collect()
+}
+
+pub fn get_core_profile_words() -> Vec<CorewordMetadata> {
+    get_words_by_profile(WordProfile::Core)
+}
+
+pub fn get_hosted_profile_words() -> Vec<CorewordMetadata> {
+    get_words_by_profile(WordProfile::Hosted)
+}
+
 /// Words whose Core listing view includes them (canonical core + core-listed
 /// boundary words).
 pub fn get_core_listed_words() -> Vec<CorewordMetadata> {
@@ -414,7 +447,15 @@ impl std::hash::Hash for CanonicalHome {
     }
 }
 
+fn builtin_profile(name: &str) -> (WordProfile, Option<HostCapability>) {
+    match name {
+        "PRINT" => (WordProfile::Hosted, Some(HostCapability::Effect)),
+        _ => (WordProfile::Core, None),
+    }
+}
+
 fn core_word_metadata_from_spec(spec: &crate::builtins::BuiltinSpec) -> CorewordMetadata {
+    let (profile, required_capability) = builtin_profile(spec.name);
     CorewordMetadata {
         name: spec.name.to_string(),
         category: spec.category.to_lowercase(),
@@ -425,6 +466,8 @@ fn core_word_metadata_from_spec(spec: &crate::builtins::BuiltinSpec) -> Coreword
         partiality: spec.partiality,
         nil_policy: spec.nil_policy,
         safety_level: spec.safety_level,
+        profile,
+        required_capability,
         canonical_home: CanonicalHome::Core,
         listed_in_core: true,
         listed_in_modules: Vec::new(),
@@ -443,6 +486,8 @@ pub(crate) fn pure(name: &str, category: &str) -> CorewordMetadata {
         partiality: Partiality::Total,
         nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::A,
+        profile: WordProfile::Core,
+        required_capability: None,
         canonical_home: CanonicalHome::Core,
         listed_in_core: true,
         listed_in_modules: Vec::new(),
@@ -466,6 +511,8 @@ pub(crate) fn observable(
         partiality: Partiality::Partial,
         nil_policy: NilPolicy::RejectsNil,
         safety_level: SafetyLevel::C,
+        profile: WordProfile::Core,
+        required_capability: None,
         canonical_home: CanonicalHome::Core,
         listed_in_core: true,
         listed_in_modules: Vec::new(),
@@ -484,6 +531,8 @@ pub(crate) fn effectful(name: &str, category: &str, effects: &[&str]) -> Corewor
         partiality: Partiality::Partial,
         nil_policy: NilPolicy::RejectsNil,
         safety_level: SafetyLevel::D,
+        profile: WordProfile::Core,
+        required_capability: None,
         canonical_home: CanonicalHome::Core,
         listed_in_core: true,
         listed_in_modules: Vec::new(),
@@ -505,8 +554,9 @@ mod tests {
         collect_duplicate_entries, collect_namespace_overlapping_names, get_boundary_words,
         get_builtin_word_metadata, get_builtin_word_registry, get_canonical_core_words,
         get_canonical_module_words, get_core_listed_words, get_coreword_metadata,
-        get_module_listed_words, is_listing_only_for_module, is_safe_preview_word, CanonicalHome,
-        NilPolicy, Partiality, SafetyLevel, WordPurity,
+        get_hosted_profile_words, get_module_listed_words, is_listing_only_for_module,
+        is_safe_preview_word, CanonicalHome, NilPolicy, Partiality, SafetyLevel, WordProfile,
+        WordPurity,
     };
 
     #[test]
@@ -1072,6 +1122,41 @@ mod tests {
         assert!(!is_listing_only_for_module("CSPRNG", "CRYPTO"));
         // Unknown word → false.
         assert!(!is_listing_only_for_module("__NOSUCH__", "IO"));
+    }
+
+    #[test]
+    fn aq_ver_profile_a_hosted_words_declare_capabilities() {
+        let hosted = get_hosted_profile_words();
+        assert!(
+            hosted.iter().any(|w| w.name == "NOW"),
+            "TIME@NOW must be classified as Hosted"
+        );
+        assert!(
+            hosted.iter().any(|w| w.name == "CSPRNG"),
+            "CRYPTO@CSPRNG must be classified as Hosted"
+        );
+        for word in hosted {
+            assert_eq!(word.profile, WordProfile::Hosted);
+            assert!(
+                word.required_capability.is_some(),
+                "{} Hosted words must declare a required capability",
+                word.name
+            );
+        }
+    }
+
+    #[test]
+    fn aq_ver_profile_b_core_profile_excludes_host_capabilities() {
+        for word in get_builtin_word_registry()
+            .iter()
+            .filter(|word| word.profile == WordProfile::Core)
+        {
+            assert!(
+                word.required_capability.is_none(),
+                "{} Core-profile words must not require host capability metadata",
+                word.name
+            );
+        }
     }
 
     #[test]

--- a/rust/src/interpreter/audio/build_audio_structure.rs
+++ b/rust/src/interpreter/audio/build_audio_structure.rs
@@ -8,6 +8,8 @@ use crate::types::{Value, ValueData};
 use num_traits::ToPrimitive;
 
 pub fn op_play(interp: &mut Interpreter) -> Result<()> {
+    interp.require_host_capability("MUSIC@PLAY", crate::interpreter::HostCapability::Audio)?;
+
     let mode = super::lookup_play_mode(interp);
     let target = interp.operation_target_mode;
 
@@ -16,9 +18,7 @@ pub fn op_play(interp: &mut Interpreter) -> Result<()> {
             let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
             let structure = build_audio_structure(&val, mode, &mut interp.output_buffer)?;
             if let Some(json) = emit_play_command(&structure, &mut interp.output_buffer) {
-                interp
-                    .host_effects
-                    .push(crate::interpreter::HostEffect::Audio(json));
+                interp.emit_host_effect(crate::interpreter::HostEffect::Audio(json));
             }
         }
         OperationTargetMode::Stack => {
@@ -46,9 +46,7 @@ pub fn op_play(interp: &mut Interpreter) -> Result<()> {
             };
 
             if let Some(json) = emit_play_command(&combined, &mut interp.output_buffer) {
-                interp
-                    .host_effects
-                    .push(crate::interpreter::HostEffect::Audio(json));
+                interp.emit_host_effect(crate::interpreter::HostEffect::Audio(json));
             }
         }
     }

--- a/rust/src/interpreter/audio/execute_audio_commands.rs
+++ b/rust/src/interpreter/audio/execute_audio_commands.rs
@@ -12,6 +12,10 @@ use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_traits::ToPrimitive;
 
+fn require_audio(interp: &mut Interpreter, word: &str) -> Result<()> {
+    interp.require_host_capability(word, crate::interpreter::HostCapability::Audio)
+}
+
 pub fn op_seq(interp: &mut Interpreter) -> Result<()> {
     update_play_mode(interp, PlayMode::Sequential);
     Ok(())
@@ -34,6 +38,7 @@ fn extract_scalar_from_value(val: &Value) -> Option<Fraction> {
 }
 
 pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
+    require_audio(interp, "MUSIC@SLOT")?;
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
     let frac = extract_scalar_from_value(&val)
@@ -61,9 +66,7 @@ pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
     }
 
     let payload = format!("{{\"slot_duration\":{}}}", seconds);
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Config(payload.clone()));
+    interp.emit_host_effect(crate::interpreter::HostEffect::Config(payload.clone()));
     interp
         .output_buffer
         .push_str(&format!("CONFIG:{}\n", payload));
@@ -72,6 +75,7 @@ pub fn op_slot(interp: &mut Interpreter) -> Result<()> {
 }
 
 pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
+    require_audio(interp, "MUSIC@GAIN")?;
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
     let frac = extract_scalar_from_value(&val)
@@ -91,9 +95,7 @@ pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
     }
 
     let payload = format!("{{\"gain\":{}}}", clamped);
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Effect(payload.clone()));
+    interp.emit_host_effect(crate::interpreter::HostEffect::Effect(payload.clone()));
     interp
         .output_buffer
         .push_str(&format!("EFFECT:{}\n", payload));
@@ -102,16 +104,16 @@ pub fn op_gain(interp: &mut Interpreter) -> Result<()> {
 }
 
 pub fn op_gain_reset(interp: &mut Interpreter) -> Result<()> {
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Effect(
-            "{\"gain\":1.0}".to_string(),
-        ));
+    require_audio(interp, "MUSIC@GAIN-RESET")?;
+    interp.emit_host_effect(crate::interpreter::HostEffect::Effect(
+        "{\"gain\":1.0}".to_string(),
+    ));
     interp.output_buffer.push_str("EFFECT:{\"gain\":1.0}\n");
     Ok(())
 }
 
 pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
+    require_audio(interp, "MUSIC@PAN")?;
     let val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
     let frac = extract_scalar_from_value(&val)
@@ -131,9 +133,7 @@ pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
     }
 
     let payload = format!("{{\"pan\":{}}}", clamped);
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Effect(payload.clone()));
+    interp.emit_host_effect(crate::interpreter::HostEffect::Effect(payload.clone()));
     interp
         .output_buffer
         .push_str(&format!("EFFECT:{}\n", payload));
@@ -142,21 +142,19 @@ pub fn op_pan(interp: &mut Interpreter) -> Result<()> {
 }
 
 pub fn op_pan_reset(interp: &mut Interpreter) -> Result<()> {
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Effect(
-            "{\"pan\":0.0}".to_string(),
-        ));
+    require_audio(interp, "MUSIC@PAN-RESET")?;
+    interp.emit_host_effect(crate::interpreter::HostEffect::Effect(
+        "{\"pan\":0.0}".to_string(),
+    ));
     interp.output_buffer.push_str("EFFECT:{\"pan\":0.0}\n");
     Ok(())
 }
 
 pub fn op_fx_reset(interp: &mut Interpreter) -> Result<()> {
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Effect(
-            "{\"gain\":1.0,\"pan\":0.0}".to_string(),
-        ));
+    require_audio(interp, "MUSIC@FX-RESET")?;
+    interp.emit_host_effect(crate::interpreter::HostEffect::Effect(
+        "{\"gain\":1.0,\"pan\":0.0}".to_string(),
+    ));
     interp
         .output_buffer
         .push_str("EFFECT:{\"gain\":1.0,\"pan\":0.0}\n");

--- a/rust/src/interpreter/datetime.rs
+++ b/rust/src/interpreter/datetime.rs
@@ -8,13 +8,9 @@
 
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::value_extraction_helpers::create_datetime_value;
-use crate::interpreter::{Interpreter, OperationTargetMode};
+use crate::interpreter::{HostCapability, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use num_bigint::BigInt;
-
-// TODO(portability): Route NOW through HostEnv instead of the default clock.
-// A deterministic clock is required for time-dependent conformance cases
-// (e.g. a DeterministicHost { now_millis, random_bytes }).
 
 /// The single host-clock boundary. Returns wall-clock milliseconds since the
 /// Unix epoch from whichever host the current build targets. WASM-specific
@@ -59,10 +55,47 @@ pub fn op_now(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
-    let now_ms = default_now_millis();
+    interp.require_host_capability("NOW", HostCapability::Clock)?;
+
+    let now_ms = interp.host_env.now_millis();
     let ms_bigint = BigInt::from(now_ms);
     let timestamp = Fraction::new(ms_bigint, BigInt::from(1000));
 
     interp.stack.push(create_datetime_value(timestamp));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpreter::{DeterministicHostEnv, HostCapability};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_now_uses_deterministic_host_clock() {
+        let host = Arc::new(DeterministicHostEnv::new(
+            1_700_000_000_123,
+            vec![],
+            vec![HostCapability::Clock],
+        ));
+        let mut interp = Interpreter::with_host(host);
+
+        let result = interp.execute("'time' IMPORT NOW").await;
+        assert!(result.is_ok(), "NOW should succeed: {:?}", result);
+        assert_eq!(interp.stack[0].to_string(), "1700000000123/1000");
+    }
+
+    #[tokio::test]
+    async fn test_now_missing_capability_emits_diagnostic_and_errors() {
+        let host = Arc::new(DeterministicHostEnv::new(0, vec![], vec![]));
+        let mut interp = Interpreter::with_host(host);
+
+        let result = interp.execute("'time' IMPORT NOW").await;
+        assert!(result.is_err(), "NOW should fail without Clock");
+        assert_eq!(interp.host_effects().len(), 1);
+        assert_eq!(interp.host_effects()[0].kind(), "diagnostic");
+        assert!(interp.host_effects()[0]
+            .payload()
+            .contains("missingCapability"));
+    }
 }

--- a/rust/src/interpreter/host.rs
+++ b/rust/src/interpreter/host.rs
@@ -14,13 +14,17 @@
 //! legacy `output_buffer` string protocol (`SERIAL:`, `AUDIO:`, ...) is still
 //! emitted in parallel so the Web/Tauri front-ends keep working unchanged.
 
+use crate::error::AjisaiError;
+use std::sync::{Arc, Mutex};
+
 /// A capability the host must provide for a Hosted-profile word to run.
 ///
 /// Core-profile words never require a `HostCapability`. Hosted-profile words
 /// declare exactly one. This enum is the vocabulary used to describe those
-/// requirements; routing words through it (and failing in a specified way when
-/// a capability is absent) is future work.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// requirements. Hosted words must query the active `HostEnv` before touching
+/// their boundary and must fail through `missing_capability_error` when absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub enum HostCapability {
     Clock,
     SecureRandom,
@@ -74,4 +78,117 @@ impl HostEffect {
             | HostEffect::Diagnostic(s) => s,
         }
     }
+}
+
+/// Runtime boundary supplied by the embedding host.
+///
+/// The interpreter owns no direct clock, entropy source, or effect sink. The
+/// default implementation delegates to the current platform, while tests and
+/// conformance runners can inject a deterministic implementation.
+pub trait HostEnv: Send + Sync {
+    fn now_millis(&self) -> i64;
+    fn fill_random(&self, buf: &mut [u8]) -> std::result::Result<(), String>;
+    fn emit_effect(&self, _effect: &HostEffect) {}
+    fn has_capability(&self, capability: HostCapability) -> bool;
+}
+
+/// Default host: exposes every currently modeled capability and delegates clock
+/// and entropy access to the platform-specific boundary functions.
+#[derive(Debug, Default)]
+pub struct DefaultHostEnv;
+
+impl HostEnv for DefaultHostEnv {
+    fn now_millis(&self) -> i64 {
+        crate::interpreter::datetime::default_now_millis()
+    }
+
+    fn fill_random(&self, buf: &mut [u8]) -> std::result::Result<(), String> {
+        crate::interpreter::random::default_fill_random(buf)
+    }
+
+    fn has_capability(&self, _capability: HostCapability) -> bool {
+        true
+    }
+}
+
+pub fn default_host_env() -> Arc<dyn HostEnv> {
+    Arc::new(DefaultHostEnv)
+}
+
+/// Deterministic host used by conformance tests for otherwise non-deterministic
+/// Hosted words such as `TIME@NOW` and `CRYPTO@CSPRNG`.
+#[derive(Debug)]
+pub struct DeterministicHostEnv {
+    now_millis: i64,
+    random_bytes: Mutex<Vec<u8>>,
+    capabilities: Vec<HostCapability>,
+    emitted_effects: Mutex<Vec<HostEffect>>,
+}
+
+impl DeterministicHostEnv {
+    pub fn new(now_millis: i64, random_bytes: Vec<u8>, capabilities: Vec<HostCapability>) -> Self {
+        Self {
+            now_millis,
+            random_bytes: Mutex::new(random_bytes),
+            capabilities,
+            emitted_effects: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn all_capabilities(now_millis: i64, random_bytes: Vec<u8>) -> Self {
+        Self::new(
+            now_millis,
+            random_bytes,
+            vec![
+                HostCapability::Clock,
+                HostCapability::SecureRandom,
+                HostCapability::Serial,
+                HostCapability::Audio,
+                HostCapability::JsonExport,
+                HostCapability::Config,
+                HostCapability::Effect,
+            ],
+        )
+    }
+
+    pub fn emitted_effects(&self) -> Vec<HostEffect> {
+        self.emitted_effects.lock().unwrap().clone()
+    }
+}
+
+impl HostEnv for DeterministicHostEnv {
+    fn now_millis(&self) -> i64 {
+        self.now_millis
+    }
+
+    fn fill_random(&self, buf: &mut [u8]) -> std::result::Result<(), String> {
+        let mut bytes = self.random_bytes.lock().unwrap();
+        if bytes.len() < buf.len() {
+            return Err(format!(
+                "deterministic host exhausted: requested {} bytes, {} remain",
+                buf.len(),
+                bytes.len()
+            ));
+        }
+        let requested = buf.len();
+        for (dst, src) in buf.iter_mut().zip(bytes.drain(..requested)) {
+            *dst = src;
+        }
+        Ok(())
+    }
+
+    fn emit_effect(&self, effect: &HostEffect) {
+        self.emitted_effects.lock().unwrap().push(effect.clone());
+    }
+
+    fn has_capability(&self, capability: HostCapability) -> bool {
+        self.capabilities.contains(&capability)
+    }
+}
+
+pub(crate) fn missing_capability_error(word: &str, capability: HostCapability) -> AjisaiError {
+    AjisaiError::from(format!(
+        "{} requires missing host capability {:?}",
+        word, capability
+    ))
 }

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -218,14 +218,12 @@ pub struct Interpreter {
     /// (`tests/conformance/`): two implementations agree iff they emit the same
     /// effect列. The legacy `output_buffer` string protocol is still emitted in
     /// parallel so existing front-ends keep working.
-    ///
-    // TODO(portability): tag each coreword with its portability profile so that
-    // Core vs Hosted membership is machine-checkable. Sketch:
-    //   pub enum WordProfile { Core, Hosted(HostCapability), PlatformSpecific }
-    // A Hosted word would then declare the single capability it requires, and a
-    // missing capability would fail in a specified way rather than at the call
-    // site.
     pub(crate) host_effects: Vec<super::HostEffect>,
+    /// Host boundary for clocks, entropy, capability checks, and effect sinks.
+    /// Core execution must not call platform APIs directly; Hosted words route
+    /// boundary access through this trait object so conformance can inject a
+    /// deterministic or restricted host.
+    pub(crate) host_env: Arc<dyn super::HostEnv>,
     pub(crate) definition_to_load: Option<String>,
     pub(crate) operation_target_mode: OperationTargetMode,
     pub(crate) consumption_mode: ConsumptionMode,
@@ -286,6 +284,10 @@ pub struct Interpreter {
 
 impl Interpreter {
     pub fn new() -> Self {
+        Self::with_host(super::default_host_env())
+    }
+
+    pub fn with_host(host_env: Arc<dyn super::HostEnv>) -> Self {
         let mut interpreter = Interpreter {
             stack: Vec::new(),
             core_vocabulary: HashMap::new(),
@@ -294,6 +296,7 @@ impl Interpreter {
             dependents: HashMap::new(),
             output_buffer: String::new(),
             host_effects: Vec::new(),
+            host_env,
             definition_to_load: None,
             operation_target_mode: OperationTargetMode::StackTop,
             consumption_mode: ConsumptionMode::Consume,
@@ -533,6 +536,29 @@ impl Interpreter {
     /// suite, distinct from the human-readable `output_buffer`.
     pub fn host_effects(&self) -> &[super::HostEffect] {
         &self.host_effects
+    }
+
+    pub(crate) fn emit_host_effect(&mut self, effect: super::HostEffect) {
+        self.host_env.emit_effect(&effect);
+        self.host_effects.push(effect);
+    }
+
+    pub(crate) fn require_host_capability(
+        &mut self,
+        word: &str,
+        capability: super::HostCapability,
+    ) -> Result<()> {
+        if self.host_env.has_capability(capability) {
+            return Ok(());
+        }
+        let payload = serde_json::json!({
+            "op": "missingCapability",
+            "word": word,
+            "capability": format!("{:?}", capability),
+        })
+        .to_string();
+        self.emit_host_effect(super::HostEffect::Diagnostic(payload));
+        Err(super::host::missing_capability_error(word, capability))
     }
 
     pub fn get_stack(&self) -> &Stack {

--- a/rust/src/interpreter/io.rs
+++ b/rust/src/interpreter/io.rs
@@ -15,9 +15,13 @@ fn extract_value_for_print(interp: &mut Interpreter, keep_mode: bool) -> Result<
 }
 
 pub fn op_print(interp: &mut Interpreter) -> Result<()> {
+    interp.require_host_capability("PRINT", crate::interpreter::HostCapability::Effect)?;
+
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
     let val = extract_value_for_print(interp, is_keep_mode)?;
-    write!(&mut interp.output_buffer, "{} ", val)
+    let payload = val.to_string();
+    interp.emit_host_effect(crate::interpreter::HostEffect::Print(payload.clone()));
+    write!(&mut interp.output_buffer, "{} ", payload)
         .map_err(|e| AjisaiError::from(format!("PRINT failed: {}", e)))?;
     Ok(())
 }

--- a/rust/src/interpreter/json.rs
+++ b/rust/src/interpreter/json.rs
@@ -286,6 +286,11 @@ pub fn op_json_set(interp: &mut Interpreter) -> Result<()> {
 }
 
 pub fn op_json_export(interp: &mut Interpreter) -> Result<()> {
+    interp.require_host_capability(
+        "JSON@EXPORT",
+        crate::interpreter::HostCapability::JsonExport,
+    )?;
+
     let is_keep = interp.consumption_mode == ConsumptionMode::Keep;
 
     let val = extract_stack_value(interp, is_keep, 0)?;
@@ -293,11 +298,9 @@ pub fn op_json_export(interp: &mut Interpreter) -> Result<()> {
     let (arena, root_id) = value_to_arena(&val);
     let json_val = arena_node_to_json(&arena, root_id);
     let json_compact = serde_json::to_string(&json_val).unwrap_or_else(|_| "null".to_string());
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::JsonExport(
-            json_compact.clone(),
-        ));
+    interp.emit_host_effect(crate::interpreter::HostEffect::JsonExport(
+        json_compact.clone(),
+    ));
     interp
         .output_buffer
         .push_str(&format!("JSONEXPORT:{}\n", json_compact));

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -100,7 +100,9 @@ mod nil_unknown_firewall_tests;
 
 pub use interpreter_core::*;
 
-pub use host::{HostCapability, HostEffect};
+pub use host::{
+    default_host_env, DefaultHostEnv, DeterministicHostEnv, HostCapability, HostEffect, HostEnv,
+};
 
 pub use crate::types::WordDefinition;
 

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,9 +1,10 @@
 use crate::builtins::WordShape;
 use crate::coreword_registry::{
-    self, CanonicalHome, CorewordMetadata, NilPolicy, Partiality, WordPurity,
+    self, CanonicalHome, CorewordMetadata, NilPolicy, Partiality, WordProfile, WordPurity,
 };
 use crate::interpreter::{
     algo_ops, audio, datetime, hash, interval_ops, json, math_ops, random, serial, sort, time_ops,
+    HostCapability,
 };
 use crate::types::{Capabilities, Stability};
 
@@ -1290,6 +1291,18 @@ fn contract_override(module: &str, word: &str) -> Option<(Partiality, NilPolicy)
     }
 }
 
+fn host_capability_for_module_word(module: &str, word: &str) -> Option<HostCapability> {
+    match (module, word) {
+        ("TIME", "NOW") => Some(HostCapability::Clock),
+        ("CRYPTO", "CSPRNG") => Some(HostCapability::SecureRandom),
+        ("SERIAL", _) => Some(HostCapability::Serial),
+        ("MUSIC", _) => Some(HostCapability::Audio),
+        ("JSON", "EXPORT") => Some(HostCapability::JsonExport),
+        ("IO", "INPUT") | ("IO", "OUTPUT") => Some(HostCapability::Effect),
+        _ => None,
+    }
+}
+
 pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
     MODULE_SPECS
         .iter()
@@ -1313,6 +1326,12 @@ pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
                 };
                 metadata.deterministic = word.deterministic;
                 metadata.safe_preview = word.safe_preview;
+                if let Some(capability) =
+                    host_capability_for_module_word(spec.name, word.short_name)
+                {
+                    metadata.profile = WordProfile::Hosted;
+                    metadata.required_capability = Some(capability);
+                }
                 metadata.canonical_home = CanonicalHome::Module(spec.name.to_string());
                 metadata.listed_in_core = false;
                 metadata.listed_in_modules = vec![spec.name.to_string()];

--- a/rust/src/interpreter/random.rs
+++ b/rust/src/interpreter/random.rs
@@ -1,6 +1,6 @@
 use crate::error::{AjisaiError, Result};
 use crate::interpreter::tensor_ops::FlatTensor;
-use crate::interpreter::{ConsumptionMode, Interpreter, OperationTargetMode};
+use crate::interpreter::{ConsumptionMode, HostCapability, Interpreter, OperationTargetMode};
 use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_bigint::{BigInt, Sign};
@@ -8,16 +8,13 @@ use num_traits::{One, ToPrimitive};
 
 const DEFAULT_DENOMINATOR_BITS: u32 = 32;
 
-// TODO(portability): Allow CSPRNG to be provided by HostEnv for deterministic
-// conformance tests (e.g. a DeterministicHost { now_millis, random_bytes }).
-
 /// The single secure-random boundary. On native std this uses the OS entropy
 /// source; on wasm it uses `getrandom/js` (selected by the `wasm` feature).
 pub(crate) fn default_fill_random(buf: &mut [u8]) -> std::result::Result<(), String> {
     getrandom::getrandom(buf).map_err(|e| format!("random generation failed: {}", e))
 }
 
-fn compute_uniform_random(denominator: &BigInt) -> Result<BigInt> {
+fn compute_uniform_random(interp: &Interpreter, denominator: &BigInt) -> Result<BigInt> {
     if *denominator <= BigInt::one() {
         return Ok(BigInt::from(0));
     }
@@ -27,7 +24,7 @@ fn compute_uniform_random(denominator: &BigInt) -> Result<BigInt> {
     let bytes = total_bits.div_ceil(8);
 
     let mut buf = vec![0u8; bytes];
-    default_fill_random(&mut buf).map_err(|e| {
+    interp.host_env.fill_random(&mut buf).map_err(|e| {
         AjisaiError::from(format!("CSPRNG: failed to generate random bytes: {}", e))
     })?;
 
@@ -87,6 +84,8 @@ pub fn op_csprng(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
+    interp.require_host_capability("CSPRNG", HostCapability::SecureRandom)?;
+
     let is_keep_mode = interp.consumption_mode == ConsumptionMode::Keep;
     let (denominator, count) = if is_keep_mode {
         parse_csprng_args_in_keep_mode(interp)?
@@ -100,7 +99,7 @@ pub fn op_csprng(interp: &mut Interpreter) -> Result<()> {
 
     let mut result_vec = Vec::with_capacity(count);
     for _ in 0..count {
-        let numerator = compute_uniform_random(&denominator)?;
+        let numerator = compute_uniform_random(interp, &denominator)?;
         let frac = Fraction::new(numerator, denominator.clone());
         result_vec.push(Value::from_number(frac));
     }
@@ -245,5 +244,38 @@ mod tests {
         let val = &interp.stack[0];
         assert!(val.is_vector(), "Expected vector-like value");
         assert_eq!(val.len(), 50);
+    }
+    #[tokio::test]
+    async fn test_csprng_uses_deterministic_host_bytes() {
+        use crate::interpreter::{DeterministicHostEnv, HostCapability};
+        use std::sync::Arc;
+
+        let host = Arc::new(DeterministicHostEnv::new(
+            0,
+            vec![3, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![HostCapability::SecureRandom],
+        ));
+        let mut interp = Interpreter::with_host(host);
+
+        let result = interp.execute("'crypto' IMPORT [ 10 ] [ 1 ] CSPRNG").await;
+        assert!(result.is_ok(), "CSPRNG should succeed: {:?}", result);
+        assert_eq!(interp.stack[0].to_string(), "[ 3/10 ]");
+    }
+
+    #[tokio::test]
+    async fn test_csprng_missing_capability_emits_diagnostic_and_errors() {
+        use crate::interpreter::DeterministicHostEnv;
+        use std::sync::Arc;
+
+        let host = Arc::new(DeterministicHostEnv::new(0, vec![0; 9], vec![]));
+        let mut interp = Interpreter::with_host(host);
+
+        let result = interp.execute("'crypto' IMPORT CSPRNG").await;
+        assert!(result.is_err(), "CSPRNG should fail without SecureRandom");
+        assert_eq!(interp.host_effects().len(), 1);
+        assert_eq!(interp.host_effects()[0].kind(), "diagnostic");
+        assert!(interp.host_effects()[0]
+            .payload()
+            .contains("missingCapability"));
     }
 }

--- a/rust/src/interpreter/serial/execute_serial_commands.rs
+++ b/rust/src/interpreter/serial/execute_serial_commands.rs
@@ -65,12 +65,11 @@ fn extract_bytes(val: &Value) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn emit(interp: &mut Interpreter, command: serde_json::Value) {
+fn emit(interp: &mut Interpreter, command: serde_json::Value) -> Result<()> {
+    interp.require_host_capability("SERIAL", crate::interpreter::HostCapability::Serial)?;
     let line = command.to_string();
     // Structured observation channel (conformance suite, kind = "serial").
-    interp
-        .host_effects
-        .push(crate::interpreter::HostEffect::Serial(line.clone()));
+    interp.emit_host_effect(crate::interpreter::HostEffect::Serial(line.clone()));
     // Legacy string protocol kept in parallel for the Web/Tauri adapters.
     if !interp.output_buffer.is_empty() && !interp.output_buffer.ends_with('\n') {
         interp.output_buffer.push('\n');
@@ -78,12 +77,13 @@ fn emit(interp: &mut Interpreter, command: serde_json::Value) {
     interp.output_buffer.push_str("SERIAL:");
     interp.output_buffer.push_str(&line);
     interp.output_buffer.push('\n');
+    Ok(())
 }
 
 /// `-- ` : ask the host adapter to enumerate available ports. The result is
 /// surfaced by the adapter (program output); a stack-returning form is Phase 2.
 pub fn op_list_ports(interp: &mut Interpreter) -> Result<()> {
-    emit(interp, json!({ "op": "listPorts" }));
+    emit(interp, json!({ "op": "listPorts" }))?;
     Ok(())
 }
 
@@ -92,7 +92,7 @@ pub fn op_list_ports(interp: &mut Interpreter) -> Result<()> {
 pub fn op_open(interp: &mut Interpreter) -> Result<()> {
     let handle = pop(interp)?;
     let id = require_port_id(&handle)?;
-    emit(interp, json!({ "op": "open", "portId": id }));
+    emit(interp, json!({ "op": "open", "portId": id }))?;
     interp.stack.push(handle);
     Ok(())
 }
@@ -109,7 +109,7 @@ pub fn op_configure(interp: &mut Interpreter) -> Result<()> {
     emit(
         interp,
         json!({ "op": "configure", "portId": id, "baudRate": baud }),
-    );
+    )?;
     interp.stack.push(handle);
     Ok(())
 }
@@ -123,7 +123,7 @@ pub fn op_write(interp: &mut Interpreter) -> Result<()> {
     emit(
         interp,
         json!({ "op": "write", "portId": id, "bytes": bytes }),
-    );
+    )?;
     interp.stack.push(handle);
     Ok(())
 }
@@ -132,7 +132,7 @@ pub fn op_write(interp: &mut Interpreter) -> Result<()> {
 pub fn op_flush(interp: &mut Interpreter) -> Result<()> {
     let handle = pop(interp)?;
     let id = require_port_id(&handle)?;
-    emit(interp, json!({ "op": "flush", "portId": id }));
+    emit(interp, json!({ "op": "flush", "portId": id }))?;
     interp.stack.push(handle);
     Ok(())
 }
@@ -141,7 +141,7 @@ pub fn op_flush(interp: &mut Interpreter) -> Result<()> {
 pub fn op_close(interp: &mut Interpreter) -> Result<()> {
     let handle = pop(interp)?;
     let id = require_port_id(&handle)?;
-    emit(interp, json!({ "op": "close", "portId": id }));
+    emit(interp, json!({ "op": "close", "portId": id }))?;
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Reduce host-dependent behavior by routing external boundaries (clock, CSPRNG, serial, audio, JSON export, print/config/effects) through a single host abstraction so the core interpreter remains host-independent.
- Make hosted words explicit in the registry so the Core profile can be machine-checked to be free of host-boundary words and hosted words declare the capability they require.
- Enable deterministic conformance testing by allowing a deterministic host to be injected for non-deterministic boundaries such as `NOW` and `CSPRNG`.

### Description

- Add a `HostEnv` trait and implementations: `DefaultHostEnv` (delegates to platform) and `DeterministicHostEnv` (injectable bytes/time and captures emitted effects), and helpers `default_host_env()`; these provide `now_millis`, `fill_random`, `emit_effect`, and `has_capability`.
- Make `Interpreter` own an injectable `host_env` (constructor helper `Interpreter::with_host` and default `Interpreter::new`), and add `emit_host_effect` and `require_host_capability` helper methods used by hosted words.
- Rewire hosted boundaries to use `HostEnv` and capability checks: `NOW` now calls `interp.host_env.now_millis()` via `require_host_capability`, `CSPRNG` uses `host_env.fill_random` and checks `SecureRandom`, and effectful emitters (`PRINT`, `JSON EXPORT`, `SERIAL`, `MUSIC`/audio, etc.) call `emit_host_effect` and perform capability checks.
- Extend the coreword registry with `WordProfile` (`Core` / `Hosted` / `PlatformSpecific`) and `required_capability` metadata, add module→capability mapping (`host_capability_for_module_word`) and registry query helpers (`get_words_by_profile`, `get_hosted_profile_words`); add tests enforcing that Hosted words declare capabilities and Core words do not.
- Add deterministic and capability-related unit tests for `NOW` and `CSPRNG`, and adapt serial/json/audio/io code paths to emit structured `HostEffect`s via the new helpers.

### Testing

- Ran `cargo fmt` (`rust/Cargo.toml`) and formatting succeeded.
- Ran `cargo check` and `cargo test` (`rust/Cargo.toml`); all relevant builds and unit tests passed, including the new deterministic-host and capability tests (final run: all unit tests passed — 1239 passed, 0 failed).
- Ran frontend/type checks and build: `npm run check` and `npm run build` both succeeded.
- Verified specific new tests passed: `test_now_uses_deterministic_host_clock`, `test_csprng_uses_deterministic_host_bytes`, and registry profile tests that assert hosted words declare `required_capability` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ba6d3e6c8326be23d20a202e5938)