### PR TITLE
Codify the documentation authority model in the specification

### DIFF
--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -233,6 +233,8 @@ Version: <strong>2026-06-11</strong></p>
 <li>WASM/TypeScript observable contracts derived from this file</li>
 </ol>
 
+<p>Items 2 and 3 are canonical only insofar as they conform to item 1. Implementation code is an expression of this specification, never an independent source of meaning: when the Rust core, the WASM boundary, or the GUI shell disagrees with this file, this file takes precedence and the implementation is corrected (Section 2.5).</p>
+
 <h3 id="22-non-canonical">2.2 Non-canonical</h3>
 
 <p>Any roadmap, handover note, TODO note, or design memo is non-canonical unless explicitly promoted here. Secondary documents must not define competing semantics and must not be treated as specification.</p>
@@ -280,6 +282,65 @@ Version: <strong>2026-06-11</strong></p>
 <p>Machine-readable semantic metadata is part of this firewall. <code>docs/word-manifest.json</code> gives every surface word a generated <code>canonical</code> spelling and <code>semantic_role</code>; <code>docs/formalization-coverage.json</code> gives canonical entries their algebraic family, derivation edges, primitive registry, effect boundary, and exploratory debt metadata. Tooling must update the generator and coverage source rather than hand-authoring contradictory manifest semantics.</p>
 
 <p>The <code>truthValue</code> axis is present only on values carrying the <code>TruthValue</code> interpretation role (Section 12.2); such values also carry the <code>truthValued</code> capability. Its three protocol strings — <code>true</code> <code>false</code> <code>unknown</code> — are the <strong>only</strong> observable surface for the three-valued logic of Section 7.5. The third value <code>unknown</code> (U) is a logical truth value, not an operational absence: how it is represented internally (for example, whether it shares storage with a NIL node) is not observable, and consumers must not infer it from <code>semanticKind = absence</code>, from any <code>absence.reason</code>, or from display text. A consumer that needs to distinguish true, false, and unknown reads the <code>truthValue</code> axis and nothing else.</p>
+
+<h3 id="24-documentation-layers">2.4 Documentation layers and their responsibilities</h3>
+
+<p>Ajisai is written down in four layers. Each layer has a single responsibility; the layers complement one another and do not compete for authority. The goal of this separation is implementation-independent semantic identity: a port implemented faithfully from these documents — without consulting the Rust, WASM, or TypeScript sources — must reproduce the same language.</p>
+
+<div class="ref-table-wrap">
+<table class="ref-table">
+<thead>
+<tr><th>Layer</th><th>Lives in</th><th>Responsibility</th><th>Authority</th></tr>
+</thead>
+<tbody>
+<tr><td>Mathematical formalization</td><td>Math blocks in this document · <code>docs/dev/ajisai-mathematical-formalization.md</code> · coverage in <code>docs/formalization-coverage.json</code></td><td>The most compact account of the intended semantics</td><td>Descriptive; constrains and motivates this document but never overrides it</td></tr>
+<tr><td>Specification</td><td><code>SPECIFICATION.html</code> (this document)</td><td>The canonical normative account, implementable by humans and AI</td><td>Canonical (Section 2.1)</td></tr>
+<tr><td>Reference</td><td><code>public/docs/</code> · <code>LOOKUP</code> (<code>?</code>) · hover text</td><td>Derived documentation for learning, search, and per-word confirmation</td><td>Derived; this document wins on conflict</td></tr>
+<tr><td>Authoring discipline</td><td><code>docs/dev/ajisai-authoring-style.md</code> and its sibling style documents</td><td>Notation rules for writing about Ajisai</td><td>Non-canonical; defines no semantics</td></tr>
+</tbody>
+</table>
+</div>
+
+<h4 id="241-mathematical-formalization">2.4.1 Mathematical formalization</h4>
+
+<p>Mathematical formalization is not decorative. It is the most compact description of Ajisai's intended semantics, and it is what keeps that meaning independent of any particular implementation. The formalization exists to:</p>
+
+<ul>
+<li>give Ajisai a semantic identity that does not depend on the Rust core, the WASM boundary, the TypeScript shell, or any other host technology;</li>
+<li>make the classification of surface words — primitive, derived, sugar, hosted effect, exploratory — verifiable rather than asserted (tracked in <code>docs/formalization-coverage.json</code>);</li>
+<li>state the algebraic and observational properties a ported implementation must preserve;</li>
+<li>ground the conformance suite and law tests in something stronger than a finite list of sample programs.</li>
+</ul>
+
+<p>The formalization does not replace this specification and does not replace the Reference, and it is not a second design authority (Section 16, item 1). The canonical implementable account remains this specification, which translates the formalization into normative language rules. The companion document <code>docs/dev/ajisai-mathematical-formalization.md</code> is a non-normative model of the phenomena this document defines.</p>
+
+<h4 id="242-the-specification">2.4.2 The specification</h4>
+
+<p>This document is the canonical normative account of Ajisai. It translates the formalized semantics into rules that an implementer — human or AI — can build from directly. It defines the value model, the surface syntax, the meaning of every word and modifier, the semantics of the stack and dictionary and effects and NIL and the Bubble Rule, the boundary with host capabilities, the criteria for conformance, and the authority that every other document and every implementation follows. Implementation code is a realization of these rules, not a competing definition of them; the precedence rule of Section 2.1 applies.</p>
+
+<h4 id="243-reference-documentation">2.4.3 Reference documentation</h4>
+
+<p>The Reference (<code>public/docs/</code>), the <code>LOOKUP</code> (<code>?</code>) help text, and the hover text are derived documentation: they exist so that users and implementers can learn, search, and confirm Ajisai's vocabulary and concepts. They are generated from or kept synchronized with the same source data as the rest of the documentation — <code>docs/word-manifest.json</code> and the builtin contract metadata (Sections 2.3 and 7.14) — so they cannot drift silently. Their authority is derivative: the Reference provides approachable explanations, per-word entries, and practical examples beyond what this document carries, but it explains how to use the language and never decides what the language means. Where a Reference page and this document disagree, this document wins and the Reference page is corrected.</p>
+
+<h4 id="244-authoring-discipline">2.4.4 Authoring discipline</h4>
+
+<p><code>docs/dev/ajisai-authoring-style.md</code> is the non-canonical authoring discipline for all authoritative writing about Ajisai, including this document. It defines no language semantics. Its subject is notation: every Ajisai-meaningful token appears in prose as marked-up code; mathematics travels in its own channel, visibly distinct from the Ajisai code channel; LaTeX-style <code>$...$</code> math delimiters are avoided because <code>$</code> is itself an Ajisai token; and marks such as <code>.</code> · <code>,</code> · <code>/</code> are Ajisai words or sugar and are kept distinct from ordinary punctuation and mathematical operators. These are rules against misreading, not rules of meaning — they ensure the semantics defined here cannot be obscured by ambiguous presentation. The full rules live in that document and are not duplicated here; the sibling documents <code>docs/dev/reference-writing-style.md</code> and <code>docs/dev/three-layer-documentation-model.md</code> govern the Reference surfaces under the same principle.</p>
+
+<h3 id="25-authority-order">2.5 Authority order</h3>
+
+<p>When sources appear to disagree, they are trusted in this order:</p>
+
+<ol>
+<li>This file (<code>SPECIFICATION.html</code>)</li>
+<li>The mathematical formalization, to the extent it is integrated into or referenced from this document</li>
+<li>The conformance suite and law tests (<code>tests/conformance/</code>)</li>
+<li>Generated source data: <code>docs/word-manifest.json</code> and the builtin contract metadata</li>
+<li>The Reference (<code>public/docs/</code>) and the <code>LOOKUP</code> and hover surfaces</li>
+<li>The style documents: authoring style, Reference writing style, documentation model</li>
+<li>The current implementation code (Rust, WASM, TypeScript, GUI)</li>
+</ol>
+
+<p>The formalization constrains and motivates the specification; the specification is the canonical normative account for implementers. If a mathematical note, a derived Reference page, or an implementation detail appears to conflict with this document, this document wins until the conflict is resolved by updating this document itself. This order resolves conflicts between sources; it does not make the lower layers optional — an implementation still demonstrates conformance through the suite (Conformance and Identity), and derived documentation is still corrected rather than abandoned.</p>
 
 <h2 id="3-syntax">3. Syntax</h2>
 

--- a/docs/dev/ajisai-authoring-style.md
+++ b/docs/dev/ajisai-authoring-style.md
@@ -6,6 +6,7 @@ The house style for **all authoritative writing about Ajisai** — the specifica
 
 - **Non-canonical.** This document governs **how** Ajisai is written about, not **what** is true of it. It defines no language semantics.
 - **Canonical source remains `SPECIFICATION.html`.** If this document ever appears to constrain meaning, the specification wins.
+- **The authority model itself is specified.** Section 2 of the specification (Specification Authority) defines the responsibilities of, and the order of trust among, the mathematical formalization, the specification, the Reference, and this authoring discipline; this document supplies the notation rules that model requires.
 - **Scope:** the specification, the README (`README.md`), the Reference (`public/docs/`), and any other authoritative text that names Ajisai words, symbols, or formulas.
 - Sibling conventions: `docs/dev/reference-writing-style.md` (the Reference site and `?`/LOOKUP text) and `docs/dev/three-layer-documentation-model.md` (user-facing guidance structure). This document is the shared notation discipline both of those, and the specification, adhere to.
 

--- a/docs/dev/ajisai-mathematical-formalization.md
+++ b/docs/dev/ajisai-mathematical-formalization.md
@@ -1,6 +1,6 @@
 # Ajisai の数学的定式化 — denotational / algebraic semantics
 
-> Status: **Non-canonical / descriptive.** 正典は `SPECIFICATION.md` のみ。
+> Status: **Non-canonical / descriptive.** 正典は `SPECIFICATION.html` のみ。
 > 本書は仕様に対する**第二の権威ではなく**、仕様が定める現象を数学の言葉で
 > 記述するモデルである(§16.1「第二の設計権威を導入しない」を尊重する)。
 > Active coverage tracking lives in `docs/formalization-coverage.json`; current language observations live in `tests/conformance/index.html`.
@@ -10,7 +10,7 @@
 
 ## 0. 動機 — 外延的同一性から内包的同一性へ
 
-`PORTABILITY.md` と `SPECIFICATION.md`「Conformance and Identity」は、
+`PORTABILITY.md` と `SPECIFICATION.html`「Conformance and Identity」は、
 Ajisai の同一性を **conformance suite が固定する入出力対応**で定義する。
 これは数学的には、意味関数
 

--- a/docs/dev/reference-writing-style.md
+++ b/docs/dev/reference-writing-style.md
@@ -2,6 +2,12 @@
 
 Ajisaiのドキュメント（`?` (LOOKUP) で表示するビルトイン説明、およびヘッダーの Reference ボタンから開くページ群）における執筆規約。目的は **Ajisaiプログラムと自然言語の説明を視覚的・形式的に区別する** こと。
 
+## 位置づけ
+
+- **非正典。** 本書は書き方の規約であり、言語意味論を定義しない。言語意味論の正準文書は `SPECIFICATION.html`（Specification Authority 節）のみ。
+- Reference・LOOKUP・hover は正準仕様から派生する文書面であり、仕様と矛盾する場合は仕様が優先する。
+- 表記全般の共通規律は `docs/dev/ajisai-authoring-style.md` に従う。
+
 ## 規約
 
 1. ドキュメント本文は Markdown で記述する。

--- a/docs/dev/three-layer-documentation-model.md
+++ b/docs/dev/three-layer-documentation-model.md
@@ -1,12 +1,12 @@
 # Ajisai Three-Layer Documentation Model
 
 Status: proposal (revision of the草案 dated 2026-05).
-Authority: non-canonical. SPECIFICATION.md remains the canonical source for language semantics. This document defines the **structure and policy of user-facing guidance**, not language behavior.
+Authority: non-canonical. `SPECIFICATION.html` remains the canonical source for language semantics; its Specification Authority section (§2.4–§2.5) defines Reference, LOOKUP, and hover as derived documentation under the specification's authority. This document defines the **structure and policy of user-facing guidance**, not language behavior.
 
 Related existing documents:
 
 - `docs/dev/reference-writing-style.md` — current writing convention. Will be amended to align with this model (see §7).
-- `SPECIFICATION.md` §7.14 — Coreword contract metadata (`partiality`, `nil_policy`, `safety_level`). Stability/contract claims in any guidance layer must agree with §7.14.
+- `SPECIFICATION.html` §7.14 — Coreword contract metadata (`partiality`, `nil_policy`, `safety_level`). Stability/contract claims in any guidance layer must agree with §7.14.
 
 ---
 
@@ -33,7 +33,7 @@ Reference is the **entire body of Ajisai-the-language documentation**. It is del
 Reference covers:
 
 1. **Getting started** — install, the editor surface, first program.
-2. **Concept guide** — value model, stack, modifiers, fractional dataflow, error model. Mirrors SPECIFICATION.md sections in tutorial form.
+2. **Concept guide** — value model, stack, modifiers, fractional dataflow, error model. Mirrors SPECIFICATION.html sections in tutorial form.
 3. **Word catalog** — one page per built-in word. Generated from the same data that drives LOOKUP, plus a `concept` field that LOOKUP does not display.
 4. **Module reference** — per-module pages.
 5. **Developer notes** — debugging model, runtime invariants, version/stability notes.
@@ -62,7 +62,7 @@ Failure / NIL Behavior
 Side Effects
 Modifier Interaction (when non-standard)
 Related Words
-Stability          ← must equal SPECIFICATION.md §7.14 contract
+Stability          ← must equal SPECIFICATION.html §7.14 contract
 Implementation Notes (optional)
 ```
 
@@ -185,7 +185,7 @@ Behavior:
 
 ### 3.6 Sugar handling
 
-For words that have sugar listed in SPECIFICATION.md §6.5, the `Syntax:` and `Examples:` blocks always show **both** the canonical and shorthand forms. For words without sugar, only `Canonical:` appears (no empty `Shorthand:` heading).
+For words that have sugar listed in SPECIFICATION.html §6.5, the `Syntax:` and `Examples:` blocks always show **both** the canonical and shorthand forms. For words without sugar, only `Canonical:` appears (no empty `Shorthand:` heading).
 
 LOOKUP's example for the word **must reflect runtime semantics**. `LOOKUP` itself pops the word name from the stack, so the canonical example is `'ADD' LOOKUP`, not `ADD LOOKUP`.
 
@@ -304,7 +304,7 @@ The current codebase already passes `BuiltinSpec` through the WASM boundary (see
 
 ### 5.3 Single source of truth: stability
 
-`stability` must mirror the contract entry from SPECIFICATION.md §7.14 (`partiality`, `nil_policy`, `safety_level`). The recommended display rule:
+`stability` must mirror the contract entry from SPECIFICATION.html §7.14 (`partiality`, `nil_policy`, `safety_level`). The recommended display rule:
 
 - `stable` ⇔ §7.14 says `safety_level: A` or `B` and the word is not deprecated.
 - `experimental` ⇔ `safety_level: C` or `D`.


### PR DESCRIPTION
## Summary

Makes the implicit responsibility separation among Ajisai's documentation layers explicit inside the canonical specification, so future extensions of the formalization, specification, and Reference cannot drift on authority.

### `SPECIFICATION.html` — Section 2 (Specification Authority) extended

- **2.1 clarification** — implementation behavior is canonical only insofar as it conforms to this file; implementation code is an expression of the specification, never an independent source of meaning.
- **New 2.4 Documentation layers and their responsibilities** — a summary table plus one subsection per layer:
  - *2.4.1 Mathematical formalization* — the most compact, implementation-independent account of the intended semantics ("not decorative"); makes the primitive/derived/sugar/hosted-effect/exploratory classification verifiable, states the properties ports must preserve, and grounds the conformance/law tests — while remaining descriptive, not a second design authority (consistent with Section 16, item 1).
  - *2.4.2 The specification* — the canonical normative account that translates the formalization into implementable rules.
  - *2.4.3 Reference documentation* — `public/docs/`, `LOOKUP`, and hover are derived documentation, synchronized from the same source data (`docs/word-manifest.json`, builtin contract metadata); they explain how to use the language, never decide what it means.
  - *2.4.4 Authoring discipline* — `docs/dev/ajisai-authoring-style.md` is non-canonical notation discipline (code-span channel for Ajisai tokens, separate math channel, no `$...$` delimiters); rules against misreading, not rules of meaning. Details referenced, not duplicated.
- **New 2.5 Authority order** — explicit 7-step trust order (specification → formalization → conformance/law tests → generated source data → Reference → style documents → implementation code), with the rule that the specification wins until a conflict is resolved by updating the specification itself.

Existing section numbering, anchors, and the TOC are untouched (new subsections append after 2.3). No new metaphors are introduced; the water metaphor stays the only one in the specification body.

### Satellite documents aligned

- `docs/dev/ajisai-authoring-style.md` — Authority section now notes the authority model is itself specified in Section 2, and that this document supplies the notation rules that model requires.
- `docs/dev/reference-writing-style.md` — new 位置づけ section: non-canonical, semantics belong to `SPECIFICATION.html`, Reference/LOOKUP/hover are derived surfaces.
- `docs/dev/three-layer-documentation-model.md` — authority line points at the new §2.4–§2.5; obsolete `SPECIFICATION.md` filename updated to `SPECIFICATION.html` (6 occurrences).
- `docs/dev/ajisai-mathematical-formalization.md` — obsolete `SPECIFICATION.md` filename updated in its canon statement (2 occurrences).

No implementation code (Rust/WASM/TypeScript/GUI) is changed.

## Verification

- HTML structure check on `SPECIFICATION.html` (tag balance, duplicate ids, internal anchors): clean — no unclosed tags, no duplicate ids, no broken `href="#..."` targets.
- `npm run word:manifest:check` — up to date (204 entries).
- `npm run check:formalization-coverage` — 204/204 surface words classified, 202 entries validated.
- Grep for forbidden metaphor vocabulary (DNA/gene/genome/memetic/transcription/epigenetics) in the specification body: no occurrences (only pre-existing "generate(d)" substrings).

https://claude.ai/code/session_01JX25xxrYsv3ubnDMTBWKhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX25xxrYsv3ubnDMTBWKhe)_