### PR TITLE
Use native select styling for dictionary selector

### DIFF
--- a/src/gui/dictionary-sheet-selector.ts
+++ b/src/gui/dictionary-sheet-selector.ts
@@ -52,6 +52,14 @@ export const createDictionarySheetSelector = (
     rootEl.classList.add('sheet-selector');
     rootEl.innerHTML = '';
 
+    // Keep the closed control visually identical to the app's native selects:
+    // the overlaid button owns the custom popup behavior, while this inert
+    // native select paints the browser-provided text, height, and chevron.
+    const nativeTrigger = document.createElement('select');
+    nativeTrigger.className = 'sheet-selector-native-trigger';
+    nativeTrigger.setAttribute('aria-hidden', 'true');
+    nativeTrigger.tabIndex = -1;
+
     const trigger = document.createElement('button');
     trigger.type = 'button';
     trigger.className = 'sheet-selector-trigger';
@@ -63,6 +71,7 @@ export const createDictionarySheetSelector = (
     panel.setAttribute('role', 'listbox');
     panel.hidden = true;
 
+    rootEl.appendChild(nativeTrigger);
     rootEl.appendChild(trigger);
     rootEl.appendChild(panel);
 
@@ -70,7 +79,22 @@ export const createDictionarySheetSelector = (
         entries.find(e => e.sheetId === sheetId)?.label ?? sheetId;
 
     const syncTrigger = (): void => {
-        trigger.textContent = currentValue ? labelFor(currentValue) : 'Select dictionary';
+        const label = currentValue ? labelFor(currentValue) : 'Select dictionary';
+        trigger.textContent = label;
+        nativeTrigger.value = currentValue;
+    };
+
+    const syncNativeTriggerOptions = (): void => {
+        nativeTrigger.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+        for (const entry of entries) {
+            const optionEl = document.createElement('option');
+            optionEl.value = entry.sheetId;
+            optionEl.textContent = entry.label;
+            fragment.appendChild(optionEl);
+        }
+        nativeTrigger.appendChild(fragment);
+        nativeTrigger.value = currentValue;
     };
 
     const closePanel = (): void => {
@@ -86,6 +110,7 @@ export const createDictionarySheetSelector = (
     const selectSheet = (sheetId: string): void => {
         currentValue = sheetId;
         rootEl.dataset.value = sheetId;
+        syncNativeTriggerOptions();
         syncTrigger();
         renderPanel();
     };
@@ -189,6 +214,7 @@ export const createDictionarySheetSelector = (
             currentValue = entries[0]?.sheetId ?? '';
             rootEl.dataset.value = currentValue;
         }
+        syncNativeTriggerOptions();
         syncTrigger();
         renderPanel();
     };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -24,7 +24,8 @@
 }
 
 .area-selector select,
-.dictionary-sheet-select {
+.dictionary-sheet-select,
+.sheet-selector-native-trigger {
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
     padding: 0.25rem 0.5rem;
@@ -38,9 +39,17 @@
 }
 
 .area-selector select:focus,
-.dictionary-sheet-select:focus {
+.dictionary-sheet-select:focus,
+.dictionary-sheet-select:focus-within,
+.sheet-selector:focus-within .sheet-selector-native-trigger {
     outline: none;
     background: var(--color-light);
+}
+
+.dictionary-sheet-select.sheet-selector {
+    border: 0;
+    background: transparent;
+    transition: none;
 }
 
 
@@ -561,23 +570,25 @@
     padding: 0;
 }
 
+.sheet-selector-native-trigger {
+    display: block;
+    pointer-events: none;
+}
+
 .sheet-selector-trigger {
-    font-family: var(--font-stack-mono);
-    font-size: 0.8rem;
+    position: absolute;
+    inset: 0;
     padding: 0.25rem 0.5rem;
     width: 100%;
-    text-align: left;
+    color: transparent;
     background: transparent;
-    color: var(--color-text);
     border: none;
     border-radius: var(--radius-main);
     cursor: pointer;
 }
 
-.sheet-selector-trigger::after {
-    content: ' \25be';
-    float: right;
-    opacity: 0.6;
+.sheet-selector-trigger:focus {
+    outline: none;
 }
 
 .sheet-selector-panel {


### PR DESCRIPTION
### Motivation
- The Dictionary sheet selector still looked different from other selectors because its closed state used a custom button and CSS-drawn caret instead of the browser-painted native control. 
- Preserve the custom long-press/module behavior while removing unnecessary visual special-casing so the closed control matches other native selects.

### Description
- Add an inert native `<select>` (`.sheet-selector-native-trigger`) inside the custom selector so the browser paints height, text rendering, and the right-side chevron; implemented in `src/gui/dictionary-sheet-selector.ts`.
- Synchronize options/value between the custom component and the inert native select via `syncNativeTriggerOptions()` and updated `syncTrigger()` and `setEntries()` to keep them in sync.
- Make the overlay button the interactive opener/listbox while keeping it visually transparent and positioned over the native select, and keep the custom panel/long-press behavior intact.
- Update `src/styles/components.css` to include `.sheet-selector-native-trigger` in the shared selector styling, make the `.dictionary-sheet-select.sheet-selector` transparent, and remove the CSS-drawn caret so the native chevron is used.

### Testing
- Ran `npm run check` (TypeScript) which succeeded. 
- Ran `npm run build:web` (Vite production build) which succeeded. 
- Ran `npm test` (Vitest) which reported all tests passing. 
- Ran `npm run lint` and `git diff --check` which succeeded; no browser executable found so screenshots were not captured (`which chromium || which chromium-browser || which google-chrome || which playwright || echo no-browser`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c912ea14c832681d9f9379327cad6)