### PR TITLE
Polish header gradient and layout (hydrangea palette, animations, responsive markup)

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -61,25 +61,39 @@
         a:hover { color: var(--color-secondary); }
 
         /* "移ろい": header と footer が共有する、ゆっくり色相が巡るグラデーション。
-           アプリ本体 base.css の意匠をラフ複製したもの。 */
-        @property --mv-h { syntax: "<number>"; inherits: false; initial-value: 20; }
-        @property --mv-gap { syntax: "<number>"; inherits: false; initial-value: 135; }
-        @property --mv-l { syntax: "<percentage>"; inherits: false; initial-value: 87%; }
+           紫陽花らしい青紫・赤紫・淡緑・淡水色の範囲に収め、0% と 100% を
+           同一にしてループ時の急な色変化を避ける。 */
+        @property --mv-h-a { syntax: "<number>"; inherits: false; initial-value: 265; }
+        @property --mv-h-b { syntax: "<number>"; inherits: false; initial-value: 215; }
+        @property --mv-l { syntax: "<percentage>"; inherits: false; initial-value: 90%; }
+        @property --mv-c-a { syntax: "<number>"; inherits: false; initial-value: 0.085; }
+        @property --mv-c-b { syntax: "<number>"; inherits: false; initial-value: 0.07; }
 
-        @keyframes mv-hue { from { --mv-h: 20; } to { --mv-h: 380; } }
-        @keyframes mv-gap { 0% { --mv-gap: 110; } 50% { --mv-gap: 160; } 100% { --mv-gap: 110; } }
-        @keyframes mv-light { 0% { --mv-l: 87%; } 50% { --mv-l: 92%; } 100% { --mv-l: 87%; } }
+        @keyframes mv-hydrangea-hues {
+            0%, 100% { --mv-h-a: 265; --mv-h-b: 215; }
+            20% { --mv-h-a: 300; --mv-h-b: 255; }
+            35% { --mv-h-a: 325; --mv-h-b: 285; }
+            50% { --mv-h-a: 285; --mv-h-b: 245; }
+            70% { --mv-h-a: 205; --mv-h-b: 155; }
+            85% { --mv-h-a: 155; --mv-h-b: 205; }
+        }
+        @keyframes mv-chroma {
+            0%, 100% { --mv-c-a: 0.085; --mv-c-b: 0.07; }
+            40% { --mv-c-a: 0.095; --mv-c-b: 0.08; }
+            60% { --mv-c-a: 0.06; --mv-c-b: 0.065; }
+        }
+        @keyframes mv-light { 0%, 100% { --mv-l: 90%; } 50% { --mv-l: 93%; } }
 
         .ref-header,
         .ref-footer {
             background: linear-gradient(
                 to right in oklch,
-                oklch(var(--mv-l) 0.1 var(--mv-h)) 0%,
-                oklch(var(--mv-l) 0.09 calc(var(--mv-h) + var(--mv-gap))) 100%
+                oklch(var(--mv-l) var(--mv-c-a) var(--mv-h-a)) 0%,
+                oklch(calc(var(--mv-l) + 1%) var(--mv-c-b) var(--mv-h-b)) 100%
             );
             animation:
-                mv-hue 240s linear infinite,
-                mv-gap 190s ease-in-out infinite,
+                mv-hydrangea-hues 260s ease-in-out infinite,
+                mv-chroma 210s ease-in-out infinite,
                 mv-light 170s ease-in-out infinite;
         }
 
@@ -91,11 +105,18 @@
             border-bottom: var(--border-main);
             padding: 1rem 2rem;
             display: flex;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 0.5rem;
+            color: var(--color-text);
+        }
+
+        .app-header-top {
+            display: flex;
             align-items: center;
             justify-content: space-between;
             gap: 1rem;
-            flex-wrap: wrap;
-            color: var(--color-text);
+            width: 100%;
         }
 
         .app-brand-meta {
@@ -349,7 +370,7 @@
                 -webkit-overflow-scrolling: touch;
             }
 
-            .ref-header { padding: 0.75rem 1rem; }
+            .ref-header { padding: 1rem 2rem; }
             .ref-article { padding: 1.25rem 1rem 2rem; }
             .ref-nav { padding: 1.25rem 1rem; }
         }
@@ -357,6 +378,7 @@
 </head>
 <body>
     <header class="ref-header">
+        <div class="app-header-top">
             <div class="app-brand-meta">
                 <a href="../index.html" class="app-brand-block" aria-label="Ajisai">
                     <img src="../images/QR_341216.png" alt="" class="logo" aria-hidden="true">
@@ -364,16 +386,17 @@
                 </a>
                 <span class="ref-tagline">Reference</span>
             </div>
-            <div class="header-actions">
-                <!-- Reference 側ではアプリ本体への動線として Playground ボタンを置く。 -->
-                <a href="../index.html" class="btn">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                        <path d="M5 3l14 9-14 9V3z"/>
-                    </svg>
-                    Playground
-                </a>
-            </div>
-        </header>
+        </div>
+        <div class="header-actions">
+            <!-- Reference 側ではアプリ本体への動線として Playground ボタンを置く。 -->
+            <a href="../index.html" class="btn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path d="M5 3l14 9-14 9V3z"/>
+                </svg>
+                Playground
+            </a>
+        </div>
+    </header>
 
         <main class="ref-main">
             <article class="ref-article">

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -91,61 +91,109 @@ select:focus-visible {
 }
 
 
-/* "移ろい": header and footer share a slowly shifting OKLCH gradient. A single
- * base hue rotates uniformly around the full colour wheel (hue 380 is hue 20,
- * so the cycle never visibly restarts), and the second endpoint co-rotates at a
- * fixed offset (--mv-gap) so the pair turns together like a hue-rotate. Because
- * both stops share one rotation, the gradient's internal OKLCH interpolation
- * keeps a constant direction and never flips — the old counter-rotation let the
- * angular gap cross 180°, which flipped the shorter-arc interpolation and made
- * the mid-tones jump across the wheel. The gap itself breathes within (0,180)
- * and a slower wave drifts the lightness, so the pair's relationship still
- * keeps changing without ever crossing the interpolation seam. */
-@property --mv-h {
+/* "移ろい": header and footer share a slowly shifting OKLCH gradient
+ * constrained to hydrangea-like hues: blue-purple, red-purple, pale green,
+ * and pale aqua. The two gradient endpoints are animated as a matched pair,
+ * with nearby hues at every keyframe so the gradient interpolation never takes
+ * a warm orange/yellow shortcut. The 100% keyframe exactly repeats 0%, keeping
+ * the infinite loop from producing a visible colour jump. */
+@property --mv-h-a {
     syntax: "<number>";
     inherits: false;
-    initial-value: 20;
+    initial-value: 265;
 }
 
-@property --mv-gap {
+@property --mv-h-b {
     syntax: "<number>";
     inherits: false;
-    initial-value: 135;
+    initial-value: 215;
 }
 
 @property --mv-l {
     syntax: "<percentage>";
     inherits: false;
-    initial-value: 87%;
+    initial-value: 90%;
 }
 
-@keyframes mv-hue {
-    from { --mv-h: 20; }
-    to   { --mv-h: 380; }
+@property --mv-c-a {
+    syntax: "<number>";
+    inherits: false;
+    initial-value: 0.085;
 }
 
-@keyframes mv-gap {
-    0%   { --mv-gap: 110; }
-    50%  { --mv-gap: 160; }
-    100% { --mv-gap: 110; }
+@property --mv-c-b {
+    syntax: "<number>";
+    inherits: false;
+    initial-value: 0.07;
+}
+
+@keyframes mv-hydrangea-hues {
+    0%,
+    100% {
+        --mv-h-a: 265;
+        --mv-h-b: 215;
+    }
+
+    20% {
+        --mv-h-a: 300;
+        --mv-h-b: 255;
+    }
+
+    35% {
+        --mv-h-a: 325;
+        --mv-h-b: 285;
+    }
+
+    50% {
+        --mv-h-a: 285;
+        --mv-h-b: 245;
+    }
+
+    70% {
+        --mv-h-a: 205;
+        --mv-h-b: 155;
+    }
+
+    85% {
+        --mv-h-a: 155;
+        --mv-h-b: 205;
+    }
+}
+
+@keyframes mv-chroma {
+    0%,
+    100% {
+        --mv-c-a: 0.085;
+        --mv-c-b: 0.07;
+    }
+
+    40% {
+        --mv-c-a: 0.095;
+        --mv-c-b: 0.08;
+    }
+
+    60% {
+        --mv-c-a: 0.06;
+        --mv-c-b: 0.065;
+    }
 }
 
 @keyframes mv-light {
-    0%   { --mv-l: 87%; }
-    50%  { --mv-l: 92%; }
-    100% { --mv-l: 87%; }
+    0%,
+    100% { --mv-l: 90%; }
+    50%  { --mv-l: 93%; }
 }
 
 header,
 footer {
     background: linear-gradient(
         to right in oklch,
-        oklch(var(--mv-l) 0.1 var(--mv-h)) 0%,
-        oklch(var(--mv-l) 0.09 calc(var(--mv-h) + var(--mv-gap))) 100%
+        oklch(var(--mv-l) var(--mv-c-a) var(--mv-h-a)) 0%,
+        oklch(calc(var(--mv-l) + 1%) var(--mv-c-b) var(--mv-h-b)) 100%
     );
     animation:
-        mv-hue 240s linear infinite,
-        mv-gap 190s ease-in-out infinite,
+        mv-hydrangea-hues 260s ease-in-out infinite,
+        mv-chroma 210s ease-in-out infinite,
         mv-light 170s ease-in-out infinite;
 }
 


### PR DESCRIPTION
### Motivation

- Replace the previous wide-ranging hue rotation with a constrained, hydrangea-inspired OKLCH palette to avoid visible color jumps during the loop. 
- Improve the header's visual expression by animating chroma and lightness separately for a subtler effect.
- Make the header markup and layout more robust and responsive by grouping brand content and actions into a top row and adjusting padding.

### Description

- Replace single rotating hue variables with paired hue properties `--mv-h-a`/`--mv-h-b`, chroma properties `--mv-c-a`/`--mv-c-b`, and updated `@property` declarations. 
- Add new keyframes `mv-hydrangea-hues`, `mv-chroma`, and adjust `mv-light` to produce a smoother hydrangea-like animation, and update the gradient stop expressions to use the new variables. 
- Rename and update animations and timing, and adjust header/footer gradient construction to avoid interpolation seams and ensure `0%` and `100%` are identical. 
- Update header layout HTML by adding an `.app-header-top` wrapper, moving `.header-actions` out of it, and tweak header CSS (flex column, gap, alignments, and padding) along with a mobile padding change in `index.html` and `src/styles/base.css`.

### Testing

- Built the docs site locally with `npm run build` and the build completed without errors. 
- No automated unit tests were changed by this PR; visual changes were inspected in the generated pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d0d463cc8326b884ada393a5a036)