### PR TITLE
Phase 6: Ajisai MCP server (thin CLI wrapper)

### DIFF
--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -1,0 +1,39 @@
+# Ajisai MCP server
+
+A thin [Model Context Protocol](https://modelcontextprotocol.io) server that
+exposes Ajisai to AI agents. It holds **no language logic**: every answer
+comes from running the `ajisai` CLI (Phase 1) or reading a generated artifact
+(`SKILL.md` from Phase 2, `docs/word-manifest.json`). Its only dependency is
+the MCP SDK.
+
+## Tools
+
+| tool | input | returns |
+|---|---|---|
+| `run` | `source` (text) **or** `file` (path) | the CLI's `ajisai run --json` envelope (status, stack, `stackDisplay`, output, diagnosis, errorFlowTrace, aiDiagnostic, runtimeMetrics incl. `energyProxyScore`) |
+| `explain_word` | `word` (e.g. `MAP`, `MUSIC@PLAY`) | matching `docs/word-manifest.json` entries |
+| `skill` | — | the full `SKILL.md` agent writing protocol |
+
+## Setup
+
+```sh
+cargo build --bin ajisai --manifest-path rust/Cargo.toml   # the CLI it wraps
+cd tools/mcp-server && npm install                          # the MCP SDK
+node selftest.js                                            # optional: end-to-end check
+```
+
+The server finds the repo (for `SKILL.md` / the manifest) and the CLI binary
+automatically. Override with `AJISAI_REPO` and `AJISAI_BIN` if needed.
+
+## Connect from Claude Code
+
+Add to `~/.claude.json` (or run `claude mcp add`), then restart Claude Code:
+
+```json
+{ "mcpServers": { "ajisai": { "command": "node",
+  "args": ["/ABSOLUTE/PATH/Ajisai/tools/mcp-server/index.js"] } } }
+```
+
+Any other MCP client connects the same way: launch `node index.js` as a
+stdio MCP server. The three tools then appear as `ajisai/run`,
+`ajisai/explain_word`, and `ajisai/skill`.

--- a/tools/mcp-server/index.js
+++ b/tools/mcp-server/index.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// Ajisai MCP server — a thin wrapper over the `ajisai` CLI, the word
+// manifest, and SKILL.md. It holds no language logic of its own: every
+// answer is produced by running the CLI (Phase 1) or reading a generated
+// artifact (SKILL.md from Phase 2, docs/word-manifest.json). See README.md.
+//
+// Tools:
+//   run(source | file)  -> the CLI's `ajisai run --json` envelope
+//   explain_word(word)  -> matching docs/word-manifest.json entries
+//   skill()             -> the contents of SKILL.md
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Locations (overridable by env) ───────────────────────────────────────
+// Repo root defaults to three levels up from this file (tools/mcp-server/).
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = process.env.AJISAI_REPO
+  ? resolve(process.env.AJISAI_REPO)
+  : resolve(here, "..", "..");
+const skillPath = join(repoRoot, "SKILL.md");
+const manifestPath = join(repoRoot, "docs", "word-manifest.json");
+
+// The CLI binary: explicit AJISAI_BIN, else the repo debug/release build.
+function resolveAjisaiBin() {
+  if (process.env.AJISAI_BIN) return process.env.AJISAI_BIN;
+  for (const profile of ["debug", "release"]) {
+    const candidate = join(repoRoot, "rust", "target", profile, "ajisai");
+    if (existsSync(candidate)) return candidate;
+  }
+  return null; // reported per-call so `explain_word`/`skill` still work
+}
+
+// ── Tool definitions (plain JSON Schema; no extra deps) ───────────────────
+const TOOLS = [
+  {
+    name: "run",
+    description:
+      "Run an Ajisai program through the `ajisai` CLI and return its " +
+      "--json envelope (status, stack, stackDisplay, output, diagnosis, " +
+      "errorFlowTrace, aiDiagnostic, runtimeMetrics). Provide the program " +
+      "as `source`, or a path with `file`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source: { type: "string", description: "Ajisai source text to run." },
+        file: { type: "string", description: "Path to a .ajisai file to run." },
+      },
+    },
+  },
+  {
+    name: "explain_word",
+    description:
+      "Look a word up in the generated word manifest (docs/word-manifest.json) " +
+      "and return its entries: surface, kind, category, module, canonical, and " +
+      "semantic metadata. Matches the bare name or a MODULE@WORD form, " +
+      "case-insensitively.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        word: { type: "string", description: "Word name, e.g. MAP or MUSIC@PLAY." },
+      },
+      required: ["word"],
+    },
+  },
+  {
+    name: "skill",
+    description:
+      "Return SKILL.md — the generated, CLI-verified agent writing protocol " +
+      "for Ajisai (run loop, syntax, control flow, NIL/UNKNOWN, examples, " +
+      "common errors, forbidden patterns, and the full word quick reference).",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+// ── Tool handlers ─────────────────────────────────────────────────────────
+function ok(text) {
+  return { content: [{ type: "text", text }] };
+}
+function fail(text) {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+function toolRun(args) {
+  const bin = resolveAjisaiBin();
+  if (!bin) {
+    return fail(
+      "ajisai CLI not found. Build it (`cargo build --bin ajisai` in rust/) " +
+        "or set AJISAI_BIN to the binary path.",
+    );
+  }
+  const source = args?.source;
+  const file = args?.file;
+  if ((source == null) === (file == null)) {
+    return fail("Provide exactly one of `source` or `file`.");
+  }
+
+  let target = file ? resolve(file) : null;
+  let scratch = null;
+  if (source != null) {
+    scratch = mkdtempSync(join(tmpdir(), "ajisai-mcp-"));
+    target = join(scratch, "program.ajisai");
+    writeFileSync(target, source.endsWith("\n") ? source : source + "\n");
+  }
+  try {
+    const proc = spawnSync(bin, ["run", target, "--json"], { encoding: "utf8" });
+    if (proc.error) return fail(`failed to run ajisai: ${proc.error.message}`);
+    // The CLI prints exactly one JSON document to stdout (pipe-safe contract).
+    // Pass it through verbatim; a non-zero exit (language error) still carries
+    // a valid JSON envelope, so it is a successful tool call with status:error.
+    const text = proc.stdout && proc.stdout.trim().length > 0
+      ? proc.stdout
+      : (proc.stderr || "(no output)");
+    return ok(text);
+  } finally {
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+let manifestCache = null;
+function loadManifest() {
+  if (manifestCache) return manifestCache;
+  manifestCache = JSON.parse(readFileSync(manifestPath, "utf8"));
+  return manifestCache;
+}
+
+function toolExplainWord(args) {
+  const word = (args?.word ?? "").trim();
+  if (!word) return fail("Provide a `word` to explain.");
+  let manifest;
+  try {
+    manifest = loadManifest();
+  } catch (e) {
+    return fail(`could not read ${manifestPath}: ${e.message}`);
+  }
+  const needle = word.toUpperCase();
+  const matches = (manifest.entries || []).filter((e) => {
+    const surface = (e.surface ?? "").toUpperCase();
+    const short = (e.short_surface ?? "").toUpperCase();
+    const canonical = (e.canonical ?? "").toUpperCase();
+    return surface === needle || short === needle || canonical === needle;
+  });
+  if (matches.length === 0) {
+    return fail(
+      `No word matching '${word}' in the manifest. ` +
+        "Use the `skill` tool's §9 quick reference to find the right name.",
+    );
+  }
+  return ok(JSON.stringify(matches, null, 2));
+}
+
+function toolSkill() {
+  try {
+    return ok(readFileSync(skillPath, "utf8"));
+  } catch (e) {
+    return fail(
+      `could not read ${skillPath}: ${e.message}. ` +
+        "Generate it with `npm run generate:skill`.",
+    );
+  }
+}
+
+// ── Wire up the server ────────────────────────────────────────────────────
+export function createServer() {
+  const server = new Server(
+    { name: "ajisai", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    switch (name) {
+      case "run":
+        return toolRun(args);
+      case "explain_word":
+        return toolExplainWord(args);
+      case "skill":
+        return toolSkill();
+      default:
+        return fail(`unknown tool: ${name}`);
+    }
+  });
+
+  return server;
+}
+
+// Auto-start over stdio only when invoked as the executable, so the module
+// can be imported (e.g. by selftest.js) without grabbing stdin/stdout.
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const transport = new StdioServerTransport();
+  await createServer().connect(transport);
+}

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ajisai-mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "MCP server exposing the Ajisai CLI (run), word manifest (explain_word), and SKILL.md (skill) to AI agents.",
+  "bin": { "ajisai-mcp-server": "index.js" },
+  "scripts": { "start": "node index.js", "selftest": "node selftest.js" },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  }
+}

--- a/tools/mcp-server/selftest.js
+++ b/tools/mcp-server/selftest.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// End-to-end self-test: drive the real MCP protocol (list tools + call each
+// of the three) over an in-memory transport pair, asserting the wrapper
+// faithfully relays the CLI and the generated artifacts. Run: `npm run selftest`.
+//
+// Requires the ajisai CLI to be built (or AJISAI_BIN set) for the `run`
+// assertions; the manifest/skill assertions only need the committed artifacts.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "./index.js";
+
+let failures = 0;
+function check(label, cond, detail = "") {
+  if (cond) {
+    console.log(`PASS  ${label}`);
+  } else {
+    failures += 1;
+    console.log(`FAIL  ${label}${detail ? `\n      ${detail}` : ""}`);
+  }
+}
+
+const [clientTransport, serverTransport] =
+  InMemoryTransport.createLinkedPair();
+const server = createServer();
+const client = new Client({ name: "selftest", version: "0.0.0" });
+await Promise.all([
+  server.connect(serverTransport),
+  client.connect(clientTransport),
+]);
+
+// 1. tools/list exposes exactly the three documented tools.
+const { tools } = await client.listTools();
+const names = tools.map((t) => t.name).sort();
+check(
+  "lists exactly run/explain_word/skill",
+  JSON.stringify(names) === JSON.stringify(["explain_word", "run", "skill"]),
+  `got ${JSON.stringify(names)}`,
+);
+
+// 2. skill returns SKILL.md (its generated header is a stable marker).
+const skill = await client.callTool({ name: "skill", arguments: {} });
+const skillText = skill.content?.[0]?.text ?? "";
+check(
+  "skill returns the generated SKILL.md",
+  skillText.includes("Agent Writing Protocol") && skillText.includes("§9"),
+  `first line: ${skillText.split("\n")[0]}`,
+);
+
+// 3. explain_word resolves a core word from the manifest.
+const explain = await client.callTool({
+  name: "explain_word",
+  arguments: { word: "map" },
+});
+let explainEntries = [];
+try {
+  explainEntries = JSON.parse(explain.content?.[0]?.text ?? "[]");
+} catch {
+  /* leave empty -> fails below */
+}
+check(
+  "explain_word(map) returns the MAP coreword entry",
+  Array.isArray(explainEntries) &&
+    explainEntries.some((e) => e.surface === "MAP" && e.kind === "coreword"),
+  `got ${explain.content?.[0]?.text?.slice(0, 80)}`,
+);
+
+// 4. explain_word on a nonexistent word reports an error result.
+const explainMiss = await client.callTool({
+  name: "explain_word",
+  arguments: { word: "definitely-not-a-word" },
+});
+check("explain_word(unknown) is an error result", explainMiss.isError === true);
+
+// 5. run executes a program and relays the CLI's --json envelope.
+const run = await client.callTool({
+  name: "run",
+  arguments: { source: "[ 1 ] [ 2 ] + PRINT" },
+});
+let runEnvelope = null;
+try {
+  runEnvelope = JSON.parse(run.content?.[0]?.text ?? "{}");
+} catch {
+  /* leave null -> fails below */
+}
+const cliMissing =
+  run.isError && (run.content?.[0]?.text ?? "").includes("CLI not found");
+if (cliMissing) {
+  console.log("SKIP  run (ajisai CLI not built; set AJISAI_BIN or cargo build)");
+} else {
+  check(
+    "run relays a valid --json envelope",
+    runEnvelope && runEnvelope.schemaVersion === 1 && runEnvelope.status === "ok",
+    `got ${run.content?.[0]?.text?.slice(0, 80)}`,
+  );
+  check(
+    "run reports PRINT output and energyProxyScore",
+    runEnvelope &&
+      Array.isArray(runEnvelope.output) &&
+      runEnvelope.output.join(" ").includes("3/1") &&
+      typeof runEnvelope.runtimeMetrics?.vtu?.energyProxyScore === "number",
+    `output: ${JSON.stringify(runEnvelope?.output)}`,
+  );
+
+  // 6. run on a language error still returns a JSON envelope (status:error).
+  const runErr = await client.callTool({
+    name: "run",
+    arguments: { source: "[ 1 ] FROBNICATE" },
+  });
+  let errEnvelope = null;
+  try {
+    errEnvelope = JSON.parse(runErr.content?.[0]?.text ?? "{}");
+  } catch {
+    /* leave null */
+  }
+  check(
+    "run surfaces a language error as a status:error envelope",
+    errEnvelope &&
+      errEnvelope.status === "error" &&
+      errEnvelope.diagnosis?.why === "typoOrUnknownName",
+    `got ${runErr.content?.[0]?.text?.slice(0, 80)}`,
+  );
+}
+
+await client.close();
+await server.close();
+
+console.log("----");
+if (failures > 0) {
+  console.log(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all checks passed");


### PR DESCRIPTION
`docs/dev/ai-first-competitive-upgrade-instructions.md` の **Phase 6（任意 — Ajisai MCP サーバー）** を実装しました。Phase 1（CLI）と Phase 2（SKILL.md）に依存し、両方とも main にマージ済みなので base は `main`。

## 実装内容
**`tools/mcp-server/`** — CLI の薄いラッパー。**言語ロジックを一切持たず**、全ての回答は `ajisai` CLI 実行または生成物（`SKILL.md` / `docs/word-manifest.json`）の読み取りに委譲。**依存は MCP SDK のみ**。

### ツール3つ（指示書 §7 どおり）
| tool | 入力 | 返却 |
|---|---|---|
| `run` | `source` または `file` | CLI の `ajisai run --json` 封筒（status/stack/stackDisplay/output/diagnosis/errorFlowTrace/aiDiagnostic/runtimeMetrics）|
| `explain_word` | `word`（`MAP` / `MUSIC@PLAY` 等）| `word-manifest.json` の該当エントリ |
| `skill` | — | `SKILL.md` 全文 |

- **`index.js`**: 低レベル SDK `Server` API + 素の JSON Schema（zod 等の追加依存なし）。リポジトリ（`AJISAI_REPO`）と CLI バイナリ（`AJISAI_BIN`、なければ `rust/target/{debug,release}/ajisai`）を自動解決。直接起動時のみ stdio に接続し、テスト用に `createServer()` を export
- **`selftest.js`**: SDK の in-memory transport + Client を使った**実 MCP プロトコル経由の E2E テスト**。3ツールの列挙と各動作（skill 内容・manifest 照合・ヒットしない語のエラー・run の正常封筒に energyProxyScore・言語エラーの status:error 封筒）を検証
- **`README.md`**: Claude Code からの接続手順を簡潔に記載

## 受け入れ基準（指示書 §7）
- [x] ツールは3つのみ（`run` / `explain_word` / `skill`）
- [x] 依存は MCP SDK のみ、ロジックは CLI と manifest に委譲
- [x] README に接続手順
- [x] ローカルで MCP プロトコル経由の3ツール動作を確認（selftest 7項目すべて pass。CLI ビルド済み環境）

## 検証 / CI 影響
- `node selftest.js` → 全7チェック pass（実 MCP ハンドシェイク経由）
- stdio 起動 smoke OK
- **既存 CI には影響なし**: root eslint は `**/*.js` を ignore、tsc は `src/**` のみ include のため Node サブプロジェクトは lint/typecheck 対象外。`node_modules`・lock ファイルは既存 gitignore 規約に従う（コミットせず）

---

これで作業指示書の **Phase 1〜6 すべて完了** です。

https://claude.ai/code/session_01L1kZbqoKFtXfrNmNPDUWN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1kZbqoKFtXfrNmNPDUWN5)_