### PR TITLE
Align algebra-primitive metadata and review inventory

### DIFF
--- a/docs/dev/ajisai-algebraic-simplification-review.md
+++ b/docs/dev/ajisai-algebraic-simplification-review.md
@@ -47,19 +47,19 @@ The coverage metadata now distinguishes formalization progress (`status`) from a
 
 The success criterion of this theme is that Ajisai reads as *few semantic primitives + derived words that are traceable through `derived_from`*. To make that checkable rather than aspirational, `formalization-coverage.json` now declares the primitives explicitly in a top-level `algebra_primitives` registry, and every `derived_from` reference must resolve to a declared primitive (enforced by `check:formalization-coverage`).
 
-The current inventory is 22 primitives, grouped by algebraic family:
+The inventory grew as later rollout phases classified more surface and module words; the registry now declares 30 primitives, grouped by algebraic family:
 
 | Family | Primitives |
 | --- | --- |
 | `k3-truth` | `algebra.k3.domain`, `algebra.k3.meet`, `algebra.k3.join`, `algebra.k3.involution` |
 | `exact-arithmetic` | `algebra.exact-real.bihomographic`, `algebra.exact-real.budgeted-order`, `algebra.exact-real.continued-fraction`, `algebra.exact-real.gosper` |
 | `exact-scalar` | `algebra.exact-scalar.codepoint-sequence` |
-| `bubble` | `algebra.bubble.passthrough` |
-| `structure-lift` | `algebra.structure-lift.applicative`, `algebra.structure-lift.zip` |
-| `modifier` | `algebra.modifier.consumption.keep`, `algebra.modifier.region.stack` |
-| `state-transformer` | `algebra.state-transformer.combinator`, `algebra.state-transformer.composition`, `algebra.eff.append`, `algebra.handle.domain` |
+| `bubble` | `algebra.bubble.domain`, `algebra.bubble.passthrough`, `algebra.bubble.handler` |
+| `structure-lift` | `algebra.structure-lift.indexed-sequence`, `algebra.structure-lift.applicative`, `algebra.structure-lift.zip`, `algebra.structure-lift.reshape-group` |
+| `modifier` | `algebra.modifier.consumption.keep`, `algebra.modifier.consumption.eat`, `algebra.modifier.region.stack`, `algebra.modifier.region.top` |
+| `state-transformer` | `algebra.state-transformer.combinator`, `algebra.state-transformer.composition`, `algebra.state-transformer.identity`, `algebra.eff.append`, `algebra.handle.domain` |
 | `dictionary` | `algebra.dictionary.lookup`, `algebra.dictionary.finite-partial-map` |
-| `observation` | `algebra.observation.structured-diagnostic` |
+| `observation` | `algebra.observation.structured-diagnostic`, `algebra.observation.digest` |
 | `hosted-effect` | `capability.check` |
 
 Reading note: `derived_from` records what an entry *rests directly on*, regardless of role. A `Primitive` Ajisai word rests on its defining domain primitive (e.g. `TRUE` rests on `algebra.k3.domain`); a `Derived` word rests on the operation(s) it specializes (e.g. `AND` rests on `algebra.k3.meet`). The `semantic_role` field, not the presence of `derived_from`, is what distinguishes a primitive injection from a derived operation.

--- a/docs/formalization-coverage.json
+++ b/docs/formalization-coverage.json
@@ -166,7 +166,8 @@
     {
       "id": "algebra.observation.digest",
       "algebraic_family": "observation",
-      "notes": "Deterministic digest observation over canonical serialized values; used by pure CRYPTO@HASH."
+      "kind": "operation",
+      "description": "Deterministic digest observation over canonical serialized values; pure CRYPTO@HASH derives from it without a host read effect."
     },
     {
       "id": "capability.check",


### PR DESCRIPTION
## Evaluation of the algebraic-simplification work

I reviewed the changes made against `docs/dev/ajisai-algebraic-simplification-review.md`. Overall the implementation is solid and faithful to the review:

- The `algebra_primitives` registry is declared and `check:formalization-coverage` closes the `derived_from` vocabulary against it. Validator passes: **203/203 surface words classified, 30 primitives declared, 201 entries validated**, with no unused primitives.
- `semantic_role` is independent of `status`; `Primitive`/`Derived`/`HostedEffect`/`Exploratory`/`Sugar` roles match the review's §2 table (e.g. `TRUE`/`FALSE`/record/string/import-resolution = Primitive, arithmetic/comparisons/modifiers/vector = Derived, `NOW`/`RANDOM`/`SERIAL-*` = HostedEffect, `SPAWN`/`AWAIT` = Exploratory).
- The validator enforces the cross-cutting invariants the review called for (no `HostedEffect`/`NotPortableYet` classified as `Core`, `Primitive` ⇒ `primitive: true`, declared-but-unused primitives surfaced as non-fatal notes).
- Design smell #1 was addressed: the value-domain equation now reads `V = 𝔸 ⊎ K3 ⊎ …` with the direct-sum invariant stated at the definition site.

## Defects found and fixed

1. **`algebra.observation.digest`** was the only one of the 30 declared primitives missing the `kind`/`description` fields every other primitive carries (it only had `notes`). Gave it `kind: "operation"` and a `description` consistent with the rest of the registry.
2. The review's §2 **primitive inventory** still claimed *"22 primitives"* with a stale per-family table, but the registry it describes now declares **30** (later rollout phases added the `bubble.domain`/`bubble.handler`, `structure-lift.indexed-sequence`/`reshape-group`, `modifier.consumption.eat`/`region.top`, `state-transformer.identity`, and `observation.digest` primitives). Updated the count and table to match the live registry.

Both are accuracy/consistency fixes; no user-visible observations change and the validator still passes.

https://claude.ai/code/session_01VM7CbERG8noUS5WkmidanK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM7CbERG8noUS5WkmidanK)_