### PR TITLE
Fix time-word algebraic family and add coverage coherence note

### DIFF
--- a/docs/formalization-coverage.json
+++ b/docs/formalization-coverage.json
@@ -3076,7 +3076,7 @@
         "algebra.exact-real.continued-fraction",
         "algebra.structure-lift.indexed-sequence"
       ],
-      "algebraic_family": "exact-scalar"
+      "algebraic_family": "exact-arithmetic"
     },
     {
       "id": "module.time.timestamp",
@@ -3102,7 +3102,7 @@
         "algebra.exact-real.continued-fraction",
         "algebra.structure-lift.indexed-sequence"
       ],
-      "algebraic_family": "exact-scalar"
+      "algebraic_family": "exact-arithmetic"
     },
     {
       "id": "module.time.date",

--- a/scripts/check-formalization-coverage.mjs
+++ b/scripts/check-formalization-coverage.mjs
@@ -293,6 +293,32 @@ if (primitiveIds) {
     // not a hard error, so it does not break backward-compatible consumers.
     console.log(`[formalization-coverage] note: ${unused.length} declared primitive(s) unused: ${unused.join(', ')}`);
   }
+
+  // Non-fatal coherence note: an entry's algebraic_family should normally name
+  // a family it actually rests on, i.e. one of its derived_from primitives'
+  // families. `observation` and `syntax-sugar` are deliberate exceptions: they
+  // describe a projection/surface role rather than the family being rested on.
+  // Surfacing drift here would have caught e.g. a datetime word mislabeled with
+  // the text scalar family while resting only on arithmetic/structure primitives.
+  const primitiveFamily = new Map(
+    coverage.algebra_primitives.map((p) => [p.id, p.algebraic_family]),
+  );
+  const projectionFamilies = new Set(['observation', 'syntax-sugar']);
+  const incoherent = [];
+  for (const entry of coverage.entries) {
+    const family = entry.algebraic_family;
+    const refs = Array.isArray(entry.derived_from) ? entry.derived_from : [];
+    if (typeof family !== 'string' || refs.length === 0) continue;
+    if (projectionFamilies.has(family)) continue;
+    const restsOn = new Set(refs.map((ref) => primitiveFamily.get(ref)));
+    if (!restsOn.has(family)) {
+      incoherent.push(`${entry.id} (${family} <= ${[...restsOn].filter(Boolean).join(', ')})`);
+    }
+  }
+  if (incoherent.length > 0) {
+    console.log(`[formalization-coverage] note: ${incoherent.length} entry/families not among their derived_from families: ${incoherent.join('; ')}`);
+  }
+
   console.log(`[formalization-coverage] ${primitiveIds.size} algebra primitives declared`);
 }
 


### PR DESCRIPTION
## Re-verification of the algebraic-simplification work

A second completeness pass over the merged metadata (validator green: 203/203 surface words, 30 primitives, 201 entries; primitive schema 100% complete; no unused primitives; all entries carry `semantic_role` + `algebraic_family`).

That pass surfaced one residual misclassification and one synergy opportunity worth realizing now.

### Defect fixed
`TIME@DATETIME` and `TIME@TIMESTAMP` were tagged `algebraic_family: "exact-scalar"`, but that family denotes the **text/codepoint** domain (its sole primitive is `algebra.exact-scalar.codepoint-sequence`). Every other `exact-scalar` entry rests on that text primitive; these two rest only on `algebra.exact-real.continued-fraction` (exact-arithmetic) and `algebra.structure-lift.indexed-sequence` — they convert between an instant scalar and a civil datetime tuple with no text involved. Reclassified both to `exact-arithmetic`, consistent with `core.count` (which likewise mixes continued-fraction + indexed-sequence).

### Synergy realized
Added a **non-fatal coherence note** to `check:formalization-coverage`: an entry's `algebraic_family` should name a family it actually rests on (one of its `derived_from` primitives' families), with `observation` and `syntax-sugar` exempted as deliberate projection/surface roles. After the fix the baseline is clean (0 drift), so the note is silent today and surfaces exactly the class of mistake the time-word fix corrected — directly serving the review's Phase 5 ("prevent regressions through coverage"). It is non-fatal, mirroring the existing unused-primitive note, so it never breaks backward-compatible consumers.

No user-visible observations change; validator still exits 0.

https://claude.ai/code/session_01VM7CbERG8noUS5WkmidanK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM7CbERG8noUS5WkmidanK)_