### PR TITLE
Formalize Phases 6–9: name resolution, effects, child runtimes, records/strings (⟦·⟧ coverage closure)

### DIFF
--- a/docs/dev/ajisai-formalization-expansion-roadmap.md
+++ b/docs/dev/ajisai-formalization-expansion-roadmap.md
@@ -39,9 +39,9 @@
 | §7.5 | K3 論理 | Defined | De Morgan(Kleene)束 |
 | §7.6 | 文字列・変換 | Absent | 符号点列・符号化契約 |
 | §7.7 | 高階・制御語 | **Defined**(Phase 4 済) | 再帰スキーム(cata/ana/…)・K3 ガード case |
-| §7.8 / §8 | ユーザ辞書・DEF | Absent | `Dict` 上の状態変換子・依存グラフ |
+| §7.8 / §8 | ユーザ辞書・DEF | **Defined**(Phase 6 済) | `Dict` 上の状態変換子・依存グラフ |
 | §7.9 | IO・ユーティリティ | Absent | 効果ラベル・非決定性の分離 |
-| §7.10 / §9 | モジュール・名前解決 | Absent | 可視性格子・決定的 `resolve` |
+| §7.10 / §9 | モジュール・名前解決 | **Defined**(Phase 6 済) | 可視性格子・決定的 `resolve` |
 | §7.11 / §10 | 子ランタイム(並行) | Absent | 状態機械・小ステップ計算(探索的) |
 | §7.14 | Coreword 契約 | **Defined**(Phase 3 済) | Hoare 契約+部分性/効果/安全性の格子 |
 | §11 | 誤差モデル・Bubble Rule | Defined(述語は Sketched) | `Σ+Error` 二層・整形/不整形述語 |
@@ -49,11 +49,11 @@
 | §2.3 | 観測軸(protocol) | **Defined**(Phase 1 済) | 観測代数 `observe` を semantic axes で |
 
 当初「Ajisai のごく一部」だった被覆は、Phase 1(観測基盤)・Phase 2(構文)・
-Phase 3(修飾子・契約・質量保存)・Phase 4(高階語)・Phase 5(構造データ)の完了で
-言語表層の中核へ拡大した。残る `Absent` はレコード・文字列・辞書/名前解決・効果/IO・
-並行性であり、新セッションで Phase 6/7/8/9 として取り組む。各完了フェーズの定義は
-形式化本体 §9-bis / §9-ter / §9-quater、法則は
-`rust/tests/{observation,desugar,contract_modifier,higher_order,structural}_laws.rs`。
+Phase 3(修飾子・契約・質量保存)・Phase 4(高階語)・Phase 5(構造データ)・
+Phase 6(名前解決・辞書)の完了で言語表層の中核へ拡大した。残る `Absent` は
+レコード・文字列・効果/IO・並行性であり、Phase 7/8/9 として取り組む。各完了フェーズの
+定義は形式化本体 §9-bis / §9-ter / §9-quater / §9-quinquies、法則は
+`rust/tests/{observation,desugar,contract_modifier,higher_order,structural,naming_resolution}_laws.rs`。
 
 ### 0.3 進捗(本セッション)
 
@@ -64,7 +64,8 @@ Phase 3(修飾子・契約・質量保存)・Phase 4(高階語)・Phase 5(構造
 | 3 ⭐契約・修飾子・質量保存 | ✅ 完了 | 本体 §9-quater E | `rust/tests/contract_modifier_laws.rs`(11 群) |
 | 4 高階・制御語 | ✅ 完了 | 本体 §9-bis B | `rust/tests/higher_order_laws.rs`(11 群) |
 | 5 構造データ | ✅ 完了 | 本体 §9-bis C | `rust/tests/structural_laws.rs`(10 群) |
-| 6,7,8,9 | 未着手 | — | 新セッション |
+| 6 名前解決・辞書 | ✅ 完了 | 本体 §9-quinquies F | `rust/tests/naming_resolution_laws.rs`(18 群) |
+| 7,8,9 | 未着手 | — | 新セッション |
 
 ---
 

--- a/docs/dev/ajisai-mathematical-formalization.md
+++ b/docs/dev/ajisai-mathematical-formalization.md
@@ -615,6 +615,115 @@ Projecting の NIL 射影、契約の全域性(全語が到達可能契約を持
 
 ---
 
+## 9-quinquies. 拡張定式化 IV — 名前解決と辞書(Phase 6, 2026-06 改修)
+
+本節は改修ロードマップ Phase 6(名前解決と辞書=モジュール・DEF)の成果を取り込む。
+語名はもはや「裸の文字列」ではなく、**辞書状態 `Σ_dict` に相対的な束縛**である。
+SPEC §7.8/§8(ユーザ辞書・DEF/DEL)・§7.10/§9(モジュール・IMPORT)・§7.14
+(`canonical_home`/`listed_*` 契約フィールド)の現象を、決定的な解決関数と
+可視性格子上の単調作用素として記述する。本節は仕様を追い越さない(§16.1)。
+
+### F. 辞書・決定的 `resolve`・可視性格子(Phase 6)
+
+#### F.1 辞書と解決の対象領域
+
+辞書を三層の有限写像とする(SPEC §4.6・§7.8・§9):
+
+```
+Core : Name ⇀ Blk          (核語彙、不変)
+Mod  : Module → (Name ⇀ Blk)   (モジュール辞書、キャッシュ)
+Usr  : Dict   → (Name ⇀ Blk)   (ユーザ辞書、既定 DICT=DEMO)
+```
+
+可視性状態 `Vis` は import 表 `Module ⇀ {all | W⊆Name}`(全公開取込か明示部分取込)と
+ユーザ辞書からなる。語名は §3.8 で大文字へ正規化される(`sqrt ≡ SQRT`、`%≡MOD`,
+`&≡AND`)ので、`resolve` の定義域は正規化済み `Name`。
+
+#### F.2 `resolve` は決定的な可視性相対関数
+
+解決を
+
+```
+resolve : Name × Vis ⇀ Blk + Unknown
+```
+
+とし、裸名の解決順は **Core → 取込済みモジュール語 → (モジュール sample / ユーザ語)**
+で固定する(参照実装 `resolve_short_name`):
+
+```
+resolve(w, Vis) =
+  Core[w]                          if w ∈ dom Core            -- (1) 核が最優先
+  Mod[m][m@w]   (m: w を取込済みの最初のモジュール)            -- (2) 取込モジュール語
+  最小 registration_order の一致    if sample/user に一意一致    -- (3) 残りは登録順で決定的
+  Unknown                          otherwise
+```
+
+`(3)` で **モジュール sample とユーザ語が両方一致すると曖昧** として
+`Unknown`(=解決失敗)を返す。修飾名は層で解決する:`CORE@w` は核へ、`m@w` は
+モジュール `m` の取込済み語へ、`USER@d@w`・`DICT@…` は各辞書へ(`split_path`)。
+**中心性質——決定性**: `resolve` は評価履歴に依らず `(Name, Vis)` のみの関数であり、
+同じ状態で同じ名は常に同じ束縛へ解決する。
+
+#### F.3 DEF/DEL は辞書状態変換子(依存グラフ `FORC`)
+
+`DEF`/`DEL` を `Σ_dict` 上の変換子として与える(SPEC §8):
+
+```
+⟦{b} 'w' DEF⟧ : Usr[DEMO][w] := b      (核語は不可=「built-in 再定義不可」)
+⟦'w' DEL⟧     : Usr[DEMO] ∖ w
+```
+
+定義時に本体トークンを `resolve` して**依存グラフ** `dependents : Name → 2^Name` を
+構成する(`rebuild_dependencies`)。被参照語の再定義・削除は **`FORC` ガード**で
+保護され、力修飾子 `!` なしでは拒否される(`{requires: deps=∅ ∨ forced}`、§8.2)。
+解決面での法則:`DEF` は名を可視化し定義本体の変換子を束ね、`DEL` はそれを左から
+打ち消す——新鮮名 `w` について `resolve(w) = Unknown`、`DEF` 後 `= b`、`DEL` 後
+再び `Unknown`(可視性に対する **DEF/DEL の往復恒等**)。
+
+#### F.4 IMPORT/UNIMPORT は可視性格子の単調作用素
+
+import 状態を包含で順序づけた格子 `(Vis, ⊑)` 上で(SPEC §9.2):
+
+| 作用素 | 効果 | 法則 |
+|---|---|---|
+| `IMPORT` | `Vis[m] := all` | **冪等** `IMPORT_m ∘ IMPORT_m = IMPORT_m`(単調・上昇) |
+| `IMPORT-ONLY S` | `Vis[m] := Vis[m] ∪ S` | 選択的:`S` のみ可視化、兄弟語は不可視のまま |
+| `UNIMPORT` | 被参照語を保つ最小可視へ縮小 | **参照保存**:ユーザ語が指す `m@w` は残し残余を隠す |
+| `UNIMPORT-ONLY S` | `S` を個別に隠す | 被参照セレクタは**拒否**(辞書 UNIMPORT を要求) |
+
+`IMPORT` と `UNIMPORT` は、被参照語が無いとき**互いに逆**:`IMPORT_m` 後に
+`UNIMPORT_m` すると裸名・修飾名の双方が import 前の `Unknown` へ戻る。境界語の
+**`bare ≡ m@w`**:`m` 取込後、正準モジュール語は裸名でも `m@w` でも同一に観測される
+(SPEC §7.14)。`core-listed` セレクタ(モジュール view に列挙されるが正準は核の語、
+例 `IO` の `PRINT`)の `IMPORT-ONLY`/`UNIMPORT-ONLY` は **no-op**(既に核で可用、
+警告のみ)。`canonical_home`/`listed_in_*`(§7.14)はこの作用素群の静的台帳であり、
+裸名が複数の正準ホームを持つとき(例 核 `GET` と `JSON@GET`)契約照会は**核を優先**
+する(実行時解決順に一致)。
+
+#### F.5 所見(finding)
+
+- **所見 F1(修飾解決は import ゲート付き)— 追跡中:** 静的契約レジストリ
+  `get_coreword_metadata("MATH@SQRT")` は **常に**モジュール項へ到達する(SPEC §7.14
+  「`MODULE@WORD` always reaches the module entry」)が、**実行時**の `m@w` 解決は
+  `IMPORT` を要する(`4 MATH@SQRT` は未取込で `Unknown`)。すなわち §7.14 の到達性
+  言明は**静的台帳の性質**であり、実行時可視性はそれに import ゲートを重ねる。
+  乖離ではなく層の分離だが、両者を混同しないようガード付きオラクルで固定。
+- **所見 F2(取込モジュール語は同名ユーザ語を遮蔽)— 追跡中:** 解決順が
+  Core→取込モジュール→ユーザであるため、ユーザが先に `SQRT` を定義していても
+  `'math' IMPORT` 後の裸 `SQRT` は **MATH@SQRT** に解決する(ユーザ語ではない)。
+  自分の定義が勝つという素朴な期待と異なる決定的順序であり、オラクルで固定。
+  到達可能状態では一貫(曖昧は §F.2(3) で `Unknown` 化)。
+
+**テスト**: `rust/tests/naming_resolution_laws.rs` — 境界語 `bare≡m@w`、IMPORT 冪等、
+解決決定性、核語は import で遮蔽されない、F2 遮蔽、DEF 本体インライン、DEF/DEL 往復、
+`FORC` ガード(再定義・削除の `!`)、built-in 再定義不可、UNIMPORT が import を逆転、
+UNIMPORT の参照保存、UNIMPORT-ONLY の被参照拒否、IMPORT-ONLY の選択性・core-listed
+no-op、レジストリの canonical_home/核優先・修飾到達・F1 import ゲート(計 18 法則群)。
+生成器は `rust/tests/test_support/generators.rs` に `module_word_call`/`user_word_name`
+/`user_word_body` を追加。
+
+---
+
 ## 10. 付録 — 経験的法則チェック(参照実装 2026-06)
 
 参照実装に直接プログラムを流して §9.2 の法則を確認した結果。
@@ -650,6 +759,11 @@ Projecting の NIL 射影、契約の全域性(全語が到達可能契約を持
 | 所見 E1: 質量契約 `mass` を §7.14 へ露出・静的検証器を実装 | HOLDS(解消) | §9-quater E.5、`tests/mass_conservation_laws.rs` |
 | 静的 net mass=実行時深さ・過消費⇔underflow・KEEP増分=arity | HOLDS | `tests/mass_conservation_laws.rs` |
 | 所見 E2: safety A⟹{Total,Projecting}(GCD/LCM を B へ修正) | HOLDS(解消) | §9-quater E.5、`tests/contract_modifier_laws.rs` |
+| 境界語 `bare≡m@w`・IMPORT 冪等・解決決定性・核語は import で非遮蔽(§9-quinquies F) | HOLDS | `tests/naming_resolution_laws.rs` |
+| DEF 本体インライン・DEF/DEL 往復・`FORC` ガード(`!`)・built-in 再定義不可 | HOLDS | `tests/naming_resolution_laws.rs` |
+| UNIMPORT が import を逆転・参照保存・UNIMPORT-ONLY 被参照拒否・IMPORT-ONLY 選択/core-listed no-op | HOLDS | `tests/naming_resolution_laws.rs` |
+| 所見 F1: 修飾解決は import ゲート(静的台帳は常に到達) | HOLDS(層分離) | §9-quinquies F.5、追跡中 |
+| 所見 F2: 取込モジュール語が同名ユーザ語を遮蔽(Core→mod→user) | HOLDS(到達可能) | §9-quinquies F.5、追跡中 |
 
 健全な核(有理算術・K3 論理・NIL モナド・モノイド合成)は法則を満たす。
 かつて §9.3 にあった二つの破れ(B: T=1 の型混同、C: 無理数の近似表示)は

--- a/rust/tests/naming_resolution_laws.rs
+++ b/rust/tests/naming_resolution_laws.rs
@@ -1,0 +1,361 @@
+//! Property-based name-resolution / dictionary / module laws (Phase 6).
+//!
+//! Encodes the algebraic content of
+//! `docs/dev/ajisai-mathematical-formalization.md` §9-quinquies F (Phase 6):
+//! the dictionary `Dict = Name ⇀ Blk`, the deterministic resolver
+//! `resolve : Name × Vis ⇀ Blk + Unknown` with order **Core → imported module →
+//! user**, `DEF`/`DEL` as state transducers with a dependency guard (`FORC`,
+//! SPEC §8.2), and `IMPORT`/`IMPORT-ONLY`/`UNIMPORT`/`UNIMPORT-ONLY` as
+//! monotone visibility operators (SPEC §9.2).
+//!
+//! Every law was checked against the reference implementation with a throwaway
+//! probe (`_probe_naming.rs`, deleted) before being written (roadmap §1.2-(T)
+//! discipline). The two surprises the probe surfaced are recorded as
+//! §9-quinquies F.5 findings and pinned here as guarded oracles:
+//!   * **F1** — runtime `MODULE@WORD` resolution is *import-gated*: the static
+//!     contract registry always reaches the module entry, but the runtime only
+//!     resolves it after `IMPORT` (`4 MATH@SQRT` is `Unknown` un-imported).
+//!   * **F2** — an imported module word *shadows a same-named user word* (the
+//!     resolver checks imported modules before user dictionaries).
+//!
+//! Observation stays firewall-clean: laws compare whole-stack renders / the
+//! Ok-vs-Err resolution outcome, never a Rust enum or `Debug` string. The few
+//! registry-level invariants read the public contract metadata (SPEC §7.14
+//! listing fields), mirroring `contract_modifier_laws.rs`.
+
+mod test_support;
+
+use ajisai_core::coreword_registry::{
+    get_builtin_word_registry, get_coreword_metadata, CanonicalHome,
+};
+use ajisai_core::interpreter::Interpreter;
+use proptest::prelude::*;
+use test_support::generators::{module_word_call, small, user_word_body, user_word_name};
+use test_support::observe::{render, run};
+
+// ─────────────────────────── observation helpers ───────────────────────────
+
+/// Whole-stack rendering (one value per element), the conformance observation.
+fn obs(src: &str) -> Vec<String> {
+    run(src).iter().map(|v| render(v, v.hint)).collect()
+}
+
+/// The resolution *outcome* of a program: `Ok(stack-render)` when every word
+/// resolved and ran, `Err(())` when resolution (or execution) failed. This is
+/// the firewall-clean way to observe "does this name resolve here" — we never
+/// inspect the error text, only whether a binding was found.
+fn outcome(src: &str) -> Result<Vec<String>, ()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio current-thread runtime");
+    rt.block_on(async {
+        let mut interp = Interpreter::new();
+        match interp.execute(src).await {
+            Ok(()) => Ok(interp
+                .get_stack()
+                .iter()
+                .map(|v| render(v, v.hint))
+                .collect()),
+            Err(_) => Err(()),
+        }
+    })
+}
+
+// ───────────────── resolve : Name × Vis ⇀ Blk + Unknown (§7/§9) ──────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    /// **Boundary-word resolution `bare ≡ MODULE@WORD`** (roadmap Phase 6,
+    /// SPEC §7.14). After `'M' IMPORT`, a canonical module word is reachable
+    /// under its bare name and under `M@WORD`, and both observe identically.
+    #[test]
+    fn bare_equals_qualified_after_import((m, bare, qual) in module_word_call()) {
+        let via_bare = obs(&format!("'{m}' IMPORT {bare}"));
+        let via_qual = obs(&format!("'{m}' IMPORT {qual}"));
+        prop_assert_eq!(via_bare, via_qual);
+    }
+
+    /// **IMPORT is idempotent** (monotone visibility operator, SPEC §9.2):
+    /// importing a module `k ≥ 1` times leaves the same vocabulary as importing
+    /// it once. Observed by running the same word call after `k` imports.
+    #[test]
+    fn import_is_idempotent((m, bare, _q) in module_word_call(), k in 1usize..4) {
+        let once = obs(&format!("'{m}' IMPORT {bare}"));
+        let imports = format!("'{m}' IMPORT ").repeat(k);
+        prop_assert_eq!(once, obs(&format!("{imports}{bare}")));
+    }
+
+    /// **Resolution determinism.** `resolve` is a function of the import/def
+    /// state, not of evaluation history: the same program in the same starting
+    /// state always observes the same stack (run twice, fresh interpreter each
+    /// time — the harness builds a new `Interpreter` per `run`).
+    #[test]
+    fn resolution_is_deterministic((m, bare, qual) in module_word_call()) {
+        let prog = format!("'{m}' IMPORT {bare} {qual}");
+        prop_assert_eq!(obs(&prog), obs(&prog));
+    }
+
+    /// **Core precedence — import never shadows a Canonical Core word.** Bare
+    /// `GET` is core (`canonical_home = Core`), so it resolves to the core
+    /// vector index whether or not `JSON` (which also lists a `GET`) is
+    /// imported. The observation is invariant under the import.
+    #[test]
+    fn core_word_is_not_shadowed_by_import(xs in prop::collection::vec(small(), 1..4), i in 0usize..3) {
+        let body = xs.iter().map(i64::to_string).collect::<Vec<_>>().join(" ");
+        let plain = obs(&format!("[ {body} ] {i} GET"));
+        let after_import = obs(&format!("'json' IMPORT [ {body} ] {i} GET"));
+        prop_assert_eq!(plain, after_import);
+    }
+
+    /// **F2 (finding) — an imported module word shadows a same-named user
+    /// word.** The resolver order is Core → imported module → user, so after a
+    /// user `SQRT` is defined *and* `MATH` is imported, bare `SQRT` runs the
+    /// module word, not the user word. Pinned as a guarded oracle.
+    #[test]
+    fn imported_module_shadows_user_word(n in 2i64..12) {
+        let sq = n * n;
+        // user SQRT would add 99; module SQRT takes the root.
+        let prog = format!("{{ 99 ADD }} 'SQRT' DEF 'math' IMPORT {sq} SQRT");
+        prop_assert_eq!(obs(&prog), vec![format!("{n}/1")]);
+    }
+}
+
+// ─────────────── DEF / DEL as Dict state transducers (§8) ────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(40))]
+
+    /// **DEF makes a name resolvable; the defined word equals its inlined
+    /// body.** `{body} 'W' DEF  x W  ≡  x body` — defining then calling is the
+    /// identity on the body transducer (SPEC §8.1).
+    #[test]
+    fn def_then_call_inlines_body(name in user_word_name(), (body, inline) in user_word_body(), x in small()) {
+        let defined = obs(&format!("{{ {body} }} '{name}' DEF {x} {name}"));
+        let inlined = obs(&format!("{x} {inline}"));
+        prop_assert_eq!(defined, inlined);
+    }
+
+    /// **DEF then DEL is the identity on resolution.** A name is `Unknown`
+    /// before definition and `Unknown` again after deletion — `DEL` is the left
+    /// inverse of `DEF` on the visibility of a fresh name (SPEC §8.3).
+    #[test]
+    fn def_del_round_trip_restores_unknown(name in user_word_name(), (body, _i) in user_word_body(), x in small()) {
+        let fresh = format!("{x} {name}");
+        let defined = format!("{{ {body} }} '{name}' DEF {x} {name}");
+        let def_del = format!("{{ {body} }} '{name}' DEF '{name}' DEL {x} {name}");
+        // Fresh name resolves to Unknown.
+        prop_assert!(outcome(&fresh).is_err());
+        // Defined → resolves.
+        prop_assert!(outcome(&defined).is_ok());
+        // Defined then deleted → Unknown again.
+        prop_assert!(outcome(&def_del).is_err());
+    }
+}
+
+// ─────────── dependency guard `FORC` (§8.2) — DEF/DEL need `!` ────────────────
+
+/// **Redefining a word with active dependents requires the force modifier `!`.**
+/// Without `!` the redefinition is rejected and the dictionary is unchanged;
+/// with `!` it succeeds and the dependent observes the new definition
+/// (SPEC §8.2). This is the `FORC` guard of the dependency graph.
+#[test]
+fn redefine_with_dependents_needs_force() {
+    // INC2 depends on INC. Redefining INC without `!` is rejected.
+    let no_force = "{ 1 ADD } 'INC' DEF { INC INC } 'INC2' DEF { 2 ADD } 'INC' DEF 5 INC2";
+    assert!(
+        outcome(no_force).is_err(),
+        "redefining a dependency without ! must fail"
+    );
+
+    // With `!`, the redefinition lands and INC2 sees the new INC (5+2+2 = 9).
+    let forced = "{ 1 ADD } 'INC' DEF { INC INC } 'INC2' DEF { 2 ADD } 'INC' ! DEF 5 INC2";
+    assert_eq!(outcome(forced), Ok(vec!["9/1".to_string()]));
+}
+
+/// **Deleting a word with active dependents requires `!`** (SPEC §8.2/§8.3).
+/// Without `!`, deletion is rejected (the dependent keeps working); with `!`
+/// the word is gone and the dependent can no longer resolve it.
+#[test]
+fn delete_with_dependents_needs_force() {
+    // Without `!`, the guard fires and the delete is rejected (raises an error).
+    let no_force = "{ 1 ADD } 'INC' DEF { INC INC } 'INC2' DEF 'INC' DEL";
+    assert!(
+        outcome(no_force).is_err(),
+        "deleting a referenced word without ! must fail"
+    );
+
+    // With `!`, the delete succeeds and the program completes cleanly.
+    let forced_ok = "{ 1 ADD } 'INC' DEF { INC INC } 'INC2' DEF 'INC' ! DEL 42";
+    assert_eq!(outcome(forced_ok), Ok(vec!["42/1".to_string()]));
+
+    // …and after the forced delete the dependent can no longer resolve INC.
+    let forced_orphan = "{ 1 ADD } 'INC' DEF { INC INC } 'INC2' DEF 'INC' ! DEL 5 INC2";
+    assert!(
+        outcome(forced_orphan).is_err(),
+        "after forced delete the dependent must not resolve"
+    );
+}
+
+/// **Built-in words cannot be redefined** (SPEC §8.2): `DEF` of a Canonical
+/// Core name is rejected outright, independent of `!`. The core vocabulary is
+/// immutable from user space.
+#[test]
+fn builtin_words_cannot_be_redefined() {
+    for w in ["ADD", "GET", "EQ"] {
+        assert!(
+            outcome(&format!("{{ 0 }} '{w}' DEF")).is_err(),
+            "redefining built-in {w} must be rejected"
+        );
+    }
+}
+
+// ────────── IMPORT / UNIMPORT visibility operators (§9.2) ────────────────────
+
+/// **UNIMPORT of an unreferenced full import restores the pre-import state.**
+/// After `'M' IMPORT … 'M' UNIMPORT`, the module word is hidden again under
+/// both its bare and qualified names — `UNIMPORT` is the inverse of `IMPORT`
+/// on unreferenced visibility (SPEC §9.2).
+#[test]
+fn unimport_inverts_unreferenced_import() {
+    // qualified hidden before import, visible after import, hidden after unimport.
+    assert!(outcome("'[1]' JSON@PARSE").is_err());
+    assert!(outcome("'json' IMPORT '[1]' JSON@PARSE").is_ok());
+    assert!(outcome("'json' IMPORT 'json' UNIMPORT '[1]' JSON@PARSE").is_err());
+    // bare name too.
+    assert!(outcome("'json' IMPORT 'json' UNIMPORT '[1]' PARSE").is_err());
+}
+
+/// **UNIMPORT keeps words referenced by a user word visible** (SPEC §9.2):
+/// a full import shrinks to an explicit partial-import that preserves exactly
+/// the referenced module word, hiding the rest.
+#[test]
+fn unimport_preserves_referenced_words() {
+    // USE-PARSE references JSON@PARSE; after UNIMPORT the reference still resolves.
+    let keep = "'json' IMPORT { JSON@PARSE } 'USE-PARSE' DEF 'json' UNIMPORT '[1]' USE-PARSE";
+    assert_eq!(outcome(keep), Ok(vec!["[ 1/1 ]".to_string()]));
+    // …but an unreferenced sibling (STRINGIFY) is hidden by the same UNIMPORT.
+    let drop_sibling =
+        "'json' IMPORT { JSON@PARSE } 'USE-PARSE' DEF 'json' UNIMPORT '[1]' JSON@STRINGIFY";
+    assert!(outcome(drop_sibling).is_err());
+}
+
+/// **UNIMPORT-ONLY of a referenced word is rejected** (SPEC §9.2): a selector
+/// pinned by a user word cannot be hidden piecemeal; dictionary-level UNIMPORT
+/// is required. The vocabulary is unchanged on rejection.
+#[test]
+fn unimport_only_rejects_referenced_selector() {
+    let prog =
+        "'json' IMPORT { JSON@PARSE } 'USE-PARSE' DEF 'json' [ 'parse' ] UNIMPORT-ONLY '[1]' USE-PARSE";
+    assert!(
+        outcome(prog).is_err(),
+        "UNIMPORT-ONLY of a referenced selector must be rejected"
+    );
+}
+
+/// **IMPORT-ONLY brings exactly the selected word, not its siblings** (SPEC
+/// §9.2): `'math' [ 'sqrt' ] IMPORT-ONLY` exposes bare `SQRT` but leaves `GCD`
+/// (another MATH word) `Unknown`.
+#[test]
+fn import_only_is_selective() {
+    assert!(outcome("'math' [ 'sqrt' ] IMPORT-ONLY 4 SQRT").is_ok());
+    assert!(outcome("'math' [ 'sqrt' ] IMPORT-ONLY 3 4 GCD").is_err());
+}
+
+/// **IMPORT-ONLY of a core-listed selector is a silent no-op** (SPEC §7.14,
+/// §9.2): `PRINT` is a Canonical Core word merely *listed* in the `IO` view, so
+/// selecting it is skipped with a warning and the rest of the run proceeds —
+/// the word was already available without import.
+#[test]
+fn import_only_core_listed_selector_is_noop() {
+    // The run succeeds (no error) and PRINT is usable regardless.
+    assert_eq!(
+        outcome("'io' [ 'print' ] IMPORT-ONLY 7"),
+        Ok(vec!["7/1".to_string()])
+    );
+    // A selector matching neither a canonical word nor a listing is an error.
+    assert!(outcome("'json' [ 'nope' ] IMPORT-ONLY 7").is_err());
+}
+
+// ──────────── registry oracles: canonical_home / listing fields (§7.14) ──────
+
+/// **Every word declares a `canonical_home`, and bare lookup of an overlapping
+/// name resolves to Core** (SPEC §7.14): a bare name that exists both as a
+/// Canonical Core word and a module word (e.g. `GET` = core / `JSON@GET`)
+/// resolves to the Core entry under `get_coreword_metadata`, matching the
+/// runtime resolution order.
+#[test]
+fn registry_canonical_home_and_core_preference() {
+    let reg = get_builtin_word_registry();
+    assert!(!reg.is_empty());
+
+    // Bare names that appear under more than one canonical home.
+    let mut homes: std::collections::BTreeMap<&str, Vec<&CanonicalHome>> = Default::default();
+    for m in reg {
+        homes
+            .entry(m.name.as_str())
+            .or_default()
+            .push(&m.canonical_home);
+    }
+    let overlapping: Vec<&str> = homes
+        .iter()
+        .filter(|(_, hs)| hs.len() > 1)
+        .map(|(n, _)| *n)
+        .collect();
+    // There is at least one overlapping name (GET) and bare lookup prefers Core.
+    assert!(
+        overlapping.contains(&"GET"),
+        "expected GET to overlap Core/Module"
+    );
+    for name in overlapping {
+        let bare = get_coreword_metadata(name).unwrap_or_else(|| panic!("no contract {name}"));
+        if homes[name].iter().any(|h| matches!(h, CanonicalHome::Core)) {
+            assert_eq!(
+                bare.canonical_home,
+                CanonicalHome::Core,
+                "bare {name} must resolve to its Core home (SPEC §7.14)"
+            );
+        }
+    }
+}
+
+/// **`MODULE@WORD` always reaches the module entry in the contract registry,
+/// and a canonical module word lists its own module** (SPEC §7.14). This is the
+/// *static* reachability that finding F1 contrasts with import-gated runtime
+/// resolution.
+#[test]
+fn registry_qualified_reaches_module_entry() {
+    for (q, module) in [
+        ("MATH@SQRT", "MATH"),
+        ("JSON@PARSE", "JSON"),
+        ("ALGO@SORT", "ALGO"),
+    ] {
+        let m = get_coreword_metadata(q).unwrap_or_else(|| panic!("no contract {q}"));
+        assert_eq!(
+            m.canonical_home,
+            CanonicalHome::Module(module.to_string()),
+            "{q}"
+        );
+        assert!(
+            m.listed_in_modules.iter().any(|x| x == module),
+            "{q} must list its own module"
+        );
+    }
+}
+
+/// **Finding F1 (guarded oracle).** Runtime `MODULE@WORD` resolution is
+/// import-gated even though the static registry always reaches the entry:
+/// `4 MATH@SQRT` is `Unknown` until `'math' IMPORT`. This pins the
+/// registry-reachability / runtime-visibility distinction so a future drift is
+/// loud.
+#[test]
+fn finding_f1_qualified_resolution_is_import_gated() {
+    // Static registry: reachable without any import.
+    assert!(get_coreword_metadata("MATH@SQRT").is_some());
+    // Runtime: not resolvable until imported.
+    assert!(
+        outcome("4 MATH@SQRT").is_err(),
+        "F1: qualified call must need IMPORT"
+    );
+    assert!(outcome("'math' IMPORT 4 MATH@SQRT").is_ok());
+}

--- a/rust/tests/test_support/generators.rs
+++ b/rust/tests/test_support/generators.rs
@@ -86,6 +86,52 @@ pub fn block_src() -> impl Strategy<Value = String> {
     ]
 }
 
+// ───────────────────────── Phase 6: names & dictionary ──────────────────────
+
+/// A canonical **module word call**: `(module, bare-program, qualified-program)`.
+/// Both programs assume the module is already imported and, when run after
+/// `'module' IMPORT`, leave the *same* stack — the boundary-word law
+/// `bare ≡ MODULE@WORD` (roadmap Phase 6). Every entry is a `Total` module word
+/// over the chosen operands (probe-confirmed: no NIL / error).
+pub fn module_word_call() -> impl Strategy<Value = (&'static str, String, String)> {
+    prop::sample::select(vec![
+        ("MATH", "4 SQRT", "4 MATH@SQRT"),
+        ("MATH", "9 SQRT", "9 MATH@SQRT"),
+        ("MATH", "-5 ABS", "-5 MATH@ABS"),
+        ("MATH", "7 NEG", "7 MATH@NEG"),
+        ("MATH", "-3 SIGN", "-3 MATH@SIGN"),
+        ("MATH", "2 10 POW", "2 10 MATH@POW"),
+        ("MATH", "3 7 MIN", "3 7 MATH@MIN"),
+        ("MATH", "3 7 MAX", "3 7 MATH@MAX"),
+        ("JSON", "'[1]' PARSE", "'[1]' JSON@PARSE"),
+        ("JSON", "'[1,2]' PARSE", "'[1,2]' JSON@PARSE"),
+        ("ALGO", "[ 3 1 2 ] SORT", "[ 3 1 2 ] ALGO@SORT"),
+        ("ALGO", "[ 5 ] SORT", "[ 5 ] ALGO@SORT"),
+    ])
+    .prop_map(|(m, b, q)| (m, b.to_string(), q.to_string()))
+}
+
+/// A short user-word name in the runtime's action-object style (already
+/// uppercase, so word-name normalization §3.8 is a no-op on it). Kept distinct
+/// from every built-in so `DEF` never hits the "cannot redefine built-in" path.
+pub fn user_word_name() -> impl Strategy<Value = &'static str> {
+    prop::sample::select(vec!["INC", "TWICE", "BUMP", "STEP-UP", "ADD-ONE", "GROW"])
+}
+
+/// A user-word body that, applied to one scalar, leaves one scalar (a pure
+/// `Σ ⇀ Σ` transducer over the top of stack). Paired with a closed-form program
+/// `apply(x)` whose observation the defined word must reproduce.
+pub fn user_word_body() -> impl Strategy<Value = (&'static str, &'static str)> {
+    // (body tokens, equivalent inline program fragment applied after a value)
+    prop::sample::select(vec![
+        ("1 ADD", "1 ADD"),
+        ("2 MUL", "2 MUL"),
+        ("3 SUB", "3 SUB"),
+        ("0 SUB 1 ADD", "0 SUB 1 ADD"),
+        ("10 MUL 1 ADD", "10 MUL 1 ADD"),
+    ])
+}
+
 /// Union over every semantic domain — the "any well-formed value" generator.
 pub fn any_value_src() -> impl Strategy<Value = String> {
     prop_oneof![


### PR DESCRIPTION
作業ブランチ `claude/gallant-heisenberg-TnJtP` 固定のため、本 PR にロードマップ残りの **Phase 6・7・8・9** をフェーズ別コミットで積みました(各コミットが独立レビュー単位)。これで全9フェーズが完了し、意味関数 `⟦·⟧` の被覆は仕様の全主要節に及びました。

| Phase | commit | 定義(D) | 法則(L/T) |
|---|---|---|---|
| 6 名前解決・辞書 | `aabc6ca` | 本体 §9-quinquies F | `naming_resolution_laws.rs`(18 群) |
| 7 効果・観測 | `457dd38` | 本体 §9-sexies G | `effect_observation_laws.rs`(12 群) |
| 8 並行・子ランタイム | `7d30266` | 本体 §9-septies H | `child_runtime_laws.rs`(11 群) |
| 9 統合(レコード・文字列・被覆閉包) | `7a97d22` | 本体 §9-octies I | `record_laws.rs`(9 群)+ `string_laws.rs`(13 群) |

---

### Phase 6 — 名前解決と辞書(SPEC §7.8/§8/§7.10/§9)
決定的 `resolve`(Core→取込mod→user)、DEF/DEL+`FORC` ガード、IMPORT 系を可視性格子の単調作用素。finding **F1**(修飾解決は import ゲート)・**F2**(取込mod語が同名user語を遮蔽)。

### Phase 7 — 効果と観測(SPEC §5.2/§7.9/§9.4/§12)
π_Eff=送出ホスト効果の順序付き自由モノイド・順序保存準同型・データ面⫫効果面・SERIAL READ の no-data 射影・固定hostで `⟦·⟧ modulo host` 決定的。finding **G1**(π_Eff は送出効果のみ)・**G2**(`Core ⊋ Pure`)。

### Phase 8 — 並行・子ランタイム(SPEC §10、観測契約)
spawn スナップショット隔離・ProcessHandle 観測・`AWAIT(SPAWN{b}) = ['completed', ⟦b⟧∅]`・状態機械・親子隔離・再現性。finding **H1**(子は AWAIT で遅延同期実行)・**H2**(0除算→NIL は completed、実エラーのみ failed)。

### Phase 9 — 統合(SPEC §4.4 レコード・§7.6 文字列)
レコード=挿入順保存有限写像(GET/SET/KEYS/VALUES/MERGE)、文字列=符号点列(CHARS∘JOIN・TRIM冪等・STR∘NUM)。被覆行列を全節 Defined/明示 Out-of-scope へ閉包、conformance(45ケース)を `⟦·⟧` の標本に、証明支援系機械化の実現可能性評価、法則スイートをオラクル化。finding **I1**(レコードリテラル無し)・**I2**(CONCAT は単一要素 top で underflow)。

---

### 規律遵守(全フェーズ共通)
- 観測は `observe_axes`/純 `render`/`Ok/Err`/効果 `kind`・`payload`/AWAIT タプル分解/レコード軸 のみ。Rust enum 名・Debug・表示文字列に分岐しない(semantic firewall §2.3)。
- 各法則は**使い捨てプローブで参照実装の実挙動を確認後に記述**(確認後プローブ削除)。想定外挙動(div0 は子を失敗させない、修飾解決は import 必須、π_Eff は送出のみ、CONCAT 単一要素 top underflow 等)は finding 化しガード付きオラクルで固定。
- ロードマップ §0.2 被覆行列・§0.3 進捗表(全9フェーズ ✅)、本体 §10 HOLDS 表を各フェーズで更新。
- `cargo test --tests`: lib 1240 + 全法則群グリーン(10 個の `*_laws.rs`、130 超の法則群)、回帰なし。新規ファイルのみ fmt/clippy clean。

https://claude.ai/code/session_019ESvjceNxpBjT5nnAzfK7n