### PR TITLE
Phase 3: energyProxyScore + energy regression guard

### DIFF
--- a/docs/dev/agent-cli-output-contract.md
+++ b/docs/dev/agent-cli-output-contract.md
@@ -181,16 +181,29 @@ machine-readable reason a value is NIL: `reason` (e.g. `divisionByZero`,
            "sparseCandidateElements": 0, "sparseCandidateNonzeroElements": 0,
            "sparseSkippableZeroElements": 0, "candidateBlockCount": 0,
            "rejectedBlockCount": 0, "fusionCandidateCount": 0,
-           "bulkKernelUseCount": 0 } }
+           "bulkKernelUseCount": 0,
+           "energyProxyScore": 0, "proxyVersion": 1, "suggestions": [ ] } }
 ```
 
-The Virtual Tensor Unit observation counters
+The 18 leading fields are the Virtual Tensor Unit observation counters
 (`docs/dev/virtual-tensor-unit-design.md`). They describe observed
 structural work (data movement, allocation, kernel selection) and are
-deterministic for a given program and input. They are **proxies** — they do
-not measure or assert energy consumption. Aggregation into a single score is
-a separate, versioned concern (Phase 3 of the AI-first work order) and will
-be added additively under this object.
+deterministic for a given program and input.
+
+- `energyProxyScore` — a single deterministic integer aggregating those
+  counters with fixed weights (`docs/quality/energy-proxy-score.md`).
+- `proxyVersion` — the scoring-formula version. Scores are comparable only
+  within one `proxyVersion`; it increments whenever a weight or the formula
+  changes.
+- `suggestions` — array of strings: mechanical, counter-derived observations
+  about structural patterns that usually admit a cheaper equivalent program
+  (e.g. fusable stages, repeated flat/nested round-trips). May be empty.
+
+These are **proxies**: they describe structural work and are *not* a joule
+measurement. Counter names and the score never assert an energy outcome
+(per the standing policy in `docs/dev/virtual-tensor-unit-design.md`). The
+score exists so that "same output, more structural work" is a CI-visible
+regression (`energy_proxy_regression_tests.rs`).
 
 ## 8. Examples (actual output)
 

--- a/docs/quality/energy-proxy-score.md
+++ b/docs/quality/energy-proxy-score.md
@@ -1,0 +1,131 @@
+# energyProxyScore — definition, weights, and honesty policy
+
+Status: quality-discipline document (non-canonical for language semantics).
+Authority for Ajisai semantics: `SPECIFICATION.html` only.
+
+## What this is — and what it is not
+
+`energyProxyScore` is a single deterministic integer that aggregates the
+Virtual Tensor Unit observation counters (`docs/dev/virtual-tensor-unit-design.md`)
+into one structural-cost figure. It exists so that a change which keeps a
+program's output identical but moves more data becomes a CI-visible
+regression instead of an unnoticed drift.
+
+**It is a proxy. It is not joules.**
+
+- It does **not** measure, estimate, or predict energy consumption,
+  wall-clock time, or power draw.
+- It counts *structural work the runtime was observed to do* — elements
+  carried across the flat/nested tensor boundary, output elements allocated,
+  per-operation dispatch — and nothing else.
+- Per the standing policy in `virtual-tensor-unit-design.md`, neither the
+  counters nor this score use result-asserting names like `energy_saved`.
+  The score is `energyProxyScore` (a proxy), never `energyUsed`.
+
+Connecting the proxy to real joules requires physical measurement, which the
+project has not yet done. Until then, README / SPECIFICATION must not claim
+Ajisai "is low-power"; the honest claim is only that Ajisai *observes and
+enforces structural indicators* that plausibly correlate with energy.
+
+## Determinism
+
+`energy_proxy_score(metrics)` is a pure function of `RuntimeMetrics`. The
+same program on the same input always produces the same counters and hence
+the same score; computing the score never affects execution. This is
+asserted by `score_is_deterministic_across_runs` in
+`energy_proxy_regression_tests.rs`.
+
+## Formula (proxyVersion = 1)
+
+```
+cost      = 4 * tensorFlattenedElements
+          + 4 * tensorRebuiltElements
+          + 2 * allocatedElements
+          + 16 * tensorFlattenCount
+          + 16 * tensorRebuildCount
+          + 8 * broadcastCount
+          + 8 * unaryFlatCount
+
+deduction = 4 * simdKernelUseCount
+          + 8 * bulkKernelUseCount
+          + 4 * projectedBroadcastCount
+
+score     = saturating_sub(cost, deduction)   // floored at 0
+```
+
+### Weight rationale
+
+| Term | Weight | Why |
+|---|---|---|
+| `tensorFlattenedElements` | 4 / element | Element-granular data movement across the flat boundary; the dominant real cost driver, charged per element. |
+| `tensorRebuiltElements` | 4 / element | Symmetric to flattening: rebuilding nested form from flat. |
+| `allocatedElements` | 2 / element | Output materialization. Charged, but lighter than a boundary round-trip. |
+| `tensorFlattenCount` | 16 / op | Fixed per-operation dispatch/setup overhead, independent of size. |
+| `tensorRebuildCount` | 16 / op | Symmetric per-op rebuild overhead. |
+| `broadcastCount` | 8 / op | Per binary-broadcast dispatch. |
+| `unaryFlatCount` | 8 / op | Per unary flat-tensor dispatch. |
+| `simdKernelUseCount` | −4 / use | Realized SIMD lane: same work, less per-element overhead → deducted. |
+| `bulkKernelUseCount` | −8 / use | Realized bulk HOF kernel iterating `&[Fraction]` without per-element Value materialization → larger deduction. |
+| `projectedBroadcastCount` | −4 / use | Index-projected broadcast avoids materializing the broadcast operand → deducted. |
+
+Deductions use saturating subtraction, so the score never underflows below
+0. An all-efficient path (e.g. same-shape 1-D SIMD arithmetic, which records
+no boundary movement) therefore scores 0 — the honest "no structural cost
+observed" result.
+
+### Counters deliberately excluded from the score
+
+- **Sparse counters** (`sparseCandidate*`, `sparseSkippableZeroElements`) are
+  *candidates*, not realized skips. They earn no deduction — the score never
+  credits work the runtime did not actually avoid. They feed `suggestions`
+  instead. (`sparse_candidates_earn_no_deduction` pins this.)
+- **Cache / plan / hedge counters** (`compiled_plan_*`, `hedged_*`,
+  `resolve_cache_*`) are execution-strategy bookkeeping, not data-movement
+  cost, and are out of scope for this proxy.
+- `sameShapeElementwiseCount`, `candidateBlockCount`, `fusionCandidateCount`,
+  `rejectedBlockCount` are classification observations (reported in
+  `suggestions`), not cost.
+
+## `suggestions`
+
+Mechanical, counter-derived observations emitted alongside the score (in the
+CLI `--json` under `runtimeMetrics.vtu.suggestions`). Each rule reads only the
+counters and states the structural pattern plus the program-level change that
+removes it. Wording stays structural ("data movement", "round-trips") and
+never asserts an energy outcome. Current rules:
+
+1. `fusionCandidateCount > 0` — adjacent fusable elementwise stages; merging
+   avoids intermediate flatten/rebuild round-trips.
+2. `tensorRebuildCount ≥ 2` and total round-trips ≥ 4 — values cross the
+   flat/nested boundary repeatedly; chaining tensor words keeps data flat.
+3. `sparseSkippableZeroElements ≥ ½ · sparseCandidateElements` — half or more
+   candidate lanes are zero; restructuring to avoid moving zero lanes reduces
+   movement.
+4. `rejectedBlockCount > 0` — quantized blocks rejected as VTU candidates;
+   build with the `trace-quant` feature to see why.
+
+## proxyVersion and re-baselining
+
+`ENERGY_PROXY_VERSION` (currently **1**) tags every score. **Any** change to a
+weight, to the formula, to which counters participate, or to a deduction
+**must** increment it and update this document in the same change. Scores
+produced under different `proxyVersion` values are not comparable.
+
+Incrementing `proxyVersion` re-baselines the entire regression catalog in
+`energy_proxy_regression_tests.rs`: re-run
+`cargo test energy_proxy_discovery -- --nocapture` and record the new
+`baseline_score` for each case.
+
+## Regression discipline
+
+`energy_proxy_regression_tests.rs` runs a fixed catalog of programs and
+asserts, for each: (a) the output stack is unchanged, and (b) the live score
+does not exceed the recorded `baseline_score`. A catalog program with a
+non-zero baseline must exist (`tensor_pipeline_is_observed`) so a globally
+zeroed counter pipeline cannot silently pass every `<=` check.
+
+- Score drops after an intentional optimization → tighten the baseline in the
+  same PR.
+- Score rises → it is a regression by default. Either fix it, or, if the
+  increase is a justified trade-off, raise the baseline **explicitly** and
+  explain why in the PR. Never bump a baseline casually to make CI green.

--- a/rust/src/cli/report.rs
+++ b/rust/src/cli/report.rs
@@ -151,9 +151,11 @@ pub(crate) fn error_flow_event_json(event: &ErrorFlowEvent) -> Json {
 }
 
 pub(crate) fn runtime_metrics_json(metrics: &RuntimeMetrics) -> Json {
-    // The VTU observation counters (docs/dev/virtual-tensor-unit-design.md).
-    // Counter names describe observed structural work; they never assert an
-    // energy outcome.
+    // The VTU observation counters (docs/dev/virtual-tensor-unit-design.md)
+    // plus the aggregate energyProxyScore (docs/quality/energy-proxy-score.md).
+    // Counter names and the score describe observed structural work; they are
+    // a proxy and never assert an energy outcome in joules.
+    let proxy = crate::interpreter::energy_proxy::energy_proxy_report(metrics);
     json!({
         "vtu": {
             "tensorFlattenCount": metrics.vtu_tensor_flatten_count,
@@ -174,6 +176,11 @@ pub(crate) fn runtime_metrics_json(metrics: &RuntimeMetrics) -> Json {
             "rejectedBlockCount": metrics.vtu_rejected_block_count,
             "fusionCandidateCount": metrics.vtu_fusion_candidate_count,
             "bulkKernelUseCount": metrics.vtu_bulk_kernel_use_count,
+            // Aggregate structural-cost proxy. Not joules; comparable only
+            // within one proxyVersion. See docs/quality/energy-proxy-score.md.
+            "energyProxyScore": proxy.score,
+            "proxyVersion": proxy.proxy_version,
+            "suggestions": proxy.suggestions,
         },
     })
 }

--- a/rust/src/cli/report_tests.rs
+++ b/rust/src/cli/report_tests.rs
@@ -37,8 +37,12 @@ fn ok_report_envelope_has_contract_fields() {
     assert!(doc["diagnosis"].is_null());
     assert!(doc["aiDiagnostic"].is_null());
     assert!(doc["runtimeMetrics"]["vtu"].is_object());
-    // All 18 VTU observation counters serialize.
-    assert_eq!(doc["runtimeMetrics"]["vtu"].as_object().unwrap().len(), 18);
+    // 18 VTU observation counters plus the aggregate energyProxyScore /
+    // proxyVersion / suggestions (docs/quality/energy-proxy-score.md).
+    assert_eq!(doc["runtimeMetrics"]["vtu"].as_object().unwrap().len(), 21);
+    assert!(doc["runtimeMetrics"]["vtu"]["energyProxyScore"].is_number());
+    assert_eq!(doc["runtimeMetrics"]["vtu"]["proxyVersion"], 1);
+    assert!(doc["runtimeMetrics"]["vtu"]["suggestions"].is_array());
 }
 
 #[test]

--- a/rust/src/interpreter/energy_proxy.rs
+++ b/rust/src/interpreter/energy_proxy.rs
@@ -1,0 +1,247 @@
+//! energyProxyScore — deterministic aggregation of the VTU observation
+//! counters into a single structural-cost figure.
+//!
+//! Honesty contract (docs/quality/energy-proxy-score.md, and the standing
+//! policy in docs/dev/virtual-tensor-unit-design.md):
+//!
+//! - The score is a **proxy**. It counts observed structural work — data
+//!   movement across the flat/nested tensor boundary, output allocation,
+//!   per-operation dispatch — with fixed integer weights. It does not
+//!   measure, estimate, or assert energy consumption in joules.
+//! - It is purely observational: computing it never changes execution
+//!   semantics, and it is a pure function of `RuntimeMetrics` — the same
+//!   program and input always produce the same score.
+//! - The weights are versioned. Any change to a weight, to the formula, or
+//!   to which counters participate must increment [`ENERGY_PROXY_VERSION`]
+//!   and update the weight table in `docs/quality/energy-proxy-score.md`.
+//!
+//! The score exists so that "same meaning, more structural work" becomes a
+//! CI-visible regression (`energy_proxy_regression_tests.rs`) instead of an
+//! anecdote.
+
+use super::interpreter_core::RuntimeMetrics;
+
+/// Version of the scoring formula. Bump on any weight/formula change and
+/// record the change in `docs/quality/energy-proxy-score.md`.
+pub const ENERGY_PROXY_VERSION: u32 = 1;
+
+// ── Cost weights (integer, per unit) ────────────────────────────────────
+// Element-granular data movement dominates: every scalar carried across the
+// flat/nested boundary or freshly allocated is charged per element. Per-
+// operation dispatch overhead is charged per call at a higher unit weight
+// but is independent of data size.
+const W_FLATTENED_ELEMENT: u64 = 4;
+const W_REBUILT_ELEMENT: u64 = 4;
+const W_ALLOCATED_ELEMENT: u64 = 2;
+const W_FLATTEN_OP: u64 = 16;
+const W_REBUILD_OP: u64 = 16;
+const W_BROADCAST_OP: u64 = 8;
+const W_UNARY_FLAT_OP: u64 = 8;
+
+// ── Efficiency deductions (integer, per use) ────────────────────────────
+// Paths that do the same semantic work with less data movement (SIMD lanes,
+// bulk HOF kernels, index-projected broadcasts) earn a fixed per-use
+// deduction, applied with saturating subtraction so the score never
+// underflows. Sparse counters are *candidates*, not realized skips, so they
+// deliberately earn no deduction (no credit for unrealized work).
+const D_SIMD_KERNEL_USE: u64 = 4;
+const D_BULK_KERNEL_USE: u64 = 8;
+const D_PROJECTED_BROADCAST: u64 = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnergyProxyReport {
+    /// Deterministic weighted aggregation of the VTU counters.
+    pub score: u64,
+    /// [`ENERGY_PROXY_VERSION`] at the time of scoring; consumers must not
+    /// compare scores across different versions.
+    pub proxy_version: u32,
+    /// Mechanical observations derived from the counters: structural
+    /// patterns that typically admit a cheaper equivalent program. Ordered
+    /// deterministically; empty when nothing noteworthy was observed.
+    pub suggestions: Vec<String>,
+}
+
+/// Pure scoring function: same `RuntimeMetrics`, same score.
+pub fn energy_proxy_score(metrics: &RuntimeMetrics) -> u64 {
+    let cost = metrics
+        .vtu_tensor_flattened_elements
+        .saturating_mul(W_FLATTENED_ELEMENT)
+        .saturating_add(
+            metrics
+                .vtu_tensor_rebuilt_elements
+                .saturating_mul(W_REBUILT_ELEMENT),
+        )
+        .saturating_add(
+            metrics
+                .vtu_allocated_elements
+                .saturating_mul(W_ALLOCATED_ELEMENT),
+        )
+        .saturating_add(
+            metrics
+                .vtu_tensor_flatten_count
+                .saturating_mul(W_FLATTEN_OP),
+        )
+        .saturating_add(
+            metrics
+                .vtu_tensor_rebuild_count
+                .saturating_mul(W_REBUILD_OP),
+        )
+        .saturating_add(metrics.vtu_broadcast_count.saturating_mul(W_BROADCAST_OP))
+        .saturating_add(metrics.vtu_unary_flat_count.saturating_mul(W_UNARY_FLAT_OP));
+
+    let deduction = metrics
+        .vtu_simd_kernel_use_count
+        .saturating_mul(D_SIMD_KERNEL_USE)
+        .saturating_add(
+            metrics
+                .vtu_bulk_kernel_use_count
+                .saturating_mul(D_BULK_KERNEL_USE),
+        )
+        .saturating_add(
+            metrics
+                .vtu_projected_broadcast_count
+                .saturating_mul(D_PROJECTED_BROADCAST),
+        );
+
+    cost.saturating_sub(deduction)
+}
+
+/// Mechanical suggestions: each rule reads only the counters and states the
+/// structural observation plus the program-level change that removes it.
+/// Wording stays structural ("data movement", "round-trips") — never an
+/// energy-outcome claim.
+pub fn energy_proxy_suggestions(metrics: &RuntimeMetrics) -> Vec<String> {
+    let mut out = Vec::new();
+
+    if metrics.vtu_fusion_candidate_count > 0 {
+        out.push(format!(
+            "fusionCandidateCount={}: adjacent elementwise stages were classified as fusable; \
+             merging them into a single block avoids intermediate flatten/rebuild round-trips",
+            metrics.vtu_fusion_candidate_count
+        ));
+    }
+
+    let round_trips = metrics.vtu_tensor_flatten_count + metrics.vtu_tensor_rebuild_count;
+    if metrics.vtu_tensor_rebuild_count >= 2 && round_trips >= 4 {
+        out.push(format!(
+            "tensorFlattenCount={} / tensorRebuildCount={}: values cross the flat/nested \
+             boundary repeatedly; chaining tensor words (or bulk HOF paths) keeps data flat \
+             between stages",
+            metrics.vtu_tensor_flatten_count, metrics.vtu_tensor_rebuild_count
+        ));
+    }
+
+    if metrics.vtu_sparse_candidate_elements > 0
+        && metrics.vtu_sparse_skippable_zero_elements * 2 >= metrics.vtu_sparse_candidate_elements
+    {
+        out.push(format!(
+            "sparseSkippableZeroElements={} of sparseCandidateElements={}: half or more of the \
+             candidate lanes are zero; restructuring to avoid moving zero lanes reduces data \
+             movement",
+            metrics.vtu_sparse_skippable_zero_elements, metrics.vtu_sparse_candidate_elements
+        ));
+    }
+
+    if metrics.vtu_rejected_block_count > 0 {
+        out.push(format!(
+            "rejectedBlockCount={}: quantized blocks were rejected as VTU candidates; build with \
+             the trace-quant feature to see the rejection reasons",
+            metrics.vtu_rejected_block_count
+        ));
+    }
+
+    out
+}
+
+pub fn energy_proxy_report(metrics: &RuntimeMetrics) -> EnergyProxyReport {
+    EnergyProxyReport {
+        score: energy_proxy_score(metrics),
+        proxy_version: ENERGY_PROXY_VERSION,
+        suggestions: energy_proxy_suggestions(metrics),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_metrics_score_zero_with_no_suggestions() {
+        let report = energy_proxy_report(&RuntimeMetrics::default());
+        assert_eq!(report.score, 0);
+        assert_eq!(report.proxy_version, ENERGY_PROXY_VERSION);
+        assert!(report.suggestions.is_empty());
+    }
+
+    #[test]
+    fn score_is_a_pure_function_of_the_counters() {
+        let metrics = RuntimeMetrics {
+            vtu_tensor_flattened_elements: 100,
+            vtu_tensor_flatten_count: 3,
+            vtu_allocated_elements: 50,
+            vtu_broadcast_count: 2,
+            ..Default::default()
+        };
+        assert_eq!(energy_proxy_score(&metrics), energy_proxy_score(&metrics));
+        // 100*4 + 3*16 + 50*2 + 2*8 = 400 + 48 + 100 + 16
+        assert_eq!(energy_proxy_score(&metrics), 564);
+    }
+
+    #[test]
+    fn efficiency_paths_deduct_and_never_underflow() {
+        let metrics = RuntimeMetrics {
+            vtu_simd_kernel_use_count: 1_000_000,
+            vtu_bulk_kernel_use_count: 1_000_000,
+            vtu_projected_broadcast_count: 1_000_000,
+            ..Default::default()
+        };
+        assert_eq!(
+            energy_proxy_score(&metrics),
+            0,
+            "deduction must saturate at zero"
+        );
+
+        let mixed = RuntimeMetrics {
+            vtu_allocated_elements: 100,   // cost 200
+            vtu_simd_kernel_use_count: 10, // deduction 40
+            ..Default::default()
+        };
+        assert_eq!(energy_proxy_score(&mixed), 160);
+    }
+
+    #[test]
+    fn sparse_candidates_earn_no_deduction() {
+        // Candidates are observations, not realized skips: they must not
+        // lower the score (no credit for unrealized work).
+        let base = RuntimeMetrics {
+            vtu_allocated_elements: 100,
+            ..Default::default()
+        };
+        let with_sparse = RuntimeMetrics {
+            vtu_sparse_candidate_count: 5,
+            vtu_sparse_candidate_elements: 1000,
+            vtu_sparse_skippable_zero_elements: 900,
+            ..base
+        };
+        assert_eq!(energy_proxy_score(&base), energy_proxy_score(&with_sparse));
+    }
+
+    #[test]
+    fn suggestion_rules_fire_mechanically() {
+        let metrics = RuntimeMetrics {
+            vtu_fusion_candidate_count: 2,
+            vtu_tensor_flatten_count: 3,
+            vtu_tensor_rebuild_count: 2,
+            vtu_sparse_candidate_elements: 10,
+            vtu_sparse_skippable_zero_elements: 9,
+            vtu_rejected_block_count: 1,
+            ..Default::default()
+        };
+        let suggestions = energy_proxy_suggestions(&metrics);
+        assert_eq!(suggestions.len(), 4);
+        assert!(suggestions[0].contains("fusionCandidateCount=2"));
+        assert!(suggestions[1].contains("tensorRebuildCount=2"));
+        assert!(suggestions[2].contains("sparseSkippableZeroElements=9"));
+        assert!(suggestions[3].contains("rejectedBlockCount=1"));
+    }
+}

--- a/rust/src/interpreter/energy_proxy_regression_tests.rs
+++ b/rust/src/interpreter/energy_proxy_regression_tests.rs
@@ -1,0 +1,217 @@
+//! Cross-cutting test suite: energy-proxy regression guards.
+//!
+//! Sibling of `perf_regression_tests.rs`, but gating on the deterministic
+//! [`energy_proxy_score`](super::energy_proxy::energy_proxy_score) instead
+//! of wall time: for a fixed catalog of programs, the observable result
+//! must stay identical AND the structural-cost proxy must not grow past
+//! its recorded baseline. A change that keeps outputs equal but moves more
+//! data (extra flatten/rebuild round-trips, lost fast paths, larger
+//! allocations) fails here instead of slipping through.
+//!
+//! Baseline discipline:
+//! - The catalog must contain tensor-bearing programs with a *non-zero*
+//!   baseline (see [`tensor_pipeline_is_observed`]); a globally zeroed
+//!   counter pipeline would otherwise silently disable the guard.
+//! - If an intentional engine change lowers a score, tighten the baseline
+//!   in the same PR. If it raises a score, either justify and raise the
+//!   baseline explicitly (saying why in the PR) or fix the regression —
+//!   never bump casually.
+//! - Scores are comparable only within one ENERGY_PROXY_VERSION; bumping
+//!   the version (docs/quality/energy-proxy-score.md) re-baselines this
+//!   whole table.
+
+use super::energy_proxy::energy_proxy_score;
+use crate::interpreter::Interpreter;
+use crate::types::Interpretation;
+
+struct EnergyCase {
+    label: &'static str,
+    code: &'static str,
+    /// Expected final stack, bottom to top, as display strings — pins that
+    /// the observable meaning of the program is unchanged.
+    expected_stack: &'static [&'static str],
+    /// Recorded energyProxyScore for ENERGY_PROXY_VERSION = 1. The guard
+    /// asserts the live score never exceeds this.
+    baseline_score: u64,
+}
+
+const ENERGY_CASES: &[EnergyCase] = &[
+    EnergyCase {
+        label: "scalar-broadcast",
+        code: "[ 5 ] [ 0 7 ] RANGE *",
+        expected_stack: &["[ 0/1 5/1 10/1 15/1 20/1 25/1 30/1 35/1 ]"],
+        baseline_score: 88,
+    },
+    EnergyCase {
+        label: "matrix-add",
+        code: "[ [ 1 2 3 ] [ 4 5 6 ] ] [ [ 10 20 30 ] [ 40 50 60 ] ] +",
+        expected_stack: &["[ [ 11/1 22/1 33/1 ] [ 44/1 55/1 66/1 ] ]"],
+        baseline_score: 100,
+    },
+    EnergyCase {
+        label: "row-broadcast",
+        code: "[ [ 1 2 3 ] [ 4 5 6 ] ] [ 10 20 30 ] +",
+        expected_stack: &["[ [ 11/1 22/1 33/1 ] [ 14/1 25/1 36/1 ] ]"],
+        baseline_score: 84,
+    },
+    EnergyCase {
+        label: "col-broadcast",
+        code: "[ [ 1 2 3 ] [ 4 5 6 ] ] [ [ 100 ] [ 200 ] ] +",
+        expected_stack: &["[ [ 101/1 102/1 103/1 ] [ 204/1 205/1 206/1 ] ]"],
+        baseline_score: 80,
+    },
+    EnergyCase {
+        // NIL bubbles through tensor arithmetic (x/0 in one lane); the
+        // result is a single NIL but the broadcast still moved data.
+        label: "nil-mixed-tensor",
+        code: "[ 1 2 3 ] [ 1 0 1 ] /",
+        expected_stack: &["NIL"],
+        baseline_score: 70,
+    },
+    EnergyCase {
+        label: "tensor-3d-add",
+        code: "[ [ [ 1 2 ] [ 3 4 ] ] [ [ 5 6 ] [ 7 8 ] ] ] \
+                [ [ [ 1 1 ] [ 1 1 ] ] [ [ 1 1 ] [ 1 1 ] ] ] +",
+        expected_stack: &["[ [ [ 2/1 3/1 ] [ 4/1 5/1 ] ] [ [ 6/1 7/1 ] [ 8/1 9/1 ] ] ]"],
+        baseline_score: 120,
+    },
+    EnergyCase {
+        label: "scalar-times-matrix",
+        code: "[ 3 ] [ [ 1 2 3 ] [ 4 5 6 ] ] *",
+        expected_stack: &["[ [ 3/1 6/1 9/1 ] [ 12/1 15/1 18/1 ] ]"],
+        baseline_score: 76,
+    },
+    EnergyCase {
+        // Two chained tensor adds: the intermediate result crosses the
+        // flat/nested boundary, so this is the round-trip-sensitive case.
+        label: "chained-tensor-add",
+        code: "[ 1 2 3 4 ] [ 2 2 ] RESHAPE [ [ 10 20 ] [ 30 40 ] ] + [ [ 1 1 ] [ 1 1 ] ] +",
+        expected_stack: &["[ [ 12/1 23/1 ] [ 34/1 45/1 ] ]"],
+        baseline_score: 160,
+    },
+    EnergyCase {
+        label: "reshape-mul",
+        code: "[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE [ 2 ] *",
+        expected_stack: &["[ [ 2/1 4/1 6/1 ] [ 8/1 10/1 12/1 ] ]"],
+        baseline_score: 76,
+    },
+    EnergyCase {
+        // Same-shape 1-D arithmetic takes the SIMD fast path, which records
+        // no boundary movement: its honest proxy cost is 0. Kept in the
+        // catalog as a guard that this path stays free — if it silently
+        // started flattening, the score would rise above 0 and fail.
+        label: "same-shape-simd",
+        code: "[ 1 2 3 4 5 6 7 8 ] [ 8 7 6 5 4 3 2 1 ] +",
+        expected_stack: &["[ 9/1 9/1 9/1 9/1 9/1 9/1 9/1 9/1 ]"],
+        baseline_score: 0,
+    },
+];
+
+/// Candidate programs spanning the structural patterns called out in the
+/// work order (§4.2). Run `cargo test energy_proxy_discovery -- --nocapture`
+/// to print discovered scores/stacks when seeding or re-baselining.
+const DISCOVERY_PROGRAMS: &[(&str, &str)] = &[
+    ("scalar-broadcast", "[ 5 ] [ 0 7 ] RANGE *"),
+    (
+        "matrix-add",
+        "[ [ 1 2 3 ] [ 4 5 6 ] ] [ [ 10 20 30 ] [ 40 50 60 ] ] +",
+    ),
+    ("row-broadcast", "[ [ 1 2 3 ] [ 4 5 6 ] ] [ 10 20 30 ] +"),
+    (
+        "col-broadcast",
+        "[ [ 1 2 3 ] [ 4 5 6 ] ] [ [ 100 ] [ 200 ] ] +",
+    ),
+    ("nil-mixed-tensor", "[ 1 2 3 ] [ 1 0 1 ] /"),
+    (
+        "tensor-3d-add",
+        "[ [ [ 1 2 ] [ 3 4 ] ] [ [ 5 6 ] [ 7 8 ] ] ] [ [ [ 1 1 ] [ 1 1 ] ] [ [ 1 1 ] [ 1 1 ] ] ] +",
+    ),
+    ("scalar-times-matrix", "[ 3 ] [ [ 1 2 3 ] [ 4 5 6 ] ] *"),
+    (
+        "chained-tensor-add",
+        "[ 1 2 3 4 ] [ 2 2 ] RESHAPE [ [ 10 20 ] [ 30 40 ] ] + [ [ 1 1 ] [ 1 1 ] ] +",
+    ),
+    ("reshape-mul", "[ 1 2 3 4 5 6 ] [ 2 3 ] RESHAPE [ 2 ] *"),
+    (
+        "same-shape-simd",
+        "[ 1 2 3 4 5 6 7 8 ] [ 8 7 6 5 4 3 2 1 ] +",
+    ),
+];
+
+fn run_collect(code: &str) -> (Vec<String>, u64) {
+    let mut interp = Interpreter::new();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(async {
+        interp.execute(code).await.expect("program should execute");
+    });
+    let hints = interp.collect_stack_hints().to_vec();
+    let stack: Vec<String> = interp
+        .get_stack()
+        .iter()
+        .enumerate()
+        .map(|(i, value)| {
+            let hint = hints.get(i).copied().unwrap_or(Interpretation::Unassigned);
+            crate::types::display::format_with_hint(value, hint)
+        })
+        .collect();
+    let score = energy_proxy_score(&interp.runtime_metrics());
+    (stack, score)
+}
+
+#[test]
+fn output_unchanged_and_score_within_baseline() {
+    for case in ENERGY_CASES {
+        let (stack, score) = run_collect(case.code);
+        assert_eq!(
+            stack, case.expected_stack,
+            "[{}] output changed — energy regression guards are only valid when meaning is preserved",
+            case.label
+        );
+        assert!(
+            score <= case.baseline_score,
+            "[{}] energyProxyScore {} exceeds baseline {} — same output, more structural work. \
+             Investigate the regression; only raise the baseline with explicit justification.",
+            case.label,
+            score,
+            case.baseline_score
+        );
+    }
+}
+
+#[test]
+fn score_is_deterministic_across_runs() {
+    for case in ENERGY_CASES {
+        let (_, first) = run_collect(case.code);
+        let (_, second) = run_collect(case.code);
+        assert_eq!(
+            first, second,
+            "[{}] energyProxyScore must be deterministic across runs",
+            case.label
+        );
+    }
+}
+
+#[test]
+fn tensor_pipeline_is_observed() {
+    // At least one tensor-bearing program must score non-zero, otherwise a
+    // broken (globally zeroed) counter pipeline would pass every `<=`
+    // assertion above while measuring nothing.
+    let max = ENERGY_CASES
+        .iter()
+        .map(|case| run_collect(case.code).1)
+        .max()
+        .unwrap_or(0);
+    assert!(
+        max > 0,
+        "no catalog program scored above zero — the VTU counter pipeline appears disabled"
+    );
+}
+
+#[test]
+fn energy_proxy_discovery() {
+    // Seeding/re-baselining aid; always passes. Run with --nocapture.
+    for (label, code) in DISCOVERY_PROGRAMS {
+        let (stack, score) = run_collect(code);
+        println!("{label} => score={score} stack={stack:?}");
+    }
+}

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -10,6 +10,7 @@ pub mod control;
 pub mod control_cond;
 pub mod datetime;
 pub mod debug_diagnosis;
+pub mod energy_proxy;
 pub mod epoch;
 pub mod error_flow_trace;
 pub mod execute_def;
@@ -70,6 +71,8 @@ mod dictionary_operation_tests;
 mod dictionary_resolution_tests;
 #[cfg(test)]
 mod dictionary_tier_tests;
+#[cfg(test)]
+mod energy_proxy_regression_tests;
 #[cfg(test)]
 mod error_flow_trace_tests;
 #[cfg(test)]


### PR DESCRIPTION
`docs/dev/ai-first-competitive-upgrade-instructions.md` の **Phase 3（energyProxyScore + エネルギー回帰テスト）** を実装しました。**base は Phase 1 ブランチ**です（#1083 マージ後に base を `main` へ変更してください。Phase 1 にのみ依存し、Phase 2 とは独立です）。

## 実装内容

### スコアリングモジュール `rust/src/interpreter/energy_proxy.rs`
- `energy_proxy_score(&RuntimeMetrics) -> u64`: VTU 17カウンタの整数重み付き和。境界移動（flatten/rebuild 要素数）と allocated 要素を重く、per-op dispatch を中量、**realized** な SIMD / bulk kernel / projected broadcast を控除（saturating_sub で 0 下限）。`RuntimeMetrics` の純関数で、計算は実行状態に一切触れません
- `energy_proxy_suggestions`: カウンタから機械的に導ける助言（fusion 候補の分断、flat/nested 往復、sparse zero lane、rejected block）。文言は構造的表現に限定し、エネルギー結果は断定しません
- `ENERGY_PROXY_VERSION = 1`。sparse カウンタは *候補* であり realized skip ではないため控除しない（未実現の work にクレジットを与えない）

### 回帰テスト `energy_proxy_regression_tests.rs`
- 固定10プログラム（scalar/row/col broadcast、matrix/3D add、NIL混在tensor、chained add、reshape、same-shape SIMD）
- 各ケースで **(a) 出力スタックが不変** かつ **(b) スコアが baseline 以下** を assert
- スコアの決定性（複数実行で不変）を assert
- tensor を含むプログラムが非ゼロスコアを出すことを assert（カウンタ全停止を検知）
- `perf_regression_tests.rs` と同じ流儀。意図的に baseline を下げると fail、戻すと pass を確認済み

### CLI / ドキュメント
- `--json` の `runtimeMetrics.vtu` に `energyProxyScore` / `proxyVersion` / `suggestions` を追加（additive、schemaVersion 据え置き）。契約文書 §7 更新
- **`docs/quality/energy-proxy-score.md`** 新規: 式・各重みの根拠・除外カウンタ・suggestion 規則・proxyVersion 再ベースライン規則、および誠実性ポリシー（「proxy であって joule ではない」、`energy_saved` 等の結果断定名を使わない）

## 受け入れ基準（指示書 §4.3）
- [x] 同一プログラム・同一入力でスコアが決定的（複数回実行で不変）
- [x] 回帰テストが `cargo test` に含まれ、意図的に劣化させると fail することを確認済み
- [x] `docs/quality/energy-proxy-score.md` に重み・proxyVersion 規則・「proxy であって joule ではない」断り書きがある
- [x] CLI JSON にスコアと suggestions が出る

## 検証
- `cargo test` lib 1282件 pass / wasm32 ビルド成功 / semantic firewall pass / fmt・clippy 新規警告なし / formalization・word-manifest チェック pass
- baseline を 100→99 に下げると該当ケースが fail、戻すと pass することを確認

https://claude.ai/code/session_01L1kZbqoKFtXfrNmNPDUWN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1kZbqoKFtXfrNmNPDUWN5)_