### PR TITLE
Apply authoring style to SPECIFICATION.md and enrich the Reference

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,15 +1,15 @@
 # Ajisai Language Specification
 
 Status: **Canonical**
-Version: **2026-06-08**
+Version: **2026-06-10**
 
 This document is the single design authority for Ajisai. It describes Ajisai as it is. It does not record development history or transitional states. If any other document conflicts with this document, this document takes precedence.
 
 Ajisai is a typed, vector-oriented dataflow language. Its safety story is the conjunction of:
 
-- **Value-shape safety** — operations check that operands have the structural shape they require (Scalar / Vector / Record / NIL / CodeBlock / handles).
+- **Value-shape safety** — operations check that operands have the structural shape they require (Scalar, Vector, Record, NIL, CodeBlock, handles).
 - **Encoding safety** — string and code values carry encoding contracts on top of their underlying fraction sequences.
-- **Contract safety** — every Coreword has machine-readable `requires` / `ensures` / partiality / NIL policy / effect metadata in the registry.
+- **Contract safety** — every Coreword carries machine-readable contract metadata in the registry: `requires` and `ensures` clauses, partiality, NIL policy, and effect classification.
 - **Bubble Rule safety** — a well-formed operation that cannot produce a value projects the failure onto NIL with a structured reason, while malformed use raises an ordinary error (Section 11.2).
 
 These layers compose. A change is conformant only if it preserves all of them.
@@ -62,11 +62,11 @@ Ajisai values are observed through independent semantic axes:
 
 | Axis | Protocol field | Initial protocol strings |
 |------|----------------|--------------------------|
-| semantic kind | `semanticKind` | `number`, `collection`, `record`, `code`, `process`, `supervisor`, `absence`, `unknown` |
-| shape | `shape` | `scalar`, `vector`, `tensor`, `record`, `codeBlock`, `handle`, `absence`, `unknown` |
-| capabilities | `capabilities` | `numeric`, `exactNumeric`, `iterable`, `indexable`, `callable`, `stackItem`, `nilPassthrough`, `diagnosable`, `serializable`, `displayable`, `userEditable`, `moduleOwned`, `coreOwned`, `aiExplainable`, `truthValued` |
-| truth value | `truthValue` | `true`, `false`, `unknown` |
-| origin | `origin` | `literal`, `computed`, `coreWord`, `builtinWord`, `moduleWord`, `userWord`, `safeProjection`, `nilPropagation`, `hostEnvironment`, `optimizer`, `unknown` |
+| semantic kind | `semanticKind` | `number` `collection` `record` `code` `process` `supervisor` `absence` `unknown` |
+| shape | `shape` | `scalar` `vector` `tensor` `record` `codeBlock` `handle` `absence` `unknown` |
+| capabilities | `capabilities` | `numeric` `exactNumeric` `iterable` `indexable` `callable` `stackItem` `nilPassthrough` `diagnosable` `serializable` `displayable` `userEditable` `moduleOwned` `coreOwned` `aiExplainable` `truthValued` |
+| truth value | `truthValue` | `true` `false` `unknown` |
+| origin | `origin` | `literal` `computed` `coreWord` `builtinWord` `moduleWord` `userWord` `safeProjection` `nilPropagation` `hostEnvironment` `optimizer` `unknown` |
 | absence metadata | `absence` | structured object |
 | diagnostic context | `diagnosis` | structured object |
 | display | `display` | human-readable only; non-canonical |
@@ -76,7 +76,7 @@ External APIs, WASM payloads, GUI logic, AI diagnostics, and user-facing machine
 
 Machine-readable semantic metadata is part of this firewall. `docs/word-manifest.json` gives every surface word a generated `canonical` spelling and `semantic_role`; `docs/formalization-coverage.json` gives canonical entries their algebraic family, derivation edges, primitive registry, effect boundary, and exploratory debt metadata. Tooling must update the generator and coverage source rather than hand-authoring contradictory manifest semantics.
 
-The `truthValue` axis is present only on values carrying the `TruthValue` interpretation role (Section 12.2); such values also carry the `truthValued` capability. Its three protocol strings — `true`, `false`, `unknown` — are the **only** observable surface for the three-valued logic of Section 7.5. The third value `unknown` (U) is a logical truth value, not an operational absence: how it is represented internally (for example, whether it shares storage with a NIL node) is not observable, and consumers must not infer it from `semanticKind = absence`, from any `absence.reason`, or from display text. A consumer that needs to distinguish true, false, and unknown reads the `truthValue` axis and nothing else.
+The `truthValue` axis is present only on values carrying the `TruthValue` interpretation role (Section 12.2); such values also carry the `truthValued` capability. Its three protocol strings — `true` `false` `unknown` — are the **only** observable surface for the three-valued logic of Section 7.5. The third value `unknown` (U) is a logical truth value, not an operational absence: how it is represented internally (for example, whether it shares storage with a NIL node) is not observable, and consumers must not infer it from `semanticKind = absence`, from any `absence.reason`, or from display text. A consumer that needs to distinguish true, false, and unknown reads the `truthValue` axis and nothing else.
 
 ---
 
@@ -105,25 +105,25 @@ The `truthValue` axis is present only on values carrying the `TruthValue` interp
 
 | Format | Examples |
 |--------|----------|
-| Integer | `42`, `-7`, `+7`, `007` |
-| Fraction | `3/4`, `-5/2`, `+3/4` |
-| Decimal | `3.14`, `.5`, `5.`, `-1.0`, `-.5` |
-| Scientific notation | `1e5`, `1.5e-2`, `-3.0e4`, `1.5E2`, `1e+5` |
+| Integer | `42` `-7` `+7` `007` |
+| Fraction | `3/4` `-5/2` `+3/4` |
+| Decimal | `3.14` `.5` `5.` `-1.0` `-.5` |
+| Scientific notation | `1e5` `1.5e-2` `-3.0e4` `1.5E2` `1e+5` |
 
 Every numeric literal may carry an optional leading sign (`+` or `-`); a leading `+` is accepted but has no effect. The accepted forms are:
 
 - **Integer** — one or more decimal digits. Leading zeros are allowed and insignificant (`007` denotes `7`).
 - **Fraction** — `<digits>/<digits>`. The denominator must be non-zero: `3/0` is **not** a valid literal and is rejected as an ordinary (malformed-literal) error. This is distinct from the runtime `DIV`-by-zero rule, under which the *operation* `3 0 DIV` projects to a `NIL` with reason `DivisionByZero` (Section 11.2); a literal `n/0` denotes no rational at all and never reaches that rule.
-- **Decimal** — an integer part, a `.`, and a fractional part, where at most one side may be empty: a leading-dot form (`.5`, `-.5`) has an empty integer part, and a trailing-dot form (`5.`) has an empty fractional part. A bare `.` is not a number — it is the `TOP` modifier (Section 3.9).
-- **Scientific notation** — an integer or decimal mantissa, the exponent marker `e` or `E`, an optional exponent sign (`+` or `-`), and one or more exponent digits (`1.5e-2`, `1e+5`, `1.5E2`).
+- **Decimal** — an integer part, a `.`, and a fractional part, where at most one side may be empty: a leading-dot form (`.5` and `-.5`) has an empty integer part, and a trailing-dot form (`5.`) has an empty fractional part. A bare `.` is not a number — it is the `TOP` modifier (Section 3.9).
+- **Scientific notation** — an integer or decimal mantissa, the exponent marker `e` or `E`, an optional exponent sign (`+` or `-`), and one or more exponent digits (`1.5e-2` `1e+5` `1.5E2`).
 
-All numeric literals are parsed as exact real numbers and stored internally as continued fractions (see Section 4.2). The surface literal forms above are convenience syntax: `42`, `42/1`, `42.0`, and `4.2e1` all produce the same internal value. Integer, fraction, decimal, and scientific-notation literals yield finite continued fractions (rationals); irrational continued fractions are produced by words such as `MATH@SQRT`, not by surface literals.
+All numeric literals are parsed as exact real numbers and stored internally as continued fractions (see Section 4.2). The surface literal forms above are convenience syntax: `42` `42/1` `42.0` `4.2e1` all produce the same internal value. Integer, fraction, decimal, and scientific-notation literals yield finite continued fractions (rationals); irrational continued fractions are produced by words such as `MATH@SQRT`, not by surface literals.
 
 The nested-parentheses form `( a0 ( a1 ( a2 ... )))` is the canonical serialization and AI-readable debug form for continued fractions (Section 4.2). It is not a source-code literal: Ajisai source uses the surface forms above, and the nested form appears only in display and serialization output under the `ContinuedFraction` interpretation role (Section 12.2).
 
 ### 3.3 String literals
 
-A string literal begins with `'` and ends with the last `'` before a token boundary. A token boundary is whitespace, end of input, or any special character other than `'` (such as `[`, `]`, `{`, `}`, `#`, `=`, `$`).
+A string literal begins with `'` and ends with the last `'` before a token boundary. A token boundary is whitespace, end of input, or any special character other than `'` (such as `[` `]` `{` `}` `#` `=` `$`).
 
 Any `'` that appears before a non-boundary character is a literal quote character in the string content.
 
@@ -152,7 +152,7 @@ Inside a `COND` expression, clauses are separated by `$`. Each `$` clause must o
 
 ### 3.7 Syntax constraints
 
-- All bracket pairs (`[`, `{`) must be balanced.
+- All bracket pairs (`[` `{`) must be balanced.
 - Each `$` `COND` clause must occupy exactly one line (at every nesting level).
 - The characters `(` and `)` are not valid in Ajisai source (Section 3.4).
 
@@ -196,9 +196,9 @@ Not every surface form is a runtime word. A surface form is classified as one of
 | `(` `)` | `RESERVED-BEGIN` `RESERVED-END` | Reserved marker | no |
 | `>CF` | `>CF` (continued-fraction conversion) | Conversion word | yes |
 
-`;` and `;;` are pure shorthand: `; == . ,` and `;; == .. ,,`. The concept names `TOP-EAT` and `STAK-KEEP` name the compound forms; they are not stand-alone runtime words.
+`;` and `;;` are pure shorthand: `;` expands to `. ,` and `;;` expands to `.. ,,`. The concept names `TOP-EAT` and `STAK-KEEP` name the compound forms; they are not stand-alone runtime words.
 
-`>` followed by an ASCII letter (e.g. `>CF`) is a single **conversion-word** token, not the `>` (`GT`) comparison alias followed by a word. Its canonical home is the runtime conversion word of the same name; `>` and `>=` remain the `GT` / `GTE` aliases.
+`>` followed by an ASCII letter (e.g. `>CF`) is a single **conversion-word** token, not the `>` (`GT`) comparison alias followed by a word. Its canonical home is the runtime conversion word of the same name; `>` and `>=` remain the aliases of `GT` and `GTE`.
 
 ---
 
@@ -217,19 +217,19 @@ Not every surface form is a runtime word. A surface form is classified as one of
 | ProcessHandle | A reference to a running child runtime |
 | SupervisorHandle | A reference to a supervisor |
 
-A Boolean carries the `TruthValue` interpretation role (Section 12.2) and the `truthValued` capability (Section 2.3); it renders uniformly as `TRUE` / `FALSE` (display-only, non-canonical). Equality and ordering treat a Boolean as distinct from every Scalar: value identity never conflates a truth value with a number. Inside element-wise numeric operations over vectors, truth lanes are represented numerically as `1` / `0`; the distinctness rule above governs Scalar-level value identity (notably `EQ`), not numeric broadcast over vector lanes.
+A Boolean carries the `TruthValue` interpretation role (Section 12.2) and the `truthValued` capability (Section 2.3); it renders uniformly as `TRUE` or `FALSE` (display-only, non-canonical). Equality and ordering treat a Boolean as distinct from every Scalar: value identity never conflates a truth value with a number. Inside element-wise numeric operations over vectors, truth lanes are represented numerically as `1` and `0`; the distinctness rule above governs Scalar-level value identity (notably `EQ`), not numeric broadcast over vector lanes.
 
 ### 4.2 Scalar: exact-real continued-fraction arithmetic
 
-All numeric values are exact reals represented as **continued fractions** (CF). A scalar is a sequence of integer partial quotients `[a0; a1, a2, ...]`, finite for rationals and lazy (potentially infinite) for irrationals.
+All numeric values are exact reals represented as **continued fractions** (CF). A scalar is a sequence of integer partial quotients [*a*₀; *a*₁, *a*₂, …], finite for rationals and lazy (potentially infinite) for irrationals.
 
 #### 4.2.1 Canonical form
 
 A continued fraction is in canonical form when:
 
-1. `a0` is any integer.
-2. `a1, a2, ...` are strictly positive integers.
-3. If the sequence is finite and has length `n >= 2`, then the last partial quotient `a_{n-1}` is greater than `1` (no trailing `1`).
+1. *a*₀ is any integer.
+2. *a*₁, *a*₂, … are strictly positive integers.
+3. If the sequence is finite and has length *n* ≥ 2, then the last partial quotient *a*ₙ₋₁ is greater than 1 (no trailing 1).
 4. The sequence terminates iff the value is rational.
 
 These rules give every real value a unique canonical CF, so equality of canonical CFs decides equality of values whenever the comparison terminates (Section 7.4).
@@ -240,7 +240,7 @@ A scalar is internally one of the following representations. Which representatio
 
 - **Rational** — a finite CF, stored equivalently as either a small `(i64, i64)` reduced fraction or a `(BigInt, BigInt)` reduced fraction. Partial quotients are generated on demand by floor-division Euclidean algorithm.
 - **AlgebraicSqrt** — `SQRT` of a non-negative rational. The CF expansion is eventually periodic (Lagrange's theorem) and produced lazily.
-- **Gosper** — an unevaluated bihomographic transform `(a x y + b x + c y + d) / (e x y + f x + g y + h)` of one or two operand CFs, used by arithmetic (Section 7.3). Partial quotients of the result are emitted as soon as the next quotient is unambiguously determined by the current Möbius coefficients.
+- **Gosper** — an unevaluated bihomographic transform (*a·xy* + *b·x* + *c·y* + *d*) / (*e·xy* + *f·x* + *g·y* + *h*) of one or two operand CFs, used by arithmetic (Section 7.3). Partial quotients of the result are emitted as soon as the next quotient is unambiguously determined by the current Möbius coefficients.
 - **LazyCf** — any other lazy CF stream (reserved for future words; not produced by the Coreword set defined in this document).
 
 Möbius coefficients used by Gosper transforms are stored as arbitrary-precision integers (BigInt) at all times. Implementations must not use bounded-width coefficient storage that can overflow during normal evaluation.
@@ -259,26 +259,24 @@ This nested form is **not** Ajisai source syntax (Section 3.4). It appears only 
 
 #### 4.2.4 Equivalence of representations
 
-Two scalars are equal as values iff they produce the same canonical CF sequence. A `Rational` scalar and a `Gosper`/`AlgebraicSqrt` scalar may compare equal whenever their generated partial quotients agree at every position. The internal representation tag is not part of value identity and must not be branched on by Corewords or external consumers.
+Two scalars are equal as values iff they produce the same canonical CF sequence. A `Rational` scalar and a `Gosper` or `AlgebraicSqrt` scalar may compare equal whenever their generated partial quotients agree at every position. The internal representation tag is not part of value identity and must not be branched on by Corewords or external consumers.
 
 #### 4.2.5 Nearest-integer continued fractions (comparison expansion)
 
 The comparison procedure of Section 7.4.1 expands operands as nearest-integer continued fractions. This is an internal expansion: the **regular** continued fraction of Sections 4.2.1–4.2.4 remains the sole basis for value identity, canonical form, display, and serialization. The nearest-integer expansion changes only how comparison consumes a value and, consequently, the unit of the comparison budget (see the end of this subsection and Section 7.4.1.1).
 
-The **regular** continued fraction (RCF) of Section 4.2.1 takes each partial quotient by *floor*, leaving a remainder in `[0, 1)` and forcing every quotient after `a0` to be a strictly positive integer. The **nearest-integer continued fraction** (NICF) instead takes each partial quotient by *rounding to the nearest integer*, leaving a remainder in `(-1/2, 1/2]`. An NICF is a *semiregular* continued fraction
+The **regular** continued fraction (RCF) of Section 4.2.1 takes each partial quotient by *floor*, leaving a remainder in [0, 1) and forcing every quotient after *a*₀ to be a strictly positive integer. The **nearest-integer continued fraction** (NICF) instead takes each partial quotient by *rounding to the nearest integer*, leaving a remainder in (−1/2, 1/2]. An NICF is a *semiregular* continued fraction
 
-```
-x = b0 + ε1 / (b1 + ε2 / (b2 + ε3 / ( ... )))
-```
+> *x* = *b*₀ + *ε*₁ / (*b*₁ + *ε*₂ / (*b*₂ + *ε*₃ / ( … )))
 
-where each `bi` is the nearest integer to the current tail, each `εi ∈ {+1, -1}` is the sign of the corresponding remainder, and `bi >= 2` for `i >= 1`. Because each step removes more of the value than a floor step can, NICF expansions are never longer than the RCF and are typically shorter: by a classical result the NICF converges at least as fast as the RCF and on average meaningfully faster (larger effective partial quotients per term). Over exact-rational, near-equal, and surd corpora the NICF reduces the agreed-prefix depth by roughly 22–28% on the mean, including ~28% on the surd (lazy-CF) case that actually exhausts the comparison budget.
+where each *b*ᵢ is the nearest integer to the current tail, each *ε*ᵢ ∈ {+1, −1} is the sign of the corresponding remainder, and *b*ᵢ ≥ 2 for *i* ≥ 1. Because each step removes more of the value than a floor step can, NICF expansions are never longer than the RCF and are typically shorter: by a classical result the NICF converges at least as fast as the RCF and on average meaningfully faster (larger effective partial quotients per term). Over exact-rational, near-equal, and surd corpora the NICF reduces the agreed-prefix depth by roughly 22–28% on the mean, including ~28% on the surd (lazy-CF) case that actually exhausts the comparison budget.
 
-**Tie-break (normative).** Each partial quotient is `bi = round(t)` of the current tail `t`, where `round` sends a value whose fractional part is exactly `1/2` **down** to the lower integer; equivalently the post-step remainder lies in the half-open interval `(-1/2, 1/2]`, and `bi = ⌈(2·num − den) / (2·den)⌉` for a tail `num/den` with `den > 0`. This makes the NICF digit sequence of every value deterministic, so two conforming implementations agree on it.
+**Tie-break (normative).** Each partial quotient is *b*ᵢ = round(*t*) of the current tail *t*, where round sends a value whose fractional part is exactly 1/2 **down** to the lower integer; equivalently the post-step remainder lies in the half-open interval (−1/2, 1/2], and *b*ᵢ = ⌈(2·*num* − *den*) / (2·*den*)⌉ for a tail *num*/*den* with *den* > 0. This makes the NICF digit sequence of every value deterministic, so two conforming implementations agree on it.
 
 NICF changes which expansion the **comparison procedure** consumes (Section 7.4.1.1). It does **not** change the following observable surfaces, which remain defined by the RCF:
 
 - **Value identity and canonical form.** The canonical CF of a value remains its RCF (Section 4.2.1); two values are equal iff their RCFs agree (Section 4.2.4). NICF is never the canonical form and is never the basis of equality.
-- **Display and serialization.** The nested form of Section 4.2.3 always renders the RCF. NICF digits, signs, and the `εi` are never serialized and must not be parsed.
+- **Display and serialization.** The nested form of Section 4.2.3 always renders the RCF. NICF digits, signs, and the *ε*ᵢ are never serialized and must not be parsed.
 - **The internal representation tag** (Section 4.2.2 / 4.2.4) remains non-observable: which stored representation backs a value must not be branched on.
 
 What NICF *does* make observable, indirectly, is the **unit of the comparison budget** (Sections 7.4.1.1, 7.4.2): a budget term, and hence an `agreedPrefix` count, is a *semiregular (NICF) term*. NICF introduces no new numeric type, no new Coreword, and no new protocol field.
@@ -294,7 +292,7 @@ A Vector value is internally represented in one of two classes:
 - **nested** — a tree of `Value` elements (`Vec<Value>`). Any element type may appear, including mixed types (Scalars, Vectors, Strings, NIL, etc.).
 - **dense** — a SIMD-oriented `DenseTensor` backed by Structure-of-Arrays numerator and denominator buffers, a shape, and a validity mask. Every valid lane is an exact small Fraction; an invalid lane represents NIL occupancy without rebuilding the dense representation into nested `Vec<Value>` form.
 
-The class is chosen at construction time. Observable semantics — `Display`, ordering, equality, NIL-ness, `SHAPE`, `LENGTH`, indexing, iteration order — are identical between the two classes. Operations are free to take a fast path when the input is dense.
+The class is chosen at construction time. Observable semantics — display, ordering, equality, NIL-ness, the results of `SHAPE` and of `LENGTH`, indexing, and iteration order — are identical between the two classes. Operations are free to take a fast path when the input is dense.
 
 Dense Tensor exactness rule:
 - Lanes admit only scalars whose canonical CF (Section 4.2) is finite and whose equivalent reduced rational fits within `(i64 numerator, i64 denominator)`. These are stored in normalized form.
@@ -335,7 +333,7 @@ NIL metadata is exposed as an optional structured `absence` object with these fi
 | `recoverability` | UI/AI hint for next action | Required lower camel case protocol string |
 | `diagnosis` | Three-layer debug diagnosis | Optional structured object |
 
-`NIL?` checks only whether a value is absent. It must not branch on `absence.reason`. Reason-specific code must use explicit diagnostic accessors such as `NIL-REASON`, `NIL-ORIGIN`, `NIL-RECOVERABLE?`, or `NIL-DIAGNOSIS` when such words are available.
+`NIL?` checks only whether a value is absent. It must not branch on `absence.reason`. Reason-specific code must use explicit diagnostic accessors such as `NIL-REASON` or `NIL-ORIGIN` or `NIL-RECOVERABLE?` or `NIL-DIAGNOSIS` when such words are available.
 
 The diagnostic object uses the existing three-layer model:
 
@@ -343,7 +341,7 @@ The diagnostic object uses the existing three-layer model:
 |------------------|---------|----------|
 | `when` | phase where the event occurred | lower camel case protocol string |
 | `where.kind` | locus kind | lower camel case protocol string |
-| `where.word` / `where.module` / `where.dictionary` | optional locus details | strings, not enum names |
+| `where.word` · `where.module` · `where.dictionary` | optional locus details | strings, not enum names |
 | `why` | cause class | lower camel case protocol string |
 | `summary` | human-readable explanation | non-canonical; do not parse |
 | `evidence` | human-readable evidence list | non-canonical; do not parse |
@@ -356,7 +354,7 @@ A Bubble/NIL result carries its own direct reason (Section 11.2). Literal NIL ha
 
 Operations classified as **NIL-passthrough** in Section 7 do not raise `StructureError` when a NIL operand is encountered. Instead, they produce NIL. The rule is uniform across consumption modes and target modes: if any operand consumed by the operation is NIL, the operation consumes its operands as it normally would and pushes a single NIL result.
 
-NIL-passthrough applies to arithmetic, comparison, and the unary numeric rounding words (see Section 7.13). It does not apply to control-flow words, type-conversion words, IO words, or to `OR-NIL` (`=>`) itself, whose entire purpose is to react to NIL.
+NIL-passthrough applies to arithmetic, comparison, and the unary numeric rounding words (see Section 7.12). It does not apply to control-flow words, type-conversion words, IO words, or to `OR-NIL` (`=>`) itself, whose entire purpose is to react to NIL.
 
 The intent is that pipelines propagate a Bubble/NIL through subsequent computation without crashing, so that a single `=>` at the end of the pipeline can supply a fallback value.
 
@@ -366,7 +364,7 @@ When a NIL-passthrough operation receives one or more NIL operands, the resultin
 
 NIL and the logical truth value `Unknown` (U, Section 7.5) are distinct and must not be conflated. **NIL is an operational absence**: a diagnostic bubble that records *why* a value is missing (division by zero, out-of-range `GET`, parse failure). **U is a logical undecidability**: a definite member of the three-valued truth domain that records that a proposition could not be settled true or false (notably a continued-fraction comparison that did not decide within its budget, Section 7.4.1). U carries the `TruthValue` role and is observed as `truthValue = unknown`; NIL is observed as `semanticKind = absence`.
 
-When NIL and U meet in the same operation, **NIL takes priority**. NIL carries a diagnostic `reason` that must be preserved (`PreservesReason`, Section 7.14), so the stronger, reason-bearing operational information is never erased by the logical value. Concretely, a logic word (Section 7.5) that receives both a NIL operand and a U operand applies its NIL handling and produces NIL, not U, unless an absorbing definite operand (`false` for `AND`, `true` for `OR`) settles the result first.
+When NIL and U meet in the same operation, **NIL takes priority**. NIL carries a diagnostic `reason` that must be preserved (`PreservesReason`, Section 7.14), so the stronger, reason-bearing operational information is never erased by the logical value. Concretely, a logic word (Section 7.5) that receives both a NIL operand and a U operand applies its NIL handling and produces NIL, not U, unless an absorbing definite operand (`false` for `AND` and `true` for `OR`) settles the result first.
 
 ### 4.6 CodeBlock
 
@@ -442,7 +440,7 @@ Ajisai vocabulary follows the rule: **Core is permanent, Module is detachable, U
 Built-in words are predefined and cannot be redefined or deleted.
 
 - **Core words** belong to the Ajisai runtime itself. They are always available and cannot be deleted, hidden, unimported, or redefined.
-- **Module words** belong to a module dictionary. Their definitions are built in and cannot be redefined or destructively deleted, but their visibility in the current vocabulary is controlled with `IMPORT`, `IMPORT-ONLY`, `UNIMPORT`, and `UNIMPORT-ONLY`.
+- **Module words** belong to a module dictionary. Their definitions are built in and cannot be redefined or destructively deleted, but their visibility in the current vocabulary is controlled with `IMPORT` `IMPORT-ONLY` `UNIMPORT` `UNIMPORT-ONLY`.
 - **User words** belong to a user dictionary. They are editable, and deletion or redefinition is controlled by dependency checks and the force modifier where applicable.
 
 Every built-in word has exactly one **canonical home**, either Core or a specific module. The canonical home determines where the implementation lives and, for module-canonical words, which module name `IMPORT` activates them under.
@@ -453,18 +451,20 @@ Listings are presentation-only. A listing does not change name resolution, IMPOR
 
 Boundary classes:
 
-- **Core-only words** — canonical home Core; listed only in Core.
-- **Canonical Core + module-listed boundary words** — canonical home Core; additionally surfaced in one or more module or category listing views (e.g. `PRINT` in `IO`, `STR`/`NUM`/`BOOL` in the `CAST` category, `SHAPE`/`RANK` in the `TENSOR` category, `SPAWN`/`AWAIT` in the `RUNTIME` category).
-- **Canonical Module + core-listed boundary words** — canonical home in a module, additionally surfaced in the Core listing view (e.g. `SORT` whose canonical home is `ALGO`).
-- **Module-only words** — canonical home in a module; listed only under that module.
+| Boundary class | Canonical home | Listings | Examples |
+|----------------|----------------|----------|----------|
+| Core-only words | Core | Core only | — |
+| Canonical Core + module-listed boundary words | Core | Core and one or more module or category listing views | `PRINT` in `IO` · `STR` `NUM` `BOOL` in the `CAST` category · `SHAPE` `RANK` in the `TENSOR` category · `SPAWN` `AWAIT` in the `RUNTIME` category |
+| Canonical Module + core-listed boundary words | a module | that module and the Core listing view | `SORT` (canonical home `ALGO`) |
+| Module-only words | a module | that module only | — |
 
-`IMPORT`, `IMPORT-ONLY`, `UNIMPORT`, and `UNIMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
+`IMPORT` `IMPORT-ONLY` `UNIMPORT` `UNIMPORT-ONLY` are Canonical Core words and remain Core-only — they are not module-listed and are not affected by listings.
 
-Categories such as `CAST`, `TEXT`, `TENSOR`, and `RUNTIME` are documentation-only labels used to group Core words by capability surface. They are **not** modules, are not registered in `MODULE_SPECS`, and cannot be supplied to `IMPORT`.
+Categories such as `CAST` `TEXT` `TENSOR` `RUNTIME` are documentation-only labels used to group Core words by capability surface. They are **not** modules, are not registered in `MODULE_SPECS`, and cannot be supplied to `IMPORT`.
 
 ### 7.0 English-word-based naming
 
-All built-in words — both Core words and module dictionary words — use English-word-based canonical names. Symbol forms (such as `+`, `-`, `*`, `/`, `%`, `=`, `<`, `<=`, `&`, `==`, `=>`, `?`, `!`, `.`, `..`, `,`, `,,`) are syntactic sugar that the tokenizer maps to canonical English names. The canonical name is the authoritative identifier; the symbol form is convenience surface syntax. Any new built-in word must be introduced under an English-word-based canonical name.
+All built-in words — both Core words and module dictionary words — use English-word-based canonical names. Symbol forms (such as `+` `-` `*` `/` `%` `=` `<` `<=` `&` `==` `=>` `?` `!` `.` `..` `,` `,,`) are syntactic sugar that the tokenizer maps to canonical English names. The canonical name is the authoritative identifier; the symbol form is convenience surface syntax. Any new built-in word must be introduced under an English-word-based canonical name.
 
 | Canonical | Sugar | Canonical | Sugar |
 |-----------|-------|-----------|-------|
@@ -536,9 +536,9 @@ Ad hoc recursive shape mutation in intermediate stages is prohibited.
 
 Arithmetic on scalars is performed directly on the continued-fraction representation by **Gosper's bihomographic algorithm**: each operation forms a Möbius (for unary) or bihomographic (for binary) transform of its operands and emits partial quotients of the result as soon as the next quotient is unambiguously determined by the current coefficients. No intermediate value is materialized as an approximate real or as a truncated rational. Coefficients are BigInt at all times (Section 4.2.2).
 
-`FLOOR`, `CEIL`, and `ROUND` pull partial quotients from their operand until the integer part of the result is determined. For finite (rational) operands this terminates after a bounded number of steps; for lazy (irrational) operands it terminates after enough partial quotients have been emitted to fix the integer part, which is always finite for irrationals strictly between consecutive integers. A value that is exactly an integer requires no pull beyond `a0`.
+`FLOOR` and `CEIL` and `ROUND` pull partial quotients from their operand until the integer part of the result is determined. For finite (rational) operands this terminates after a bounded number of steps; for lazy (irrational) operands it terminates after enough partial quotients have been emitted to fix the integer part, which is always finite for irrationals strictly between consecutive integers. A value that is exactly an integer requires no pull beyond *a*₀.
 
-`MOD` is defined as `x - FLOOR(x / y) * y` and is computed by composing the underlying Gosper transforms. `DIV` by a value whose CF reduces to zero produces NIL with `reason = divisionByZero` (Section 11.2 Bubble Rule); division by an irrational that cannot be distinguished from zero within the comparison budget produces NIL with `reason = undecidable` (Section 7.4). This is an *operational* absence — `DIV` could not produce a number — and remains a NIL; it is distinct from the *logical* `unknown` (U) that the comparison words themselves return on budget exhaustion (Section 7.4.1, Section 4.5.2).
+`MOD` is defined by the identity *x* − ⌊*x* / *y*⌋ · *y* (the `FLOOR`-based remainder) and is computed by composing the underlying Gosper transforms. `DIV` by a value whose CF reduces to zero produces NIL with `reason = divisionByZero` (Section 11.2 Bubble Rule); division by an irrational that cannot be distinguished from zero within the comparison budget produces NIL with `reason = undecidable` (Section 7.4). This is an *operational* absence — `DIV` could not produce a number — and remains a NIL; it is distinct from the *logical* `unknown` (U) that the comparison words themselves return on budget exhaustion (Section 7.4.1, Section 4.5.2).
 
 ### 7.4 Comparison
 
@@ -551,11 +551,20 @@ Arithmetic on scalars is performed directly on the continued-fraction representa
 | `EQ` | `=` | Equal |
 | `NEQ` | `<>` | Not equal |
 
-Comparisons return a truth value with the `TruthValue` interpretation role: `true`, `false`, or — when the comparison is not decidable within the comparison budget (see below) — `unknown` (U, the third value of the three-valued logic of Section 7.5).
+Comparisons return a truth value with the `TruthValue` interpretation role: `true` or `false`, or — when the comparison is not decidable within the comparison budget (see below) — `unknown` (U, the third value of the three-valued logic of Section 7.5).
 
-The set of comparison primitives is intentionally complete (all six standard ordering relations), so that an automated producer can emit the relation that matches its intent directly rather than rewriting it as a negation or operand swap. `GT` and `GTE` are the strict mirrors of `LT` and `LTE`; `NEQ` is the negation of `EQ`. Every relation is independently registered with its own Coreword contract metadata (Section 7.14), is NIL-passthrough (Section 7.12), and supports the same modifier combinations (`TOP` / `STAK`, `EAT` / `KEEP`).
+The set of comparison primitives is intentionally complete (all six standard ordering relations), so that an automated producer can emit the relation that matches its intent directly rather than rewriting it as a negation or operand swap. `GT` and `GTE` are the strict mirrors of `LT` and `LTE`; `NEQ` is the negation of `EQ`. Every relation is independently registered with its own Coreword contract metadata (Section 7.14), is NIL-passthrough (Section 7.12), and supports the same modifier combinations (`TOP` or `STAK` crossed with `EAT` or `KEEP`).
 
-Under `STAK` mode, ordering comparisons describe a sequence property of the consumed values: `LT` true iff strictly increasing, `LTE` non-decreasing, `GT` strictly decreasing, `GTE` non-increasing, `EQ` all equal, `NEQ` all adjacent pairs unequal.
+Under `STAK` mode, an ordering comparison describes a sequence property of the consumed values — it is `true` iff the sequence satisfies the property:
+
+| Word | `STAK`-mode sequence property |
+|------|-------------------------------|
+| `LT` | strictly increasing |
+| `LTE` | non-decreasing |
+| `GT` | strictly decreasing |
+| `GTE` | non-increasing |
+| `EQ` | all values equal |
+| `NEQ` | all adjacent pairs unequal |
 
 #### 7.4.1 Decidability and comparison budget
 
@@ -565,9 +574,9 @@ To preserve totality, every comparison operation runs under an implementation-de
 
 - the comparison produces the truth value `unknown` (U), observed as `truthValue = unknown`, with the `TruthValue` interpretation role;
 - U is a logical truth value, not an operational absence: the comparison does **not** produce a `reason = undecidable` NIL, and the Bubble Rule (Section 11.2) does not apply to it;
-- U flows into the three-valued logic of Section 7.5 directly. It is not a NIL, so the NIL-passthrough machinery of Section 7.12 does not carry it; instead `AND`/`OR`/`NOT` settle it according to the Kleene truth tables.
+- U flows into the three-valued logic of Section 7.5 directly. It is not a NIL, so the NIL-passthrough machinery of Section 7.12 does not carry it; instead `AND` `OR` `NOT` settle it according to the Kleene truth tables.
 
-The U outcome is required for `EQ`, `LT`, `LTE`, `GT`, `GTE`, `NEQ`, and for any downstream Coreword whose result depends on a comparison (notably `MIN`, `MAX`, `SORT`, and `COND` clauses whose head reduces to such a comparison); the propagation rule for those words is fixed in Section 7.4.3. The budget value itself is not part of observable semantics; it must be high enough that distinct rationals always decide.
+The U outcome is required for all six relations (`EQ` `NEQ` `LT` `LTE` `GT` `GTE`) and for any downstream Coreword whose result depends on a comparison (notably `MIN` `MAX` `SORT` and the `COND` clauses whose head reduces to such a comparison); the propagation rule for those words is fixed in Section 7.4.3. The budget value itself is not part of observable semantics; it must be high enough that distinct rationals always decide.
 
 The agreed-prefix length — the number of leading partial quotients that matched before the budget was exhausted — is carried on the comparison's `Unknown` result in the machine-readable `diagnosis.agreedPrefix` field (Section 4.5.0): a non-negative integer. It means "the two values are equal to at least this depth of continued-fraction precision" and is the CF-specific evidence behind the U result. It is diagnostic context only and does not change the observable `truthValue`.
 
@@ -579,9 +588,15 @@ The comparison procedure of Section 7.4.1 decides the order of two operands by e
 
 The order computed over NICF is the true order of the values: it is **identical** to the order RCF would compute whenever RCF decides within any budget. NICF never flips a decided order; it only moves the budget *boundary* at which a pair of distinct values crosses from U to decided, in the favorable direction. Equal values never differ in either expansion, so they still yield U.
 
-**Budget unit and `agreedPrefix`.** One budget term is one **semiregular (NICF) term**, uniformly for the six relations (Section 7.4) and for `COMPARE-WITHIN` (Section 7.4.2). The `agreedPrefix` of a U result (Sections 4.5.0, 7.4.1) therefore counts matching NICF terms. Its contract is otherwise unchanged: a non-negative integer, monotone (a larger budget never decreases it), `0` for operands that differ at the first term, diagnostic-only (it never affects `truthValue`), and for `COMPARE-WITHIN` equal to the consumed `budget` on U. Because the unit is uniformly NICF, there is no RCF-versus-NICF unit ambiguity to reconcile: a caller of `COMPARE-WITHIN` who names `budget = n` buys `n` semiregular terms, and that is the documented meaning. The correspondence between an NICF term count and an RCF term count is **not** observable and must not be relied upon.
+**Budget unit and `agreedPrefix`.** One budget term is one **semiregular (NICF) term**, uniformly for the six relations (Section 7.4) and for `COMPARE-WITHIN` (Section 7.4.2). The `agreedPrefix` of a U result (Sections 4.5.0, 7.4.1) therefore counts matching NICF terms. Its contract is otherwise unchanged:
 
-**Conformance requirement.** Because the budget unit is user-observable through `COMPARE-WITHIN`, NICF expansion is not an optional per-implementation choice: a conforming implementation must emit NICF terms for **every** comparable scalar representation (Section 4.2.2) — `Rational`, `AlgebraicSqrt`, and `Gosper` (which backs the results of arithmetic). For the homographic and bihomographic (`Gosper`) representations this is a local change to the partial-quotient emitter: a term is emitted when the *nearest integer* (rather than the floor) agrees across the transform's value-range endpoints, and the post-emit coefficient update is unchanged from the floor case — a negative semiregular remainder propagates its sign through the reciprocal continuation, so no separate `εi` bookkeeping is carried in the transform coefficients.
+- a non-negative integer;
+- monotone — a larger budget never decreases it;
+- `0` for operands that differ at the first term;
+- diagnostic-only — it never affects `truthValue`;
+- for `COMPARE-WITHIN`, equal to the consumed `budget` on U. Because the unit is uniformly NICF, there is no RCF-versus-NICF unit ambiguity to reconcile: a caller of `COMPARE-WITHIN` who names `budget = n` buys `n` semiregular terms, and that is the documented meaning. The correspondence between an NICF term count and an RCF term count is **not** observable and must not be relied upon.
+
+**Conformance requirement.** Because the budget unit is user-observable through `COMPARE-WITHIN`, NICF expansion is not an optional per-implementation choice: a conforming implementation must emit NICF terms for **every** comparable scalar representation (Section 4.2.2) — `Rational` and `AlgebraicSqrt` and `Gosper` (which backs the results of arithmetic). For the homographic and bihomographic (`Gosper`) representations this is a local change to the partial-quotient emitter: a term is emitted when the *nearest integer* (rather than the floor) agrees across the transform's value-range endpoints, and the post-emit coefficient update is unchanged from the floor case — a negative semiregular remainder propagates its sign through the reciprocal continuation, so no separate `εi` bookkeeping is carried in the transform coefficients.
 
 #### 7.4.2 Explicit-budget comparison: `COMPARE-WITHIN`
 
@@ -593,30 +608,32 @@ The six relations of Section 7.4 run under an implementation-defined budget that
 
 Stack effect: `[ a ] [ b ] [ budget ] -> [ -1 | 0 | 1 | UNKNOWN ]`.
 
-`COMPARE-WITHIN` consumes two numeric values `a` and `b` and a positive integer `budget`, and emits partial quotients of `a` and `b` in parallel (Section 7.4.1) for at most `budget` steps. It produces:
+`COMPARE-WITHIN` consumes two numeric values *a* and *b* and a positive integer `budget`, and emits partial quotients of *a* and *b* in parallel (Section 7.4.1) for at most `budget` steps. It produces:
 
-- the scalar `-1` (role `RawNumber`) if `a < b`,
-- the scalar `0` if `a = b`,
-- the scalar `1` if `a > b`,
-- the logical `Unknown` (U, Section 7.5) if the order is not settled within `budget` partial quotients; the U result carries `diagnosis.agreedPrefix` (Section 4.5.0), which for this word equals the consumed `budget`.
+| Result | Condition |
+|--------|-----------|
+| the scalar `-1` (role `RawNumber`) | *a* < *b* |
+| the scalar `0` | *a* = *b* |
+| the scalar `1` | *a* > *b* |
+| the logical `Unknown` (U, Section 7.5) | the order is not settled within `budget` partial quotients; the U result carries `diagnosis.agreedPrefix` (Section 4.5.0), which for this word equals the consumed `budget` |
 
-The decided outcome is the exact sign of `a − b`; the six relations of Section 7.4 are recoverable from it (`a < b` iff `-1`, `a <= b` iff not `1`, and so on). For two finite (rational) operands the comparison always decides regardless of `budget`, because finite CFs differ at a bounded index; `budget` only governs lazy irrationals.
+The decided outcome is the exact sign of *a* − *b*; the six relations of Section 7.4 are recoverable from it (*a* < *b* iff `-1`, *a* ≤ *b* iff not `1`, and so on). For two finite (rational) operands the comparison always decides regardless of `budget`, because finite CFs differ at a bounded index; `budget` only governs lazy irrationals.
 
-`COMPARE-WITHIN` is `Projecting` (Section 7.14): it is total over well-shaped input because it projects the undecided case onto U. It is NIL-passthrough (Section 7.12) for its `a`/`b` operands. A non-positive or non-integer `budget`, or non-numeric `a`/`b`, is malformed use and raises an error (Section 11.2), not U. The implicit budget of the bare relations is an implementation-defined constant; `COMPARE-WITHIN` does not change it and is the only way to observe or override the depth.
+`COMPARE-WITHIN` is `Projecting` (Section 7.14): it is total over well-shaped input because it projects the undecided case onto U. It is NIL-passthrough (Section 7.12) for its *a* and *b* operands. A non-positive or non-integer `budget`, or a non-numeric *a* or *b*, is malformed use and raises an error (Section 11.2), not U. The implicit budget of the bare relations is an implementation-defined constant; `COMPARE-WITHIN` does not change it and is the only way to observe or override the depth.
 
 #### 7.4.3 Propagation of U through comparison-dependent words
 
-The U outcome named in Section 7.4.1 is required not only of the comparison primitives themselves but of every Coreword whose result depends on a comparison. This section fixes how U flows through the four such words — `MIN`, `MAX`, `SORT`, and `COND` — so that an undecidable comparison never silently produces a wrong order, a spurious error, or a definite truth value it has not earned.
+The U outcome named in Section 7.4.1 is required not only of the comparison primitives themselves but of every Coreword whose result depends on a comparison. This section fixes how U flows through the four such words — `MIN` `MAX` `SORT` `COND` — so that an undecidable comparison never silently produces a wrong order, a spurious error, or a definite truth value it has not earned.
 
-Of these four, `COND` is a Canonical Core word; `MIN` and `MAX` are canonically owned by the `MATH` module and `SORT` by the `ALGO` module (Section 9.1). `SORT` is additionally Core-listed (Section 7.1); `MIN` / `MAX` are reached as bare names only after `IMPORT 'MATH'`, and always as `MATH@MIN` / `MATH@MAX`. The U-propagation contract below is a property of each word wherever it is invoked, independent of its canonical home.
+Of these four, `COND` is a Canonical Core word; `MIN` and `MAX` are canonically owned by the `MATH` module and `SORT` by the `ALGO` module (Section 9.1). `SORT` is additionally Core-listed (Section 7.1); `MIN` and `MAX` are reached as bare names only after `IMPORT 'MATH'`, and always as `MATH@MIN` and `MATH@MAX`. The U-propagation contract below is a property of each word wherever it is invoked, independent of its canonical home.
 
 The common rule is **U-honesty**: when the comparison a word relies on is undecidable, the word must surface that undecidability (as U, or, for `COND`, as the absence of a satisfied clause) rather than fabricate a decision. None of these words may treat U as `true`, as `false`, or as a malformed-input error.
 
-**`MIN` / `MAX`.** These select one of two (or, in sequence form, several) numeric operands by the order relation. They accept the full numeric domain, including the lazy continued-fraction operands of Section 4.2, and decide the order through the same budgeted comparison as the relations (Section 7.4.1). When the governing comparison decides, the selected operand is returned unchanged. When it does not decide within the budget, the result is the logical `Unknown` (U), observed as `truthValue = unknown` and carrying `diagnosis.agreedPrefix` (Section 4.5.0) — because the program cannot be told *which* operand is the minimum/maximum when their order is unknown. `MIN` and `MAX` remain NIL-passthrough (Section 7.12): a NIL operand yields NIL, and NIL takes priority over a U-producing comparison per Section 4.5.2. In sequence form they short-circuit on the first undecidable pair, matching the `STAK`-mode rule of Section 7.4.1.
+**`MIN` and `MAX`.** These select one of two (or, in sequence form, several) numeric operands by the order relation. They accept the full numeric domain, including the lazy continued-fraction operands of Section 4.2, and decide the order through the same budgeted comparison as the relations (Section 7.4.1). When the governing comparison decides, the selected operand is returned unchanged. When it does not decide within the budget, the result is the logical `Unknown` (U), observed as `truthValue = unknown` and carrying `diagnosis.agreedPrefix` (Section 4.5.0) — because the program cannot be told *which* operand is the minimum/maximum when their order is unknown. `MIN` and `MAX` remain NIL-passthrough (Section 7.12): a NIL operand yields NIL, and NIL takes priority over a U-producing comparison per Section 4.5.2. In sequence form they short-circuit on the first undecidable pair, matching the `STAK`-mode rule of Section 7.4.1.
 
 **`SORT`.** Sorting is a transitive cascade of pairwise order comparisons; a single undecidable pair makes the position of those elements relative to each other unknown, and the sorted order as a whole is therefore not established. When every pairwise comparison the sort requires decides, `SORT` returns the elements in ascending order as before. When any required comparison is undecidable within the budget, `SORT` produces the logical `Unknown` (U) for the whole result, carrying `diagnosis.agreedPrefix` for the first undecidable pair encountered. `SORT` does not return a partially-sorted vector, and it does not fall back to a tie-break: a partial order is not a sort. (The earlier exact-fraction-only behavior is the decided case of this rule: finite rationals always decide, so a vector of rationals always sorts.) A NIL element is handled by `SORT`'s existing NIL policy and takes priority over a U-producing comparison per Section 4.5.2.
 
-**`COND`.** A `COND` clause fires when its guard evaluates to a definite `true`. Under three-valued logic a guard may now reduce to U (for example, a guard that is itself an undecidable comparison). A guard that yields U is **not** a definite `true`, so its clause does **not** fire; evaluation falls through to the next clause exactly as it would for a `false` guard, and ultimately to the `IDLE` / else clause if no guard yields a definite `true`. A U guard is therefore neither an error nor a match: it is the K3-faithful reading of "this clause's condition could not be established." If no clause fires and there is no else clause, the existing `CondExhausted` outcome (Section 11) applies unchanged. This makes a U guard behave, for clause-selection purposes, like `false` — but the distinction is observable while the guard value is on the stack (it reads `truthValue = unknown`, not `false`), and it is only the *clause-firing decision* that treats "not definitely true" uniformly.
+**`COND`.** A `COND` clause fires when its guard evaluates to a definite `true`. Under three-valued logic a guard may now reduce to U (for example, a guard that is itself an undecidable comparison). A guard that yields U is **not** a definite `true`, so its clause does **not** fire; evaluation falls through to the next clause exactly as it would for a `false` guard, and ultimately to the `IDLE` else clause if no guard yields a definite `true`. A U guard is therefore neither an error nor a match: it is the K3-faithful reading of "this clause's condition could not be established." If no clause fires and there is no else clause, the existing `CondExhausted` outcome (Section 11) applies unchanged. This makes a U guard behave, for clause-selection purposes, like `false` — but the distinction is observable while the guard value is on the stack (it reads `truthValue = unknown`, not `false`), and it is only the *clause-firing decision* that treats "not definitely true" uniformly.
 
 In all four words the budget is the same implementation-defined constant used by the bare relations (Section 7.4.1); none of them expose or override it. `COMPARE-WITHIN` (Section 7.4.2) remains the only word that names the budget explicitly.
 
@@ -631,17 +648,29 @@ In all four words the budget is the same implementation-defined constant used by
 | `FALSE` | — | Push truth value `false` |
 | `NIL` | — | Push NIL |
 
-`AND`, `OR`, and `NOT` implement **strong Kleene three-valued logic (K3)** over the truth domain {`true` (T), `false` (F), `unknown` (U)}. U is a first-class logical truth value, observed as `truthValue = unknown` (Section 2.3), and arises in particular from undecidable continued-fraction comparisons (Section 7.4.1). The truth tables are:
+`AND` `OR` `NOT` implement **strong Kleene three-valued logic (K3)** over the truth domain {T, F, U}, whose members are observed as the protocol strings `true` and `false` and `unknown`. U is a first-class logical truth value, observed as `truthValue = unknown` (Section 2.3), and arises in particular from undecidable continued-fraction comparisons (Section 7.4.1). The truth tables are:
 
-```
-AND:  T∧T=T   T∧U=U   T∧F=F   U∧U=U   U∧F=F   F∧anything=F
-OR :  F∨F=F   F∨U=U   F∨T=T   U∨U=U   U∨T=T   T∨anything=T
-NOT:  ¬T=F    ¬U=U    ¬F=T
-```
+| `AND` | T | U | F |
+|-------|---|---|---|
+| **T** | T | U | F |
+| **U** | U | U | F |
+| **F** | F | F | F |
+
+| `OR` | T | U | F |
+|------|---|---|---|
+| **T** | T | T | T |
+| **U** | T | U | U |
+| **F** | T | U | F |
+
+| `NOT` | result |
+|-------|--------|
+| **T** | F |
+| **U** | U |
+| **F** | T |
 
 The absorbing elements are exact: `AND` returns F whenever either operand is F (even if the other is U), and `OR` returns T whenever either operand is T (even if the other is U). U propagates in every other case where it appears.
 
-**Interaction with NIL.** NIL (operational absence, Section 4.5) and U (logical undecidability) are distinct values; see Section 4.5.2. The absorbing rule that previously collapsed NIL — `AND` with a definite F yields F, `OR` with a definite T yields T — is unchanged and continues to apply to NIL operands. In all other cases involving a NIL operand the logic word produces NIL (preserving the leftmost reason, Section 4.5.1), and `NOT` of NIL is NIL. When an operation receives both a NIL operand and a U operand and no absorbing definite operand settles the result, **NIL takes priority** and the result is NIL, not U (Section 4.5.2). This keeps the reason-bearing diagnostic value from being erased by the logical value.
+**Interaction with NIL.** NIL (operational absence, Section 4.5) and U (logical undecidability) are distinct values; see Section 4.5.2. The absorbing rule that previously collapsed NIL — `AND` with a definite F yields F and `OR` with a definite T yields T — is unchanged and continues to apply to NIL operands. In all other cases involving a NIL operand the logic word produces NIL (preserving the leftmost reason, Section 4.5.1), and `NOT` of NIL is NIL. When an operation receives both a NIL operand and a U operand and no absorbing definite operand settles the result, **NIL takes priority** and the result is NIL, not U (Section 4.5.2). This keeps the reason-bearing diagnostic value from being erased by the logical value.
 
 ### 7.6 String and type conversion
 
@@ -664,10 +693,10 @@ The absorbing elements are exact: `AND` returns F whenever either operand is F (
 
 `>CF` is the conversion-word surface form of Section 3.9: it changes only the requested display/serialization role of its operand (the nested-parentheses continued-fraction form of Section 3.2 / Section 4.2), never the value. It is a Canonical Core word.
 
-`TRIM` / `TRIM-LEFT` / `TRIM-RIGHT` / `TOKENIZE` / `SUBSTITUTE` /
-`STARTS-WITH?` / `ENDS-WITH?` are Canonical Core words also listed in the
-`TEXT` documentation category alongside `CHR` / `CHARS` / `JOIN`. The
-listing is presentation-only and does not introduce a `TEXT` module.
+`TRIM` `TRIM-LEFT` `TRIM-RIGHT` `TOKENIZE` `SUBSTITUTE` `STARTS-WITH?`
+`ENDS-WITH?` are Canonical Core words also listed in the `TEXT`
+documentation category alongside `CHR` `CHARS` `JOIN`. The listing is
+presentation-only and does not introduce a `TEXT` module.
 
 ### 7.7 Control and higher-order words
 
@@ -680,7 +709,7 @@ listing is presentation-only and does not introduce a `TEXT` module.
 | `ANY` | — | True if at least one element satisfies the predicate |
 | `ALL` | — | True if all elements satisfy the predicate |
 | `COUNT` | — | Count elements satisfying the predicate |
-| `SCAN` | — | Like FOLD but returns all intermediate accumulator values |
+| `SCAN` | — | Like `FOLD` but returns all intermediate accumulator values |
 | `COND` | — | Evaluate clauses separated by `$`; execute the first whose guard is definitely true (a U guard does not fire, Section 7.4.3) |
 | `IDLE` | — | No-op; does nothing |
 | `EXEC` | — | Execute a code block |
@@ -708,7 +737,7 @@ listing is presentation-only and does not introduce a `TEXT` module.
 | `CSPRNG` | `CRYPTO` | — | Push a cryptographically secure random number |
 | `HASH` | `CRYPTO` | — | Compute a hash of the top stack value |
 
-Only `PRINT` is a Canonical Core word here; it is additionally boundary-listed in the `IO` view (Section 7). `NOW` / `DATETIME` / `TIMESTAMP` are canonically owned by the `TIME` module and `CSPRNG` / `HASH` by the `CRYPTO` module (Section 9.1): they are **not** Core-listed, so a bare name resolves only after `IMPORT`, and they are always reachable as `TIME@NOW`, `CRYPTO@HASH`, and so on. They are grouped here by utility role, not by canonical home.
+Only `PRINT` is a Canonical Core word here; it is additionally boundary-listed in the `IO` view (Section 7). `NOW` `DATETIME` `TIMESTAMP` are canonically owned by the `TIME` module and `CSPRNG` `HASH` by the `CRYPTO` module (Section 9.1): they are **not** Core-listed, so a bare name resolves only after `IMPORT`, and they are always reachable in qualified form (`TIME@NOW` and `CRYPTO@HASH` and so on). They are grouped here by utility role, not by canonical home.
 
 ### 7.10 Module loading
 
@@ -734,15 +763,25 @@ The following built-in words follow the NIL passthrough rule defined in Section 
 
 | Category | Words |
 |----------|-------|
-| Arithmetic | `ADD`, `SUB`, `MUL`, `DIV`, `MOD`, `FLOOR`, `CEIL`, `ROUND` |
-| Comparison | `LT`, `LTE`, `GT`, `GTE`, `EQ`, `NEQ` |
-| Logic | `AND`, `OR`, `NOT` (three-valued; see below) |
+| Arithmetic | `ADD` `SUB` `MUL` `DIV` `MOD` `FLOOR` `CEIL` `ROUND` |
+| Comparison | `LT` `LTE` `GT` `GTE` `EQ` `NEQ` |
+| Logic | `AND` `OR` `NOT` (three-valued; see below) |
 
-`AND`, `OR`, and `NOT` implement strong Kleene three-valued logic (K3) over {`true`, `false`, `unknown`}; the truth tables and the U value are defined in Section 7.5. The three-valued behavior listed here concerns NIL operands specifically: NIL combined with a definite false (for `AND`) or definite true (for `OR`) collapses to that definite value; in all other cases involving NIL the result is NIL, and `NOT` of NIL is NIL. The logical third value U is separate from NIL (Section 4.5.2); when both appear, NIL takes priority.
+`AND` `OR` `NOT` implement strong Kleene three-valued logic (K3) over the truth domain {T, F, U}; the truth tables and the U value are defined in Section 7.5. The three-valued behavior listed here concerns NIL operands specifically: NIL combined with a definite false (for `AND`) or definite true (for `OR`) collapses to that definite value; in all other cases involving NIL the result is NIL, and `NOT` of NIL is NIL. The logical third value U is separate from NIL (Section 4.5.2); when both appear, NIL takes priority.
 
 The comparison words are NIL-passthrough for NIL operands as listed above. They do **not** produce a `reason = undecidable` NIL on budget exhaustion; that case now yields the truth value `unknown` (Section 7.4.1), which is a `TruthValue` result rather than an absence.
 
-Words not listed here retain their existing handling of NIL. In particular, control-flow words (`COND`, `EXEC`, `MAP`, `FILTER`, `FOLD`, `UNFOLD`, `ANY`, `ALL`, `COUNT`, `SCAN`), most conversion words (`STR`, `BOOL`, `CHARS`, `JOIN`), IO words (`PRINT`, `NOW`, `DATETIME`, `TIMESTAMP`, `CSPRNG`, `HASH`), child-runtime words, and `OR-NIL` (`=>`) itself are not NIL-passthrough. `NUM` and `CHR` can create reasoned Bubble/NIL values for well-formed conversion failures as described by the Bubble Rule.
+Words not listed here retain their existing handling of NIL. In particular, the following are **not** NIL-passthrough:
+
+| Category | Words |
+|----------|-------|
+| Control flow | `COND` `EXEC` `MAP` `FILTER` `FOLD` `UNFOLD` `ANY` `ALL` `COUNT` `SCAN` |
+| Conversion (most) | `STR` `BOOL` `CHARS` `JOIN` |
+| IO and utilities | `PRINT` `NOW` `DATETIME` `TIMESTAMP` `CSPRNG` `HASH` |
+| Child runtime | `SPAWN` `AWAIT` `STATUS` `KILL` `MONITOR` `SUPERVISE` |
+| NIL coalescing | `OR-NIL` (`=>`) itself, whose entire purpose is to react to NIL |
+
+`NUM` and `CHR` can create reasoned Bubble/NIL values for well-formed conversion failures as described by the Bubble Rule.
 
 ---
 
@@ -750,26 +789,26 @@ Words not listed here retain their existing handling of NIL. In particular, cont
 
 Every Coreword (built-in or module-provided) has a machine-readable contract entry in the Coreword registry. The contract is the authoritative description of the word's input requirements, output guarantees, and runtime classification. Tests, documentation, and tooling consume this metadata; narrative text is non-canonical.
 
-A contract entry has the following fields, in addition to the existing identification (`name`, `category`), effect-classification fields (`purity`, `effects`, `deterministic`, `safe_preview`), and listing fields (`canonical_home`, `listed_in_core`, `listed_in_modules`, `listed_in_categories`):
+A contract entry has the following fields, in addition to the existing identification fields (`name` `category`), effect-classification fields (`purity` `effects` `deterministic` `safe_preview`), and listing fields (`canonical_home` `listed_in_core` `listed_in_modules` `listed_in_categories`):
 
 | Field | Domain | Meaning |
 |-------|--------|---------|
-| `partiality` | `Total` / `Partial` / `Projecting` | `Total`: the operation is defined on every well-shaped input. `Partial`: the operation has well-shaped inputs for which it raises an error. `Projecting`: the operation is total because it projects all failures onto NIL with reason. |
-| `nil_policy` | `Passthrough` / `CreatesNil` / `RejectsNil` / `ConsumesNil` / `PreservesReason` | How the word reacts to and produces NIL. `Passthrough` words follow Section 4.5.1; `CreatesNil` words project domain failures (e.g. division by zero); `RejectsNil` words raise `StructureError` on NIL; `ConsumesNil` words inspect or branch on NIL (e.g. `OR-NIL`); `PreservesReason` words must not erase a reason that is already attached to a propagated NIL. |
-| `safety_level` | `A` / `B` / `C` / `D` / `Quarantined` | Increasing strength of safety guarantees. `A`: total, pure, deterministic; `B`: partial but with explicit error categories; `C`: observable or has external state read; `D`: effectful; `Quarantined`: not eligible for self-host execution. A `Partial` word is therefore at least `B` (it is not total); `Projecting` words are total by projection and may be `A`. |
-| `mass` | `Fixed { consumes, produces }` / `Dynamic` | The static flow-mass contract of Section 13.1: under the default `TOP`/`EAT` mode the word reads `consumes` operands and pushes `produces` results; under `KEEP` the `consumes` operands are additionally retained (bifurcation, Section 13.2). `Dynamic` marks a word whose arity is not a statically pinned `Fixed` value — either because it is genuinely data-dependent (for example the `STAK` count-fold or runtime-shaped vector operations) or because it has not been probe-verified into the `Fixed` set. `Dynamic` is sound in both cases: the static mass-conservation validator simply abstains on `Dynamic` words, so marking a fixed-arity word `Dynamic` only forgoes static checking, it never asserts a wrong arity. |
+| `partiality` | `Total` · `Partial` · `Projecting` | `Total`: the operation is defined on every well-shaped input. `Partial`: the operation has well-shaped inputs for which it raises an error. `Projecting`: the operation is total because it projects all failures onto NIL with reason. |
+| `nil_policy` | `Passthrough` · `CreatesNil` · `RejectsNil` · `ConsumesNil` · `PreservesReason` | How the word reacts to and produces NIL. `Passthrough` words follow Section 4.5.1; `CreatesNil` words project domain failures (e.g. division by zero); `RejectsNil` words raise `StructureError` on NIL; `ConsumesNil` words inspect or branch on NIL (e.g. `OR-NIL`); `PreservesReason` words must not erase a reason that is already attached to a propagated NIL. |
+| `safety_level` | `A` · `B` · `C` · `D` · `Quarantined` | Increasing strength of safety guarantees. `A`: total, pure, deterministic; `B`: partial but with explicit error categories; `C`: observable or has external state read; `D`: effectful; `Quarantined`: not eligible for self-host execution. A `Partial` word is therefore at least `B` (it is not total); `Projecting` words are total by projection and may be `A`. |
+| `mass` | `Fixed { consumes, produces }` · `Dynamic` | The static flow-mass contract of Section 13.1: under the default `TOP` and `EAT` modes the word reads `consumes` operands and pushes `produces` results; under `KEEP` the `consumes` operands are additionally retained (bifurcation, Section 13.2). `Dynamic` marks a word whose arity is not a statically pinned `Fixed` value — either because it is genuinely data-dependent (for example the `STAK` count-fold or runtime-shaped vector operations) or because it has not been probe-verified into the `Fixed` set. `Dynamic` is sound in both cases: the static mass-conservation validator simply abstains on `Dynamic` words, so marking a fixed-arity word `Dynamic` only forgoes static checking, it never asserts a wrong arity. |
 
-`partiality` and `nil_policy` are independent axes. For example, under the Bubble Rule `/` (division) is `Projecting` with `nil_policy = CreatesNil`: `/`, `GET`, `NUM`, and `CHR` are `Projecting`/`CreatesNil` for well-formed domain misses while malformed inputs remain ordinary errors.
+`partiality` and `nil_policy` are independent axes. For example, under the Bubble Rule `DIV` (`/`) is `Projecting` with `nil_policy = CreatesNil`: `DIV` `GET` `NUM` `CHR` are `Projecting` with `CreatesNil` for well-formed domain misses while malformed inputs remain ordinary errors.
 
-Comparison words (`EQ`, `NEQ`, `LT`, `LTE`, `GT`, `GTE`) are `Projecting`: they are total because every well-shaped input yields a `TruthValue` result, projecting the undecidable case onto the truth value `unknown` (U) rather than raising. Their `nil_policy` is `Passthrough` (they pass NIL operands through per Section 7.12); on budget exhaustion they produce U, which is a `TruthValue` result and **not** a `reason`-bearing NIL, so they are no longer classified `CreatesNil` for that case. (The `reason = undecidable` NIL of earlier revisions is retired from the comparison path; see Section 7.4.1.)
+Comparison words (`EQ` `NEQ` `LT` `LTE` `GT` `GTE`) are `Projecting`: they are total because every well-shaped input yields a `TruthValue` result, projecting the undecidable case onto the truth value `unknown` (U) rather than raising. Their `nil_policy` is `Passthrough` (they pass NIL operands through per Section 7.12); on budget exhaustion they produce U, which is a `TruthValue` result and **not** a `reason`-bearing NIL, so they are no longer classified `CreatesNil` for that case. (The `reason = undecidable` NIL of earlier revisions is retired from the comparison path; see Section 7.4.1.)
 
-Logic words (`AND`, `OR`, `NOT`) are `Total` over the three-valued domain {`true`, `false`, `unknown`} (Section 7.5). Their registry `nil_policy` is `Passthrough`: they pass NIL operands through per Section 7.12. The `nil_policy` field holds a single value, so reason-preservation is **not** a second simultaneous policy here but an additional behavioral requirement layered on `Passthrough` — the leftmost NIL reason must survive and a NIL operand is never silently replaced by U (Section 4.5.2). The distinct `PreservesReason` value is reserved for words whose *only* NIL contract is to carry a reason through unchanged: the pure no-op / marker words (`TOP`, `STAK`, `EAT`, `KEEP`, `TRUE`, `FALSE`, `NIL`, `IDLE`, `PIPE`, `OR-NIL`).
+Logic words (`AND` `OR` `NOT`) are `Total` over the three-valued truth domain of Section 7.5. Their registry `nil_policy` is `Passthrough`: they pass NIL operands through per Section 7.12. The `nil_policy` field holds a single value, so reason-preservation is **not** a second simultaneous policy here but an additional behavioral requirement layered on `Passthrough` — the leftmost NIL reason must survive and a NIL operand is never silently replaced by U (Section 4.5.2). The distinct `PreservesReason` value is reserved for words whose *only* NIL contract is to carry a reason through unchanged: the pure no-op and marker words `TOP` `STAK` `EAT` `KEEP` `TRUE` `FALSE` `NIL` `IDLE` `PIPE` `OR-NIL`.
 
-`COMPARE-WITHIN` (Section 7.4.2) is `Projecting`: it is total over well-shaped input because it projects the budget-undecided case onto the logical `Unknown` (a result, not a reasoned NIL). Its `nil_policy` is `Passthrough` for the `a`/`b` operands. A non-positive or non-integer `budget` or non-numeric operands are malformed use and raise an error, so it is not `CreatesNil`.
+`COMPARE-WITHIN` (Section 7.4.2) is `Projecting`: it is total over well-shaped input because it projects the budget-undecided case onto the logical `Unknown` (a result, not a reasoned NIL). Its `nil_policy` is `Passthrough` for the *a* and *b* operands. A non-positive or non-integer `budget` or non-numeric operands are malformed use and raise an error, so it is not `CreatesNil`.
 
-`MIN`, `MAX`, and `SORT` (Section 7.4.3) are `Projecting`: each is total over well-shaped numeric input because it projects an undecidable governing comparison onto the logical `Unknown` (a result, not a reasoned NIL). Their `nil_policy` is `Passthrough`, with NIL taking priority over a U-producing comparison (Section 4.5.2). `MIN` and `MAX` are canonically `MATH` words and `SORT` is canonically an `ALGO` word (Sections 7.4.3, 9.1); their contracts are registry entries on the same footing as Core contracts. `COND` (Section 7.7) treats a U guard as not-firing rather than producing U as a value, so its existing partiality and `CondExhausted` behavior are unchanged by Section 7.4.3.
+`MIN` and `MAX` and `SORT` (Section 7.4.3) are `Projecting`: each is total over well-shaped numeric input because it projects an undecidable governing comparison onto the logical `Unknown` (a result, not a reasoned NIL). Their `nil_policy` is `Passthrough`, with NIL taking priority over a U-producing comparison (Section 4.5.2). `MIN` and `MAX` are canonically `MATH` words and `SORT` is canonically an `ALGO` word (Sections 7.4.3, 9.1); their contracts are registry entries on the same footing as Core contracts. `COND` (Section 7.7) treats a U guard as not-firing rather than producing U as a value, so its existing partiality and `CondExhausted` behavior are unchanged by Section 7.4.3.
 
-Other module-canonical words carry registry contracts on the same footing. `MATH@POW` is `Projecting` / `CreatesNil`: it projects `0` raised to a negative exponent onto Bubble/NIL (`reason = divisionByZero`) while malformed use raises an error. `MATH@GCD` and `MATH@LCM` are `Partial` / `Passthrough`: a non-integer numeric operand is malformed use and raises an error (cf. `CHR`), while NIL operands pass through. `ALGO@INDEX-OF` and `TIME@PARSE-ISO` are `Projecting` / `CreatesNil`, projecting a well-formed miss (value absent / unparseable text) onto Bubble/NIL with `reason = missingField` and `reason = invalidEncoding` respectively. Adding any Coreword — Core or module — without a contract entry is a conformance violation.
+Other module-canonical words carry registry contracts on the same footing. `MATH@POW` is `Projecting` with `CreatesNil`: it projects `0` raised to a negative exponent onto Bubble/NIL (`reason = divisionByZero`) while malformed use raises an error. `MATH@GCD` and `MATH@LCM` are `Partial` with `Passthrough`: a non-integer numeric operand is malformed use and raises an error (cf. `CHR`), while NIL operands pass through. `ALGO@INDEX-OF` and `TIME@PARSE-ISO` are `Projecting` with `CreatesNil`, projecting a well-formed miss (value absent or unparseable text) onto Bubble/NIL with `reason = missingField` and `reason = invalidEncoding` respectively. Adding any Coreword — Core or module — without a contract entry is a conformance violation.
 
 Contract metadata is reachable from both the Rust runtime and the WASM boundary. Adding a Coreword without a contract entry is a conformance violation.
 
@@ -777,10 +816,10 @@ The listing fields work as follows:
 
 | Field | Domain | Meaning |
 |-------|--------|---------|
-| `canonical_home` | `Core` / `Module(name)` | Where the canonical implementation lives. For module-canonical words this is also the only module that can resolve the word as `MODULE@WORD` and the only module whose `IMPORT` brings the word into bare scope. |
+| `canonical_home` | `Core` · `Module(name)` | Where the canonical implementation lives. For module-canonical words this is also the only module that can resolve the word as `MODULE@WORD` and the only module whose `IMPORT` brings the word into bare scope. |
 | `listed_in_core` | `bool` | Whether the word appears in the Core listing view. Does not affect resolution. |
 | `listed_in_modules` | `[module_name]` | Module listing views in which the word appears. A canonical module word always has its own module here. Boundary listings (e.g. `PRINT` in `IO`) are presentation-only. |
-| `listed_in_categories` | `[category_label]` | Documentation-only category labels (e.g. `CAST`, `TEXT`, `TENSOR`, `RUNTIME`). Categories are not modules and cannot be `IMPORT`ed. |
+| `listed_in_categories` | `[category_label]` | Documentation-only category labels (e.g. `CAST` `TEXT` `TENSOR` `RUNTIME`). Categories are not modules and cannot be `IMPORT`ed. |
 
 `IMPORT-ONLY` of a selector that is core-listed in the target module's view but not canonically owned by that module is a no-op: the word is already available as a Canonical Core word, so the selector is silently skipped with a single warning line. Selectors that match neither a canonical word nor a listing remain an error.
 
@@ -834,10 +873,12 @@ User words may call themselves or other user words recursively. There is no hard
 
 ### 8.5 Naming conventions
 
-Word names follow action-object convention (e.g., `APPLY-GAIN`, `RESOLVE-PATH`). The runtime emits a warning for:
+Word names follow action-object convention (e.g. `APPLY-GAIN` and `RESOLVE-PATH`). The runtime emits a warning for:
 
-- Ambiguous prefixes: `DO-`, `HANDLE-`, `PROCESS-`, `MANAGE-`, `UTIL-`, `HELPER-`
-- Ambiguous standalone names: `CALC`, `RUN`, `EXEC2`, `TEMP`, `MAIN`, `TEST`, `STUFF`, `THING`
+| Warned form | Names |
+|-------------|-------|
+| Ambiguous prefixes | `DO-` `HANDLE-` `PROCESS-` `MANAGE-` `UTIL-` `HELPER-` |
+| Ambiguous standalone names | `CALC` `RUN` `EXEC2` `TEMP` `MAIN` `TEST` `STUFF` `THING` |
 
 Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object names; short unambiguous names (6 characters or fewer).
 
@@ -852,10 +893,10 @@ Acceptable forms: `IS-*` and `HAS-*` predicates; hyphen-separated action-object 
 | `MUSIC` | Audio sequencing and synthesis |
 | `JSON` | JSON parsing, generation, and manipulation |
 | `IO` | Standard input/output |
-| `TIME` | Exact, timezone-free date/time values (instant / datetime / date / time); timezone is supplied only at instant↔civil conversion as a UTC offset in hours |
+| `TIME` | Exact, timezone-free date/time values (instant, datetime, date, time); timezone is supplied only at instant↔civil conversion as a UTC offset in hours |
 | `CRYPTO` | Cryptographically secure random and hash |
 | `ALGO` | Sorting and other deterministic algorithms |
-| `MATH` | Square root, exact-rational interval arithmetic, and scalar utilities (`ABS`, `NEG`, `SIGN`, `MIN`, `MAX`, `POW`, `GCD`, `LCM`) |
+| `MATH` | Square root, exact-rational interval arithmetic, and scalar utilities (`ABS` `NEG` `SIGN` `MIN` `MAX` `POW` `GCD` `LCM`) |
 | `SERIAL` | Host-mediated serial port output |
 
 ### 9.2 Import and unimport syntax
@@ -877,7 +918,7 @@ Selectors that name Core words merely listed in a module view are no-ops for `IM
 
 ### 9.3 Module-provided sample words
 
-Modules may provide sample words for demonstration. Sample words are part of the module dictionary for import visibility: they can be introduced with `IMPORT` / `IMPORT-ONLY` and hidden with `UNIMPORT` / `UNIMPORT-ONLY`, but they are not destructively deleted with `DEL`.
+Modules may provide sample words for demonstration. Sample words are part of the module dictionary for import visibility: they can be introduced with `IMPORT` or `IMPORT-ONLY` and hidden with `UNIMPORT` or `UNIMPORT-ONLY`, but they are not destructively deleted with `DEL`.
 
 ### 9.4 SERIAL module (host-mediated serial output)
 
@@ -899,9 +940,9 @@ The module provides the following words:
 | `FLUSH` | `port-id -- port-id` | Flush the port's outgoing data |
 | `CLOSE` | `port-id --` | Close the port and release the connection |
 
-Contract classification (Section 7.14): every `SERIAL` word has `purity = Effectful`, `deterministic = false`, `safe_preview = false`, and `safety_level = D`. The outbound words (`LIST-PORTS`, `OPEN`, `CONFIGURE`, `WRITE`, `FLUSH`, `CLOSE`) are `partiality = Partial`, `nil_policy = RejectsNil`. `READ` is `partiality = Projecting`, `nil_policy = CreatesNil`: it projects the no-data and disconnected conditions onto Bubble/NIL. Because they drive or observe external hardware, `SERIAL` words are never eligible for speculative reordering, caching, or `safe_preview` execution.
+Contract classification (Section 7.14): every `SERIAL` word has `purity = Effectful` and `deterministic = false` and `safe_preview = false` and `safety_level = D`. The outbound words (`LIST-PORTS` `OPEN` `CONFIGURE` `WRITE` `FLUSH` `CLOSE`) are `partiality = Partial` with `nil_policy = RejectsNil`. `READ` is `partiality = Projecting` with `nil_policy = CreatesNil`: it projects the no-data and disconnected conditions onto Bubble/NIL. Because they drive or observe external hardware, `SERIAL` words are never eligible for speculative reordering, caching, or `safe_preview` execution.
 
-Misuse raises an error rather than producing Bubble/NIL (Section 11.2 "malformed use → error"): a non-text port id, a byte outside `0`–`255`, a non-positive baud rate, or a missing operand raises `StructureError` or `StackUnderflow`. For `READ`, the absence of data is a well-formed outcome, not misuse: with no buffered bytes it projects Bubble/NIL with `reason = noData`, or `reason = portDisconnected` when the host has reported the port gone. The host-side outcome of a well-formed outbound command (for example a device that is physically disconnected) is reported through the host environment and does not change the runtime stack effect of the word.
+Misuse raises an error rather than producing Bubble/NIL (Section 11.2 "malformed use → error"): a non-text port id, a byte outside `0`–`255`, a non-positive baud rate, or a missing operand raises `StructureError` or `StackUnderflow`. For `READ`, the absence of data is a well-formed outcome, not misuse: with no buffered bytes it projects Bubble/NIL with `reason = noData` — or `reason = portDisconnected` when the host has reported the port gone. The host-side outcome of a well-formed outbound command (for example a device that is physically disconnected) is reported through the host environment and does not change the runtime stack effect of the word.
 
 ### 9.5 IO module (host-mediated standard input/output)
 
@@ -912,7 +953,7 @@ The `IO` module (Section 9.1) provides host-mediated textual standard input and 
 | `INPUT` | `-> [ text ]` | Read text from the host input buffer (observable host ingress) |
 | `OUTPUT` | `[ value ] ->` | Write a value to the host output buffer (effectful host egress) |
 
-`IO@INPUT` is `purity = Observable` (it reads external host state); `IO@OUTPUT` is `purity = Effectful`. Both are imported and resolved like any other module word (`IMPORT 'IO'`, or `IO@INPUT` / `IO@OUTPUT`). The Canonical Core word `PRINT` (Section 7.9) is boundary-listed in the `IO` view but is not the same word as `IO@OUTPUT`.
+`IO@INPUT` is `purity = Observable` (it reads external host state); `IO@OUTPUT` is `purity = Effectful`. Both are imported and resolved like any other module word (via `IMPORT 'IO'`, or in qualified form as `IO@INPUT` and `IO@OUTPUT`). The Canonical Core word `PRINT` (Section 7.9) is boundary-listed in the `IO` view but is not the same word as `IO@OUTPUT`.
 
 ---
 
@@ -979,17 +1020,17 @@ The Bubble Rule is the user-level failure model for well-formed partial operatio
 
 > If an operation is well-formed but cannot produce a value, it produces a Bubble/NIL with a reason. If the operation is malformed, it raises an error.
 
-In Japanese user-facing guidance this is summarized as: "できなかった -> 泡 / そもそも使い方が違う -> エラー". Internally, Bubble/NIL is represented by `Value::Nil` with `AbsenceMetadata` and a direct `NilReason`. A malformed operation raises an ordinary error, which propagates rather than becoming a value.
+In Japanese user-facing guidance this is summarized as: 「できなかった → 泡 / そもそも使い方が違う → エラー」. Internally, Bubble/NIL is represented by `Value::Nil` with `AbsenceMetadata` and a direct `NilReason`. A malformed operation raises an ordinary error, which propagates rather than becoming a value.
 
 Initial Core words following this rule include:
 
 | Word | Bubble/NIL case | Error case |
 |------|-----------------|------------|
-| `DIV` / `/` | Division by zero (`NilReason::DivisionByZero`); divisor indistinguishable from zero within the comparison budget (`NilReason::Undecidable`) | Non-numeric operands or malformed shapes |
+| `DIV` (`/`) | Division by zero (`NilReason::DivisionByZero`); divisor indistinguishable from zero within the comparison budget (`NilReason::Undecidable`) | Non-numeric operands or malformed shapes |
 | `GET` | Valid vector target with an out-of-range index (`NilReason::IndexOutOfBounds`) | Non-vector target or non-numeric index |
 | `NUM` | Text cannot be parsed as a number (`NilReason::InvalidEncoding`) | Input shape is not convertible text |
 | `CHR` | Numeric code point is outside the valid Unicode scalar range (`NilReason::InvalidEncoding`) | Operand is not numeric, or numeric operand is not an integer |
-| `EQ` / `NEQ` / `LT` / `LTE` / `GT` / `GTE` | None: budget exhaustion on lazy continued fractions yields the truth value `unknown` (U), a `TruthValue` result, not a Bubble/NIL (Section 7.4.1). These words still pass NIL operands through (Section 7.12). | Non-numeric operands or malformed shapes |
+| `EQ` `NEQ` `LT` `LTE` `GT` `GTE` | None: budget exhaustion on lazy continued fractions yields the truth value `unknown` (U), a `TruthValue` result, not a Bubble/NIL (Section 7.4.1). These words still pass NIL operands through (Section 7.12). | Non-numeric operands or malformed shapes |
 | `SERIAL@READ` | Receive buffer empty (`NilReason::NoData`); host reported the port disconnected with no remaining data (`NilReason::PortDisconnected`); both with `absence.origin = hostEnvironment` (Section 9.4) | Non-text port id, or a missing operand |
 
 `OR-NIL` (`=>`) replaces Bubble/NIL with a fallback value. Existing NIL passthrough behavior preserves the reason as Bubble/NIL flows through later operations.
@@ -1017,9 +1058,9 @@ The semantic plane holds an **interpretation role** for each stack position. A r
 | `Unassigned` | No role has been assigned. The value is rendered in its raw structural form. The runtime never infers a richer meaning (such as "string-like") at render time; interpretation is decided once, at construction. |
 | `RawNumber` | A plain number. A rational scalar renders as a reduced `numerator/denominator`, integers included (`3` renders as `3/1`). There is no decimal surface form and no per-value style: the display is uniform and matches the exact-real internal model. |
 | `ContinuedFraction` | Display a numeric scalar as the nested right-associative continued-fraction form `( a0 ( a1 ( a2 ... )))` (Section 4.2.3); lazy CFs render with a `...)` truncation marker |
-| `Interval` | A 2-element vector interpreted as the closed interval `[lo, hi]` |
+| `Interval` | A 2-element vector interpreted as the closed interval [*lo*, *hi*] |
 | `Text` | A codepoint sequence interpreted as text |
-| `TruthValue` | A three-state truth value drawn from {`true`, `false`, `unknown`} (Section 7.5). The definite states `true` / `false` are carried by a Boolean value (Section 4.1) — a distinct value kind, not a number; the third state `unknown` (U) is the logical-undecidability value of Section 7.4.1. Observed through the `truthValue` axis (`true` / `false` / `unknown`, Section 2.3); carries the `truthValued` capability. Displays as `TRUE`, `FALSE`, or `UNKNOWN` (display-only, non-canonical). How U is represented internally is not observable. |
+| `TruthValue` | A three-state truth value drawn from the truth domain of Section 7.5. The definite states `true` and `false` are carried by a Boolean value (Section 4.1) — a distinct value kind, not a number; the third state `unknown` (U) is the logical-undecidability value of Section 7.4.1. Observed through the `truthValue` axis (protocol strings `true` `false` `unknown` — Section 2.3); carries the `truthValued` capability. Displays as `TRUE` or `FALSE` or `UNKNOWN` (display-only, non-canonical). How U is represented internally is not observable. |
 | `Timestamp` | An integer interpreted as a formatted datetime |
 | `Nil` | A diagnostic absence value, displayed as `NIL` |
 
@@ -1033,7 +1074,7 @@ The `ContinuedFraction` role is the canonical AI-readable numeric serialization 
 
 ### 13.1 Static Mass Conservation
 
-Ajisai treats flow mass conservation as a compile/JIT/load-time property. A Coreword Contract declares arity, consumption, production, bifurcation, and NIL-projection behavior: arity/consumption/production are carried by the `mass` contract field (Section 7.14), bifurcation by the `KEEP` modifier (Section 13.2), and NIL-projection by `nil_policy`. Optimized execution paths may be entered only after those contracts have been validated for the surrounding flow.
+Ajisai treats flow mass conservation as a compile/JIT/load-time property. A Coreword Contract declares arity, consumption, production, bifurcation, and NIL-projection behavior: arity, consumption, and production are carried by the `mass` contract field (Section 7.14), bifurcation by the `KEEP` modifier (Section 13.2), and NIL-projection by `nil_policy`. Optimized execution paths may be entered only after those contracts have been validated for the surrounding flow.
 
 The ordinary runtime must not maintain per-value `FlowToken` objects or perform step-by-step mass accounting. Flow-accounting failures such as over-consumption, unconsumed leaks, flow breaks, and bifurcation-ratio violations are contract-validation failures and must be reported by the compiler/JIT, loader, or developer diagnostics before the optimized path executes. A word whose `mass` is `Dynamic` has a data-dependent arity that the static validator does not certify; flows through such words are validated only up to that point.
 
@@ -1082,13 +1123,13 @@ Every NIL-producing path must have at least one test that asserts both the surfa
 
 Words whose behavior depends on more than one independent condition (e.g. `/` decides on left-operand validity, right-operand validity, right-operand zero-ness, and NIL-passthrough applicability) must have tests that vary each condition independently with all others held fixed. Each condition must be shown to flip the outcome on its own.
 
-The three-valued logic words (`AND`, `OR`, `NOT`, Section 7.5) must cover every cell of the K3 truth tables — `AND` and `OR` over the nine {T, F, U}² combinations, `NOT` over the three {T, F, U} inputs — plus the NIL-interaction cases (absorbing collapse, NIL propagation, and the NIL-over-U priority rule of Section 4.5.2). The comparison words must cover at least: finite CFs always deciding to a definite truth value, equal irrationals yielding `unknown` (U), and distinct irrationals deciding at a finite prefix.
+The three-valued logic words (`AND` `OR` `NOT` — Section 7.5) must cover every cell of the K3 truth tables — `AND` and `OR` over the nine {T, F, U}² combinations, `NOT` over the three {T, F, U} inputs — plus the NIL-interaction cases (absorbing collapse, NIL propagation, and the NIL-over-U priority rule of Section 4.5.2). The comparison words must cover at least: finite CFs always deciding to a definite truth value, equal irrationals yielding `unknown` (U), and distinct irrationals deciding at a finite prefix.
 
-`COMPARE-WITHIN` (Section 7.4.2) must cover: each decided sign (`-1` / `0` / `1`); the budget-undecided case yielding `unknown` with `diagnosis.agreedPrefix` equal to the consumed `budget`; finite operands deciding regardless of `budget`; the same lazy-irrational pair deciding at a large `budget` but yielding U at a small `budget`; NIL operand passthrough; and the malformed-`budget` / non-numeric-operand error paths.
+`COMPARE-WITHIN` (Section 7.4.2) must cover: each decided sign (`-1` `0` `1`); the budget-undecided case yielding `unknown` with `diagnosis.agreedPrefix` equal to the consumed `budget`; finite operands deciding regardless of `budget`; the same lazy-irrational pair deciding at a large `budget` but yielding U at a small `budget`; NIL operand passthrough; and the malformed-`budget` / non-numeric-operand error paths.
 
-NICF-accelerated comparison (Section 7.4.1.1) must cover: (i) a reference set of decided comparisons producing an identical `truthValue` whether reasoned about via the RCF or computed via the NICF expansion — across `Rational`, `AlgebraicSqrt`, and `Gosper` operands — so the acceleration never changes a decided order; (ii) `agreedPrefix` being monotone non-decreasing in the budget under NICF; and (iii) the normative tie-break of Section 4.2.5 yielding the specified semiregular digit on the singular `1/2`-remainder cases, including the round-half-down boundary.
+NICF-accelerated comparison (Section 7.4.1.1) must cover: (i) a reference set of decided comparisons producing an identical `truthValue` whether reasoned about via the RCF or computed via the NICF expansion — across `Rational` and `AlgebraicSqrt` and `Gosper` operands — so the acceleration never changes a decided order; (ii) `agreedPrefix` being monotone non-decreasing in the budget under NICF; and (iii) the normative tie-break of Section 4.2.5 yielding the specified semiregular digit on the singular `1/2`-remainder cases, including the round-half-down boundary.
 
-The propagation of U through comparison-dependent words (Section 7.4.3) must cover, for `MIN` and `MAX`: a decided comparison selecting the correct operand; an undecidable comparison yielding `unknown` with `diagnosis.agreedPrefix`; NIL-operand passthrough with NIL taking priority over a U-producing comparison; and the sequence-form short-circuit on the first undecidable pair. For `SORT`: a fully-decidable input (notably any vector of rationals) sorting to ascending order; an input with at least one undecidable pair yielding `unknown` for the whole result (never a partially-sorted vector) carrying `diagnosis.agreedPrefix`; and NIL handling. For `COND`: a definite-`true` guard firing its clause; a U guard **not** firing and falling through to the next clause; a U guard before a later definite-`true` guard selecting the later clause; and a U guard with no other match reaching the `IDLE`/else clause, or `CondExhausted` when none exists.
+The propagation of U through comparison-dependent words (Section 7.4.3) must cover, for `MIN` and `MAX`: a decided comparison selecting the correct operand; an undecidable comparison yielding `unknown` with `diagnosis.agreedPrefix`; NIL-operand passthrough with NIL taking priority over a U-producing comparison; and the sequence-form short-circuit on the first undecidable pair. For `SORT`: a fully-decidable input (notably any vector of rationals) sorting to ascending order; an input with at least one undecidable pair yielding `unknown` for the whole result (never a partially-sorted vector) carrying `diagnosis.agreedPrefix`; and NIL handling. For `COND`: a definite-`true` guard firing its clause; a U guard **not** firing and falling through to the next clause; a U guard before a later definite-`true` guard selecting the later clause; and a U guard with no other match reaching the `IDLE` else clause, or `CondExhausted` when none exists.
 
 ---
 
@@ -1103,7 +1144,7 @@ A change is conformant only if all of the following hold:
 5. It keeps vector/tensor staged pipeline boundaries explicit.
 6. It improves or preserves AI-first structural clarity.
 7. Every built-in word (Core or module) introduced or renamed has an English-word-based canonical name; any symbolic form is registered as syntactic sugar that maps to that canonical name.
-8. Every introduced or modified Coreword has a contract entry covering `partiality`, `nil_policy`, and `safety_level` (Section 7.14).
+8. Every introduced or modified Coreword has a contract entry covering `partiality` and `nil_policy` and `safety_level` (Section 7.14).
 9. Every NIL-producing path attaches appropriate structured `absence` metadata (Section 4.5.0).
 10. Per-Coreword contract tests, NIL reason tests, MC/DC-style tests, and stack-discipline tests exist as required by Section 15.
 11. Scalar arithmetic and comparison operate on the continued-fraction representation (Section 4.2) without intermediate rounding or truncation; Möbius coefficients in Gosper transforms are BigInt; comparison-budget exhaustion in the comparison words produces the truth value `unknown` (U) rather than an error or a non-deterministic answer (Section 7.4.1).
@@ -1121,7 +1162,7 @@ this appendix and any numbered section disagree, the numbered section governs.
 Ajisai does not have a global "safe mode" that wraps evaluation. Ordinary value
 flow is **safe by design**: a well-formed operation that cannot produce a value
 yields a Bubble/NIL (Section 11.2), an observation that cannot decide a truth
-value yields the logical `Unknown` / Stagnation (Sections 4.5.2, 7.4.1), and a
+value yields the logical `Unknown` (Stagnation; Sections 4.5.2, 7.4.1), and a
 malformed use raises a channel error (Section 11.1). A raised channel error
 propagates and halts the current evaluation; Ajisai has no modifier or mode that
 converts an error into a value (Section 11.4).
@@ -1135,7 +1176,7 @@ existing boundaries:
 | Gate (vocabulary) | Direction | Normative mechanism |
 |-------------------|-----------|---------------------|
 | Host effects (serial, future IO) | outward | IO/semantic boundary; effects are emitted as host commands and the host performs them; absence of a capable host is an environment condition, not a semantic error (Sections 5.2, 9.4) |
-| Module dictionary import | inward | `IMPORT` / `IMPORT-ONLY` / `UNIMPORT` visibility control and dependency tracking across the Core / Module / User boundary (Sections 7, 9) |
+| Module dictionary import | inward | `IMPORT` `IMPORT-ONLY` `UNIMPORT` visibility control and dependency tracking across the Core, Module, and User boundary (Sections 7, 9) |
 
 **Water Levels — how much flow may run.** A water level bounds the amount of
 work or expansion. These are the existing budgets and limits:
@@ -1143,7 +1184,7 @@ work or expansion. These are the existing budgets and limits:
 | Water Level (vocabulary) | Normative mechanism | Outcome on reaching the level |
 |--------------------------|---------------------|-------------------------------|
 | Evaluation step budget | step limit, default 100,000 (Section 5.3) | raises `ExecutionLimitExceeded` (Section 11.1) |
-| Comparison / observation depth | comparison budget (Section 7.4.1); explicitly via `COMPARE-WITHIN` (Section 7.4.2) | yields the logical `Unknown` (U) / Stagnation, **not** a Bubble/NIL (Sections 4.5.2, 7.4.3) |
+| Comparison and observation depth | comparison budget (Section 7.4.1); explicitly via `COMPARE-WITHIN` (Section 7.4.2) | yields the logical `Unknown` (U, Stagnation), **not** a Bubble/NIL (Sections 4.5.2, 7.4.3) |
 
 The defining distinction of Section 4.5.2 is preserved by this vocabulary: a gate
 refusal or a step-budget exhaustion is an operational or environment condition,
@@ -1155,14 +1196,15 @@ operational absence.
 
 ### Core Profile
 Host-independent semantics only: tokenization, vector evaluation, exact
-arithmetic, vectors, blocks, map/form/fold, NIL/UNKNOWN, user definitions.
+arithmetic, vectors, code blocks, the higher-order words (`MAP` `FILTER`
+`FOLD`), NIL and the logical Unknown, user definitions.
 
 ### Hosted Profile
-Words requiring host capabilities: NOW, CSPRNG, SERIAL, AUDIO, JSONEXPORT,
-persistence, file I/O.
+Words requiring host capabilities: `NOW` `CSPRNG` and the `SERIAL` module,
+audio, JSON export, persistence, file I/O.
 
 ### Platform Profile
-Concrete runtime bindings: Web/WASM, Tauri, CLI, WASI, Native desktop.
+Concrete runtime bindings: Web/WASM, Tauri, CLI, WASI, native desktop.
 
 ## Conformance and Identity
 An implementation is an Ajisai implementation if and only if it passes the

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -12,6 +12,11 @@
       アプリ本体の CSS バンドルには依存できない。ヘッダー/フッターの意匠（移ろいの
       グラデーションを含む）とデザイントークンは、ラフ版として最小限を本ファイルに
       インライン複製している。意匠を本格運用する段階で共通化を検討する。
+
+      執筆規約: docs/dev/ajisai-authoring-style.md / docs/dev/reference-writing-style.md。
+      - Ajisai のトークンは必ず <code> で囲む（灰色背景 = Ajisai チャネル）。
+      - 期待値はサンプル表の Expected value 列に置く（行内コメント矢印は使わない）。
+      - Expected value は conformance スイートと同じ観測（最終スタックの表示文字列）。
     -->
     <style>
         :root {
@@ -279,6 +284,11 @@
             color: var(--color-text-light);
         }
 
+        /* Word/sugar summary tables (not samples): same look, slightly tighter. */
+        .word-table {
+            margin: 0.75rem 0 1.25rem;
+        }
+
         .ref-note {
             font-size: 0.85rem;
             color: var(--color-text-light);
@@ -379,14 +389,17 @@
             <article class="ref-article">
                 <section id="intro" class="ref-page">
                     <h2>Introduction</h2>
-                    <p>Ajisai is an AI-first, vector-oriented, fractional-dataflow stack language. This reference introduces each feature with short examples.</p>
-                    <p>Every example has an <strong>"Open in Playground"</strong> button. Pressing it loads the code into the app's editor so you can run it and see how it behaves.</p>
-                    <p class="ref-note">This is a rough draft. The content will be expanded gradually.</p>
+                    <p>Ajisai is an AI-first, vector-oriented, fractional-dataflow stack language. A program is a sequence of <strong>words</strong>: values are pushed onto a single stack, and each word consumes operands from the stack and pushes its results. Every number is an <strong>exact real</strong> — internally a continued fraction — so arithmetic never rounds.</p>
+                    <p>This reference introduces each feature with short, verified examples. Every example has an <strong>"Open in Playground"</strong> button; pressing it loads the code into the app's editor so you can run it and see how it behaves.</p>
+                    <h3>How to read the examples</h3>
+                    <p>The <strong>Expected value</strong> column shows the final stack exactly as the language renders it, value by value. Two display conventions matter from the start:</p>
+                    <p>Numbers display as exact fractions in <code>numerator/denominator</code> form — the integer three renders as <code>3/1</code>. Truth values display as <code>TRUE</code> and <code>FALSE</code> and <code>UNKNOWN</code>; the absence of a value displays as <code>NIL</code>.</p>
+                    <p>In the text of this reference, anything with a gray background is an Ajisai token. Nearly every ASCII symbol in Ajisai is a word in disguise — <code>+</code> is <code>ADD</code> and <code>,,</code> is <code>KEEP</code> — so the gray background is the signal that a mark belongs to the program, not to the prose.</p>
                 </section>
 
                 <section id="vectors" class="ref-page">
                     <h2>Values and Vectors</h2>
-                    <p>Every value in Ajisai is wrapped in a vector. Enclose elements in square brackets <code>[ ]</code> and separate them with spaces. Numbers can be exact fractions (rationals).</p>
+                    <p>A vector encloses values in square brackets <code>[ ]</code>, separated by spaces. A vector literal evaluates to itself, and vectors may nest freely.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -396,8 +409,27 @@
                             <tbody>
                                 <tr>
                                     <td><code>[ 1 2 3 ]</code></td>
-                                    <td><code>[ 1 2 3 ]</code></td>
-                                    <td class="notes">A vector pushed onto the stack.</td>
+                                    <td><code>[ 1/1 2/1 3/1 ]</code></td>
+                                    <td class="notes">A vector pushed onto the stack. Integers display as exact fractions over 1.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ [ 1 2 ] [ 3 4 ] ]</code></td>
+                                    <td><code>[ [ 1/1 2/1 ] [ 3/1 4/1 ] ]</code></td>
+                                    <td class="notes">Nesting is preserved; nested vectors act as tensors.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -416,7 +448,222 @@
                                 <tr>
                                     <td><code>[ 7/3 ]</code></td>
                                     <td><code>[ 7/3 ]</code></td>
-                                    <td class="notes">Numbers are kept as exact rationals.</td>
+                                    <td class="notes">Fractions are first-class literals and stay exact.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">There is no empty-vector literal: use <code>NIL</code> for the absence of a value.</p>
+                </section>
+
+                <section id="numbers" class="ref-page">
+                    <h2>Exact Numbers</h2>
+                    <p>Every numeric value is an exact real, stored as a continued fraction. Integer, fraction, decimal, and scientific-notation literals are all surface forms of the same exact representation — <code>0.5</code> <em>is</em> one half, not a binary approximation.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>0.5 0.25 +</code></td>
+                                    <td><code>3/4</code></td>
+                                    <td class="notes">Decimal literals are exact rationals.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>1 3 /</code></td>
+                                    <td><code>1/3</code></td>
+                                    <td class="notes">Division yields an exact rational, never a rounded float.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>2 3 / 1 3 / +</code></td>
+                                    <td><code>1/1</code></td>
+                                    <td class="notes">Two thirds plus one third is exactly one.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>1000000000000 1000000000000 *</code></td>
+                                    <td><code>1000000000000000000000000/1</code></td>
+                                    <td class="notes">Arbitrary-precision integers never fall back to floating point.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 9 SQRT</code></td>
+                                    <td><code>3/1</code></td>
+                                    <td class="notes">A perfect-square root is the exact rational answer.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 2 SQRT 2 LT</code></td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">An irrational like √2 is a lazy continued fraction; comparisons against it are computed exactly.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">An irrational value itself renders as a nested continued fraction such as <code>( 1 ( 2 ( 2 ( 2 ...) ) ) )</code>, truncated at a display budget. The nested form is display output only — it is not source syntax, and <code>(</code> <code>)</code> are rejected in programs.</p>
+                </section>
+
+                <section id="stack" class="ref-page">
+                    <h2>Stack and Modifiers</h2>
+                    <p>Words take their operands from the stack and push their results back. Two pairs of <strong>modifiers</strong>, written before a word, control where the operands come from and whether they survive:</p>
+                    <div class="ref-table-wrap word-table">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Canonical</th><th>Sugar</th><th>Effect</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr><td><code>TOP</code></td><td><code>.</code></td><td class="notes">Operate on the top value(s) of the stack (default).</td></tr>
+                                <tr><td><code>STAK</code></td><td><code>..</code></td><td class="notes">Fold the operation across many stack values; the count on top of the stack says how many.</td></tr>
+                                <tr><td><code>EAT</code></td><td><code>,</code></td><td class="notes">Consume the operands (default).</td></tr>
+                                <tr><td><code>KEEP</code></td><td><code>,,</code></td><td class="notes">Retain the operands and push the result as well.</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>3 4 +</code></td>
+                                    <td><code>7/1</code></td>
+                                    <td class="notes">Default mode: both operands are consumed and the sum is pushed.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>3 4 KEEP ADD</code></td>
+                                    <td><code>3/1 4/1 7/1</code></td>
+                                    <td class="notes"><code>KEEP</code> (<code>,,</code>) retains the operands; the result is pushed on top.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>1 2 3 3 STAK ADD</code></td>
+                                    <td><code>6/1</code></td>
+                                    <td class="notes"><code>STAK</code> (<code>..</code>) folds <code>ADD</code> across the three values below the count.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>1 2 3 3 STAK KEEP ADD</code></td>
+                                    <td><code>1/1 2/1 3/1 6/1</code></td>
+                                    <td class="notes">Modifiers combine: fold across the stack and keep the operands too.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -429,7 +676,21 @@
 
                 <section id="arithmetic" class="ref-page">
                     <h2>Arithmetic</h2>
-                    <p>The four arithmetic operations act element-wise between vectors. <code>MOD</code> gives the remainder.</p>
+                    <p>The arithmetic words act element-wise between vectors, and a one-element vector broadcasts across a longer one. Each word has a canonical English name; the symbol is sugar:</p>
+                    <div class="ref-table-wrap word-table">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Canonical</th><th>Sugar</th><th>Meaning</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr><td><code>ADD</code></td><td><code>+</code></td><td class="notes">Addition</td></tr>
+                                <tr><td><code>SUB</code></td><td><code>-</code></td><td class="notes">Subtraction</td></tr>
+                                <tr><td><code>MUL</code></td><td><code>*</code></td><td class="notes">Multiplication</td></tr>
+                                <tr><td><code>DIV</code></td><td><code>/</code></td><td class="notes">Exact-real division</td></tr>
+                                <tr><td><code>MOD</code></td><td><code>%</code></td><td class="notes">Remainder</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -438,8 +699,8 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>[ 1 2 3 ] [ 10 20 30 ] +</code></td>
-                                    <td><code>[ 11 22 33 ]</code></td>
+                                    <td><code>[ 1 2 3 ] [ 4 5 6 ] +</code></td>
+                                    <td><code>[ 5/1 7/1 9/1 ]</code></td>
                                     <td class="notes">Element-wise addition.</td>
                                 </tr>
                             </tbody>
@@ -457,8 +718,27 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>[ 7 ] [ 3 ] MOD PRINT</code></td>
-                                    <td><code>[ 1 ]</code></td>
+                                    <td><code>[ 1 2 3 ] [ 10 ] *</code></td>
+                                    <td><code>[ 10/1 20/1 30/1 ]</code></td>
+                                    <td class="notes">A singleton vector broadcasts across the other operand.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>7 3 MOD</code></td>
+                                    <td><code>1/1</code></td>
                                     <td class="notes">Remainder of 7 divided by 3.</td>
                                 </tr>
                             </tbody>
@@ -468,11 +748,27 @@
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
+                    <p class="ref-note">The rounding words <code>FLOOR</code> and <code>CEIL</code> and <code>ROUND</code> also live here. Division by zero does not crash — see <a href="#nil">NIL and the Bubble Rule</a>.</p>
                 </section>
 
-                <section id="output" class="ref-page">
-                    <h2>Output</h2>
-                    <p><code>PRINT</code> shows the value at the top of the stack in the output area.</p>
+                <section id="comparison" class="ref-page">
+                    <h2>Comparison and Truth Values</h2>
+                    <p>All six ordering relations exist as words. The result is a <strong>truth value</strong>, which is its own kind of value — a Boolean is not a number.</p>
+                    <div class="ref-table-wrap word-table">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Canonical</th><th>Sugar</th><th>Meaning</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr><td><code>EQ</code></td><td><code>=</code></td><td class="notes">Equal</td></tr>
+                                <tr><td><code>NEQ</code></td><td><code>&lt;&gt;</code></td><td class="notes">Not equal</td></tr>
+                                <tr><td><code>LT</code></td><td><code>&lt;</code></td><td class="notes">Less than</td></tr>
+                                <tr><td><code>LTE</code></td><td><code>&lt;=</code></td><td class="notes">Less than or equal</td></tr>
+                                <tr><td><code>GT</code></td><td><code>&gt;</code></td><td class="notes">Greater than</td></tr>
+                                <tr><td><code>GTE</code></td><td><code>&gt;=</code></td><td class="notes">Greater than or equal</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -481,9 +777,148 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>[ 42 ] PRINT</code></td>
-                                    <td><code>[ 42 ]</code></td>
-                                    <td class="notes">Writes the top of the stack to the output area.</td>
+                                    <td><code>5 3 GT</code></td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">A decided comparison yields a Boolean.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>TRUE 1 EQ</code></td>
+                                    <td><code>FALSE</code></td>
+                                    <td class="notes">A truth value is not the number 1.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ</code></td>
+                                    <td><code>UNKNOWN</code></td>
+                                    <td class="notes">√2 − √2 cannot be told apart from 0 within the comparison budget, so the honest answer is the third truth value.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>5 3 10 COMPARE-WITHIN</code></td>
+                                    <td><code>1/1</code></td>
+                                    <td class="notes">Three-way compare with an explicit budget: the sign of a − b, or <code>UNKNOWN</code> if undecided within the budget.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">Comparing exact lazy values (like square roots) cannot always terminate, so every comparison runs under a budget. Equal irrationals exhaust it and yield <code>UNKNOWN</code> — a logical truth value, distinct from <code>NIL</code>.</p>
+                </section>
+
+                <section id="logic" class="ref-page">
+                    <h2>Three-Valued Logic</h2>
+                    <p><code>AND</code> (<code>&amp;</code>) and <code>OR</code> and <code>NOT</code> implement strong Kleene three-valued logic over true, false, and unknown. The absorbing cases are exact: false absorbs <code>AND</code>, true absorbs <code>OR</code>; unknown propagates everywhere else.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>TRUE FALSE AND</code></td>
+                                    <td><code>FALSE</code></td>
+                                    <td class="notes">Logical AND of two definite values.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>TRUE FALSE OR</code></td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">Logical OR.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>TRUE NOT</code></td>
+                                    <td><code>FALSE</code></td>
+                                    <td class="notes">Logical NOT.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ TRUE AND</code></td>
+                                    <td><code>UNKNOWN</code></td>
+                                    <td class="notes">Unknown flows through the Kleene tables: true AND unknown is unknown.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -494,9 +929,10 @@
                     </div>
                 </section>
 
-                <section id="range" class="ref-page">
-                    <h2>Range</h2>
-                    <p><code>RANGE</code> builds a continuous vector from a start value and an end value.</p>
+                <section id="nil" class="ref-page">
+                    <h2>NIL and the Bubble Rule</h2>
+                    <p>The failure model in one line: <strong>could not produce a value → a bubble; used incorrectly → an error.</strong> A well-formed operation that cannot produce a result projects onto <code>NIL</code> — a "bubble" carrying a structured reason — while malformed use (wrong types, missing operands) raises an ordinary error.</p>
+                    <p>Bubbles flow: arithmetic and comparison are NIL-passthrough, so a <code>NIL</code> operand makes the result <code>NIL</code> without crashing the pipeline. At the end, <code>OR-NIL</code> (<code>=&gt;</code>) supplies a fallback.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -505,9 +941,9 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>[ 0 ] [ 5 ] RANGE PRINT</code></td>
-                                    <td><code>[ 0 1 2 3 4 5 ]</code></td>
-                                    <td class="notes">Inclusive range from 0 to 5.</td>
+                                    <td><code>1 0 /</code></td>
+                                    <td><code>NIL</code></td>
+                                    <td class="notes">Division by zero is a bubble with reason, not a trap.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -516,11 +952,685 @@
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>NIL 1 +</code></td>
+                                    <td><code>NIL</code></td>
+                                    <td class="notes">NIL passes through arithmetic, keeping its reason traceable.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 10 20 30 ] [ 5 ] GET</code></td>
+                                    <td><code>[ 10/1 20/1 30/1 ] NIL</code></td>
+                                    <td class="notes">An out-of-range index on a valid vector is a bubble (reason: index out of bounds).</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'ABC' NUM</code></td>
+                                    <td><code>NIL</code></td>
+                                    <td class="notes">Text that cannot be parsed as a number is a bubble (reason: invalid encoding).</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>1 0 / =&gt; 99</code></td>
+                                    <td><code>99/1</code></td>
+                                    <td class="notes"><code>OR-NIL</code> (<code>=&gt;</code>) replaces a bubble with the fallback value.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>7 2 / =&gt; 99</code></td>
+                                    <td><code>7/2</code></td>
+                                    <td class="notes">When the result is a real value, the fallback is not used.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                </section>
+
+                <section id="vector-ops" class="ref-page">
+                    <h2>Vector Operations</h2>
+                    <p>Vectors are 0-indexed; a negative index counts from the end. Reading words such as <code>GET</code> and <code>LENGTH</code> leave the source vector on the stack and push the answer on top of it.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 10 20 30 ] [ 0 ] GET</code></td>
+                                    <td><code>[ 10/1 20/1 30/1 ] 10/1</code></td>
+                                    <td class="notes">Index 0 is the first element; the source vector is retained.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 10 20 30 ] [ -1 ] GET</code></td>
+                                    <td><code>[ 10/1 20/1 30/1 ] 30/1</code></td>
+                                    <td class="notes">Negative indices count from the end.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 ] LENGTH</code></td>
+                                    <td><code>[ 1/1 2/1 3/1 ] 3/1</code></td>
+                                    <td class="notes">Element count, with the source vector retained.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 ] [ 3 4 ] CONCAT</code></td>
+                                    <td><code>[ 1/1 2/1 3/1 4/1 ]</code></td>
+                                    <td class="notes">Concatenate two vectors.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 ] REVERSE</code></td>
+                                    <td><code>[ 3/1 2/1 1/1 ]</code></td>
+                                    <td class="notes">Reverse the element order.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 5 ] RANGE</code></td>
+                                    <td><code>[ 1/1 2/1 3/1 4/1 5/1 ]</code></td>
+                                    <td class="notes">Inclusive integer sequence from start to end.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 0 10 2 ] RANGE</code></td>
+                                    <td><code>[ 0/1 2/1 4/1 6/1 8/1 10/1 ]</code></td>
+                                    <td class="notes">A third element gives the step; a negative step descends.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 4 5 ] [ 3 ] TAKE</code></td>
+                                    <td><code>[ 1/1 2/1 3/1 ]</code></td>
+                                    <td class="notes">Keep the first N elements.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'algo' IMPORT [ 3 1 2 ] SORT</code></td>
+                                    <td><code>[ 1/1 2/1 3/1 ]</code></td>
+                                    <td class="notes">Ascending sort. <code>SORT</code> is owned by the <code>ALGO</code> module.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ [ 1 2 ] [ 3 4 ] ] SHAPE</code></td>
+                                    <td><code>[ 2/1 2/1 ]</code></td>
+                                    <td class="notes">The size of each dimension of a nested vector.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ [ 1 2 ] [ 3 4 ] ] RANK</code></td>
+                                    <td><code>2/1</code></td>
+                                    <td class="notes">The number of dimensions.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">Further structural words: <code>INSERT</code> <code>REPLACE</code> <code>REMOVE</code> <code>SPLIT</code> <code>REORDER</code> <code>COLLECT</code> <code>RESHAPE</code> <code>TRANSPOSE</code> <code>FILL</code>.</p>
+                </section>
+
+                <section id="higher-order" class="ref-page">
+                    <h2>Higher-Order Words</h2>
+                    <p>A code block <code>{ }</code> is a first-class value. The higher-order words apply a block — or the quoted name of a defined word — across the elements of a vector.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 ] { [ 2 ] * } MAP</code></td>
+                                    <td><code>[ 2/1 4/1 6/1 ]</code></td>
+                                    <td class="notes">Apply the block to each element.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>{ [ 2 ] * } 'DBL' DEF [ 1 2 3 ] 'DBL' MAP</code></td>
+                                    <td><code>[ 2/1 4/1 6/1 ]</code></td>
+                                    <td class="notes">A defined word can be passed by its quoted name.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 4 ] { [ 2 ] MOD [ 0 ] = } FILTER</code></td>
+                                    <td><code>[ 2/1 4/1 ]</code></td>
+                                    <td class="notes">Keep the elements for which the predicate is true (here: the even ones).</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 4 ] [ 0 ] '+' FOLD</code></td>
+                                    <td><code>[ 10/1 ]</code></td>
+                                    <td class="notes">Reduce with an initial accumulator: 0 + 1 + 2 + 3 + 4.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 4 ] [ 0 ] '+' SCAN</code></td>
+                                    <td><code>[ 1/1 3/1 6/1 10/1 ]</code></td>
+                                    <td class="notes">Like <code>FOLD</code>, but keeps every intermediate accumulator (running totals).</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 4 5 ] { [ 2 ] MOD [ 0 ] = } COUNT</code></td>
+                                    <td><code>[ 2/1 ]</code></td>
+                                    <td class="notes">Count the elements satisfying the predicate.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 3 5 8 ] { [ 2 ] MOD [ 0 ] = } ANY</code></td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">True if at least one element satisfies the predicate; short-circuits.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 2 4 6 8 ] { [ 2 ] MOD [ 0 ] = } ALL</code></td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">True if every element satisfies the predicate; short-circuits on the first false.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note"><code>UNFOLD</code> generates a sequence from a seed and a generator block; <code>EXEC</code> runs a block; <code>EVAL</code> runs a string as code.</p>
+                </section>
+
+                <section id="cond" class="ref-page">
+                    <h2>Conditionals</h2>
+                    <p><code>COND</code> evaluates guard-and-body clauses in order and executes the body of the first guard that is definitely true. In the clause form, <code>$</code> separates the guard from the body and each clause occupies exactly one line; <code>IDLE</code> (a no-op) makes an always-true else guard.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 0 ]
+{ [ 0 ] &lt; $ 'negative' }
+{ [ 0 ] = $ 'zero' }
+{ IDLE $ 'positive' }
+COND</code></td>
+                                    <td><code>'zero'</code></td>
+                                    <td class="notes">Clause form: guard left of <code>$</code>, body right; one clause per line.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ -5 ] { [ 0 ] &lt; } { 'negative' } { IDLE } { 'positive' } COND</code></td>
+                                    <td><code>'negative'</code></td>
+                                    <td class="notes">Pair form: alternating guard and body blocks.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">A guard that evaluates to <code>UNKNOWN</code> does <em>not</em> fire its clause; evaluation falls through as if it were false. If no clause matches and there is no else clause, <code>COND</code> raises an error.</p>
+                </section>
+
+                <section id="strings" class="ref-page">
+                    <h2>Strings</h2>
+                    <p>A string is quoted with <code>'</code> and displays in quotes. Strings convert to and from numbers and characters with the cast words.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'hello'</code></td>
+                                    <td><code>'hello'</code></td>
+                                    <td class="notes">A string literal evaluates to itself.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>42 STR</code></td>
+                                    <td><code>'42'</code></td>
+                                    <td class="notes">Number to string.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'1/3' NUM</code></td>
+                                    <td><code>1/3</code></td>
+                                    <td class="notes">String to exact number; unparseable text yields <code>NIL</code>.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>65 CHR</code></td>
+                                    <td><code>'A'</code></td>
+                                    <td class="notes">Unicode code point to character.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 'hel' 'lo' ] JOIN</code></td>
+                                    <td><code>'hello'</code></td>
+                                    <td class="notes">Join a vector of strings.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'  hi  ' TRIM</code></td>
+                                    <td><code>'hi'</code></td>
+                                    <td class="notes">Strip whitespace from both ends; <code>TRIM-LEFT</code> and <code>TRIM-RIGHT</code> take one side.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'hello world' 'world' 'ajisai' SUBSTITUTE</code></td>
+                                    <td><code>'hello ajisai'</code></td>
+                                    <td class="notes">Replace every occurrence of a substring.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'banana' 'ba' STARTS-WITH?</code></td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">Prefix test; <code>ENDS-WITH?</code> tests the suffix.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note"><code>CHARS</code> splits a string into its characters and <code>TOKENIZE</code> splits by a separator; both produce code-point values that <code>JOIN</code> assembles back into text.</p>
                 </section>
 
                 <section id="define" class="ref-page">
                     <h2>Defining Words</h2>
-                    <p>You can give a name to a snippet of code to define a new word. Definitions use <code>DEF</code>.</p>
+                    <p>A new word is defined from a code block and a name: <code>{ body } 'NAME' DEF</code>. The body runs each time the word is called.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -529,10 +1639,162 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>[ '[ 2 ] *' ] 'DOUBLE' DEF
-[ 21 ] DOUBLE PRINT</code></td>
-                                    <td><code>[ 42 ]</code></td>
-                                    <td class="notes"><code>DOUBLE</code> multiplies the top vector by 2.</td>
+                                    <td><code>{ [ 10 ] + } 'ADD10' DEF
+5 ADD10</code></td>
+                                    <td><code>[ 15/1 ]</code></td>
+                                    <td class="notes">Define <code>ADD10</code>, then call it.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>{ [ 2 ] * } 'DBL' DEF
+[ 1 2 3 ] 'DBL' MAP</code></td>
+                                    <td><code>[ 2/1 4/1 6/1 ]</code></td>
+                                    <td class="notes">User words combine with the higher-order words by quoted name.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <h3>Managing words</h3>
+                    <p><code>DEL</code> deletes a user word by quoted name. Dependencies are tracked: redefining or deleting a word that other words depend on requires the force modifier <code>FORC</code> (<code>!</code>). Built-in words can never be redefined or deleted. <code>LOOKUP</code> (<code>?</code>) shows the definition of a word — for a user word it returns the original source for editing.</p>
+                    <p class="ref-note">Word names are case-insensitive (<code>add10</code> and <code>ADD10</code> are the same word) and conventionally follow an action-object style such as <code>APPLY-GAIN</code>.</p>
+                </section>
+
+                <section id="modules" class="ref-page">
+                    <h2>Modules</h2>
+                    <p>Module words become visible with <code>IMPORT</code>: the quoted module name is case-insensitive. <code>IMPORT-ONLY</code> brings in selected words; <code>UNIMPORT</code> and <code>UNIMPORT-ONLY</code> hide them again without deleting anything.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 9 SQRT</code></td>
+                                    <td><code>3/1</code></td>
+                                    <td class="notes">After <code>IMPORT</code>, the module's words resolve as bare names.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'algo' IMPORT [ 3 1 2 ] SORT</code></td>
+                                    <td><code>[ 1/1 2/1 3/1 ]</code></td>
+                                    <td class="notes"><code>SORT</code> is canonically an <code>ALGO</code> word.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <h3>Available modules</h3>
+                    <div class="ref-table-wrap word-table">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Module</th><th>Purpose</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr><td><code>MATH</code></td><td class="notes">Square root, exact-rational interval arithmetic, and scalar utilities</td></tr>
+                                <tr><td><code>ALGO</code></td><td class="notes">Sorting and other deterministic algorithms</td></tr>
+                                <tr><td><code>JSON</code></td><td class="notes">JSON parsing, generation, and manipulation</td></tr>
+                                <tr><td><code>IO</code></td><td class="notes">Standard input/output</td></tr>
+                                <tr><td><code>TIME</code></td><td class="notes">Exact, timezone-free date and time values</td></tr>
+                                <tr><td><code>CRYPTO</code></td><td class="notes">Cryptographically secure random and hash</td></tr>
+                                <tr><td><code>MUSIC</code></td><td class="notes">Audio sequencing and synthesis</td></tr>
+                                <tr><td><code>SERIAL</code></td><td class="notes">Host-mediated serial port access</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section id="pipeline" class="ref-page">
+                    <h2>Pipelines</h2>
+                    <p><code>PIPE</code> (<code>==</code>) is a purely visual pipeline marker — it has no runtime effect. Use it to punctuate the stages of a dataflow so a long line reads as a pipeline.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>[ 1 2 3 ] == REVERSE</code></td>
+                                    <td><code>[ 3/1 2/1 1/1 ]</code></td>
+                                    <td class="notes">Identical to the same code without <code>==</code>.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">A typical shape: compute == transform == compare, with a single <code>OR-NIL</code> (<code>=&gt;</code>) fallback at the end of the line to absorb any bubble produced along the way.</p>
+                </section>
+
+                <section id="output" class="ref-page">
+                    <h2>Output</h2>
+                    <p><code>PRINT</code> writes the top stack value to the output area. Like any word it consumes its operand by default; with <code>KEEP</code> (<code>,,</code>) the value also stays on the stack. The Playground always shows the final stack, so <code>PRINT</code> is for the output channel, not for seeing results.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>42 ,, PRINT</code></td>
+                                    <td><code>42/1</code></td>
+                                    <td class="notes">The value goes to the output area and, thanks to <code>,,</code>, stays on the stack.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>42 PRINT</code></td>
+                                    <td>—</td>
+                                    <td class="notes">Default mode consumes the operand: the stack ends empty and the value appears only in the output area.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -549,10 +1811,20 @@
                 <ul>
                     <li><a href="#intro">Introduction</a></li>
                     <li><a href="#vectors">Values and Vectors</a></li>
+                    <li><a href="#numbers">Exact Numbers</a></li>
+                    <li><a href="#stack">Stack and Modifiers</a></li>
                     <li><a href="#arithmetic">Arithmetic</a></li>
-                    <li><a href="#output">Output</a></li>
-                    <li><a href="#range">Range</a></li>
+                    <li><a href="#comparison">Comparison and Truth Values</a></li>
+                    <li><a href="#logic">Three-Valued Logic</a></li>
+                    <li><a href="#nil">NIL and the Bubble Rule</a></li>
+                    <li><a href="#vector-ops">Vector Operations</a></li>
+                    <li><a href="#higher-order">Higher-Order Words</a></li>
+                    <li><a href="#cond">Conditionals</a></li>
+                    <li><a href="#strings">Strings</a></li>
                     <li><a href="#define">Defining Words</a></li>
+                    <li><a href="#modules">Modules</a></li>
+                    <li><a href="#pipeline">Pipelines</a></li>
+                    <li><a href="#output">Output</a></li>
                 </ul>
             </nav>
         </main>


### PR DESCRIPTION
## Summary

`docs/dev/ajisai-authoring-style.md` に基づいて仕様書と Reference を書き直しました。仕様書は**表記のみの変更（意味の変更なし）**、Reference は現行の見せ方を維持したまま内容を大幅拡充しています。

## SPECIFICATION.md（プレゼンテーションのみ・意味変更なし）

- **トークン列挙のテーブル化** — boundary class の例示、`STAK` モード比較のシーケンス特性、NIL パススルー対象外ワードの列挙（Bubble Rule まわり）、命名規約の警告対象、`COMPARE-WITHIN` の結果一覧。
- **Ajisai ワードを散文の区切りに使わない** — コードトークン間の `,` / `/` 区切りを、空白区切りのコードスパン列・"and"/"or"・中黒（セル内）へ置換。
- **数学を灰色チャネルから分離** — CF の部分商表記、NICF の半正則展開式とタイブレーク、Gosper の双一次変換、`MOD` の定義式、閉区間、`COMPARE-WITHIN` の符号条件を Unicode 数学表記（イタリック変数）へ。
- **K3 真理値表**をコードフェンスから Markdown テーブルへ。
- Portability Profiles の裸トークンをコードマーク化（`map/form/fold` のタイポは `MAP` `FILTER` `FOLD` に修正）。
- 欠番参照の修正（Section 7.13 → 7.12）、Version 日付の更新。

## public/docs/index.html（Reference）

見せ方（1行サンプル表＋サンプルごとの Open in Playground、ページ単位ナビ、移ろいの意匠）は現行のまま、**6ページ → 16ページ・66サンプル**へ拡充:

- 新ページ: Exact Numbers / Stack and Modifiers / Comparison and Truth Values / Three-Valued Logic / NIL and the Bubble Rule / Vector Operations / Higher-Order Words / Conditionals / Strings / Modules / Pipelines。
- **全サンプルを実機検証** — conformance スイート（`tests/conformance/index.html`）の事例をそのまま使うか、Rust インタプリタを直接実行して期待値を確認済み。期待値は言語境界のスタック表示（`[ 1/1 2/1 3/1 ]`・`TRUE`・`NIL`・`UNKNOWN`）で統一。
- 既存サンプルの誤りを修正: 旧 `[ '...' ] 'NAME' DEF` 形式 → 実際の `{ body } 'NAME' DEF`、旧 `[ 0 ] [ 5 ] RANGE` → 検証済みの `[ 1 5 ] RANGE`、整数表示も実表示（`n/1`）に合わせました。

## 検証

- 全サンプルの期待値を `cargo test`（使い捨てプローブ）で実行確認（プローブはコミットに含まれません）。
- Reference HTML のタグ整合・ナビとセクション ID の一致をスクリプトで確認。

https://claude.ai/code/session_01JwA6zFjc6jgNihNb9gke64

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwA6zFjc6jgNihNb9gke64)_