### PR TITLE
Unify dictionary selector styling

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -38,7 +38,8 @@
 }
 
 .area-selector select:focus,
-.dictionary-sheet-select:focus {
+.dictionary-sheet-select:focus,
+.dictionary-sheet-select:focus-within {
     outline: none;
     background: var(--color-light);
 }
@@ -562,8 +563,13 @@
 }
 
 .sheet-selector-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
+    line-height: normal;
     padding: 0.25rem 0.5rem;
     width: 100%;
     text-align: left;
@@ -575,8 +581,13 @@
 }
 
 .sheet-selector-trigger::after {
-    content: ' \25be';
-    float: right;
+    content: '';
+    flex: 0 0 auto;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: rotate(45deg) translateY(-0.1rem);
     opacity: 0.6;
 }
 


### PR DESCRIPTION
### Motivation
- The custom dictionary sheet selector in the Dictionary area looked visually different from other selectors (vertical size and the right-side glyph), so styling was unified for consistency.

### Description
- Update `src/styles/components.css` to include `:focus-within` for the `dictionary-sheet-select` so the custom selector gets the same focus background as native selects.
- Change `.sheet-selector-trigger` to a flex layout with `align-items: center`, `justify-content: space-between`, `gap: 0.5rem`, and `line-height: normal` to match other selector sizing and alignment.
- Replace the filled triangle glyph (`content: ' \25be'`) with a CSS-drawn chevron in `.sheet-selector-trigger::after` using `border-right`/`border-bottom` and `transform` so the caret visually matches other selectors.
- Minor padding/spacing tweaks to align the trigger's vertical height with native selectors.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`), which completed successfully.
- Ran `npm run build:web` (`vite build`) to verify production build, which completed successfully and emitted the `dist` assets.
- Ran `git diff --check` to validate diffs, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c912ea14c832681d9f9379327cad6)