### PR TITLE
Resolve Phase 3 findings: mass-conservation contract + validator (E1), GCD/LCM safety (E2)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -734,7 +734,8 @@ A contract entry has the following fields, in addition to the existing identific
 |-------|--------|---------|
 | `partiality` | `Total` / `Partial` / `Projecting` | `Total`: the operation is defined on every well-shaped input. `Partial`: the operation has well-shaped inputs for which it raises an error. `Projecting`: the operation is total because it projects all failures onto NIL with reason. |
 | `nil_policy` | `Passthrough` / `CreatesNil` / `RejectsNil` / `ConsumesNil` / `PreservesReason` | How the word reacts to and produces NIL. `Passthrough` words follow Section 4.5.1; `CreatesNil` words project domain failures (e.g. division by zero); `RejectsNil` words raise `StructureError` on NIL; `ConsumesNil` words inspect or branch on NIL (e.g. `OR-NIL`); `PreservesReason` words must not erase a reason that is already attached to a propagated NIL. |
-| `safety_level` | `A` / `B` / `C` / `D` / `Quarantined` | Increasing strength of safety guarantees. `A`: total, pure, deterministic; `B`: partial but with explicit error categories; `C`: observable or has external state read; `D`: effectful; `Quarantined`: not eligible for self-host execution. |
+| `safety_level` | `A` / `B` / `C` / `D` / `Quarantined` | Increasing strength of safety guarantees. `A`: total, pure, deterministic; `B`: partial but with explicit error categories; `C`: observable or has external state read; `D`: effectful; `Quarantined`: not eligible for self-host execution. A `Partial` word is therefore at least `B` (it is not total); `Projecting` words are total by projection and may be `A`. |
+| `mass` | `Fixed { consumes, produces }` / `Dynamic` | The static flow-mass contract of Section 13.1: under the default `TOP`/`EAT` mode the word reads `consumes` operands and pushes `produces` results; under `KEEP` the `consumes` operands are additionally retained (bifurcation, Section 13.2). `Dynamic` marks a data-dependent arity (for example the `STAK` count-fold or runtime-shaped vector operations) that is not statically pinned. |
 
 `partiality` and `nil_policy` are independent axes. For example, under the Bubble Rule `/` (division) is `Projecting` with `nil_policy = CreatesNil`: `/`, `GET`, `NUM`, and `CHR` are `Projecting`/`CreatesNil` for well-formed domain misses while malformed inputs remain ordinary errors.
 
@@ -986,9 +987,9 @@ The `ContinuedFraction` role is the canonical AI-readable numeric serialization 
 
 ### 13.1 Static Mass Conservation
 
-Ajisai treats flow mass conservation as a compile/JIT/load-time property. A Coreword Contract declares arity, consumption, production, bifurcation, and NIL-projection behavior. Optimized execution paths may be entered only after those contracts have been validated for the surrounding flow.
+Ajisai treats flow mass conservation as a compile/JIT/load-time property. A Coreword Contract declares arity, consumption, production, bifurcation, and NIL-projection behavior: arity/consumption/production are carried by the `mass` contract field (Section 7.14), bifurcation by the `KEEP` modifier (Section 13.2), and NIL-projection by `nil_policy`. Optimized execution paths may be entered only after those contracts have been validated for the surrounding flow.
 
-The ordinary runtime must not maintain per-value `FlowToken` objects or perform step-by-step mass accounting. Flow-accounting failures such as over-consumption, unconsumed leaks, flow breaks, and bifurcation-ratio violations are contract-validation failures and must be reported by the compiler/JIT, loader, or developer diagnostics before the optimized path executes.
+The ordinary runtime must not maintain per-value `FlowToken` objects or perform step-by-step mass accounting. Flow-accounting failures such as over-consumption, unconsumed leaks, flow breaks, and bifurcation-ratio violations are contract-validation failures and must be reported by the compiler/JIT, loader, or developer diagnostics before the optimized path executes. A word whose `mass` is `Dynamic` has a data-dependent arity that the static validator does not certify; flows through such words are validated only up to that point.
 
 ### 13.2 Bifurcation
 

--- a/docs/dev/ajisai-mathematical-formalization.md
+++ b/docs/dev/ajisai-mathematical-formalization.md
@@ -577,18 +577,25 @@ HOLDS):
   `requires` を含意するとき合成は安全。partiality は `Partial` が伝播で支配的
   (一方が Partial なら合成も Partial 以上)であり、`Total/Projecting` は閉じる。
 
-#### E.5 所見(finding、descriptive)
+#### E.5 所見(finding)
 
-- **所見 E1(質量フィールドの未実装):** SPEC §13.1 は Coreword Contract が
-  `arity / consumption / production / bifurcation` を宣言すると記すが、実装の
-  `CorewordMetadata` 構造体は `nil_policy` 以外の質量フィールドを **持たない**。
-  本モデルは質量保存を **観測的(スタック深さ差分)**に検証する。仕様は正典の
-  まま、メタデータ拡張 or 仕様注記のいずれかを要する **乖離として追跡**。
-- **所見 E2(safety A と partiality の不整合、追跡オラクル):** SPEC §7.14 は
-  safety `A` を「total・pure・deterministic」と定義するが、registry は **Partial**
-  な `GCD`/`LCM` を `A` と宣言する(`Projecting` の `POW` 等は total-by-projection
-  で `A` と整合する一方、`Partial` は整合しない)。乖離集合が **ちょうど
-  {GCD, LCM}** であることをテストで固定し、契約修正・新規不整合の双方を可視化する。
+- **所見 E1(質量フィールドの未実装)— 解消済み:** かつて SPEC §13.1 が宣言すると
+  記す `arity / consumption / production / bifurcation` が `CorewordMetadata` に
+  **無かった**。本改修で機械可読な質量契約 `mass : Fixed{consumes,produces} |
+  Dynamic` を §7.14 契約フィールドへ追加(arity/consumption/production を担い、
+  bifurcation は KEEP 修飾子=§13.2、NIL 射影は nil_policy が担う)。コンパイル済み
+  プラン解析器(`quantized_block::builtin_arity`)と契約レジストリは同一の
+  `coreword_registry::mass_contract` を読み、乖離しない。静的検証器
+  `interpreter::mass_conservation::validate_mass_conservation` が CompiledPlan を
+  抽象解釈し、過消費(空スタックからの深さが負)を **診断として**報告する
+  (§13.1「reported by ... developer diagnostics」。最適化経路の gating は変更せず
+  実行時は per-value FlowToken を持たない)。SPEC §7.14/§13.1 を相応に改訂。
+- **所見 E2(safety A と partiality の不整合)— 解消済み:** SPEC §7.14 は safety `A`
+  を「total・pure・deterministic」と定義する。`GCD`/`LCM` は非整数入力で実際に
+  エラーを出す真の `Partial` なので、契約を `A`→`B`(「partial but explicit error
+  categories」)へ修正(`Projecting` の `POW` 等は total-by-projection で `A` 据置)。
+  以後「safety A ⟹ partiality∈{Total,Projecting}」が反例なく成立し、テストで不変
+  条件として固定。仕様は正典のまま実装を仕様へ一致させた。
 - **所見 E3(GET は非消費):** `[v…] i GET` は **元ベクタを保持**し要素(範囲外は
   NIL)を積む(`obs([1 2 3] 9 GET) = [[1 2 3], NIL]`)。GET の consumption profile は
   (vector 保持, index 消費, element 生成)であり、素朴な arity 計算と異なる
@@ -600,8 +607,11 @@ HOLDS):
 **テスト**: `rust/tests/contract_modifier_laws.rs` — 既定修飾子の恒等、KEEP 分岐、
 KEEP−EAT=arity(質量)、STAK 畳み込み・`..`≡STAK、STAK KEEP の保持、Total 無エラー、
 Projecting の NIL 射影、契約の全域性(全語が到達可能契約を持つ)、safety 格子の
-単調性、所見 E2 の追跡オラクル、§7.14 アンカー契約(ADD/DIV/EQ/LT/AND/OR/NOT)
-(計 11 法則群)。
+単調性(A⟹{Total,Projecting})、所見 E2 不変条件(A+Partial 皆無・GCD/LCM=B)、
+§7.14 アンカー契約(ADD/DIV/EQ/LT/AND/OR/NOT)(計 11 法則群)。
+`rust/tests/mass_conservation_laws.rs` — 質量契約の §7.14 露出、静的純 net mass=実行時
+深さの健全性、KEEP の net mass 増分=arity、過消費⇔実行時 underflow、Dynamic で abstain
+(計 5 法則群)。
 
 ---
 
@@ -637,8 +647,9 @@ Projecting の NIL 射影、契約の全域性(全語が到達可能契約を持
 | 既定修飾子の恒等・KEEP 分岐・KEEP−EAT=arity・STAK 畳み込み(§9-quater E) | HOLDS | `tests/contract_modifier_laws.rs` |
 | Total 無エラー・Projecting の NIL 射影・契約全域性・safety 格子単調 | HOLDS | `tests/contract_modifier_laws.rs` |
 | §7.14 アンカー契約(ADD/DIV/EQ/LT/AND/OR/NOT) | HOLDS | `tests/contract_modifier_laws.rs` |
-| 所見 E1: 質量フィールド(arity 等)が registry に未実装 | 乖離(追跡) | §9-quater E.5、観測的に代替検証 |
-| 所見 E2: safety A だが Partial({GCD,LCM}) | BREAKS(§7.14) | §9-quater E.5、追跡オラクル化 |
+| 所見 E1: 質量契約 `mass` を §7.14 へ露出・静的検証器を実装 | HOLDS(解消) | §9-quater E.5、`tests/mass_conservation_laws.rs` |
+| 静的 net mass=実行時深さ・過消費⇔underflow・KEEP増分=arity | HOLDS | `tests/mass_conservation_laws.rs` |
+| 所見 E2: safety A⟹{Total,Projecting}(GCD/LCM を B へ修正) | HOLDS(解消) | §9-quater E.5、`tests/contract_modifier_laws.rs` |
 
 健全な核(有理算術・K3 論理・NIL モナド・モノイド合成)は法則を満たす。
 かつて §9.3 にあった二つの破れ(B: T=1 の型混同、C: 無理数の近似表示)は

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -40,6 +40,57 @@ pub enum SafetyLevel {
     Quarantined,
 }
 
+/// Static mass contract (SPEC §13.1): a word's flow-mass relationship under the
+/// default `TOP`/`EAT` mode. `consumes` operands are read and `produces` results
+/// are pushed; under `KEEP` the `consumes` operands are additionally retained
+/// (bifurcation, §13.2). This is the machine-readable form of the §13.1 "arity /
+/// consumption / production / bifurcation" declaration; the NIL-projection part
+/// of §13.1 is carried by `nil_policy`.
+///
+/// `Dynamic` marks a data-dependent arity (e.g. the `STAK` count-driven fold or
+/// runtime-shaped vector ops) that is not statically pinned; the static
+/// mass-conservation validator abstains on `Dynamic` words.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum MassContract {
+    Fixed { consumes: u8, produces: u8 },
+    Dynamic,
+}
+
+impl MassContract {
+    /// `(consumes, produces)` when the contract is statically fixed.
+    pub fn fixed(self) -> Option<(u8, u8)> {
+        match self {
+            MassContract::Fixed { consumes, produces } => Some((consumes, produces)),
+            MassContract::Dynamic => None,
+        }
+    }
+}
+
+/// The canonical mass contract for a Coreword, keyed by its canonical name.
+/// Single source of truth for static arity: the compiled-plan analyzer
+/// (`quantized_block::builtin_arity`) and the §7.14 contract registry both read
+/// this so they cannot drift. Values are probe-verified against the reference
+/// implementation; unpinned words are `Dynamic`.
+pub fn mass_contract(name: &str) -> MassContract {
+    match name {
+        // Binary arithmetic / comparison / logic: read two, push one.
+        "ADD" | "SUB" | "MUL" | "DIV" | "MOD" | "LT" | "LTE" | "GT" | "GTE" | "EQ" | "NEQ"
+        | "AND" | "OR" => MassContract::Fixed {
+            consumes: 2,
+            produces: 1,
+        },
+        // Unary arithmetic / math / cast: read one, push one.
+        "NOT" | "ABS" | "NEG" | "SQRT" | "FLOOR" | "CEIL" | "ROUND" | "STR" | "BOOL" => {
+            MassContract::Fixed {
+                consumes: 1,
+                produces: 1,
+            }
+        }
+        _ => MassContract::Dynamic,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum WordProfile {
@@ -76,6 +127,9 @@ pub struct CorewordMetadata {
     pub partiality: Partiality,
     pub nil_policy: NilPolicy,
     pub safety_level: SafetyLevel,
+    /// Static flow-mass contract (SPEC §13.1): arity / production, with
+    /// bifurcation governed by the `KEEP` modifier (§13.2).
+    pub mass: MassContract,
     /// Portability profile used by conformance tooling to keep the Core
     /// profile free of host-boundary words.
     pub profile: WordProfile,
@@ -466,6 +520,7 @@ fn core_word_metadata_from_spec(spec: &crate::builtins::BuiltinSpec) -> Coreword
         partiality: spec.partiality,
         nil_policy: spec.nil_policy,
         safety_level: spec.safety_level,
+        mass: mass_contract(spec.name),
         profile,
         required_capability,
         canonical_home: CanonicalHome::Core,
@@ -486,6 +541,7 @@ pub(crate) fn pure(name: &str, category: &str) -> CorewordMetadata {
         partiality: Partiality::Total,
         nil_policy: NilPolicy::Passthrough,
         safety_level: SafetyLevel::A,
+        mass: mass_contract(name),
         profile: WordProfile::Core,
         required_capability: None,
         canonical_home: CanonicalHome::Core,
@@ -511,6 +567,7 @@ pub(crate) fn observable(
         partiality: Partiality::Partial,
         nil_policy: NilPolicy::RejectsNil,
         safety_level: SafetyLevel::C,
+        mass: mass_contract(name),
         profile: WordProfile::Core,
         required_capability: None,
         canonical_home: CanonicalHome::Core,
@@ -531,6 +588,7 @@ pub(crate) fn effectful(name: &str, category: &str, effects: &[&str]) -> Corewor
         partiality: Partiality::Partial,
         nil_policy: NilPolicy::RejectsNil,
         safety_level: SafetyLevel::D,
+        mass: mass_contract(name),
         profile: WordProfile::Core,
         required_capability: None,
         canonical_home: CanonicalHome::Core,

--- a/rust/src/interpreter/mass_conservation.rs
+++ b/rust/src/interpreter/mass_conservation.rs
@@ -1,0 +1,155 @@
+//! Static mass-conservation validator (SPEC §13.1).
+//!
+//! SPEC §13.1 makes flow-mass conservation a compile/JIT/load-time property: a
+//! Coreword Contract declares arity / consumption / production / bifurcation,
+//! and flow-accounting failures (over-consumption, unconsumed leaks, flow
+//! breaks, bifurcation-ratio violations) must be reported by the compiler/JIT,
+//! loader, or **developer diagnostics** before an optimized path executes. The
+//! optimized path itself already exists (`compiled_plan::execute_compiled_plan`,
+//! gated by `is_plan_valid`).
+//!
+//! This module supplies the missing piece: a pure, diagnostic-only abstract
+//! interpretation over a [`CompiledPlan`]. It reads each word's static
+//! [`MassContract`](crate::coreword_registry::MassContract) (the §7.14 contract
+//! field) and tracks abstract stack depth, reporting over-consumption. It does
+//! **not** gate execution and the ordinary runtime keeps no per-value
+//! `FlowToken` (SPEC §13.1); it is a load-time/diagnostic check.
+//!
+//! The validator abstains (`all_known = false`) the moment it meets a word
+//! whose arity is not statically pinned (`Dynamic`: `STAK` count-folds, vector
+//! ops, user words, fallbacks), since the abstract depth is then unreliable.
+
+use super::compiled_plan::{compile_word_definition, CompiledOp, CompiledPlan};
+use super::Interpreter;
+use crate::coreword_registry::mass_contract;
+use crate::types::{Capabilities, ExecutionLine, Stability, Tier, WordDefinition};
+
+/// Result of statically analyzing a flow for mass conservation. Depths are
+/// measured from an empty starting stack over the statically-known prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MassReport {
+    /// Net stack-depth change contributed by the analyzed (known) prefix.
+    pub net_mass: i64,
+    /// Lowest abstract depth reached over the known prefix. Negative means the
+    /// flow reads more operands than it has produced/been given — i.e. it can
+    /// only run against a pre-existing stack of at least `-min_depth` items.
+    pub min_depth: i64,
+    /// `false` once a `Dynamic`-arity word is reached; the analysis then froze.
+    pub all_known: bool,
+}
+
+impl MassReport {
+    /// A flow is self-contained mass-conserving when, from an empty stack, it
+    /// never over-consumes (never dips below zero) over the known prefix.
+    pub fn over_consumes_from_empty(&self) -> bool {
+        self.min_depth < 0
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Target {
+    Top,
+    Stack,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Consume {
+    Eat,
+    Keep,
+}
+
+/// Abstract-interpret a compiled plan against the static mass contracts.
+pub fn validate_mass_conservation(plan: &CompiledPlan) -> MassReport {
+    let mut cur: i64 = 0;
+    let mut min: i64 = 0;
+    let mut all_known = true;
+    // Modifier state applies to the next word, then resets to the defaults
+    // (TOP / EAT, SPEC §6.1/§6.2).
+    let mut target = Target::Top;
+    let mut consume = Consume::Eat;
+
+    'outer: for line in &plan.lines {
+        for op in &line.ops {
+            match op {
+                CompiledOp::PushLiteral(_) | CompiledOp::PushCodeBlock(_) => {
+                    cur += 1;
+                }
+                CompiledOp::SetTargetModeStackTop => target = Target::Top,
+                CompiledOp::SetTargetModeStack => target = Target::Stack,
+                CompiledOp::SetConsumptionConsume => consume = Consume::Eat,
+                CompiledOp::SetConsumptionKeep => consume = Consume::Keep,
+                CompiledOp::LineBreak | CompiledOp::BeginGuardedBlock => {}
+                CompiledOp::CallBuiltin(name) => {
+                    let canonical = crate::core_word_aliases::canonicalize_core_word_name(name);
+                    // STAK folds the top `count` items — a data-dependent arity
+                    // (§6.1) we cannot pin statically; abstain.
+                    if target == Target::Stack {
+                        all_known = false;
+                        break 'outer;
+                    }
+                    match mass_contract(canonical.as_ref()).fixed() {
+                        Some((consumes, produces)) => {
+                            // The word reads `consumes` operands (a depth dip),
+                            // then pushes `produces`; under KEEP the operands
+                            // are also retained (bifurcation, §13.2).
+                            cur -= consumes as i64;
+                            if cur < min {
+                                min = cur;
+                            }
+                            cur += produces as i64;
+                            if consume == Consume::Keep {
+                                cur += consumes as i64;
+                            }
+                        }
+                        None => {
+                            all_known = false;
+                            break 'outer;
+                        }
+                    }
+                    target = Target::Top;
+                    consume = Consume::Eat;
+                }
+                // User words, qualified words and raw fallbacks have no static
+                // arity here; freeze the analysis.
+                CompiledOp::CallUserWord(_)
+                | CompiledOp::CallQualifiedWord { .. }
+                | CompiledOp::FallbackToken(_) => {
+                    all_known = false;
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    MassReport {
+        net_mass: cur,
+        min_depth: min,
+        all_known,
+    }
+}
+
+/// Developer-diagnostic entry point: tokenize a source flow, compile it to a
+/// plan in the context of `interp` (for word resolution), and statically
+/// validate its mass conservation. This is the load-time/diagnostic check of
+/// SPEC §13.1; it never executes the flow.
+pub fn analyze_source(interp: &Interpreter, src: &str) -> Result<MassReport, String> {
+    let tokens = crate::tokenizer::tokenize(src)?;
+    let def = WordDefinition {
+        lines: vec![ExecutionLine {
+            body_tokens: tokens.into(),
+        }]
+        .into(),
+        is_builtin: false,
+        tier: Tier::Contrib,
+        stability: Stability::Stable,
+        capabilities: Capabilities::PURE,
+        description: None,
+        dependencies: Default::default(),
+        original_source: None,
+        namespace: None,
+        registration_order: 0,
+        execution_plans: None,
+    };
+    let plan = compile_word_definition(&def, interp);
+    Ok(validate_mass_conservation(&plan))
+}

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -25,6 +25,7 @@ pub mod io;
 pub mod json;
 pub mod logic;
 pub mod logic_kleene;
+pub mod mass_conservation;
 pub mod math_ops;
 pub mod modules;
 pub(crate) mod naming_convention_checker;

--- a/rust/src/interpreter/modules/module_builtins.rs
+++ b/rust/src/interpreter/modules/module_builtins.rs
@@ -1,6 +1,7 @@
 use crate::builtins::WordShape;
 use crate::coreword_registry::{
-    self, CanonicalHome, CorewordMetadata, NilPolicy, Partiality, WordProfile, WordPurity,
+    self, CanonicalHome, CorewordMetadata, NilPolicy, Partiality, SafetyLevel, WordProfile,
+    WordPurity,
 };
 use crate::interpreter::{
     algo_ops, audio, datetime, hash, interval_ops, json, math_ops, random, serial, sort, time_ops,
@@ -1341,6 +1342,16 @@ pub(crate) fn module_word_metadata_entries() -> Vec<CorewordMetadata> {
                 {
                     metadata.partiality = partiality;
                     metadata.nil_policy = nil_policy;
+                }
+                // SPEC §7.14: safety A is reserved for *total* words. A pure
+                // word that the override makes `Partial` (it raises on some
+                // well-shaped input, e.g. MATH@GCD / MATH@LCM on non-integers)
+                // must be safety B ("partial but with explicit error
+                // categories"). `Projecting` is total-by-projection and stays A.
+                if metadata.safety_level == SafetyLevel::A
+                    && metadata.partiality == Partiality::Partial
+                {
+                    metadata.safety_level = SafetyLevel::B;
                 }
                 metadata
             })

--- a/rust/src/interpreter/quantized_block.rs
+++ b/rust/src/interpreter/quantized_block.rs
@@ -145,20 +145,12 @@ pub struct QuantizedBlock {
 /// Returns (inputs_consumed, outputs_produced) for well-known pure builtins.
 /// Returns None for unknown or variable-arity builtins.
 fn builtin_arity(name: &str) -> Option<(i32, i32)> {
-    match name {
-        // Binary arithmetic
-        "ADD" | "SUB" | "MUL" | "DIV" | "MOD" => Some((2, 1)),
-        // Binary comparison
-        "LT" | "LTE" | "GT" | "GTE" | "EQ" | "NEQ" => Some((2, 1)),
-        // Binary logical
-        "AND" | "OR" => Some((2, 1)),
-        // Unary arithmetic / math (ABS/NEG paired with FastUnaryMapKernel)
-        "NOT" | "ABS" | "NEG" | "SQRT" | "FLOOR" | "CEIL" | "ROUND" => Some((1, 1)),
-        // Type cast / unary
-        "STR" | "BOOL" => Some((1, 1)),
-        // Unknown arity (vector ops, HOF, stack words not in BUILTIN_SPECS, etc.) → None
-        _ => None,
-    }
+    // Single source of truth: the §7.14 Coreword mass contract. Keeping this a
+    // thin adapter prevents the compiled-plan analyzer and the contract registry
+    // from drifting on arity (SPEC §13.1).
+    crate::coreword_registry::mass_contract(name)
+        .fixed()
+        .map(|(consumes, produces)| (consumes as i32, produces as i32))
 }
 
 /// Returns true if the given builtin name has observable side effects

--- a/rust/tests/contract_modifier_laws.rs
+++ b/rust/tests/contract_modifier_laws.rs
@@ -186,6 +186,15 @@ fn safety_lattice_is_monotone() {
         if m.safety_level == SafetyLevel::A {
             assert_eq!(m.purity, WordPurity::Pure, "{} A must be pure", m.name);
             assert!(m.deterministic, "{} A must be deterministic", m.name);
+            // SPEC §7.14: A is reserved for *total* words. `Projecting` is total
+            // by projection (failures land on NIL), so it qualifies; `Partial`
+            // does not (finding E2, resolved).
+            assert!(
+                matches!(m.partiality, Partiality::Total | Partiality::Projecting),
+                "{} A must be total (or total-by-projection), got {:?}",
+                m.name,
+                m.partiality
+            );
         }
         if !m.effects.is_empty() {
             assert!(
@@ -212,26 +221,28 @@ fn safety_lattice_is_monotone() {
     }
 }
 
-/// **Finding E2 (tracked oracle).** SPEC §7.14 defines safety `A` as
-/// "total, pure, deterministic", yet the registry marks the `Partial` words
-/// `GCD` and `LCM` as `A`. (`Projecting` words such as `POW` are *total by
-/// projection* and reconcile with `A`; `Partial` ones do not.) We assert the
-/// divergence set is *exactly* `{GCD, LCM}` so that fixing the contracts — or a
-/// new mismatch appearing — makes this test fail and forces a spec/impl review
-/// (descriptive discipline: SPECIFICATION.md remains canonical).
+/// **Finding E2 (resolved).** SPEC §7.14 defines safety `A` as "total, pure,
+/// deterministic". `GCD`/`LCM` genuinely raise on non-integer input (they are
+/// `Partial`), so they were corrected from `A` to `B` ("partial but with
+/// explicit error categories"). The invariant now holds with no exceptions:
+/// **no** word is both safety `A` and `Partial`, and `GCD`/`LCM` are `B`. This
+/// guards against regressing the contract.
 #[test]
-fn finding_e2_safety_a_partial_words_are_exactly_gcd_lcm() {
-    let mut a_but_partial: Vec<String> = get_builtin_word_registry()
+fn safety_a_partial_invariant_holds_and_gcd_lcm_are_b() {
+    let a_but_partial: Vec<&str> = get_builtin_word_registry()
         .iter()
         .filter(|m| m.safety_level == SafetyLevel::A && m.partiality == Partiality::Partial)
-        .map(|m| m.name.clone())
+        .map(|m| m.name.as_str())
         .collect();
-    a_but_partial.sort();
-    assert_eq!(
-        a_but_partial,
-        vec!["GCD".to_string(), "LCM".to_string()],
-        "safety-A-but-Partial set drifted; reconcile with SPEC §7.14 finding E2"
+    assert!(
+        a_but_partial.is_empty(),
+        "SPEC §7.14: safety A must be total, but these are A+Partial: {a_but_partial:?}"
     );
+    for w in ["GCD", "LCM"] {
+        let m = get_coreword_metadata(w).unwrap_or_else(|| panic!("no contract {w}"));
+        assert_eq!(m.partiality, Partiality::Partial, "{w}");
+        assert_eq!(m.safety_level, SafetyLevel::B, "{w} must be safety B");
+    }
 }
 
 /// Concrete §7.14 anchor contracts (the narrative examples of §7.14, pinned as

--- a/rust/tests/mass_conservation_laws.rs
+++ b/rust/tests/mass_conservation_laws.rs
@@ -1,0 +1,133 @@
+//! Property-based mass-conservation laws (SPEC §13, finding E1 resolved).
+//!
+//! Encodes the static mass contract (`§9-quater E.3`) now that arity/production
+//! are surfaced into the §7.14 Coreword contract (`CorewordMetadata.mass`) and a
+//! diagnostic-only validator (`interpreter::mass_conservation`) consumes them.
+//!
+//! The central soundness law ties the *static* contract to *observed* mass: for
+//! a flow of fixed-arity words the validator's abstract net depth equals the
+//! real runtime stack depth, and static over-consumption coincides with a
+//! runtime stack underflow. Probed against the reference implementation before
+//! being written (roadmap §1.2-(T) discipline).
+
+mod test_support;
+
+use ajisai_core::coreword_registry::{get_coreword_metadata, mass_contract, MassContract};
+use ajisai_core::interpreter::mass_conservation::analyze_source;
+use ajisai_core::interpreter::Interpreter;
+use proptest::prelude::*;
+use test_support::generators::small;
+
+/// Runtime stack depth, or `None` if the flow errors (e.g. underflow).
+fn runtime_depth(src: &str) -> Option<usize> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let mut interp = Interpreter::new();
+        interp
+            .execute(src)
+            .await
+            .ok()
+            .map(|_| interp.get_stack().len())
+    })
+}
+
+fn analyze(src: &str) -> ajisai_core::interpreter::mass_conservation::MassReport {
+    analyze_source(&Interpreter::new(), src).expect("tokenizes")
+}
+
+// ───────────────────────── contract is surfaced (§7.14/§13.1) ───────────────
+
+/// The mass contract is now a machine-readable §7.14 field, and it is the same
+/// single source the compiled-plan analyzer reads. Fixed for pinned words,
+/// `Dynamic` for data-dependent ones (finding E1 resolved).
+#[test]
+fn mass_contract_is_surfaced_in_the_registry() {
+    let add = get_coreword_metadata("ADD").unwrap();
+    assert_eq!(
+        add.mass,
+        MassContract::Fixed {
+            consumes: 2,
+            produces: 1
+        }
+    );
+    assert_eq!(add.mass, mass_contract("ADD"));
+
+    let not = get_coreword_metadata("NOT").unwrap();
+    assert_eq!(
+        not.mass,
+        MassContract::Fixed {
+            consumes: 1,
+            produces: 1
+        }
+    );
+
+    // GET has a data-dependent / non-consuming profile (finding E3) → Dynamic.
+    assert_eq!(
+        get_coreword_metadata("GET").unwrap().mass,
+        MassContract::Dynamic
+    );
+}
+
+// ─────────────────── validator soundness vs observed mass ───────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    /// **Soundness.** For a flow built only from fixed-arity words, the static
+    /// net mass equals the observed runtime stack depth, and the flow is not
+    /// flagged as over-consuming.
+    #[test]
+    fn static_net_mass_matches_runtime_depth(
+        a in small(), b in small(), c in small(),
+        w1 in prop_oneof![Just("ADD"), Just("MUL"), Just("SUB")],
+        w2 in prop_oneof![Just("ADD"), Just("MUL"), Just("SUB")],
+    ) {
+        // a b w1 c w2 : push a,b -> w1 (->1) ; push c -> w2 (->1). Net = 1.
+        let src = format!("{a} {b} {w1} {c} {w2}");
+        let report = analyze(&src);
+        prop_assert!(report.all_known, "should be fully known: {src}");
+        prop_assert!(!report.over_consumes_from_empty(), "{src}");
+        prop_assert_eq!(report.net_mass, runtime_depth(&src).unwrap() as i64);
+    }
+
+    /// **KEEP changes net mass by exactly the production** (§13.2 bifurcation):
+    /// `a b KEEP w` retains its `consumes` operands, so its static net mass
+    /// exceeds `a b w` by `consumes` (= 2 for a binary word).
+    #[test]
+    fn keep_raises_static_net_mass_by_arity(a in small(), b in small()) {
+        let eat = analyze(&format!("{a} {b} ADD")).net_mass;
+        let keep = analyze(&format!("{a} {b} KEEP ADD")).net_mass;
+        prop_assert_eq!(keep - eat, 2);
+    }
+}
+
+/// **Over-consumption ⇔ runtime underflow.** A flow that reads more operands
+/// than it is given dips below zero statically and underflows at runtime.
+#[test]
+fn static_over_consumption_coincides_with_runtime_underflow() {
+    // `5 ADD`: one operand for a binary word.
+    let report = analyze("5 ADD");
+    assert!(
+        report.over_consumes_from_empty(),
+        "static must flag over-consumption"
+    );
+    assert_eq!(runtime_depth("5 ADD"), None, "runtime must underflow");
+
+    // A balanced flow does neither.
+    let ok = analyze("2 3 ADD");
+    assert!(!ok.over_consumes_from_empty());
+    assert_eq!(runtime_depth("2 3 ADD"), Some(1));
+}
+
+/// The validator **abstains** (does not claim mass knowledge) on data-dependent
+/// arity: the `STAK` count-fold and runtime-shaped vector ops are `Dynamic`.
+#[test]
+fn validator_abstains_on_dynamic_arity() {
+    assert!(
+        !analyze("1 2 3 3 STAK ADD").all_known,
+        "STAK is count-driven"
+    );
+    assert!(!analyze("[ 1 2 3 ] 0 GET").all_known, "GET is Dynamic");
+}


### PR DESCRIPTION
## 概要

Phase 3 で記録した未解決 finding 2 件（仕様改訂の判断が保留だったもの）を、あなたの判断に従い解決しました。

- **E2 → 実装修正（safety B）**
- **E1 → JIT 実装（質量契約＋静的検証器・診断のみ）**

## E1 — 質量保存契約と静的検証器（SPEC §13.1 の load-time ゲートを実装）

最適化経路 `CompiledPlan`／`execute_compiled_plan` は既存。不足していた「質量契約＋静的検証」を実装:

- **機械可読な質量契約を §7.14 へ露出**: `CorewordMetadata.mass : Fixed{consumes,produces} | Dynamic` を追加。arity/consumption/production を担い、bifurcation は KEEP 修飾子（§13.2）、NIL 射影は `nil_policy` が担う。
- **単一の真実源**: `coreword_registry::mass_contract` を新設し、コンパイル済みプラン解析器 `quantized_block::builtin_arity` はこれに委譲（解析器と契約レジストリが乖離しない）。値はプローブで実挙動検証済み（binary=2→1, NOT=1→1）。
- **静的検証器** `interpreter::mass_conservation::validate_mass_conservation`: `CompiledPlan` を抽象解釈し、過消費（空スタックからの深さが負）を **診断として**報告。実行 gating は変更せず、実行時は per-value `FlowToken` を持たない（§13.1 厳守）。`Dynamic` 語（STAK 畳み込み・ベクタ操作・ユーザ語）では abstain。
- SPEC §7.14 のフィールド表に `mass` を追記、§13.1 を整合的に改訂。

## E2 — GCD/LCM の safety（実装を §7.14 へ一致）

`MATH@GCD`/`MATH@LCM` は非整数入力で**実際にエラーを出す真の `Partial`**（誤分類ではない）。§7.14「A: total」に反する `A` を、上書きで `Partial` になった純粋語は `B`（partial but explicit error categories）へ補正。`Projecting` の `POW`/`INDEX-OF`/`PARSE-ISO` は total-by-projection で `A` 据置。以後「safety A ⟹ partiality ∈ {Total, Projecting}」が反例なく成立。

## テスト（プローブで実挙動を確認してから法則化）

- 新規 `rust/tests/mass_conservation_laws.rs`（5 群）: 質量契約の §7.14 露出 / **静的 net mass = 実行時スタック深さ**（健全性）/ **過消費 ⇔ 実行時 underflow** / KEEP の net mass 増分 = arity / Dynamic で abstain。
- `rust/tests/contract_modifier_laws.rs`: safety 格子法則を強化（A⟹{Total,Projecting}）、E2 オラクルを**解消済み不変条件**（A+Partial 皆無・GCD/LCM=B）へ転換。
- 形式化本体 §9-quater E.3/E.5 を「解消済み」へ更新、§10 HOLDS 表も更新。

## 検証

- `cargo test --tests` … 全 10 binary グリーン（lib 1240 + 全 law スイート）、回帰なし。
- レジストリ構造体への `mass` フィールド追加は serialize 追加のみ（WASM は registry を丸ごと serialize、TS/JSON の golden に契約フィールド参照なし）。
- 触れたファイルのみ rustfmt 整形・clippy クリーン（無関係な整形差分は revert 済み。残 warning は既存 lib 由来）。

これで Phase 3 の finding はすべて解消。残フェーズは 6（名前解決）/7（効果）/8（並行）/9（統合）。

https://claude.ai/code/session_01LkCsXRwULvazmzXdUiEpHq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkCsXRwULvazmzXdUiEpHq)_