### PR TITLE
Formalize observation foundation (Phase 1)

### DIFF
--- a/docs/dev/ajisai-formalization-expansion-roadmap.md
+++ b/docs/dev/ajisai-formalization-expansion-roadmap.md
@@ -45,23 +45,24 @@
 | §7.11 / §10 | 子ランタイム(並行) | Absent | 状態機械・小ステップ計算(探索的) |
 | §7.14 | Coreword 契約 | Absent | Hoare 契約+部分性/効果/安全性の格子 |
 | §11 | 誤差モデル・Bubble Rule | Defined(述語は Sketched) | `Σ+Error` 二層・整形/不整形述語 |
-| §12 | 意味プレーン・ロール | Sketched | `render : (data, role) → display` 純関数 |
-| §2.3 | 観測軸(protocol) | Sketched | 観測代数 `observe` を semantic axes で |
+| §12 | 意味プレーン・ロール | **Defined**(Phase 1 済) | `render : (data, role) → display` 純関数 |
+| §2.3 | 観測軸(protocol) | **Defined**(Phase 1 済) | 観測代数 `observe` を semantic axes で |
 
-当初「Ajisai のごく一部」だった被覆は、Phase 2(構文)・Phase 4(高階語)・
-Phase 5(構造データ)の完了で言語表層の中核へ拡大した。残る `Absent` は
-レコード・文字列・辞書/名前解決・効果/IO・契約/質量保存・並行性であり、
-新セッションで Phase 1/3/6/7/8/9 として取り組む。各完了フェーズの定義は
-形式化本体 §9-bis、法則は `rust/tests/{desugar,higher_order,structural}_laws.rs`。
+当初「Ajisai のごく一部」だった被覆は、Phase 1(観測基盤)・Phase 2(構文)・
+Phase 4(高階語)・Phase 5(構造データ)の完了で言語表層の中核へ拡大した。残る
+`Absent` はレコード・文字列・辞書/名前解決・効果/IO・契約/質量保存・並行性であり、
+新セッションで Phase 3/6/7/8/9 として取り組む。各完了フェーズの定義は形式化本体
+§9-bis / §9-ter、法則は `rust/tests/{observation,desugar,higher_order,structural}_laws.rs`。
 
 ### 0.3 進捗(本セッション)
 
 | Phase | 状態 | 定義(D) | 法則・テスト(L/T) |
 |---|---|---|---|
+| 1 観測基盤 | ✅ 完了 | 本体 §9-ter D | `rust/tests/observation_laws.rs`(10 群)+ `tests/test_support/{generators,observe}.rs` |
 | 2 構文・脱糖 | ✅ 完了 | 本体 §9-bis A | `rust/tests/desugar_laws.rs`(6 群) |
 | 4 高階・制御語 | ✅ 完了 | 本体 §9-bis B | `rust/tests/higher_order_laws.rs`(11 群) |
 | 5 構造データ | ✅ 完了 | 本体 §9-bis C | `rust/tests/structural_laws.rs`(10 群) |
-| 1,3,6,7,8,9 | 未着手 | — | 新セッション |
+| 3,6,7,8,9 | 未着手 | — | 新セッション |
 
 ---
 

--- a/docs/dev/ajisai-mathematical-formalization.md
+++ b/docs/dev/ajisai-mathematical-formalization.md
@@ -396,6 +396,108 @@ reorder 恒等/反転、sort 冪等/置換不変(計 10 法則群)。
 
 ---
 
+## 9-ter. 拡張定式化 II — 観測基盤(Phase 1, 2026-06 改修)
+
+本節は改修ロードマップ Phase 1(観測基盤と観測代数の確定)の成果を取り込む。
+§8 の観測関数 `observe` を SPEC §2.3 の semantic axes で再定義し、§8 が用いる
+表示函数 `render` を **全ロールについて純関数**として特徴づける。以後の全フェーズは
+本節が固定する観測基盤(protocol 軸 + 純 `render`)の上に立つ。
+
+### D. 観測代数 — 軸射影と純 `render`(Phase 1)
+
+#### D.1 観測の二層分解
+
+観測を **データ面の軸射影**と **表示**に分ける。値 `v ∈ V` の観測可能面は、
+SPEC §2.3 の semantic axes への射影で与えられる:
+
+```
+obs_axes(v) = ( semanticKind(v), shape(v), capabilities(v),
+                truthValue(v),   origin(v), absence(v) )
+```
+
+各成分は protocol 文字列(lower camelCase)であり、Rust enum 名・`Debug`・表示
+テキスト・GUI 配色には一切分岐しない(semantic firewall)。プログラム全体の観測は
+
+```
+observe(p) = ( render*(π_Stack ⟦p⟧ σ₀), π_Eff ⟦p⟧ σ₀ )
+```
+
+で、`render*` はスタック各値への `render` の写像。**`π_Eff`(効果列)は Phase 7**
+の効果代数で与え、本節はデータ面 `render*` と軸射影を確定する。
+
+#### D.2 `render` は `(data, role)` の純関数
+
+表示函数を
+
+```
+render : ValueData × Role → Display
+```
+
+とする(SPEC §12.1)。`Role` は SPEC §12.2 の解釈ロール 8 種
+`{Unassigned, RawNumber, ContinuedFraction, Interval, Text, TruthValue,
+Timestamp, Nil}`。`render` は **全ロールで定義された全域関数**であり、値が
+内部に持つ既定ロール(hint)には依存しない。観測上の中心法則:
+
+| 法則 | 内容 |
+|---|---|
+| 全域性・決定性 | `render(d, r)` は 8 ロール全てで定義(網羅)・決定的(SPEC §12.2) |
+| ロール純粋性 | `render(d, r)` は `(data, role)` のみに依存し、担体値の hint に依存しない。すなわち **データとロールが等しければ表示は等しい**(SPEC §12.2 末尾) |
+| 既定観測の分解 | 既定の表示 `to_string(v)` は `render(v, hint(v))`。`observe` の表示半は `render` を経由する |
+| U の表示吸収 | 論理 Unknown は **全ロールで `UNKNOWN`** に表示され、`NIL` や数値形へ漏れない(SPEC §2.3, §7.5) |
+
+ロール純粋性は「表示は意味プレーン(ロール割当)だけの関数であり、データ面を
+変えない」という二面分離(SPEC §5.2, §12.1)の表示側の内容である。
+
+#### D.3 semantic firewall — 構造軸はロール直交
+
+データ面の **構造軸** `semanticKind` / `shape` / `origin` は値の data と absence
+だけを読む。ゆえにロール(意味プレーン)の割当は構造軸を変えない:
+
+```
+obs_struct(v) = obs_struct(v with role := r)   (∀ r)
+```
+
+これは「意味面の変更が計算・データ面に非干渉」(SPEC §5.2)の軸レベルの言明。
+真偽軸 `truthValue` と `truthValued` capability は **意図的にロール結合**で、
+SPEC §2.3 が言う「`TruthValue` ロールを担う値にのみ truthValue 軸が現れる」を
+反映する(構造軸とは別扱い)。
+
+#### D.4 軸整合(runtime-produced 値)
+
+参照実装が生成する値の上で、真偽軸と capability は整合する:
+
+```
+truthValue(v) ≠ ⊥  ⟺  truthValued ∈ capabilities(v)
+```
+
+また全値は基底 capability `{stackItem, serializable, displayable}` を備える。
+
+#### D.5 所見(finding、descriptive)
+
+- **所見 D1(真偽 capability のロール結合):** `truthValued` capability は
+  `hint = TruthValue` を鍵に算出される一方、`truthValue` 軸は **Boolean を
+  本質的に真偽値**として扱う(ロール非依存に `true`/`false` を返す)。両者は
+  **runtime-produced 値では整合**するが、Boolean の担体を `TruthValue` 以外の
+  ロールへ人為的に付け替えると軸=Some・capability=なしと **乖離する**。
+  これは SPEC §2.3 が要求する「truthValue 軸を持つ値は truthValued capability も
+  持つ」の境界事例であり、実行時に Boolean は常に `TruthValue` ロールを担うため
+  実害はない。**モデル/実装の不変条件として追跡**(到達可能状態では HOLDS、
+  人為再ロールでは BREAKS)。仕様は正典(§16.1)であり、本所見は記述に留める。
+- **所見 D2(完全平方の√は有理に縮退):** `√4`・`√9` 等は有理数へ collapse し、
+  等値比較が `U` でなく定値 `true` を返す。U を得る生成器は **非完全平方の
+  radicand** に限定する必要がある(モデリング上の注意。仕様上の乖離ではない)。
+- **所見 D3(空ブロックの表示は空文字列):** `{ }` は空文字列に表示される。
+  したがって `render` の **非空性は法則ではない**;全域性・決定性のみが法則。
+
+**テスト**: `rust/tests/observation_laws.rs` — render 全域/決定性、ロール純粋性、
+既定観測=`render(·,hint)`、U の表示吸収、構造軸のロール直交、真偽軸=capability
+整合、基底 capability、真偽値≠数値(所見 B の観測層再確認)、protocol 文字列の
+lower camelCase(計 10 法則群)。生成器は `rust/tests/test_support/generators.rs`
+(意味領域別)、観測は `rust/tests/test_support/observe.rs`(軸射影 + 純 `render`)。
+以後のフェーズは generator を足すだけで法則を追加できる。
+
+---
+
 ## 10. 付録 — 経験的法則チェック(参照実装 2026-06)
 
 参照実装に直接プログラムを流して §9.2 の法則を確認した結果。
@@ -421,6 +523,10 @@ reorder 恒等/反転、sort 冪等/置換不変(計 10 法則群)。
 | EXEC inline、`EVAL(STR p) ≡ p`、COND の U 不発火 | HOLDS | `tests/higher_order_laws.rs` |
 | REVERSE 対合/反同型、CONCAT 結合、SPLIT↔CONCAT | HOLDS | `tests/structural_laws.rs` |
 | TRANSPOSE 対合、RESHAPE 往復、SORT 冪等/置換不変 | HOLDS | `tests/structural_laws.rs` |
+| render 全域/決定性・ロール純粋・既定観測=`render(·,hint)`(§9-ter D) | HOLDS | `tests/observation_laws.rs` |
+| U の表示吸収・構造軸のロール直交・真偽軸=capability 整合 | HOLDS | `tests/observation_laws.rs` |
+| 真偽値≠数値(所見 B 観測層)・protocol 文字列 lower camelCase | HOLDS | `tests/observation_laws.rs` |
+| 所見 D1: 真偽 capability のロール結合(人為再ロールで乖離) | BREAKS(人為) / HOLDS(到達可能) | §9-ter D.5、追跡中 |
 
 健全な核(有理算術・K3 論理・NIL モナド・モノイド合成)は法則を満たす。
 かつて §9.3 にあった二つの破れ(B: T=1 の型混同、C: 無理数の近似表示)は

--- a/rust/tests/observation_laws.rs
+++ b/rust/tests/observation_laws.rs
@@ -1,0 +1,189 @@
+//! Property-based observation-foundation laws (Phase 1).
+//!
+//! These encode the algebraic content of the observation function and the
+//! renderer from `docs/dev/ajisai-mathematical-formalization.md` §9-ter D
+//! (Phase 1): `observe(p) = (render(π_Stack ⟦p⟧ σ₀), π_Eff)` with
+//! `render : (data, role) → display` a **pure** function over **all** SPEC
+//! §12.2 roles, observed through the SPEC §2.3 semantic axes only.
+//!
+//! Unlike `algebraic_laws.rs` — which observes through whole-stack
+//! `Value::to_string()` (a *display* surface, non-canonical per §2.3) — this
+//! file observes through protocol axes and treats `render` as the explicit
+//! `(data, role)` function. It is the firewall-clean basis later phases reuse
+//! by adding domain generators (`test_support::generators`).
+//!
+//! Every law below was checked against the reference implementation with a
+//! throwaway probe before being written (roadmap §1.2-(T) discipline).
+
+mod test_support;
+
+use ajisai_core::semantic::Capability;
+use ajisai_core::types::Interpretation;
+use proptest::prelude::*;
+use test_support::generators::*;
+use test_support::observe::{observe_axes, render, run, run_one, ALL_ROLES};
+
+// ─────────────────────────── concrete-witness laws ───────────────────────────
+
+/// Render is genuinely role-sensitive (a positive control): it is not a
+/// constant function that ignores its role argument. A definite Boolean renders
+/// as the bare truth word under `TruthValue` but as quoted text under `Text`.
+#[test]
+fn render_is_role_sensitive() {
+    let t = run_one("TRUE");
+    assert_ne!(
+        render(&t, Interpretation::TruthValue),
+        render(&t, Interpretation::Text),
+        "render must depend on its role argument"
+    );
+}
+
+/// Finding B at the observation layer: a truth value is observably **not** a
+/// number. `TRUE` carries the `truthValue` axis and the `truthValued`
+/// capability; the scalar `1` carries neither, and they render differently.
+#[test]
+fn truth_value_is_observably_not_a_number() {
+    let t = observe_axes(&run_one("TRUE"));
+    let one = observe_axes(&run_one("1"));
+    assert_eq!(t.truth_value, Some("true"));
+    assert_eq!(one.truth_value, None);
+    assert!(t.capabilities.contains(&"truthValued"));
+    assert!(!one.capabilities.contains(&"truthValued"));
+    assert_ne!(
+        render(&run_one("TRUE"), Interpretation::Unassigned),
+        render(&run_one("1"), Interpretation::Unassigned),
+    );
+}
+
+/// Every observed protocol string is canonical lower-camelCase (SPEC §2.3):
+/// nonempty, lowercase first letter, ASCII-alphanumeric only (no `_`, no `-`).
+#[test]
+fn protocol_strings_are_lower_camel_case() {
+    fn ok(s: &str) -> bool {
+        let mut chars = s.chars();
+        matches!(chars.next(), Some(c) if c.is_ascii_lowercase())
+            && s.chars().all(|c| c.is_ascii_alphanumeric())
+    }
+    for src in [
+        "5",
+        "TRUE",
+        "FALSE",
+        "1 0 /",
+        "[ 1 2 3 ]",
+        "{ 1 ADD }",
+        "'math' IMPORT 2 MATH@SQRT",
+        "'math' IMPORT 2 MATH@SQRT 2 MATH@SQRT SUB 0 EQ",
+    ] {
+        for v in run(src) {
+            let o = observe_axes(&v);
+            assert!(ok(o.semantic_kind), "semanticKind {:?}", o.semantic_kind);
+            assert!(ok(o.shape), "shape {:?}", o.shape);
+            assert!(ok(o.origin), "origin {:?}", o.origin);
+            for c in &o.capabilities {
+                assert!(ok(c), "capability {c:?}");
+            }
+            if let Some(tv) = o.truth_value {
+                assert!(ok(tv), "truthValue {tv:?}");
+            }
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    // ───────────────────────── render is a pure (data, role) function ─────────
+
+    /// **Totality + determinism**: `render` is defined on every SPEC §12.2 role
+    /// for every well-formed value (the role match is exhaustive over the 8
+    /// roles) and is a deterministic pure function — two calls agree. (Probe
+    /// finding: an empty code block `{ }` renders to the empty string, so
+    /// nonemptiness is *not* a render law; totality and determinism are.)
+    #[test]
+    fn render_total_and_deterministic_over_all_roles(src in any_value_src()) {
+        let v = run_one(&src);
+        for role in ALL_ROLES {
+            prop_assert_eq!(render(&v, role), render(&v, role));
+        }
+    }
+
+    /// **Purity / hint-independence** (SPEC §12.2: "two values are displayed
+    /// identically whenever their data and role are equal"). `render(v, r)`
+    /// depends only on `(data, role)`, never on the value's stored hint, so
+    /// re-roling the carrier value leaves every rendering fixed.
+    #[test]
+    fn render_depends_only_on_data_and_role(src in any_value_src()) {
+        let v = run_one(&src);
+        let mut reroled = v.clone();
+        reroled.hint = if v.hint == Interpretation::RawNumber {
+            Interpretation::Text
+        } else {
+            Interpretation::RawNumber
+        };
+        for role in ALL_ROLES {
+            prop_assert_eq!(render(&v, role), render(&reroled, role));
+        }
+    }
+
+    /// The default observation `Value::to_string()` is exactly `render` at the
+    /// value's own role: `observe`'s display half factors through `render`.
+    #[test]
+    fn default_observation_is_render_at_own_role(src in any_value_src()) {
+        let v = run_one(&src);
+        prop_assert_eq!(v.to_string(), render(&v, v.hint));
+    }
+
+    /// **U is render-absorbing** (SPEC §2.3, §7.5): the logical Unknown renders
+    /// as `UNKNOWN` under *every* role — its truth surface is role-invariant and
+    /// never leaks as `NIL` or a numeric form.
+    #[test]
+    fn unknown_renders_absorbingly(src in unknown_src()) {
+        let u = run_one(&src);
+        prop_assert_eq!(u.truth_value(), Some("unknown"));
+        for role in ALL_ROLES {
+            prop_assert_eq!(render(&u, role), "UNKNOWN");
+        }
+    }
+
+    // ───────────────────────── semantic firewall on the axes ─────────────────
+
+    /// **Structural axes are role-orthogonal** (semantic firewall): the
+    /// data-plane axes `semanticKind`, `shape`, and `origin` read only the data
+    /// and absence metadata, so assigning a display role never changes them.
+    #[test]
+    fn structural_axes_are_role_orthogonal(src in any_value_src()) {
+        let v = run_one(&src);
+        let mut reroled = v.clone();
+        reroled.hint = if v.hint == Interpretation::TruthValue {
+            Interpretation::Unassigned
+        } else {
+            Interpretation::TruthValue
+        };
+        let a = observe_axes(&v);
+        let b = observe_axes(&reroled);
+        prop_assert_eq!(a.semantic_kind, b.semantic_kind);
+        prop_assert_eq!(a.shape, b.shape);
+        prop_assert_eq!(a.origin, b.origin);
+    }
+
+    /// **Axis coherence** on runtime-produced values (SPEC §2.3: a truth-valued
+    /// value "also carries the `truthValued` capability"): the `truthValue` axis
+    /// is present iff the `truthValued` capability is present.
+    #[test]
+    fn truth_axis_and_capability_cohere(src in any_value_src()) {
+        let v = run_one(&src);
+        let has_axis = v.truth_value().is_some();
+        let has_cap = v.has_capability(Capability::TruthValued);
+        prop_assert_eq!(has_axis, has_cap);
+    }
+
+    /// Every value advertises the universal stack capabilities (§2.3 baseline):
+    /// it is a `stackItem`, `serializable`, and `displayable`.
+    #[test]
+    fn every_value_is_a_displayable_stack_item(src in any_value_src()) {
+        let o = observe_axes(&run_one(&src));
+        for cap in ["stackItem", "serializable", "displayable"] {
+            prop_assert!(o.capabilities.contains(&cap), "missing {cap}");
+        }
+    }
+}

--- a/rust/tests/test_support/generators.rs
+++ b/rust/tests/test_support/generators.rs
@@ -1,0 +1,100 @@
+//! Semantic-domain generators (Phase 1 foundation).
+//!
+//! Each strategy yields an **Ajisai source program** that leaves exactly one
+//! value of a given semantic domain on the stack. Property-based law tests
+//! (`observation_laws.rs` and later phases) consume these so that adding a new
+//! law for a new domain is "add a generator, write the equation" — the土台
+//! the formalization-expansion roadmap §1.2-(T) asks for.
+//!
+//! Programs are deliberately small (cheap to run thousands of times) while
+//! still covering the boundary values the roadmap §4 calls out: zero, sign,
+//! NIL, irrationals, the logical Unknown, and empty/short vectors.
+
+use proptest::prelude::*;
+
+/// Small signed integers, including zero and both signs.
+pub fn small() -> impl Strategy<Value = i64> {
+    -20i64..=20
+}
+
+/// A nonzero divisor (keeps `_ _ /` away from the Bubble path when a value is
+/// wanted; a separate [`nil_src`] exercises the division-by-zero NIL).
+pub fn nonzero() -> impl Strategy<Value = i64> {
+    (1i64..=20).prop_flat_map(|n| prop_oneof![Just(n), Just(-n)])
+}
+
+/// Pushes a single rational scalar (RawNumber role).
+pub fn scalar_src() -> impl Strategy<Value = String> {
+    prop_oneof![
+        small().prop_map(|n| n.to_string()),
+        (small(), nonzero()).prop_map(|(a, b)| format!("{a} {b} /")),
+        (small(), small()).prop_map(|(a, b)| format!("{a} {b} ADD")),
+        (small(), small()).prop_map(|(a, b)| format!("{a} {b} MUL")),
+    ]
+}
+
+/// Pushes a single definite truth value (Boolean, TruthValue role).
+pub fn boolean_src() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("TRUE".to_string()),
+        Just("FALSE".to_string()),
+        (small(), small()).prop_map(|(a, b)| format!("{a} {b} LT")),
+        (small(), small()).prop_map(|(a, b)| format!("{a} {b} EQ")),
+        (small(), small()).prop_map(|(a, b)| format!("{a} {b} GT")),
+    ]
+}
+
+/// Pushes a reasoned NIL via the Bubble Rule (division by zero, §11.2).
+pub fn nil_src() -> impl Strategy<Value = String> {
+    small().prop_map(|n| format!("{n} 0 /"))
+}
+
+/// Radicands that are **not** perfect squares, so `√n` stays a genuine
+/// irrational. (Probe finding: `√4`, `√9` collapse to the rationals `2`, `3`,
+/// so a comparison of equal `√(square)` decides `true`, not the logical U.)
+fn non_square_radicand() -> impl Strategy<Value = i64> {
+    prop::sample::select(vec![2i64, 3, 5, 6, 7, 8, 10, 11, 13])
+}
+
+/// Pushes the logical Unknown (U): an undecidable comparison of equal
+/// irrationals, `√n √n SUB 0 EQ` (confirmed by probe to render `UNKNOWN`).
+pub fn unknown_src() -> impl Strategy<Value = String> {
+    non_square_radicand()
+        .prop_map(|n| format!("'math' IMPORT {n} MATH@SQRT {n} MATH@SQRT SUB 0 EQ"))
+}
+
+/// Pushes an irrational exact-real scalar `√n` (n not a perfect square, so the
+/// value is a genuine lazy continued fraction).
+pub fn irrational_src() -> impl Strategy<Value = String> {
+    non_square_radicand().prop_map(|n| format!("'math' IMPORT {n} MATH@SQRT"))
+}
+
+/// Pushes a single vector/tensor literal (1–3 elements).
+pub fn vector_src() -> impl Strategy<Value = String> {
+    prop::collection::vec(small(), 1..4).prop_map(|xs| {
+        let body = xs.iter().map(i64::to_string).collect::<Vec<_>>().join(" ");
+        format!("[ {body} ]")
+    })
+}
+
+/// Pushes a single code block (callable).
+pub fn block_src() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just("{ 1 ADD }".to_string()),
+        Just("{ DUP MUL }".to_string()),
+        Just("{ }".to_string()),
+    ]
+}
+
+/// Union over every semantic domain — the "any well-formed value" generator.
+pub fn any_value_src() -> impl Strategy<Value = String> {
+    prop_oneof![
+        scalar_src(),
+        boolean_src(),
+        nil_src(),
+        unknown_src(),
+        irrational_src(),
+        vector_src(),
+        block_src(),
+    ]
+}

--- a/rust/tests/test_support/mod.rs
+++ b/rust/tests/test_support/mod.rs
@@ -1,15 +1,8 @@
-use ajisai_core::interpreter::Interpreter;
-use ajisai_core::types::Value;
+//! Shared test-support modules for the property-based law suites.
+//!
+//! `generators` provides semantic-domain Ajisai-source strategies and
+//! `observe` provides the firewall-clean §2.3 axis observation and the pure
+//! `render : (data, role) → display` function (Phase 1 foundation).
 
-pub async fn exec_ok_gui(code: &str) -> Result<Vec<Value>, String> {
-    let mut interp = Interpreter::new();
-    interp.gui_mode = true;
-    interp.execute(code).await.map_err(|e| e.to_string())?;
-    Ok(interp.get_stack().clone())
-}
-
-pub async fn exec_err_gui(code: &str) -> bool {
-    let mut interp = Interpreter::new();
-    interp.gui_mode = true;
-    interp.execute(code).await.is_err()
-}
+pub mod generators;
+pub mod observe;

--- a/rust/tests/test_support/observe.rs
+++ b/rust/tests/test_support/observe.rs
@@ -1,0 +1,94 @@
+//! Firewall-clean observation (Phase 1).
+//!
+//! The formalization §8 defines the observation function
+//! `observe(p) = (render(π_Stack ⟦p⟧ σ₀), π_Eff ⟦p⟧ σ₀)`. This module gives the
+//! data-plane half of that: it reads a value **only** through the SPEC §2.3
+//! semantic axes (`semanticKind`, `shape`, `capabilities`, `truthValue`,
+//! `origin`, `absence`) and through the pure renderer `render : (data, role) →
+//! display`. It never branches on a Rust enum name, `Debug` string, or display
+//! text — the semantic-firewall discipline the roadmap §1.2-3 mandates.
+//!
+//! The effect component `π_Eff` is intentionally out of scope here; the effect
+//! algebra is Phase 7. Phase 1 fixes the data-plane observation basis that all
+//! later phases build on.
+
+use ajisai_core::interpreter::Interpreter;
+use ajisai_core::types::display::format_with_hint;
+use ajisai_core::types::{Interpretation, Value};
+
+/// Every interpretation role of SPEC §12.2, in table order.
+pub const ALL_ROLES: [Interpretation; 8] = [
+    Interpretation::Unassigned,
+    Interpretation::RawNumber,
+    Interpretation::ContinuedFraction,
+    Interpretation::Interval,
+    Interpretation::Text,
+    Interpretation::TruthValue,
+    Interpretation::Timestamp,
+    Interpretation::Nil,
+];
+
+/// The pure renderer `render : (data, role) → display` (SPEC §12.1). Exposed as
+/// a named function so laws read as equations over `render`, not over the
+/// `Display` impl.
+pub fn render(v: &Value, role: Interpretation) -> String {
+    format_with_hint(v, role)
+}
+
+/// The protocol-level observation of one value: the SPEC §2.3 semantic axes as
+/// canonical lower-camel-case protocol strings. Capabilities are sorted so the
+/// observation is order-insensitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisObservation {
+    pub semantic_kind: &'static str,
+    pub shape: &'static str,
+    pub capabilities: Vec<&'static str>,
+    pub truth_value: Option<&'static str>,
+    pub origin: &'static str,
+}
+
+/// Observe a value through the semantic axes only (firewall-clean).
+pub fn observe_axes(v: &Value) -> AxisObservation {
+    let mut capabilities: Vec<&'static str> = v
+        .capabilities()
+        .iter()
+        .map(|c| c.as_protocol_str())
+        .collect();
+    capabilities.sort_unstable();
+    AxisObservation {
+        semantic_kind: v.semantic_kind().as_protocol_str(),
+        shape: v.shape_kind().as_protocol_str(),
+        capabilities,
+        truth_value: v.truth_value(),
+        origin: v.origin().as_protocol_str(),
+    }
+}
+
+/// Run an Ajisai program and return the final stack. Panics on execution error
+/// so a malformed law program is loud rather than silently skipped (mirrors the
+/// existing `algebraic_laws.rs` harness).
+pub fn run(src: &str) -> Vec<Value> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio current-thread runtime");
+    rt.block_on(async {
+        let mut interp = Interpreter::new();
+        interp
+            .execute(src)
+            .await
+            .unwrap_or_else(|e| panic!("program failed: {src:?}: {e}"));
+        interp.get_stack().clone()
+    })
+}
+
+/// Run a program expected to leave exactly one value, returning that value.
+pub fn run_one(src: &str) -> Value {
+    let stack = run(src);
+    assert_eq!(
+        stack.len(),
+        1,
+        "generator program {src:?} must leave exactly one value, got {}",
+        stack.len()
+    );
+    stack.into_iter().next().unwrap()
+}


### PR DESCRIPTION
## 概要

数学的定式化の全面拡張ロードマップ **Phase 1（観測基盤）** を実施。`observe` を
SPEC §2.3 の semantic axes で再定義し、§8 の表示函数 `render` を **全 §12.2 ロールに
ついて純関数 `render : (data, role) → display`** として特徴づけた。これは依存の少ない
全フェーズの土台であり、以後のフェーズは生成器を足すだけで法則を追加できる。

既存 4 点セット（D/L/T/X）の規律を踏襲。

## 成果物

- **(D) 定義** — 形式化本体に `§9-ter D 観測代数` を追記:
  - 観測の二層分解 `observe(p) = (render*(π_Stack), π_Eff)`（`π_Eff` は Phase 7 へ）
  - 軸射影 `obs_axes = (semanticKind, shape, capabilities, truthValue, origin, absence)`
  - `render` のロール純粋性・全域性・既定観測分解・U の表示吸収
  - semantic firewall（構造軸のロール直交）と真偽軸=capability 整合
- **(L/T) 法則・テスト** — `rust/tests/observation_laws.rs`（10 法則群）:
  - render 全域/決定性、ロール純粋（data+role が等しければ表示が等しい）、
    既定観測 `to_string = render(·,hint)`、U の全ロール `UNKNOWN`、
    構造軸のロール直交、真偽軸=capability 整合、基底 capability、
    真偽値≠数値（所見 B の観測層再確認）、protocol 文字列の lower camelCase
  - 再利用可能な土台: `tests/test_support/generators.rs`（意味領域別生成器）+
    `tests/test_support/observe.rs`（軸射影 + 純 `render`）
- **(X) 相互参照・finding** — SPEC §2.3/§12.1/§12.2 へ相互参照。検出した所見を
  記述的に記録（仕様が正典・§16.1 を尊重し、第二権威化しない）。

## 規律どおりプローブで実挙動を確認してから法則化（推測しない）

使い捨てプローブで参照実装の実挙動を確認し、3 件の所見を得てから法則を書いた:

- **所見 D1**: `truthValued` capability は `hint==TruthValue` 結合だが、`truthValue`
  軸は Boolean を本質的に真偽値として扱う。**runtime-produced 値では整合**するが、
  人為的な再ロールでのみ乖離する境界事例。仕様は正典のまま、モデル/実装の不変
  条件として追跡（到達可能状態では HOLDS）。
- **所見 D2**: 完全平方の `√n`（√4, √9 …）は有理に縮退し等値比較が U でなく定値に
  なる → U 生成器は非完全平方 radicand に限定。
- **所見 D3**: 空ブロック `{ }` は空文字列に表示される → render の非空性は法則では
  なく、全域性・決定性が法則。

## 検証

- `cargo test --test observation_laws` … 10 群グリーン
- 全体回帰なし: lib 1240 + algebraic(14)/desugar(6)/higher_order(11)/structural(10) すべてグリーン
- 新規ファイルのみ rustfmt 整形（無関係な整形差分なし）

ロードマップ §0.2（§2.3/§12 → Defined）・§0.3 進捗表、本体 §10 HOLDS 表も更新済み。

https://claude.ai/code/session_01LkCsXRwULvazmzXdUiEpHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkCsXRwULvazmzXdUiEpHq)_