### PR TITLE
Constrain header/footer gradient to hydrangea palette and remove loop jump

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -61,25 +61,38 @@
         a:hover { color: var(--color-secondary); }
 
         /* "移ろい": header と footer が共有する、ゆっくり色相が巡るグラデーション。
-           アプリ本体 base.css の意匠をラフ複製したもの。 */
-        @property --mv-h { syntax: "<number>"; inherits: false; initial-value: 20; }
-        @property --mv-gap { syntax: "<number>"; inherits: false; initial-value: 135; }
-        @property --mv-l { syntax: "<percentage>"; inherits: false; initial-value: 87%; }
+           紫陽花らしい青紫・赤紫・淡緑・淡水色の範囲に収め、0% と 100% を
+           同一にしてループ時の急な色変化を避ける。 */
+        @property --mv-h-a { syntax: "<number>"; inherits: false; initial-value: 265; }
+        @property --mv-h-b { syntax: "<number>"; inherits: false; initial-value: 215; }
+        @property --mv-l { syntax: "<percentage>"; inherits: false; initial-value: 90%; }
+        @property --mv-c-a { syntax: "<number>"; inherits: false; initial-value: 0.085; }
+        @property --mv-c-b { syntax: "<number>"; inherits: false; initial-value: 0.07; }
 
-        @keyframes mv-hue { from { --mv-h: 20; } to { --mv-h: 380; } }
-        @keyframes mv-gap { 0% { --mv-gap: 110; } 50% { --mv-gap: 160; } 100% { --mv-gap: 110; } }
-        @keyframes mv-light { 0% { --mv-l: 87%; } 50% { --mv-l: 92%; } 100% { --mv-l: 87%; } }
+        @keyframes mv-hydrangea-hues {
+            0%, 100% { --mv-h-a: 265; --mv-h-b: 215; }
+            20% { --mv-h-a: 290; --mv-h-b: 245; }
+            40% { --mv-h-a: 325; --mv-h-b: 285; }
+            60% { --mv-h-a: 155; --mv-h-b: 205; }
+            80% { --mv-h-a: 205; --mv-h-b: 155; }
+        }
+        @keyframes mv-chroma {
+            0%, 100% { --mv-c-a: 0.085; --mv-c-b: 0.07; }
+            40% { --mv-c-a: 0.095; --mv-c-b: 0.08; }
+            60% { --mv-c-a: 0.06; --mv-c-b: 0.065; }
+        }
+        @keyframes mv-light { 0%, 100% { --mv-l: 90%; } 50% { --mv-l: 93%; } }
 
         .ref-header,
         .ref-footer {
             background: linear-gradient(
                 to right in oklch,
-                oklch(var(--mv-l) 0.1 var(--mv-h)) 0%,
-                oklch(var(--mv-l) 0.09 calc(var(--mv-h) + var(--mv-gap))) 100%
+                oklch(var(--mv-l) var(--mv-c-a) var(--mv-h-a)) 0%,
+                oklch(calc(var(--mv-l) + 1%) var(--mv-c-b) var(--mv-h-b)) 100%
             );
             animation:
-                mv-hue 240s linear infinite,
-                mv-gap 190s ease-in-out infinite,
+                mv-hydrangea-hues 260s ease-in-out infinite,
+                mv-chroma 210s ease-in-out infinite,
                 mv-light 170s ease-in-out infinite;
         }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -91,61 +91,104 @@ select:focus-visible {
 }
 
 
-/* "移ろい": header and footer share a slowly shifting OKLCH gradient. A single
- * base hue rotates uniformly around the full colour wheel (hue 380 is hue 20,
- * so the cycle never visibly restarts), and the second endpoint co-rotates at a
- * fixed offset (--mv-gap) so the pair turns together like a hue-rotate. Because
- * both stops share one rotation, the gradient's internal OKLCH interpolation
- * keeps a constant direction and never flips — the old counter-rotation let the
- * angular gap cross 180°, which flipped the shorter-arc interpolation and made
- * the mid-tones jump across the wheel. The gap itself breathes within (0,180)
- * and a slower wave drifts the lightness, so the pair's relationship still
- * keeps changing without ever crossing the interpolation seam. */
-@property --mv-h {
+/* "移ろい": header and footer share a slowly shifting OKLCH gradient
+ * constrained to hydrangea-like hues: blue-purple, red-purple, pale green,
+ * and pale aqua. The two gradient endpoints are animated as a matched pair,
+ * with nearby hues at every keyframe so the gradient interpolation never takes
+ * a warm orange/yellow shortcut. The 100% keyframe exactly repeats 0%, keeping
+ * the infinite loop from producing a visible colour jump. */
+@property --mv-h-a {
     syntax: "<number>";
     inherits: false;
-    initial-value: 20;
+    initial-value: 265;
 }
 
-@property --mv-gap {
+@property --mv-h-b {
     syntax: "<number>";
     inherits: false;
-    initial-value: 135;
+    initial-value: 215;
 }
 
 @property --mv-l {
     syntax: "<percentage>";
     inherits: false;
-    initial-value: 87%;
+    initial-value: 90%;
 }
 
-@keyframes mv-hue {
-    from { --mv-h: 20; }
-    to   { --mv-h: 380; }
+@property --mv-c-a {
+    syntax: "<number>";
+    inherits: false;
+    initial-value: 0.085;
 }
 
-@keyframes mv-gap {
-    0%   { --mv-gap: 110; }
-    50%  { --mv-gap: 160; }
-    100% { --mv-gap: 110; }
+@property --mv-c-b {
+    syntax: "<number>";
+    inherits: false;
+    initial-value: 0.07;
+}
+
+@keyframes mv-hydrangea-hues {
+    0%,
+    100% {
+        --mv-h-a: 265;
+        --mv-h-b: 215;
+    }
+
+    20% {
+        --mv-h-a: 290;
+        --mv-h-b: 245;
+    }
+
+    40% {
+        --mv-h-a: 325;
+        --mv-h-b: 285;
+    }
+
+    60% {
+        --mv-h-a: 155;
+        --mv-h-b: 205;
+    }
+
+    80% {
+        --mv-h-a: 205;
+        --mv-h-b: 155;
+    }
+}
+
+@keyframes mv-chroma {
+    0%,
+    100% {
+        --mv-c-a: 0.085;
+        --mv-c-b: 0.07;
+    }
+
+    40% {
+        --mv-c-a: 0.095;
+        --mv-c-b: 0.08;
+    }
+
+    60% {
+        --mv-c-a: 0.06;
+        --mv-c-b: 0.065;
+    }
 }
 
 @keyframes mv-light {
-    0%   { --mv-l: 87%; }
-    50%  { --mv-l: 92%; }
-    100% { --mv-l: 87%; }
+    0%,
+    100% { --mv-l: 90%; }
+    50%  { --mv-l: 93%; }
 }
 
 header,
 footer {
     background: linear-gradient(
         to right in oklch,
-        oklch(var(--mv-l) 0.1 var(--mv-h)) 0%,
-        oklch(var(--mv-l) 0.09 calc(var(--mv-h) + var(--mv-gap))) 100%
+        oklch(var(--mv-l) var(--mv-c-a) var(--mv-h-a)) 0%,
+        oklch(calc(var(--mv-l) + 1%) var(--mv-c-b) var(--mv-h-b)) 100%
     );
     animation:
-        mv-hue 240s linear infinite,
-        mv-gap 190s ease-in-out infinite,
+        mv-hydrangea-hues 260s ease-in-out infinite,
+        mv-chroma 210s ease-in-out infinite,
         mv-light 170s ease-in-out infinite;
 }
 


### PR DESCRIPTION
### Motivation
- The existing OKLCH hue-rotate gradient could wander into warm orange/yellow hues that feel inconsistent with a hydrangea theme. 
- When the animation completes a cycle the color change could be visually abrupt and attract unnecessary attention. 

### Description
- Replace the free-running hue rotation with a constrained hydrangea palette by introducing `--mv-h-a`, `--mv-h-b`, `--mv-c-a`, and `--mv-c-b` CSS custom properties and keyframes. 
- Add `@keyframes mv-hydrangea-hues`, `@keyframes mv-chroma`, and adjust `mv-light` so endpoints stay in blue-purple / red-purple / pale-green / pale-aqua regions and chroma/lightness breathe subtly. 
- Update `header` / `footer` `linear-gradient(... in oklch ...)` to use the new properties so both gradient stops animate as a matched pair and avoid warm orange/yellow shortcuts. 
- Mirror the same styles in the generated reference page at `public/docs/index.html` so docs reflect the updated visual behavior. 

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`) which completed with no errors. 
- Built the web bundle with `npm run build:web` (Vite) which completed successfully. 
- Ran `npm run lint` (`eslint .`) with no reported problems. 
- Ran `git diff --check` and repository checks showed no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d0d463cc8326b884ada393a5a036)