### PR TITLE
Fix zero-denominator literal panic; align SPEC §3.2 with implementation

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -103,12 +103,19 @@ The `truthValue` axis is present only on values carrying the `TruthValue` interp
 
 ### 3.2 Numeric literal formats
 
-| Format | Example |
-|--------|---------|
-| Integer | `42`, `-7` |
-| Fraction | `3/4`, `-5/2` |
-| Decimal | `3.14`, `.5`, `-1.0` |
-| Scientific notation | `1e5`, `1.5e-2`, `-3.0e4` |
+| Format | Examples |
+|--------|----------|
+| Integer | `42`, `-7`, `+7`, `007` |
+| Fraction | `3/4`, `-5/2`, `+3/4` |
+| Decimal | `3.14`, `.5`, `5.`, `-1.0`, `-.5` |
+| Scientific notation | `1e5`, `1.5e-2`, `-3.0e4`, `1.5E2`, `1e+5` |
+
+Every numeric literal may carry an optional leading sign (`+` or `-`); a leading `+` is accepted but has no effect. The accepted forms are:
+
+- **Integer** — one or more decimal digits. Leading zeros are allowed and insignificant (`007` denotes `7`).
+- **Fraction** — `<digits>/<digits>`. The denominator must be non-zero: `3/0` is **not** a valid literal and is rejected as an ordinary (malformed-literal) error. This is distinct from the runtime `DIV`-by-zero rule, under which the *operation* `3 0 DIV` projects to a `NIL` with reason `DivisionByZero` (Section 11.2); a literal `n/0` denotes no rational at all and never reaches that rule.
+- **Decimal** — an integer part, a `.`, and a fractional part, where at most one side may be empty: a leading-dot form (`.5`, `-.5`) has an empty integer part, and a trailing-dot form (`5.`) has an empty fractional part. A bare `.` is not a number — it is the `TOP` modifier (Section 3.9).
+- **Scientific notation** — an integer or decimal mantissa, the exponent marker `e` or `E`, an optional exponent sign (`+` or `-`), and one or more exponent digits (`1.5e-2`, `1e+5`, `1.5E2`).
 
 All numeric literals are parsed as exact real numbers and stored internally as continued fractions (see Section 4.2). The surface literal forms above are convenience syntax: `42`, `42/1`, `42.0`, and `4.2e1` all produce the same internal value. Integer, fraction, decimal, and scientific-notation literals yield finite continued fractions (rationals); irrational continued fractions are produced by words such as `MATH@SQRT`, not by surface literals.
 

--- a/rust/src/types/fraction.rs
+++ b/rust/src/types/fraction.rs
@@ -344,27 +344,48 @@ impl Fraction {
         if let Some(pos) = s.find('/') {
             let num: BigInt = BigInt::from_str(&s[..pos]).map_err(|e| e.to_string())?;
             let den: BigInt = BigInt::from_str(&s[pos + 1..]).map_err(|e| e.to_string())?;
+            // A fraction literal denotes a rational (SPEC §3.2); `n/0` denotes
+            // none, so it is rejected here rather than reaching `Fraction::new`,
+            // which panics on a zero denominator. This is distinct from the
+            // runtime `DIV`-by-zero totality rule (a NIL `DivisionByZero`):
+            // that governs the *operation*, whereas this is a malformed
+            // *literal*.
+            if den.is_zero() {
+                return Err(format!(
+                    "zero denominator: '{s}' is not a valid fraction literal (the denominator must be non-zero)"
+                ));
+            }
             Ok(Fraction::new(num, den))
         } else if let Some(dot_pos) = s.find('.') {
-            let int_part_str = if s.starts_with('.') {
+            // Strip an optional leading sign up front so that signed
+            // leading-dot decimals (`-.5`, `+.5`) parse exactly like `.5`.
+            // (Numeric literals are ASCII, so byte and char indices coincide.)
+            let (neg, body, dot_pos) = if let Some(rest) = s.strip_prefix('-') {
+                (true, rest, dot_pos - 1)
+            } else if let Some(rest) = s.strip_prefix('+') {
+                (false, rest, dot_pos - 1)
+            } else {
+                (false, s, dot_pos)
+            };
+            let int_part_str = if body.starts_with('.') {
                 "0"
             } else {
-                &s[..dot_pos]
+                &body[..dot_pos]
             };
-            let frac_part_str = &s[dot_pos + 1..];
-            if frac_part_str.is_empty() {
-                return Self::from_str(int_part_str);
-            }
+            let frac_part_str = &body[dot_pos + 1..];
             let int_part: BigInt = BigInt::from_str(int_part_str).map_err(|e| e.to_string())?;
+            if frac_part_str.is_empty() {
+                // Trailing-dot decimal such as `5.` denotes the integer part.
+                return Ok(Fraction::new(
+                    if neg { -int_part } else { int_part },
+                    BigInt::one(),
+                ));
+            }
             let frac_num: BigInt = BigInt::from_str(frac_part_str).map_err(|e| e.to_string())?;
             let frac_den: BigInt = BigInt::from(10).pow(frac_part_str.len() as u32);
-            let total_num: BigInt = int_part.abs() * &frac_den + frac_num;
+            let total_num: BigInt = int_part * &frac_den + frac_num;
             Ok(Fraction::new(
-                if int_part < BigInt::zero() {
-                    -total_num
-                } else {
-                    total_num
-                },
+                if neg { -total_num } else { total_num },
                 frac_den,
             ))
         } else {
@@ -565,5 +586,53 @@ mod literal_parsing_tests {
         let right = Fraction::from_str("0.5").expect("literal parses");
         let sum = left.add(&right);
         assert_eq!(sum.to_string(), "1");
+    }
+
+    #[test]
+    fn zero_denominator_fraction_literal_is_an_error_not_a_panic() {
+        // `n/0` denotes no rational (SPEC §3.2). It must surface as a clean
+        // parse error, never a `Fraction::new` "Division by zero" panic.
+        for src in ["3/0", "0/0", "-5/0"] {
+            assert!(
+                Fraction::from_str(src).is_err(),
+                "`{src}` must be rejected as a malformed fraction literal"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_leading_dot_decimals_parse() {
+        // The tokenizer accepts `-.5` / `+.5`; the converter must agree.
+        assert_eq!(
+            Fraction::from_str("-.5").unwrap(),
+            Fraction::from_str("-1/2").unwrap()
+        );
+        assert_eq!(
+            Fraction::from_str("+.5").unwrap(),
+            Fraction::from_str("1/2").unwrap()
+        );
+    }
+
+    #[test]
+    fn documented_surface_variants_are_accepted() {
+        // Forms now documented in SPEC §3.2 beyond the canonical examples:
+        // leading `+`, uppercase `E`, explicit `e+`, leading zeros, and
+        // trailing-dot decimals. All reduce to their canonical value.
+        let cases = [
+            ("+7", "7"),
+            ("+3/4", "3/4"),
+            ("007", "7"),
+            ("5.", "5"),
+            ("1.E5", "100000"),
+            ("1.5E2", "150"),
+            ("1e+5", "100000"),
+        ];
+        for (src, expected) in cases {
+            assert_eq!(
+                Fraction::from_str(src).unwrap(),
+                Fraction::from_str(expected).unwrap(),
+                "`{src}` should equal `{expected}`"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Background

Reviewing the §3.2 *Numeric literal formats* Example against the implementation surfaced two issues. All ten examples in the table parse and convert correctly, but the implementation accepts a **superset** of the documented forms and has a crash and an internal inconsistency.

Approach chosen (with the repo owner): **A** — align the spec with the implementation's accepted forms — and **C** — fix the panic and the tokenizer/converter disagreement.

## C — runtime fixes (`rust/src/types/fraction.rs`)

- **Zero-denominator panic.** `Fraction::from_str` reached `Fraction::new` for `n/0`, panicking the interpreter (`Division by zero`) instead of surfacing a normal error. A fraction literal denotes a rational (§3.2); `n/0` denotes none, so it is now rejected as an ordinary malformed-literal error. This is distinct from the runtime `DIV`-by-zero rule (§11.2), which projects the *operation* `3 0 DIV` to a `NIL DivisionByZero` — a literal never reaches that rule.
- **Signed leading-dot decimals.** `-.5` / `+.5` were accepted by the tokenizer but rejected by the converter (`cannot parse integer from empty string`). The decimal branch now strips an optional leading sign up front so they parse the same as `.5`.

## A — spec alignment (`SPECIFICATION.md` §3.2)

The table and prose now cover the forms the parser actually supports, beyond the canonical examples:

- leading `+` (no effect), leading zeros (`007`)
- uppercase `E` and explicit `e+` exponent sign
- trailing-dot decimals (`5.`)
- explicit statement of the non-zero-denominator rule and how it differs from runtime `DIV`-by-zero

## Tests

Added regression tests in `fraction.rs` covering the zero-denominator rejection (no panic), signed leading-dot decimals, and the newly documented surface variants. Verified end-to-end through the interpreter that `3/0`/`0/0` now error cleanly and `-.5`/`+.5` evaluate to `-1/2`/`1/2`. Existing fraction, tokenizer, and conformance suites pass.

## Note on the original observation

The Stack display already normalizes every numeric value to a fraction (`42` → `42/1`, `3.14` → `157/50`, `1.5e-2` → `3/200`), so that intuition is already satisfied by the implementation; the investigation is what surfaced the `3/0` crash.

https://claude.ai/code/session_01VcgH3GgdurdN4HFMJY8av4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcgH3GgdurdN4HFMJY8av4)_