### PR TITLE
Algebraic simplification: close the derived_from vocabulary with a primitive registry

### DIFF
--- a/docs/dev/ajisai-algebraic-simplification-review.md
+++ b/docs/dev/ajisai-algebraic-simplification-review.md
@@ -43,6 +43,27 @@ The coverage metadata now distinguishes formalization progress (`status`) from a
 - `Exploratory`: modeled but not part of the Core portability contract.
 - `NotPortableYet`: not currently safe to classify as Core. No tracked entry currently uses this role.
 
+### Semantic primitive inventory (closed `derived_from` vocabulary)
+
+The success criterion of this theme is that Ajisai reads as *few semantic primitives + derived words that are traceable through `derived_from`*. To make that checkable rather than aspirational, `formalization-coverage.json` now declares the primitives explicitly in a top-level `algebra_primitives` registry, and every `derived_from` reference must resolve to a declared primitive (enforced by `check:formalization-coverage`).
+
+The current inventory is 22 primitives, grouped by algebraic family:
+
+| Family | Primitives |
+| --- | --- |
+| `k3-truth` | `algebra.k3.domain`, `algebra.k3.meet`, `algebra.k3.join`, `algebra.k3.involution` |
+| `exact-arithmetic` | `algebra.exact-real.bihomographic`, `algebra.exact-real.budgeted-order`, `algebra.exact-real.continued-fraction`, `algebra.exact-real.gosper` |
+| `exact-scalar` | `algebra.exact-scalar.codepoint-sequence` |
+| `bubble` | `algebra.bubble.passthrough` |
+| `structure-lift` | `algebra.structure-lift.applicative`, `algebra.structure-lift.zip` |
+| `modifier` | `algebra.modifier.consumption.keep`, `algebra.modifier.region.stack` |
+| `state-transformer` | `algebra.state-transformer.combinator`, `algebra.state-transformer.composition`, `algebra.eff.append`, `algebra.handle.domain` |
+| `dictionary` | `algebra.dictionary.lookup`, `algebra.dictionary.finite-partial-map` |
+| `observation` | `algebra.observation.structured-diagnostic` |
+| `hosted-effect` | `capability.check` |
+
+Reading note: `derived_from` records what an entry *rests directly on*, regardless of role. A `Primitive` Ajisai word rests on its defining domain primitive (e.g. `TRUE` rests on `algebra.k3.domain`); a `Derived` word rests on the operation(s) it specializes (e.g. `AND` rests on `algebra.k3.meet`). The `semantic_role` field, not the presence of `derived_from`, is what distinguishes a primitive injection from a derived operation.
+
 ## 3. Algebraic compression candidates
 
 ### 3.1 K3 truth operations
@@ -165,6 +186,8 @@ Safe future candidates, after tests are clearly grouped:
 ### Phase 5: Prevent regressions through coverage and conformance
 
 Keep `check:formalization-coverage` in CI. Extend it only backward-compatibly: new fields should be validated when present, while older metadata-free entries should not break consumers unless the project later decides to require these fields globally.
+
+Done in this pass: the validator now closes the `derived_from` vocabulary against the `algebra_primitives` registry. Any new derived word must point at a declared semantic primitive, and a declared-but-unused primitive is surfaced as a non-fatal note so dead metadata is visible. This turns "few primitives, traceable derived words" from a documentation claim into a CI-checked invariant without changing any user-visible observation.
 
 ## 6. Revised instruction shape
 

--- a/docs/formalization-coverage.json
+++ b/docs/formalization-coverage.json
@@ -1,5 +1,139 @@
 {
   "version": 1,
+  "algebra_primitives": [
+    {
+      "id": "algebra.k3.domain",
+      "algebraic_family": "k3-truth",
+      "kind": "domain",
+      "description": "Kleene three-valued truth domain {T,F,U}; a direct-sum component of V, disjoint from numbers."
+    },
+    {
+      "id": "algebra.k3.meet",
+      "algebraic_family": "k3-truth",
+      "kind": "operation",
+      "description": "Strong Kleene meet (greatest lower bound) on K3; the algebraic primitive AND derives from."
+    },
+    {
+      "id": "algebra.k3.join",
+      "algebraic_family": "k3-truth",
+      "kind": "operation",
+      "description": "Strong Kleene join (least upper bound) on K3; the algebraic primitive OR derives from."
+    },
+    {
+      "id": "algebra.k3.involution",
+      "algebraic_family": "k3-truth",
+      "kind": "operation",
+      "description": "Order-reversing involution on K3 fixing U; the algebraic primitive NOT derives from."
+    },
+    {
+      "id": "algebra.exact-real.bihomographic",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "operation",
+      "description": "Bihomographic (Gosper) transform over exact reals; ADD/SUB/MUL/DIV are coefficient instances."
+    },
+    {
+      "id": "algebra.exact-real.budgeted-order",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "operation",
+      "description": "Budgeted exact-real ordering; decides <, =, > within a budget or yields the logical U."
+    },
+    {
+      "id": "algebra.exact-real.continued-fraction",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "construction",
+      "description": "Continued-fraction construction of exact reals; canonical irrational observation, not an approximation."
+    },
+    {
+      "id": "algebra.exact-real.gosper",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "operation",
+      "description": "Gosper normalization over continued fractions; exact-real combination without rational fallback."
+    },
+    {
+      "id": "algebra.exact-scalar.codepoint-sequence",
+      "algebraic_family": "exact-scalar",
+      "kind": "domain",
+      "description": "Text value domain as a codepoint sequence, tracked separately from numeric scalar arithmetic."
+    },
+    {
+      "id": "algebra.bubble.passthrough",
+      "algebraic_family": "bubble",
+      "kind": "operation",
+      "description": "Bubble monad pass-through: an operational NIL with reason propagates through a derived word unchanged."
+    },
+    {
+      "id": "algebra.structure-lift.applicative",
+      "algebraic_family": "structure-lift",
+      "kind": "operation",
+      "description": "Functorial/applicative lift of a scalar operation over a tensor index structure (map)."
+    },
+    {
+      "id": "algebra.structure-lift.zip",
+      "algebraic_family": "structure-lift",
+      "kind": "operation",
+      "description": "zipWith lift of a scalar binary operation with documented broadcast rules."
+    },
+    {
+      "id": "algebra.modifier.consumption.keep",
+      "algebraic_family": "modifier",
+      "kind": "operation",
+      "description": "Consumption policy that preserves operands; one axis of the modifier combinator."
+    },
+    {
+      "id": "algebra.modifier.region.stack",
+      "algebraic_family": "modifier",
+      "kind": "operation",
+      "description": "Region selection over the whole operand stack; one axis of the modifier combinator."
+    },
+    {
+      "id": "algebra.state-transformer.combinator",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "description": "Combinator that transforms a base state transformer (region x consumption x reconstruction)."
+    },
+    {
+      "id": "algebra.state-transformer.composition",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "description": "Monoid composition of state transformers over Sigma = Stack x Dict x Eff."
+    },
+    {
+      "id": "algebra.dictionary.lookup",
+      "algebraic_family": "dictionary",
+      "kind": "operation",
+      "description": "Deterministic dictionary lookup / name resolution over Dict."
+    },
+    {
+      "id": "algebra.dictionary.finite-partial-map",
+      "algebraic_family": "dictionary",
+      "kind": "domain",
+      "description": "Finite partial map with insertion order; the value-domain component records inhabit."
+    },
+    {
+      "id": "algebra.eff.append",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "description": "Append into the free-monoid effect log Eff, the third component of Sigma."
+    },
+    {
+      "id": "algebra.observation.structured-diagnostic",
+      "algebraic_family": "observation",
+      "kind": "operation",
+      "description": "Structured diagnostic observation; never a leaked host/Rust error variant."
+    },
+    {
+      "id": "capability.check",
+      "algebraic_family": "hosted-effect",
+      "kind": "capability",
+      "description": "Capability gate guarding a hosted effect; failure is a structured diagnostic, not a Core value."
+    },
+    {
+      "id": "algebra.handle.domain",
+      "algebraic_family": "state-transformer",
+      "kind": "domain",
+      "description": "Child-runtime/supervisor handle value domain; currently Exploratory, outside the Core contract."
+    }
+  ],
   "entries": [
     {
       "id": "core.true",

--- a/scripts/check-formalization-coverage.mjs
+++ b/scripts/check-formalization-coverage.mjs
@@ -45,6 +45,29 @@ const coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
 if (coverage.version !== 1) fail('version must be 1');
 if (!Array.isArray(coverage.entries)) fail('entries must be an array');
 
+// Optional algebra-primitive registry. When present it closes the
+// `derived_from` vocabulary: every derived word must resolve to a declared
+// semantic primitive, so the derivation graph is checked rather than free-form.
+// Absent => the reference check is skipped (backward compatible).
+let primitiveIds = null;
+if ('algebra_primitives' in coverage) {
+  if (!Array.isArray(coverage.algebra_primitives)) fail('algebra_primitives must be an array');
+  primitiveIds = new Set();
+  for (const [index, prim] of coverage.algebra_primitives.entries()) {
+    const pw = prim?.id ?? `algebra_primitive #${index}`;
+    if (!prim || typeof prim !== 'object') fail(`${pw}: primitive must be an object`);
+    if (typeof prim.id !== 'string' || prim.id.trim() === '') fail(`${pw}: missing non-empty id`);
+    if (primitiveIds.has(prim.id)) fail(`${pw}: duplicate primitive id`);
+    primitiveIds.add(prim.id);
+    if (
+      typeof prim.algebraic_family !== 'string' ||
+      !allowedAlgebraicFamilies.has(prim.algebraic_family)
+    ) {
+      fail(`${pw}: primitive needs a known algebraic_family`);
+    }
+  }
+}
+
 const conformanceHtml = readFileSync(conformancePath, 'utf8');
 const caseIds = new Set(
   [...conformanceHtml.matchAll(/<section\b[^>]*\bclass=["'][^"']*\bajisai-case\b[^"']*["'][^>]*\bid=["']([^"']+)["']/g)]
@@ -100,6 +123,16 @@ for (const [index, entry] of coverage.entries.entries()) {
       }
     }
 
+    // When the registry is declared, every derived_from reference must
+    // resolve to a known semantic primitive (closed derivation vocabulary).
+    if (primitiveIds && Array.isArray(entry.derived_from)) {
+      for (const ref of entry.derived_from) {
+        if (!primitiveIds.has(ref)) {
+          fail(`${where}: derived_from references unknown algebra primitive ${ref}`);
+        }
+      }
+    }
+
     if (entry.semantic_role === 'Primitive' && entry.primitive !== true) {
       fail(`${where}: Primitive entries must set primitive to true`);
     }
@@ -126,6 +159,20 @@ for (const [index, entry] of coverage.entries.entries()) {
       fail(`${where}: referenced law test file does not exist: ${lawTest}`);
     }
   }
+}
+
+if (primitiveIds) {
+  const used = new Set();
+  for (const entry of coverage.entries) {
+    for (const ref of Array.isArray(entry.derived_from) ? entry.derived_from : []) used.add(ref);
+  }
+  const unused = [...primitiveIds].filter((id) => !used.has(id));
+  if (unused.length > 0) {
+    // Non-fatal: a declared-but-unused primitive is a hint of dead metadata,
+    // not a hard error, so it does not break backward-compatible consumers.
+    console.log(`[formalization-coverage] note: ${unused.length} declared primitive(s) unused: ${unused.join(', ')}`);
+  }
+  console.log(`[formalization-coverage] ${primitiveIds.size} algebra primitives declared`);
 }
 
 console.log(`[formalization-coverage] ${coverage.entries.length} entries validated`);


### PR DESCRIPTION
## Context

評価依頼に対する応答です。先行の「Add algebraic simplification review metadata」改修を評価し、問題がないことを確認した上で、**代数的簡約を一段階前進**させました。

## 評価結果（先行改修）

- レビュー文書 `docs/dev/ajisai-algebraic-simplification-review.md`、`semantic_role`/`derived_from`/`algebraic_family` メタデータ、validator 拡張、`V = 𝔸 ⊎ K3 ⊎ …` 明示化 — いずれも **妥当かつ後方互換・観測非変更**。
- `§5.3 で実装が破れている` という記述の削除は、所見B(T=1 型混同)が本ブランチで解消済みである現状と整合しており問題なし。`(§5)` → `(§4)` も真偽値領域節への正しい参照修正。
- 実装側の K3 は既に `rust/src/interpreter/logic_kleene.rs` に単一正準実装として集約済みで、§7.2 が示す helper 共通化は完了状態。重複再実装は不要と判断。
- 全テスト緑（vitest 29、cargo 全テスト、semantic-firewall、conformance manifest、coverage validator）。

## このPRで進めた簡約（metadata-first / observation-preserving)

本テーマの最終判断基準「**意味原始は少なく一貫し、導出語は `derived_from` で追跡できる**」を、文書上の主張から **CI で強制される不変条件**へ引き上げました。

- `formalization-coverage.json` に **`algebra_primitives` レジストリ**(22 primitives: id / algebraic_family / kind / description)を追加。意味原始を明示・計数可能に。
- `check:formalization-coverage` を拡張し、各 entry の `derived_from` 参照が宣言済み primitive に解決することを検査(未知参照は失敗)。未使用 primitive は非致命の note として可視化。レジストリ非在時は検査スキップで後方互換。
- レビュー文書に primitive インベントリと閉じた語彙の不変条件を追記(Classification / Phase 5)。

## 非変更

- ユーザー可視の観測結果、conformance expectation、Rust/ランタイム — 一切変更なし。
- `SPECIFICATION.md` は正典のまま。数式・メタデータは設計レンズとして従属。

## Test results

- `npm test` → 29 passed
- `npm run check:semantic-firewall` → passed
- `npm run check:formalization-coverage` → 22 primitives declared, 19 entries validated
- `npm run conformance:manifest` → OK
- `cargo test` → 全グリーン（本PRでは Rust 無変更）

https://claude.ai/code/session_01S86SwGk3k7KwPBghKxtd2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01S86SwGk3k7KwPBghKxtd2A)_