### PR TITLE
Make Reference navigation full-height on desktop

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -298,11 +298,13 @@
         .ref-footer a { color: var(--color-text-light); }
         .ref-footer a:hover { color: var(--color-text); }
 
-        /* デスクトップ: 横軸 3:7。nav を左（30%）、article を右（70%）に。 */
+        /* デスクトップ: 横軸 3:7。nav を左（30%）、article を右（70%）に。
+           align-items: stretch（既定）により両カラムが同じ高さに伸び、nav の
+           背景色と分割線がコンテンツ領域の縦 100% を覆う。 */
         @media (min-width: 769px) {
             .ref-main {
                 flex-direction: row;
-                align-items: flex-start;
+                align-items: stretch;
             }
 
             .ref-nav {
@@ -311,9 +313,6 @@
                 max-width: 30%;
                 border-top: none;
                 border-right: var(--border-main);
-                position: sticky;
-                top: 0;
-                align-self: flex-start;
             }
 
             .ref-article {


### PR DESCRIPTION
## 概要

レビューでご指摘いただいた、Reference ページ（デスクトップ表示）の navigation 縦幅の見栄えを修正します。

## 問題

navigation を `position: sticky` + 内容分の高さにしていたため、article より背が低く、**分割線と背景色がコンテンツ領域の途中で途切れて**中途半端な印象でした。

## 修正

デスクトップ表示の `.ref-main` を `align-items: stretch`（既定）にし、nav の sticky 指定を外しました。これで navigation がコンテンツ領域の縦 **100%** に伸び、分割線と背景色が下端まで届きます。

https://claude.ai/code/session_01Ak4Pp89FzhgqKCT6tgveTj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak4Pp89FzhgqKCT6tgveTj)_