### PR TITLE
Fix DEF to treat string-vector bodies as source lines

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -798,7 +798,9 @@ A bare name may legitimately appear under more than one canonical home (for exam
 { tokens... } 'NAME' 'description' DEF
 ```
 
-A code block followed by a name string defines a user word in the active dictionary. An optional description string may follow the name. Multiple consecutive code blocks on the stack are merged before definition. A vector may also serve as the definition body.
+A code block followed by a name string defines a user word in the active dictionary. An optional description string may follow the name. Multiple consecutive code blocks on the stack are merged before definition.
+
+A vector may also serve as the definition body. When the vector's elements are strings, each string is one source line of the definition (multiple strings become successive lines); the body of `[ '[ 2 ] *' ] 'DOUBLE' DEF` is therefore the source `[ 2 ] *`, not the codepoints of that text. A vector whose elements are not strings is serialized to source as ordinary data.
 
 ### 8.2 Rules
 

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -94,6 +94,39 @@ fn check_definition_descriptor_on_stack(stack: &[Value]) -> bool {
     is_string_like(last) && is_string_like(second_last)
 }
 
+fn is_text(val: &Value) -> bool {
+    val.hint == crate::types::Interpretation::Text
+}
+
+/// Interpret a definition body supplied as text rather than raw data.
+///
+/// A string is itself a codepoint vector, so without this handling a body such
+/// as `[ '[ 2 ] *' ]` would be serialized by `format_vector_to_source` as the
+/// literal codepoints (`[ 91 32 50 ... ]`) instead of the source line it spells
+/// out. Two text-shaped bodies are recognized here:
+///
+/// - a bare string body, treated as a single source line; and
+/// - a vector whose elements are all strings, treated as one source line each
+///   (joined by line breaks).
+///
+/// Returns `None` for any other value so the caller falls back to the standard
+/// data-to-source serialization.
+fn string_vector_to_source(val: &Value) -> Option<Result<String>> {
+    if is_text(val) {
+        return Some(extract_string_from_value(val));
+    }
+
+    if let ValueData::Vector(children) = &val.data {
+        if !children.is_empty() && children.iter().all(is_text) {
+            let lines: Result<Vec<String>> =
+                children.iter().map(extract_string_from_value).collect();
+            return Some(lines.map(|lines| lines.join("\n")));
+        }
+    }
+
+    None
+}
+
 pub fn op_def(interp: &mut Interpreter) -> Result<()> {
     if interp.operation_target_mode != OperationTargetMode::StackTop {
         return Err(AjisaiError::ModeUnsupported {
@@ -157,7 +190,12 @@ pub fn op_def(interp: &mut Interpreter) -> Result<()> {
             })
             .collect::<Vec<_>>()
             .join(" "),
-        ValueData::Vector(_) | ValueData::Record { .. } => format_vector_to_source(&def_val)?,
+        ValueData::Vector(_) | ValueData::Record { .. } => {
+            match string_vector_to_source(&def_val) {
+                Some(source) => source?,
+                None => format_vector_to_source(&def_val)?,
+            }
+        }
         _ => {
             return Err(AjisaiError::from(
                 "DEF requires a code block ({ ... } / ( ... )) or vector as definition body",

--- a/rust/src/interpreter/interpreter_definition_tests.rs
+++ b/rust/src/interpreter/interpreter_definition_tests.rs
@@ -541,4 +541,53 @@ mod tests {
         assert!(err.contains("PRECOMPUTE"));
         assert!(err.contains("recursive dependency"));
     }
+
+    #[tokio::test]
+    async fn test_def_with_string_vector_body() {
+        // A vector of strings is a definition body whose elements are source
+        // lines. `[ '[ 2 ] *' ] 'DOUBLE' DEF` must define DOUBLE with the body
+        // `[ 2 ] *`, not a word built from the string's codepoints.
+        let mut interp = Interpreter::new();
+        interp
+            .execute("[ '[ 2 ] *' ] 'DOUBLE' DEF")
+            .await
+            .expect("DEF with string-vector body should succeed");
+        let result = interp.execute("[ 21 ] DOUBLE").await;
+        assert!(result.is_ok(), "DOUBLE should run: {:?}", result);
+        assert_eq!(interp.stack.len(), 1);
+        let val = interp.stack.last().expect("result present");
+        assert!(val.is_vector(), "Expected vector result");
+        assert_eq!(val.len(), 1);
+        assert_eq!(
+            val.child(0)
+                .expect("child")
+                .as_scalar()
+                .expect("scalar")
+                .numerator()
+                .to_string(),
+            "42"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_def_with_multiline_string_vector_body() {
+        // Each string element is a separate source line.
+        let mut interp = Interpreter::new();
+        interp
+            .execute("[ '[ 1 ] +' '[ 2 ] *' ] 'INCDOUBLE' DEF")
+            .await
+            .expect("multi-line string-vector body should succeed");
+        let result = interp.execute("[ 10 ] INCDOUBLE").await;
+        assert!(result.is_ok(), "INCDOUBLE should run: {:?}", result);
+        let val = interp.stack.last().expect("result present");
+        assert_eq!(
+            val.child(0)
+                .expect("child")
+                .as_scalar()
+                .expect("scalar")
+                .numerator()
+                .to_string(),
+            "22"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

While building the Reference page, the documented `DEF` example did not work:

```
[ '[ 2 ] *' ] 'DOUBLE' DEF
[ 21 ] DOUBLE PRINT   →  expected [ 42 ]
```

A definition body supplied as a **vector of strings** was serialized through `format_vector_to_source`, which renders a string as its raw codepoints. So `[ '[ 2 ] *' ]` became the body `[ 91 32 50 32 93 32 42 ]` (the codepoints of the text `[ 2 ] *`) instead of the source line `[ 2 ] *`. The defined word therefore just pushed a codepoint vector rather than doubling its input.

## Fix

In `op_def`, recognize text-shaped definition bodies before serializing:

- a bare string body → a single source line; and
- a vector whose elements are all strings → one source line per element (joined by line breaks).

Strings are detected by their `Interpretation::Text` hint, so non-string vectors (e.g. `[ 1 2 3 ]`) keep the existing data-to-source behavior.

## Verification

- New tests `test_def_with_string_vector_body` and `test_def_with_multiline_string_vector_body` cover the single- and multi-line forms; `[ 21 ] DOUBLE` now yields `[ 42 ]`.
- Full Rust suite green (1248 lib tests + integration suites).
- `SPECIFICATION.md` §8.1 clarified to document the vector-of-strings body form.

https://claude.ai/code/session_015ZT5X8MncyzBYEY3MQ9nRf

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZT5X8MncyzBYEY3MQ9nRf)_