### PR TITLE
Add hidden native <select> behind custom sheet selector and adjust styles for consistent metrics

### DIFF
--- a/src/gui/dictionary-sheet-selector.ts
+++ b/src/gui/dictionary-sheet-selector.ts
@@ -52,6 +52,14 @@ export const createDictionarySheetSelector = (
     rootEl.classList.add('sheet-selector');
     rootEl.innerHTML = '';
 
+    // Keep the closed control visually identical to the app's native selects:
+    // the overlaid button owns the custom popup behavior, while this inert
+    // native select paints the browser-provided text, height, and chevron.
+    const nativeTrigger = document.createElement('select');
+    nativeTrigger.className = 'sheet-selector-native-trigger';
+    nativeTrigger.setAttribute('aria-hidden', 'true');
+    nativeTrigger.tabIndex = -1;
+
     const trigger = document.createElement('button');
     trigger.type = 'button';
     trigger.className = 'sheet-selector-trigger';
@@ -63,6 +71,7 @@ export const createDictionarySheetSelector = (
     panel.setAttribute('role', 'listbox');
     panel.hidden = true;
 
+    rootEl.appendChild(nativeTrigger);
     rootEl.appendChild(trigger);
     rootEl.appendChild(panel);
 
@@ -70,7 +79,22 @@ export const createDictionarySheetSelector = (
         entries.find(e => e.sheetId === sheetId)?.label ?? sheetId;
 
     const syncTrigger = (): void => {
-        trigger.textContent = currentValue ? labelFor(currentValue) : 'Select dictionary';
+        const label = currentValue ? labelFor(currentValue) : 'Select dictionary';
+        trigger.textContent = label;
+        nativeTrigger.value = currentValue;
+    };
+
+    const syncNativeTriggerOptions = (): void => {
+        nativeTrigger.innerHTML = '';
+        const fragment = document.createDocumentFragment();
+        for (const entry of entries) {
+            const optionEl = document.createElement('option');
+            optionEl.value = entry.sheetId;
+            optionEl.textContent = entry.label;
+            fragment.appendChild(optionEl);
+        }
+        nativeTrigger.appendChild(fragment);
+        nativeTrigger.value = currentValue;
     };
 
     const closePanel = (): void => {
@@ -86,6 +110,7 @@ export const createDictionarySheetSelector = (
     const selectSheet = (sheetId: string): void => {
         currentValue = sheetId;
         rootEl.dataset.value = sheetId;
+        syncNativeTriggerOptions();
         syncTrigger();
         renderPanel();
     };
@@ -189,6 +214,7 @@ export const createDictionarySheetSelector = (
             currentValue = entries[0]?.sheetId ?? '';
             rootEl.dataset.value = currentValue;
         }
+        syncNativeTriggerOptions();
         syncTrigger();
         renderPanel();
     };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -24,10 +24,15 @@
 }
 
 .area-selector select,
-.dictionary-sheet-select {
+.dictionary-sheet-select,
+.sheet-selector-native-trigger {
+    /* Chrome OS's monospace metrics render slightly high in compact controls.
+       Use shared asymmetric block padding so selector labels sit optically centered. */
+    --control-text-y-adjust: 0.0625rem;
     font-family: var(--font-stack-mono);
     font-size: 0.8rem;
-    padding: 0.25rem 0.5rem;
+    line-height: 1.2;
+    padding: calc(0.25rem + var(--control-text-y-adjust)) 0.5rem calc(0.25rem - var(--control-text-y-adjust));
     border: var(--border-main);
     border-radius: var(--radius-main);
     background: #fff;
@@ -38,9 +43,17 @@
 }
 
 .area-selector select:focus,
-.dictionary-sheet-select:focus {
+.dictionary-sheet-select:focus,
+.dictionary-sheet-select:focus-within,
+.sheet-selector:focus-within .sheet-selector-native-trigger {
     outline: none;
     background: var(--color-light);
+}
+
+.dictionary-sheet-select.sheet-selector {
+    border: 0;
+    background: transparent;
+    transition: none;
 }
 
 
@@ -507,13 +520,18 @@
 
 
 .word-button {
+    --control-text-y-adjust: 0.0625rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     margin: 2px;
-    padding: 0.2rem 0.4rem;
+    padding: calc(0.2rem + var(--control-text-y-adjust)) 0.4rem calc(0.2rem - var(--control-text-y-adjust));
     background: #fff;
     color: var(--color-text);
     border: var(--border-main);
     font-family: var(--font-stack-mono);
     font-size: 0.75rem;
+    line-height: 1.2;
     font-weight: 400;
     cursor: pointer;
     border-radius: var(--radius-word-button);
@@ -561,23 +579,25 @@
     padding: 0;
 }
 
+.sheet-selector-native-trigger {
+    display: block;
+    pointer-events: none;
+}
+
 .sheet-selector-trigger {
-    font-family: var(--font-stack-mono);
-    font-size: 0.8rem;
-    padding: 0.25rem 0.5rem;
+    position: absolute;
+    inset: 0;
+    padding: calc(0.25rem + var(--control-text-y-adjust)) 0.5rem calc(0.25rem - var(--control-text-y-adjust));
     width: 100%;
-    text-align: left;
+    color: transparent;
     background: transparent;
-    color: var(--color-text);
     border: none;
     border-radius: var(--radius-main);
     cursor: pointer;
 }
 
-.sheet-selector-trigger::after {
-    content: ' \25be';
-    float: right;
-    opacity: 0.6;
+.sheet-selector-trigger:focus {
+    outline: none;
 }
 
 .sheet-selector-panel {


### PR DESCRIPTION
### Motivation
- Ensure the custom dictionary sheet selector visually matches native browser selects (text baseline, height, chevron) by painting a native control underneath the custom trigger.
- Keep the custom popup behavior and long-press features while restoring native text rendering for consistency across platforms.
- Introduce shared vertical text alignment adjustments so compact controls (selectors and word buttons) sit optically centered across platforms.

### Description
- Create a hidden native `select` (`.sheet-selector-native-trigger`) appended to the selector root and marked `aria-hidden`/`tabIndex=-1` so it paints native metrics while remaining inert.
- Add `syncNativeTriggerOptions()` to populate the native `select` options and wire updates into `selectSheet()` and `setEntries()` so the native element stays in sync with the custom UI.
- Update `syncTrigger()` to set the native select value and make the custom trigger text transparent so the native select provides the visible label and chevron.
- Add CSS changes including `--control-text-y-adjust`, layout/padding/line-height tweaks, `.sheet-selector-native-trigger` and focus/visual adjustments for `.sheet-selector` and `.sheet-selector-trigger` to match native appearance and keep interactive behavior.

### Testing
- Ran the build with `npm run build` and the build completed successfully.
- Executed the test suite with `npm test` and all tests passed.
- Ran linting with `npm run lint` and the linter returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c912ea14c832681d9f9379327cad6)