### PR TITLE
Add primitive → test reverse-index map

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Generate word manifest
         run: npm run word:manifest
 
+      - name: Generate primitive test map
+        run: npm run primitive:test-map
+
       - name: Check formalization coverage
         run: npm run check:formalization-coverage
 

--- a/docs/dev/ajisai-algebraic-simplification-review.md
+++ b/docs/dev/ajisai-algebraic-simplification-review.md
@@ -175,6 +175,8 @@ Completed in this review for K3, exact arithmetic, structure lift, Bubble/OR-NIL
 
 Recommended follow-up: annotate law-test groups and conformance sections as either primitive-domain checks or derived-word examples. For example, K3 law tests should be treated as one algebra family with word-level examples.
 
+Realized in this pass as a reverse index rather than by re-tagging tests in place: `scripts/generate-primitive-test-map.mjs` (`npm run primitive:test-map`) inverts each word's `derived_from` / `law_tests` / `conformance_cases` into a primitive → tests map at `docs/primitive-test-map.json`, so every declared primitive is traceable to the concrete tests exercising the words that rest on it. `check:formalization-coverage` additionally emits a non-fatal note if any declared primitive is exercised by no test, so a newly admitted primitive cannot stay silently untested.
+
 ### Phase 4: Move small derived words toward shared primitive implementations
 
 Safe future candidates, after tests are clearly grouped:

--- a/docs/primitive-test-map.json
+++ b/docs/primitive-test-map.json
@@ -1,0 +1,1056 @@
+{
+  "version": 1,
+  "generated_from": [
+    "docs/formalization-coverage.json"
+  ],
+  "summary": {
+    "primitives": 30,
+    "primitives_without_tests": 0,
+    "distinct_law_test_files": 23,
+    "distinct_conformance_cases": 52
+  },
+  "primitives": [
+    {
+      "id": "algebra.k3.domain",
+      "algebraic_family": "k3-truth",
+      "kind": "domain",
+      "status": "accepted",
+      "derived_word_count": 26,
+      "law_test_count": 10,
+      "conformance_case_count": 11,
+      "derived_words": [
+        "core.all",
+        "core.any",
+        "core.bool",
+        "core.compare-within",
+        "core.comparison",
+        "core.cond",
+        "core.count",
+        "core.ends-with",
+        "core.eq",
+        "core.false",
+        "core.filter",
+        "core.gt",
+        "core.gte",
+        "core.lt",
+        "core.lte",
+        "core.neq",
+        "core.starts-with",
+        "core.true",
+        "module.algo.contains",
+        "module.algo.sort",
+        "module.algo.unique",
+        "module.json.has",
+        "module.math.is-exact",
+        "module.math.max",
+        "module.math.min",
+        "module.math.sign"
+      ],
+      "law_tests": [
+        "rust/src/arithmetic_operation_tests.rs",
+        "rust/src/interpreter/algo_ops_tests.rs",
+        "rust/src/interpreter/math_ops_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/higher_order_laws.rs",
+        "rust/tests/observation_laws.rs",
+        "rust/tests/record_laws.rs",
+        "rust/tests/string_laws.rs",
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-boolean-is-not-a-number",
+        "core-compare-within-eq",
+        "core-compare-within-gt",
+        "core-compare-within-lt",
+        "core-decided-comparison-false",
+        "core-decided-comparison-true",
+        "core-false-literal",
+        "core-sqrt2-eq-sqrt2",
+        "core-sqrt2-less-than-two",
+        "core-sqrt2-not-less-than-one",
+        "core-true-literal"
+      ]
+    },
+    {
+      "id": "algebra.k3.meet",
+      "algebraic_family": "k3-truth",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 1,
+      "conformance_case_count": 2,
+      "derived_words": [
+        "core.and"
+      ],
+      "law_tests": [
+        "rust/tests/algebraic_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-kleene-and-definite",
+        "core-unknown-propagation"
+      ]
+    },
+    {
+      "id": "algebra.k3.join",
+      "algebraic_family": "k3-truth",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 1,
+      "conformance_case_count": 1,
+      "derived_words": [
+        "core.or"
+      ],
+      "law_tests": [
+        "rust/tests/algebraic_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-kleene-or-definite"
+      ]
+    },
+    {
+      "id": "algebra.k3.involution",
+      "algebraic_family": "k3-truth",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 1,
+      "conformance_case_count": 1,
+      "derived_words": [
+        "core.not"
+      ],
+      "law_tests": [
+        "rust/tests/algebraic_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-kleene-not-definite"
+      ]
+    },
+    {
+      "id": "algebra.exact-real.bihomographic",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 6,
+      "law_test_count": 2,
+      "conformance_case_count": 4,
+      "derived_words": [
+        "core.add",
+        "core.arithmetic.rational",
+        "core.div",
+        "core.mod",
+        "core.mul",
+        "core.sub"
+      ],
+      "law_tests": [
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/desugar_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-bignum-does-not-fall-to-float",
+        "core-division-by-zero-is-nil",
+        "core-exact-addition",
+        "core-exact-division"
+      ]
+    },
+    {
+      "id": "algebra.exact-real.budgeted-order",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 19,
+      "law_test_count": 6,
+      "conformance_case_count": 9,
+      "derived_words": [
+        "core.compare-within",
+        "core.comparison",
+        "core.eq",
+        "core.gt",
+        "core.gte",
+        "core.lt",
+        "core.lte",
+        "core.neq",
+        "module.algo.contains",
+        "module.algo.index-of",
+        "module.algo.sort",
+        "module.algo.unique",
+        "module.math.abs",
+        "module.math.interval",
+        "module.math.is-exact",
+        "module.math.max",
+        "module.math.min",
+        "module.math.sign",
+        "module.math.sqrt-eps"
+      ],
+      "law_tests": [
+        "rust/src/arithmetic_operation_tests.rs",
+        "rust/src/interpreter/algo_ops_tests.rs",
+        "rust/src/interpreter/math_ops_tests.rs",
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/observation_laws.rs",
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-boolean-is-not-a-number",
+        "core-compare-within-eq",
+        "core-compare-within-gt",
+        "core-compare-within-lt",
+        "core-decided-comparison-false",
+        "core-decided-comparison-true",
+        "core-sqrt2-eq-sqrt2",
+        "core-sqrt2-less-than-two",
+        "core-sqrt2-not-less-than-one"
+      ]
+    },
+    {
+      "id": "algebra.exact-real.continued-fraction",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "construction",
+      "status": "accepted",
+      "derived_word_count": 51,
+      "law_test_count": 12,
+      "conformance_case_count": 3,
+      "derived_words": [
+        "core.ceil",
+        "core.cf",
+        "core.count",
+        "core.exact-real.sqrt",
+        "core.floor",
+        "core.mod",
+        "core.num",
+        "core.round",
+        "module.math.gcd",
+        "module.math.interval",
+        "module.math.lcm",
+        "module.math.lower",
+        "module.math.pow",
+        "module.math.sqrt-eps",
+        "module.math.upper",
+        "module.music.adsr",
+        "module.music.chord",
+        "module.music.dur",
+        "module.music.edo",
+        "module.music.edr",
+        "module.music.fx-reset",
+        "module.music.gain",
+        "module.music.gain-reset",
+        "module.music.hz",
+        "module.music.measure",
+        "module.music.note",
+        "module.music.pan",
+        "module.music.pan-reset",
+        "module.music.phrase",
+        "module.music.play",
+        "module.music.rest",
+        "module.music.saw",
+        "module.music.seq-group",
+        "module.music.sim-group",
+        "module.music.sine",
+        "module.music.slot",
+        "module.music.square",
+        "module.music.step",
+        "module.music.track",
+        "module.music.tri",
+        "module.music.voice",
+        "module.music.with-tuning",
+        "module.time.datetime",
+        "module.time.day",
+        "module.time.hour",
+        "module.time.minute",
+        "module.time.month",
+        "module.time.second",
+        "module.time.timestamp",
+        "module.time.weekday",
+        "module.time.year"
+      ],
+      "law_tests": [
+        "rust/src/arithmetic_operation_tests.rs",
+        "rust/src/interpreter/audio/audio_effect_tests.rs",
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/interpreter/audio/audio_unit_tests.rs",
+        "rust/src/interpreter/datetime_tests.rs",
+        "rust/src/interpreter/math_ops_tests.rs",
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/desugar_laws.rs",
+        "rust/tests/higher_order_laws.rs",
+        "rust/tests/nicf_gosper_feasibility.rs",
+        "rust/tests/observation_laws.rs",
+        "rust/tests/string_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-sqrt2-continued-fraction",
+        "core-sqrt2-plus-one-continued-fraction",
+        "core-sqrt2-plus-sqrt2-gosper"
+      ]
+    },
+    {
+      "id": "algebra.exact-real.gosper",
+      "algebraic_family": "exact-arithmetic",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 9,
+      "law_test_count": 5,
+      "conformance_case_count": 3,
+      "derived_words": [
+        "core.exact-real.sqrt",
+        "module.math.abs",
+        "module.math.neg",
+        "module.math.pow",
+        "module.math.width",
+        "module.time.add-days",
+        "module.time.add-months",
+        "module.time.add-years",
+        "module.time.diff-days"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/datetime_tests.rs",
+        "rust/src/interpreter/math_ops_tests.rs",
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/nicf_gosper_feasibility.rs",
+        "rust/tests/observation_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-sqrt2-continued-fraction",
+        "core-sqrt2-plus-one-continued-fraction",
+        "core-sqrt2-plus-sqrt2-gosper"
+      ]
+    },
+    {
+      "id": "algebra.exact-scalar.codepoint-sequence",
+      "algebraic_family": "exact-scalar",
+      "kind": "domain",
+      "status": "accepted",
+      "derived_word_count": 27,
+      "law_test_count": 8,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "core.await",
+        "core.bool",
+        "core.chars",
+        "core.chr",
+        "core.ends-with",
+        "core.eval",
+        "core.join",
+        "core.kill",
+        "core.num",
+        "core.print",
+        "core.starts-with",
+        "core.status",
+        "core.str",
+        "core.structural.string",
+        "core.substitute",
+        "core.tokenize",
+        "core.trim",
+        "core.trim-left",
+        "core.trim-right",
+        "module.crypto.hash",
+        "module.io.input",
+        "module.io.output",
+        "module.json.export",
+        "module.json.parse",
+        "module.json.stringify",
+        "module.time.format",
+        "module.time.parse-iso"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/datetime_tests.rs",
+        "rust/src/interpreter/hash_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/child_runtime_laws.rs",
+        "rust/tests/effect_observation_laws.rs",
+        "rust/tests/higher_order_laws.rs",
+        "rust/tests/record_laws.rs",
+        "rust/tests/string_laws.rs"
+      ],
+      "conformance_cases": []
+    },
+    {
+      "id": "algebra.bubble.domain",
+      "algebraic_family": "bubble",
+      "kind": "domain",
+      "status": "accepted",
+      "derived_word_count": 12,
+      "law_test_count": 10,
+      "conformance_case_count": 6,
+      "derived_words": [
+        "core.chr",
+        "core.get",
+        "core.nil",
+        "core.num",
+        "core.or-nil",
+        "core.remove",
+        "module.algo.index-of",
+        "module.json.get",
+        "module.json.parse",
+        "module.math.gcd",
+        "module.math.lcm",
+        "module.time.parse-iso"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/algo_ops_tests.rs",
+        "rust/src/interpreter/datetime_tests.rs",
+        "rust/src/interpreter/math_ops_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/contract_modifier_laws.rs",
+        "rust/tests/observation_laws.rs",
+        "rust/tests/record_laws.rs",
+        "rust/tests/string_laws.rs",
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-division-by-zero-is-nil",
+        "core-get-negative-index",
+        "core-get-zero-index",
+        "core-nil-propagation",
+        "core-nil-spelling",
+        "core-or-nil-fallback"
+      ]
+    },
+    {
+      "id": "algebra.bubble.passthrough",
+      "algebraic_family": "bubble",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 15,
+      "law_test_count": 3,
+      "conformance_case_count": 10,
+      "derived_words": [
+        "core.add",
+        "core.arithmetic.rational",
+        "core.ceil",
+        "core.div",
+        "core.eq",
+        "core.floor",
+        "core.gt",
+        "core.gte",
+        "core.lt",
+        "core.lte",
+        "core.mod",
+        "core.mul",
+        "core.neq",
+        "core.round",
+        "core.sub"
+      ],
+      "law_tests": [
+        "rust/src/arithmetic_operation_tests.rs",
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/desugar_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-bignum-does-not-fall-to-float",
+        "core-boolean-is-not-a-number",
+        "core-decided-comparison-false",
+        "core-decided-comparison-true",
+        "core-division-by-zero-is-nil",
+        "core-exact-addition",
+        "core-exact-division",
+        "core-sqrt2-eq-sqrt2",
+        "core-sqrt2-less-than-two",
+        "core-sqrt2-not-less-than-one"
+      ]
+    },
+    {
+      "id": "algebra.bubble.handler",
+      "algebraic_family": "bubble",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 1,
+      "conformance_case_count": 1,
+      "derived_words": [
+        "core.or-nil"
+      ],
+      "law_tests": [
+        "rust/tests/algebraic_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-or-nil-fallback"
+      ]
+    },
+    {
+      "id": "algebra.structure-lift.indexed-sequence",
+      "algebraic_family": "structure-lift",
+      "kind": "domain",
+      "status": "accepted",
+      "derived_word_count": 78,
+      "law_test_count": 12,
+      "conformance_case_count": 11,
+      "derived_words": [
+        "core.all",
+        "core.any",
+        "core.collect",
+        "core.concat",
+        "core.count",
+        "core.fill",
+        "core.filter",
+        "core.fold",
+        "core.get",
+        "core.insert",
+        "core.length",
+        "core.range",
+        "core.rank",
+        "core.remove",
+        "core.reorder",
+        "core.replace",
+        "core.reshape",
+        "core.reverse",
+        "core.scan",
+        "core.shape",
+        "core.split",
+        "core.take",
+        "core.transpose",
+        "core.unfold",
+        "module.algo.contains",
+        "module.algo.index-of",
+        "module.algo.sort",
+        "module.algo.unique",
+        "module.json.keys",
+        "module.json.values",
+        "module.math.lower",
+        "module.math.upper",
+        "module.math.width",
+        "module.music.adsr",
+        "module.music.chord",
+        "module.music.dur",
+        "module.music.edo",
+        "module.music.edr",
+        "module.music.explain",
+        "module.music.fx-reset",
+        "module.music.gain",
+        "module.music.gain-reset",
+        "module.music.hz",
+        "module.music.measure",
+        "module.music.note",
+        "module.music.pan",
+        "module.music.pan-reset",
+        "module.music.phrase",
+        "module.music.play",
+        "module.music.rest",
+        "module.music.saw",
+        "module.music.seq-group",
+        "module.music.sim-group",
+        "module.music.sine",
+        "module.music.slot",
+        "module.music.square",
+        "module.music.step",
+        "module.music.track",
+        "module.music.tri",
+        "module.music.voice",
+        "module.music.with-tuning",
+        "module.time.add-days",
+        "module.time.add-months",
+        "module.time.add-years",
+        "module.time.date",
+        "module.time.datetime",
+        "module.time.day",
+        "module.time.diff-days",
+        "module.time.format",
+        "module.time.hour",
+        "module.time.minute",
+        "module.time.month",
+        "module.time.parse-iso",
+        "module.time.second",
+        "module.time.time",
+        "module.time.timestamp",
+        "module.time.weekday",
+        "module.time.year"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/algo_ops_tests.rs",
+        "rust/src/interpreter/audio/audio_effect_tests.rs",
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/interpreter/audio/audio_unit_tests.rs",
+        "rust/src/interpreter/datetime_tests.rs",
+        "rust/src/interpreter/math_ops_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/contract_modifier_laws.rs",
+        "rust/tests/higher_order_laws.rs",
+        "rust/tests/observation_laws.rs",
+        "rust/tests/record_laws.rs",
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-concat",
+        "core-fold",
+        "core-fold-word-name",
+        "core-get-negative-index",
+        "core-get-zero-index",
+        "core-length",
+        "core-range",
+        "core-rank",
+        "core-reverse",
+        "core-shape",
+        "core-take"
+      ]
+    },
+    {
+      "id": "algebra.structure-lift.applicative",
+      "algebraic_family": "structure-lift",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 2,
+      "law_test_count": 2,
+      "conformance_case_count": 7,
+      "derived_words": [
+        "core.map",
+        "core.structural.vector-tensor"
+      ],
+      "law_tests": [
+        "rust/tests/higher_order_laws.rs",
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-map",
+        "core-nesting-preserved",
+        "core-rank",
+        "core-shape",
+        "core-vector-scalar-broadcast-add",
+        "core-vector-self-evaluates",
+        "core-vector-singleton-broadcast-mul"
+      ]
+    },
+    {
+      "id": "algebra.structure-lift.zip",
+      "algebraic_family": "structure-lift",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 1,
+      "conformance_case_count": 6,
+      "derived_words": [
+        "core.structural.vector-tensor"
+      ],
+      "law_tests": [
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-nesting-preserved",
+        "core-rank",
+        "core-shape",
+        "core-vector-scalar-broadcast-add",
+        "core-vector-self-evaluates",
+        "core-vector-singleton-broadcast-mul"
+      ]
+    },
+    {
+      "id": "algebra.structure-lift.reshape-group",
+      "algebraic_family": "structure-lift",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 5,
+      "law_test_count": 1,
+      "conformance_case_count": 2,
+      "derived_words": [
+        "core.fill",
+        "core.rank",
+        "core.reshape",
+        "core.shape",
+        "core.transpose"
+      ],
+      "law_tests": [
+        "rust/tests/structural_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-rank",
+        "core-shape"
+      ]
+    },
+    {
+      "id": "algebra.modifier.consumption.keep",
+      "algebraic_family": "modifier",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 2,
+      "conformance_case_count": 2,
+      "derived_words": [
+        "core.modifier.keep"
+      ],
+      "law_tests": [
+        "rust/tests/contract_modifier_laws.rs",
+        "rust/tests/mass_conservation_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-keep-modifier",
+        "core-stak-keep-add"
+      ]
+    },
+    {
+      "id": "algebra.modifier.consumption.eat",
+      "algebraic_family": "modifier",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 2,
+      "law_test_count": 2,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "core.eat",
+        "core.forc"
+      ],
+      "law_tests": [
+        "rust/tests/contract_modifier_laws.rs",
+        "rust/tests/naming_resolution_laws.rs"
+      ],
+      "conformance_cases": []
+    },
+    {
+      "id": "algebra.modifier.region.stack",
+      "algebraic_family": "modifier",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 2,
+      "conformance_case_count": 2,
+      "derived_words": [
+        "core.modifier.stak"
+      ],
+      "law_tests": [
+        "rust/tests/contract_modifier_laws.rs",
+        "rust/tests/mass_conservation_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-stak-add",
+        "core-stak-keep-add"
+      ]
+    },
+    {
+      "id": "algebra.modifier.region.top",
+      "algebraic_family": "modifier",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 1,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "core.top"
+      ],
+      "law_tests": [
+        "rust/tests/contract_modifier_laws.rs"
+      ],
+      "conformance_cases": []
+    },
+    {
+      "id": "algebra.state-transformer.combinator",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 4,
+      "law_test_count": 2,
+      "conformance_case_count": 3,
+      "derived_words": [
+        "core.eat",
+        "core.modifier.keep",
+        "core.modifier.stak",
+        "core.top"
+      ],
+      "law_tests": [
+        "rust/tests/contract_modifier_laws.rs",
+        "rust/tests/mass_conservation_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-keep-modifier",
+        "core-stak-add",
+        "core-stak-keep-add"
+      ]
+    },
+    {
+      "id": "algebra.state-transformer.composition",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 24,
+      "law_test_count": 8,
+      "conformance_case_count": 6,
+      "derived_words": [
+        "core.await",
+        "core.cond",
+        "core.del",
+        "core.eval",
+        "core.exec",
+        "core.filter",
+        "core.fold",
+        "core.import-only",
+        "core.import.name-resolution",
+        "core.kill",
+        "core.map",
+        "core.monitor",
+        "core.precompute",
+        "core.scan",
+        "core.spawn",
+        "core.unfold",
+        "core.unimport",
+        "core.unimport-only",
+        "exploratory.child-runtime",
+        "module.json.delete",
+        "module.json.merge",
+        "module.json.set",
+        "module.music.seq",
+        "module.music.sim"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/audio/audio_effect_tests.rs",
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/interpreter/interpreter_definition_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/child_runtime_laws.rs",
+        "rust/tests/higher_order_laws.rs",
+        "rust/tests/naming_resolution_laws.rs",
+        "rust/tests/record_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-fold",
+        "core-fold-word-name",
+        "core-map",
+        "core-sort-imported",
+        "core-sqrt2-continued-fraction",
+        "core-user-definition-resolved"
+      ]
+    },
+    {
+      "id": "algebra.state-transformer.identity",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 2,
+      "law_test_count": 2,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "core.idle",
+        "core.pipe"
+      ],
+      "law_tests": [
+        "rust/tests/algebraic_laws.rs",
+        "rust/tests/desugar_laws.rs"
+      ],
+      "conformance_cases": []
+    },
+    {
+      "id": "algebra.dictionary.lookup",
+      "algebraic_family": "dictionary",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 7,
+      "law_test_count": 3,
+      "conformance_case_count": 3,
+      "derived_words": [
+        "core.import-only",
+        "core.import.name-resolution",
+        "core.lookup",
+        "core.unimport",
+        "core.unimport-only",
+        "module.json.get",
+        "module.json.has"
+      ],
+      "law_tests": [
+        "rust/src/json_io_tests.rs",
+        "rust/tests/naming_resolution_laws.rs",
+        "rust/tests/record_laws.rs"
+      ],
+      "conformance_cases": [
+        "core-sort-imported",
+        "core-sqrt2-continued-fraction",
+        "core-user-definition-resolved"
+      ]
+    },
+    {
+      "id": "algebra.dictionary.finite-partial-map",
+      "algebraic_family": "dictionary",
+      "kind": "domain",
+      "status": "accepted",
+      "derived_word_count": 36,
+      "law_test_count": 6,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "core.del",
+        "core.forc",
+        "core.import-only",
+        "core.precompute",
+        "core.structural.record",
+        "core.unimport",
+        "core.unimport-only",
+        "module.json.delete",
+        "module.json.get",
+        "module.json.has",
+        "module.json.keys",
+        "module.json.merge",
+        "module.json.parse",
+        "module.json.set",
+        "module.json.stringify",
+        "module.json.values",
+        "module.music.adsr",
+        "module.music.chord",
+        "module.music.dur",
+        "module.music.edo",
+        "module.music.edr",
+        "module.music.hz",
+        "module.music.measure",
+        "module.music.note",
+        "module.music.phrase",
+        "module.music.rest",
+        "module.music.saw",
+        "module.music.seq-group",
+        "module.music.sim-group",
+        "module.music.sine",
+        "module.music.square",
+        "module.music.step",
+        "module.music.track",
+        "module.music.tri",
+        "module.music.voice",
+        "module.music.with-tuning"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/interpreter/audio/audio_unit_tests.rs",
+        "rust/src/interpreter/interpreter_definition_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/naming_resolution_laws.rs",
+        "rust/tests/record_laws.rs"
+      ],
+      "conformance_cases": []
+    },
+    {
+      "id": "algebra.eff.append",
+      "algebraic_family": "state-transformer",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 13,
+      "law_test_count": 4,
+      "conformance_case_count": 6,
+      "derived_words": [
+        "core.print",
+        "hosted.clock.deterministic",
+        "hosted.csprng.deterministic",
+        "hosted.serial.effects",
+        "module.io.output",
+        "module.json.export",
+        "module.music.fx-reset",
+        "module.music.gain",
+        "module.music.gain-reset",
+        "module.music.pan",
+        "module.music.pan-reset",
+        "module.music.play",
+        "module.music.slot"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/audio/audio_effect_tests.rs",
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/effect_observation_laws.rs"
+      ],
+      "conformance_cases": [
+        "hosted-csprng-deterministic",
+        "hosted-csprng-missing-capability",
+        "hosted-now-deterministic",
+        "hosted-serial-list-ports",
+        "hosted-serial-missing-capability",
+        "hosted-serial-open-then-write"
+      ]
+    },
+    {
+      "id": "algebra.observation.structured-diagnostic",
+      "algebraic_family": "observation",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 4,
+      "law_test_count": 5,
+      "conformance_case_count": 2,
+      "derived_words": [
+        "core.lookup",
+        "hosted.missing-capability.diagnostics",
+        "module.io.input",
+        "module.music.explain"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/audio/audio_effect_tests.rs",
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/effect_observation_laws.rs",
+        "rust/tests/naming_resolution_laws.rs"
+      ],
+      "conformance_cases": [
+        "hosted-csprng-missing-capability",
+        "hosted-serial-missing-capability"
+      ]
+    },
+    {
+      "id": "algebra.observation.digest",
+      "algebraic_family": "observation",
+      "kind": "operation",
+      "status": "accepted",
+      "derived_word_count": 1,
+      "law_test_count": 2,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "module.crypto.hash"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/hash_tests.rs",
+        "rust/tests/effect_observation_laws.rs"
+      ],
+      "conformance_cases": []
+    },
+    {
+      "id": "capability.check",
+      "algebraic_family": "hosted-effect",
+      "kind": "capability",
+      "status": "accepted",
+      "derived_word_count": 15,
+      "law_test_count": 4,
+      "conformance_case_count": 6,
+      "derived_words": [
+        "core.print",
+        "hosted.clock.deterministic",
+        "hosted.csprng.deterministic",
+        "hosted.missing-capability.diagnostics",
+        "hosted.serial.effects",
+        "module.io.input",
+        "module.io.output",
+        "module.json.export",
+        "module.music.fx-reset",
+        "module.music.gain",
+        "module.music.gain-reset",
+        "module.music.pan",
+        "module.music.pan-reset",
+        "module.music.play",
+        "module.music.slot"
+      ],
+      "law_tests": [
+        "rust/src/interpreter/audio/audio_effect_tests.rs",
+        "rust/src/interpreter/audio/audio_integration_tests.rs",
+        "rust/src/json_io_tests.rs",
+        "rust/tests/effect_observation_laws.rs"
+      ],
+      "conformance_cases": [
+        "hosted-csprng-deterministic",
+        "hosted-csprng-missing-capability",
+        "hosted-now-deterministic",
+        "hosted-serial-list-ports",
+        "hosted-serial-missing-capability",
+        "hosted-serial-open-then-write"
+      ]
+    },
+    {
+      "id": "algebra.handle.domain",
+      "algebraic_family": "state-transformer",
+      "kind": "domain",
+      "status": "accepted",
+      "derived_word_count": 6,
+      "law_test_count": 1,
+      "conformance_case_count": 0,
+      "derived_words": [
+        "core.await",
+        "core.kill",
+        "core.monitor",
+        "core.spawn",
+        "core.status",
+        "exploratory.child-runtime"
+      ],
+      "law_tests": [
+        "rust/tests/child_runtime_laws.rs"
+      ],
+      "conformance_cases": []
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "conformance:manifest": "node scripts/generate-conformance-manifest.mjs",
     "word:manifest": "node scripts/generate-word-manifest.mjs",
     "check:formalization-coverage": "node scripts/check-formalization-coverage.mjs",
-    "simplify:report": "node scripts/ajisai-simplify-report.mjs"
+    "simplify:report": "node scripts/ajisai-simplify-report.mjs",
+    "primitive:test-map": "node scripts/generate-primitive-test-map.mjs"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/scripts/check-formalization-coverage.mjs
+++ b/scripts/check-formalization-coverage.mjs
@@ -376,6 +376,26 @@ if (primitiveIds) {
     console.log(`[formalization-coverage] note: ${incoherent.length} entry/families not among their derived_from families: ${incoherent.join('; ')}`);
   }
 
+  // Non-fatal traceability note: every declared primitive should be reachable
+  // from at least one test. We invert derived_from -> {law_tests, conformance}
+  // (see scripts/generate-primitive-test-map.mjs) and flag primitives that no
+  // resting word exercises, so a newly admitted primitive cannot stay untested
+  // unnoticed.
+  const primitiveTested = new Map([...primitiveIds].map((id) => [id, false]));
+  for (const entry of coverage.entries) {
+    const hasTest =
+      (Array.isArray(entry.law_tests) && entry.law_tests.some((t) => hasNonEmptyString(t))) ||
+      (Array.isArray(entry.conformance_cases) && entry.conformance_cases.some((c) => hasNonEmptyString(c)));
+    if (!hasTest) continue;
+    for (const ref of Array.isArray(entry.derived_from) ? entry.derived_from : []) {
+      if (primitiveTested.has(ref)) primitiveTested.set(ref, true);
+    }
+  }
+  const untestedPrimitives = [...primitiveTested.entries()].filter(([, t]) => !t).map(([id]) => id);
+  if (untestedPrimitives.length > 0) {
+    console.log(`[formalization-coverage] note: ${untestedPrimitives.length} primitive(s) exercised by no test: ${untestedPrimitives.join(', ')}`);
+  }
+
   console.log(`[formalization-coverage] ${primitiveIds.size} algebra primitives declared`);
 }
 

--- a/scripts/generate-primitive-test-map.mjs
+++ b/scripts/generate-primitive-test-map.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Primitive -> test reverse index.
+//
+// `formalization-coverage.json` records, per word, which algebra primitives it
+// `derived_from` and which `law_tests` / `conformance_cases` exercise it. That
+// is a forward map (word -> primitives, word -> tests). This generator inverts
+// it into a primitive -> tests map so each declared semantic primitive can be
+// traced to the concrete tests that exercise the words resting on it. It turns
+// the review's "few primitives, traceable derived words" goal into a queryable
+// artifact (docs/primitive-test-map.json).
+//
+// Usage:
+//   node scripts/generate-primitive-test-map.mjs            # write JSON artifact
+//   node scripts/generate-primitive-test-map.mjs --stdout   # print JSON
+//   node scripts/generate-primitive-test-map.mjs --markdown # print a table
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const coveragePath = resolve(repoRoot, 'docs/formalization-coverage.json');
+const outputPath = resolve(repoRoot, 'docs/primitive-test-map.json');
+
+function fail(message) {
+  throw new Error(`[primitive-test-map] ${message}`);
+}
+
+const coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
+if (!Array.isArray(coverage.algebra_primitives)) {
+  fail('coverage has no algebra_primitives registry to invert');
+}
+if (!Array.isArray(coverage.entries)) fail('coverage entries must be an array');
+
+const sorted = (set) => [...set].sort((a, b) => a.localeCompare(b));
+
+// Registry order is the canonical order; preserve it so diffs stay stable.
+const acc = new Map(
+  coverage.algebra_primitives.map((primitive) => [
+    primitive.id,
+    {
+      primitive,
+      derivedWords: new Set(),
+      lawTests: new Set(),
+      conformanceCases: new Set(),
+    },
+  ]),
+);
+
+for (const entry of coverage.entries) {
+  const refs = Array.isArray(entry.derived_from) ? entry.derived_from : [];
+  for (const ref of refs) {
+    const bucket = acc.get(ref);
+    if (!bucket) continue; // unknown refs are the validator's job, not ours
+    bucket.derivedWords.add(entry.id);
+    for (const test of Array.isArray(entry.law_tests) ? entry.law_tests : []) {
+      if (typeof test === 'string' && test.trim() !== '') bucket.lawTests.add(test);
+    }
+    for (const c of Array.isArray(entry.conformance_cases) ? entry.conformance_cases : []) {
+      if (typeof c === 'string' && c.trim() !== '') bucket.conformanceCases.add(c);
+    }
+  }
+}
+
+const primitives = [...acc.values()].map(({ primitive, derivedWords, lawTests, conformanceCases }) => ({
+  id: primitive.id,
+  algebraic_family: primitive.algebraic_family,
+  kind: primitive.kind,
+  status: primitive.status,
+  derived_word_count: derivedWords.size,
+  law_test_count: lawTests.size,
+  conformance_case_count: conformanceCases.size,
+  derived_words: sorted(derivedWords),
+  law_tests: sorted(lawTests),
+  conformance_cases: sorted(conformanceCases),
+}));
+
+const untested = primitives.filter((p) => p.law_test_count === 0 && p.conformance_case_count === 0);
+const allLawTests = new Set();
+const allConformanceCases = new Set();
+for (const p of primitives) {
+  for (const t of p.law_tests) allLawTests.add(t);
+  for (const c of p.conformance_cases) allConformanceCases.add(c);
+}
+
+const map = {
+  version: 1,
+  generated_from: ['docs/formalization-coverage.json'],
+  summary: {
+    primitives: primitives.length,
+    primitives_without_tests: untested.length,
+    distinct_law_test_files: allLawTests.size,
+    distinct_conformance_cases: allConformanceCases.size,
+  },
+  primitives,
+};
+
+if (process.argv.includes('--markdown')) {
+  const rows = primitives
+    .map((p) => `| \`${p.id}\` | ${p.algebraic_family} | ${p.derived_word_count} | ${p.law_test_count} | ${p.conformance_case_count} |`)
+    .join('\n');
+  process.stdout.write(
+    `# Primitive -> test reverse index\n\n` +
+      `Generated from docs/formalization-coverage.json. ` +
+      `${primitives.length} primitives, ${untested.length} without tests.\n\n` +
+      `| Primitive | Family | Words | Law tests | Conformance cases |\n` +
+      `| --- | --- | --- | --- | --- |\n${rows}\n`,
+  );
+} else if (process.argv.includes('--stdout')) {
+  process.stdout.write(`${JSON.stringify(map, null, 2)}\n`);
+} else {
+  writeFileSync(outputPath, `${JSON.stringify(map, null, 2)}\n`);
+  console.log(
+    `[primitive-test-map] wrote ${primitives.length} primitives to docs/primitive-test-map.json` +
+      (untested.length > 0 ? ` (${untested.length} without tests: ${untested.map((p) => p.id).join(', ')})` : ''),
+  );
+}


### PR DESCRIPTION
## Primitive → test reverse-index map (review Phase 3)

`formalization-coverage.json` records, per word, the primitives it `derived_from` and the `law_tests` / `conformance_cases` that exercise it — a forward map. This adds the inverse: a **primitive → tests** map so every declared algebra primitive is traceable to the concrete tests exercising the words that rest on it. This realizes the review's Phase 3 ("reclassify tests by semantic primitive") as a queryable artifact rather than by re-tagging tests in place.

### What's added
- **`scripts/generate-primitive-test-map.mjs`** → writes `docs/primitive-test-map.json`. Each primitive lists its `derived_words`, the union of `law_tests` and `conformance_cases` reaching it, and counts, plus a top-level summary. Supports `--stdout` (JSON) and `--markdown` (table) views. Wired as `npm run primitive:test-map`.
- **CI**: runs `npm run primitive:test-map` before the coverage check (mirrors the word-manifest step).
- **`check:formalization-coverage`**: a new **non-fatal** note flags any declared primitive exercised by no test, so a newly admitted primitive cannot stay silently untested. Matches the existing non-fatal note style.

### Current state
All **30** primitives are traced to at least one test (`primitives_without_tests: 0`); 23 distinct law-test files and 52 distinct conformance cases across the registry. The new note is therefore silent today and guards future additions. Verified the note fires correctly on a synthetic untested primitive.

No user-visible observations change; validator still exits 0 and map regeneration is deterministic.

https://claude.ai/code/session_01VM7CbERG8noUS5WkmidanK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM7CbERG8noUS5WkmidanK)_