### PR TITLE
Content-addressed word identity (§8.6): resolution, identity engine, identity-keyed export/import, body content store

### DIFF
--- a/rust/src/interpreter/dictionary_operation_tests.rs
+++ b/rust/src/interpreter/dictionary_operation_tests.rs
@@ -47,6 +47,53 @@ mod tests {
         }
     }
 
+    /// Section 8.6: a word group imported into its own dictionary must be
+    /// self-referential. When the same names already exist in another dictionary
+    /// (e.g. the bundled Example Words), references inside the imported group
+    /// must bind to the group's own words for both dependency tracking and
+    /// execution — not to the earlier-loaded dictionary.
+    #[tokio::test]
+    async fn test_imported_dictionary_is_self_referential() {
+        let mut interp = Interpreter::new();
+
+        // EXAMPLE dictionary: SAY pushes [ 1 ], GREET calls SAY.
+        interp.execute("{ [ 1 ] } 'SAY' DEF").await.unwrap();
+        interp.execute("{ SAY } 'GREET' DEF").await.unwrap();
+
+        // TEST dictionary duplicates the names; here SAY pushes [ 2 ].
+        interp.active_user_dictionary = "TEST".to_string();
+        interp.execute("{ [ 2 ] } 'SAY' DEF").await.unwrap();
+        interp.execute("{ SAY } 'GREET' DEF").await.unwrap();
+
+        interp.rebuild_dependencies().unwrap();
+
+        // Dependency graph: TEST@GREET depends on TEST@SAY (not EXAMPLE@SAY),
+        // so TEST@SAY is shown as referenced rather than unreferenced.
+        let test_say_deps = interp.dependents.get("TEST@SAY");
+        assert!(
+            test_say_deps.is_some_and(|d| d.contains("TEST@GREET")),
+            "TEST@SAY should be referenced by TEST@GREET; got {:?}",
+            test_say_deps
+        );
+        assert!(
+            !test_say_deps.is_some_and(|d| d.contains("EXAMPLE@GREET")),
+            "EXAMPLE@GREET must not depend on TEST@SAY"
+        );
+        let example_say_deps = interp.dependents.get("EXAMPLE@SAY");
+        assert!(
+            example_say_deps.is_some_and(|d| d.contains("EXAMPLE@GREET")),
+            "EXAMPLE@SAY should be referenced by EXAMPLE@GREET; got {:?}",
+            example_say_deps
+        );
+
+        // Execution: TEST@GREET runs TEST@SAY ([ 2 ]), not EXAMPLE@SAY ([ 1 ]).
+        interp.stack.clear();
+        interp.execute("TEST@GREET").await.unwrap();
+        let top = interp.stack.last().expect("result present");
+        let only = top.child(0).expect("vector has one child");
+        assert_eq!(only.as_scalar().unwrap().to_i64().unwrap(), 2);
+    }
+
     #[tokio::test]
     async fn test_cannot_override_other_builtin_words() {
         let mut interp = Interpreter::new();

--- a/rust/src/interpreter/dictionary_operation_tests.rs
+++ b/rust/src/interpreter/dictionary_operation_tests.rs
@@ -94,6 +94,75 @@ mod tests {
         assert_eq!(only.as_scalar().unwrap().to_i64().unwrap(), 2);
     }
 
+    /// Section 8.6: identical content yields one identity regardless of name or
+    /// dictionary (the basis for automatic deduplication on import).
+    #[tokio::test]
+    async fn test_identical_content_shares_identity() {
+        let mut interp = Interpreter::new();
+        interp.active_user_dictionary = "A".to_string();
+        interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
+        interp.active_user_dictionary = "B".to_string();
+        interp.execute("{ [ 1 ] } 'LEED' DEF").await.unwrap();
+        interp.execute("{ [ 2 ] } 'OTHER' DEF").await.unwrap();
+        interp.rebuild_dependencies().unwrap();
+
+        let a_leaf = interp.word_identity("A@LEAF").cloned();
+        let b_leed = interp.word_identity("B@LEED").cloned();
+        let b_other = interp.word_identity("B@OTHER").cloned();
+        assert!(a_leaf.is_some(), "identity should be computed");
+        assert_eq!(a_leaf, b_leed, "identical bodies must share an identity");
+        assert_ne!(a_leaf, b_other, "different bodies must differ");
+    }
+
+    /// Section 8.6: a word's identity depends on the content of its dependency,
+    /// not on the dependency's name. Two words that call differently-named but
+    /// identical helpers must share an identity.
+    #[tokio::test]
+    async fn test_identity_is_name_independent() {
+        let mut interp = Interpreter::new();
+        interp.active_user_dictionary = "A".to_string();
+        interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
+        interp.execute("{ LEAF } 'USE' DEF").await.unwrap();
+        interp.active_user_dictionary = "B".to_string();
+        interp.execute("{ [ 1 ] } 'LEED' DEF").await.unwrap();
+        interp.execute("{ LEED } 'USE' DEF").await.unwrap();
+        interp.rebuild_dependencies().unwrap();
+
+        let a_use = interp.word_identity("A@USE").cloned();
+        let b_use = interp.word_identity("B@USE").cloned();
+        assert!(a_use.is_some());
+        assert_eq!(
+            a_use, b_use,
+            "callers of identical helpers must share an identity regardless of the helper's name"
+        );
+    }
+
+    /// Section 8.6: a recursive word's identity is well-defined (cycle hashing)
+    /// and reproducible across independent interpreters.
+    #[tokio::test]
+    async fn test_recursive_identity_is_stable() {
+        async fn rec_id() -> Option<String> {
+            let mut interp = Interpreter::new();
+            interp.active_user_dictionary = "R".to_string();
+            interp.execute("{ REC } 'REC' DEF").await.unwrap();
+            interp.rebuild_dependencies().unwrap();
+            // The self-reference must be recorded, then hashed as a cycle.
+            assert!(
+                interp
+                    .dependents
+                    .get("R@REC")
+                    .is_some_and(|d| d.contains("R@REC")),
+                "recursive self-reference should be tracked"
+            );
+            interp.word_identity("R@REC").cloned()
+        }
+
+        let first = rec_id().await;
+        let second = rec_id().await;
+        assert!(first.is_some(), "recursive word should have an identity");
+        assert_eq!(first, second, "recursive identity must be reproducible");
+    }
+
     #[tokio::test]
     async fn test_cannot_override_other_builtin_words() {
         let mut interp = Interpreter::new();

--- a/rust/src/interpreter/execute_builtin.rs
+++ b/rust/src/interpreter/execute_builtin.rs
@@ -103,6 +103,13 @@ impl Interpreter {
         }
         self.call_depth += 1;
 
+        // Section 8.6: resolve this word's bare references through its own
+        // dictionary first, both while compiling its execution plan and while
+        // running its body. Saved and restored so nested calls into other
+        // dictionaries see their own dictionary's context.
+        let owning_dict = self.split_qualified_name(&resolved_name).map(|(dict, _)| dict);
+        let prev_owning = std::mem::replace(&mut self.owning_dictionary_context, owning_dict);
+
         let plan_set = self.get_execution_plan_set(&resolved_name, &def);
 
         self.call_stack.push(resolved_name.clone());
@@ -154,6 +161,7 @@ impl Interpreter {
             self.execute_guard_structure(&def.lines)
         };
         self.call_stack.pop();
+        self.owning_dictionary_context = prev_owning;
         self.call_depth -= 1;
         result
     }

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -133,6 +133,12 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
     let staged_tokens = crate::interpreter::comptime::precompute_definition_tokens(interp, tokens)?;
     let lines = parse_definition_body(&staged_tokens)?;
 
+    // Section 8.6: resolve this word's references through its own dictionary
+    // first, so the dependency it records is its own dictionary's word rather
+    // than a same-named word in another (e.g. earlier-loaded) dictionary.
+    let prev_owning = interp
+        .owning_dictionary_context
+        .replace(dict_name.clone());
     let mut new_dependencies = HashSet::new();
     for line in &lines {
         for token in line.body_tokens.iter() {
@@ -146,6 +152,7 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
             }
         }
     }
+    interp.owning_dictionary_context = prev_owning;
 
     for dep_name in &new_dependencies {
         interp

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -191,6 +191,7 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         .words
         .insert(upper_name.clone(), Arc::new(new_def));
     interp.sync_user_words_cache();
+    interp.recompute_word_identities();
     interp
         .output_buffer
         .push_str(&format!("Defined word: {}@{}\n", dict_name, name));

--- a/rust/src/interpreter/execute_del.rs
+++ b/rust/src/interpreter/execute_del.rs
@@ -131,6 +131,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         .output_buffer
         .push_str(&format!("Deleted word: {}\n", fq_name));
 
+    interp.recompute_word_identities();
     interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -264,6 +264,13 @@ pub struct Interpreter {
     pub(crate) elastic_cache: crate::elastic::CacheManager,
     pub(crate) resolve_cache: HashMap<String, ResolveCacheEntry>,
     pub(crate) validation_policy: ValidationPolicy,
+
+    /// Owning user dictionary of the word currently being defined,
+    /// dependency-scanned, or executed. Bare names resolve through this
+    /// dictionary's words first (Section 8.6), so an imported word group is
+    /// self-referential regardless of which other dictionaries are loaded.
+    /// `None` at top level, where resolution falls back to the global order.
+    pub(crate) owning_dictionary_context: Option<String>,
 }
 
 impl Interpreter {
@@ -321,6 +328,7 @@ impl Interpreter {
             elastic_cache: crate::elastic::CacheManager::new(),
             resolve_cache: HashMap::new(),
             validation_policy: ValidationPolicy::default(),
+            owning_dictionary_context: None,
         };
         crate::elastic::tracer::init_from_env();
         crate::builtins::register_builtins(&mut interpreter.core_vocabulary);
@@ -483,6 +491,7 @@ impl Interpreter {
         self.module_state.clear();
         self.call_stack.clear();
         self.call_depth = 0;
+        self.owning_dictionary_context = None;
         self.import_table.modules.clear();
         self.module_vocabulary.clear();
         self.dictionary_dependencies.clear();

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -271,6 +271,11 @@ pub struct Interpreter {
     /// self-referential regardless of which other dictionaries are loaded.
     /// `None` at top level, where resolution falls back to the global order.
     pub(crate) owning_dictionary_context: Option<String>,
+
+    /// Content identity of each user word, keyed by fully-qualified name
+    /// (Section 8.6). Derived state: recomputed whenever the user-word graph
+    /// changes.
+    pub(crate) word_identities: HashMap<String, String>,
 }
 
 impl Interpreter {
@@ -329,6 +334,7 @@ impl Interpreter {
             resolve_cache: HashMap::new(),
             validation_policy: ValidationPolicy::default(),
             owning_dictionary_context: None,
+            word_identities: HashMap::new(),
         };
         crate::elastic::tracer::init_from_env();
         crate::builtins::register_builtins(&mut interpreter.core_vocabulary);
@@ -492,6 +498,7 @@ impl Interpreter {
         self.call_stack.clear();
         self.call_depth = 0;
         self.owning_dictionary_context = None;
+        self.word_identities.clear();
         self.import_table.modules.clear();
         self.module_vocabulary.clear();
         self.dictionary_dependencies.clear();

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -44,6 +44,7 @@ pub mod time_ops;
 pub(crate) mod value_extraction_helpers;
 pub mod vector_exec;
 pub mod vector_ops;
+mod word_identity;
 
 pub mod interpreter_core;
 

--- a/rust/src/interpreter/resolve_cache.rs
+++ b/rust/src/interpreter/resolve_cache.rs
@@ -5,8 +5,20 @@ impl Interpreter {
         crate::core_word_aliases::canonicalize_core_word_name(name)
     }
 
+    /// Cache key qualified by the active owning-dictionary context (Section 8.6).
+    /// A bare name can resolve to different targets depending on which
+    /// dictionary's word is currently executing, so the cache must not share an
+    /// entry across contexts.
+    fn contextual_resolve_cache_key(&self, name: &str) -> String {
+        let base = Self::make_resolve_cache_key(name);
+        match &self.owning_dictionary_context {
+            Some(ctx) => format!("{}\u{1}{}", ctx, base),
+            None => base,
+        }
+    }
+
     pub(crate) fn lookup_resolve_cache(&mut self, name: &str) -> Option<String> {
-        let key = Self::make_resolve_cache_key(name);
+        let key = self.contextual_resolve_cache_key(name);
         let entry = self.resolve_cache.get(&key)?;
         if entry.dictionary_epoch == self.dictionary_epoch
             && entry.module_epoch == self.module_epoch
@@ -25,7 +37,7 @@ impl Interpreter {
         resolved_name: &str,
         registration_order: u64,
     ) {
-        let key = Self::make_resolve_cache_key(input_name);
+        let key = self.contextual_resolve_cache_key(input_name);
         self.resolve_cache.insert(
             key,
             ResolveCacheEntry {

--- a/rust/src/interpreter/resolve_word.rs
+++ b/rust/src/interpreter/resolve_word.rs
@@ -340,6 +340,7 @@ impl Interpreter {
         }
 
         self.sync_user_words_cache();
+        self.recompute_word_identities();
         Ok(())
     }
 

--- a/rust/src/interpreter/resolve_word.rs
+++ b/rust/src/interpreter/resolve_word.rs
@@ -81,6 +81,17 @@ impl Interpreter {
             }
         }
 
+        // Section 8.6: a bare name resolves through the owning dictionary's
+        // words before any other user dictionary, so an imported word group is
+        // self-referential regardless of which other dictionaries are loaded.
+        if let Some(owning) = &self.owning_dictionary_context {
+            if let Some(dict) = self.user_dictionaries.get(owning) {
+                if let Some(def) = dict.words.get(&upper) {
+                    return Some((format!("{}@{}", owning, upper), def.clone()));
+                }
+            }
+        }
+
         let mut user_matches: Vec<(String, Arc<WordDefinition>, u64)> = Vec::new();
         for (dict_name, dict) in &self.user_dictionaries {
             if let Some(def) = dict.words.get(&upper) {
@@ -260,6 +271,11 @@ impl Interpreter {
         let mut dictionary_edges: HashMap<String, HashSet<String>> = HashMap::new();
 
         for (word_name, word_def) in &all_words {
+            // Section 8.6: scan each word's references through its own dictionary
+            // first, so dependents are recorded against the word's own
+            // dictionary rather than a same-named word elsewhere.
+            self.owning_dictionary_context =
+                self.split_qualified_name(word_name).map(|(dict, _)| dict);
             let mut dependencies = HashSet::new();
             for line in word_def.lines.iter() {
                 for token in line.body_tokens.iter() {
@@ -295,6 +311,8 @@ impl Interpreter {
                 }
             }
         }
+
+        self.owning_dictionary_context = None;
 
         for dict in self.user_dictionaries.keys() {
             self.dictionary_dependencies

--- a/rust/src/interpreter/word_identity.rs
+++ b/rust/src/interpreter/word_identity.rs
@@ -1,0 +1,358 @@
+//! Content-addressed word identity (Section 8.6).
+//!
+//! Each user word has a stable identity derived from its content, not its name:
+//! `id = H(normalize(body) ⊕ { id(dep) })`. Every reference inside a body is
+//! replaced by the identity of its target before hashing, so identity is
+//! independent of which names happen to be in scope. A recursive group (a
+//! strongly connected component of the dependency graph) is hashed as a unit
+//! with its members referenced by position within the component.
+//!
+//! The digest below is a deterministic 256-bit-class polynomial hash built on
+//! the same big-integer primitives `hash.rs` already uses. Its exact byte
+//! encoding is an implementation contract (Section 2.1/2.3) and may be replaced
+//! by a standard cryptographic hash without changing identity semantics
+//! elsewhere.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use num_bigint::BigInt;
+
+use crate::core_word_aliases::canonicalize_core_word_name;
+use crate::types::fraction::Fraction;
+use crate::types::{Token, WordDefinition};
+
+use super::Interpreter;
+
+lazy_static::lazy_static! {
+    // Two distinct ~127-bit moduli; concatenating the two residues yields a
+    // 256-bit-class digest (32 hex chars each).
+    static ref ID_PRIME_A: BigInt =
+        BigInt::parse_bytes(b"170141183460469231731687303715884105727", 10).unwrap();
+    static ref ID_PRIME_B: BigInt =
+        BigInt::parse_bytes(b"170141183460469231731687303715884105619", 10).unwrap();
+    static ref ID_BASE: BigInt = BigInt::from(257u32);
+}
+
+fn poly_hash(bytes: &[u8], modulus: &BigInt) -> BigInt {
+    let mut acc = BigInt::from(1u32);
+    for &b in bytes {
+        acc = (&acc * &*ID_BASE + BigInt::from(b as u32 + 1)) % modulus;
+    }
+    acc
+}
+
+/// Deterministic content digest. Returns a `#`-prefixed 64-hex-char string.
+fn content_digest(bytes: &[u8]) -> String {
+    let a = poly_hash(bytes, &ID_PRIME_A);
+    let b = poly_hash(bytes, &ID_PRIME_B);
+    format!("#{:0>32}{:0>32}", a.to_str_radix(16), b.to_str_radix(16))
+}
+
+/// One canonical element of a word body.
+enum Atom {
+    /// A reference to another user word (a dependency), by fully-qualified name.
+    Ref(String),
+    /// Any other token, already serialized to canonical bytes.
+    Raw(Vec<u8>),
+}
+
+fn structural_atom(tag: u8) -> Atom {
+    Atom::Raw(vec![tag])
+}
+
+fn number_atom(n: &str) -> Atom {
+    match Fraction::from_str(n) {
+        Ok(frac) => {
+            let (num, den) = frac.to_bigint_pair();
+            let mut b = vec![b'N'];
+            b.extend_from_slice(num.to_str_radix(16).as_bytes());
+            b.push(b'/');
+            b.extend_from_slice(den.to_str_radix(16).as_bytes());
+            Atom::Raw(b)
+        }
+        // Unparseable numeric literal: fall back to the raw spelling so the
+        // shape is still total and deterministic.
+        Err(_) => {
+            let mut b = vec![b'n'];
+            b.extend_from_slice(n.as_bytes());
+            Atom::Raw(b)
+        }
+    }
+}
+
+/// Serialize a body shape to bytes, encoding each user-word reference with the
+/// supplied closure (which differs between the pre-ordering pass and the final
+/// pass for recursive components).
+fn serialize_shape(atoms: &[Atom], encode_ref: &dyn Fn(&str) -> Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::new();
+    for atom in atoms {
+        match atom {
+            Atom::Raw(b) => {
+                out.push(0x1f);
+                out.extend_from_slice(b);
+            }
+            Atom::Ref(target) => {
+                out.push(0x1e);
+                out.extend_from_slice(&encode_ref(target));
+            }
+        }
+    }
+    out
+}
+
+/// Tarjan's SCC algorithm. Returns components in reverse topological order
+/// (dependencies before the words that depend on them), with deterministic
+/// node iteration so the result does not depend on hash-map ordering.
+fn tarjan_sccs(nodes: &HashSet<String>, adj: &HashMap<String, Vec<String>>) -> Vec<Vec<String>> {
+    struct State<'a> {
+        adj: &'a HashMap<String, Vec<String>>,
+        index: usize,
+        indices: HashMap<String, usize>,
+        lowlink: HashMap<String, usize>,
+        on_stack: HashSet<String>,
+        stack: Vec<String>,
+        out: Vec<Vec<String>>,
+    }
+
+    fn strongconnect(st: &mut State, v: &str) {
+        st.indices.insert(v.to_string(), st.index);
+        st.lowlink.insert(v.to_string(), st.index);
+        st.index += 1;
+        st.stack.push(v.to_string());
+        st.on_stack.insert(v.to_string());
+
+        if let Some(neighbors) = st.adj.get(v) {
+            for w in neighbors.clone() {
+                if !st.indices.contains_key(&w) {
+                    strongconnect(st, &w);
+                    let lw = st.lowlink[&w];
+                    let lv = st.lowlink[v];
+                    st.lowlink.insert(v.to_string(), lv.min(lw));
+                } else if st.on_stack.contains(&w) {
+                    let iw = st.indices[&w];
+                    let lv = st.lowlink[v];
+                    st.lowlink.insert(v.to_string(), lv.min(iw));
+                }
+            }
+        }
+
+        if st.lowlink[v] == st.indices[v] {
+            let mut comp = Vec::new();
+            loop {
+                let w = st.stack.pop().unwrap();
+                st.on_stack.remove(&w);
+                let is_root = w == v;
+                comp.push(w);
+                if is_root {
+                    break;
+                }
+            }
+            st.out.push(comp);
+        }
+    }
+
+    let mut st = State {
+        adj,
+        index: 0,
+        indices: HashMap::new(),
+        lowlink: HashMap::new(),
+        on_stack: HashSet::new(),
+        stack: Vec::new(),
+        out: Vec::new(),
+    };
+
+    let mut sorted_nodes: Vec<&String> = nodes.iter().collect();
+    sorted_nodes.sort();
+    for v in sorted_nodes {
+        if !st.indices.contains_key(v) {
+            strongconnect(&mut st, v);
+        }
+    }
+    st.out
+}
+
+impl Interpreter {
+    /// Content identity of a user word, if it has been computed.
+    pub(crate) fn word_identity(&self, fq_name: &str) -> Option<&String> {
+        self.word_identities.get(fq_name)
+    }
+
+    fn build_word_shape(&self, def: &WordDefinition, user_set: &HashSet<String>) -> Vec<Atom> {
+        let mut atoms = Vec::new();
+        for line in def.lines.iter() {
+            atoms.push(structural_atom(b'\n'));
+            for tok in line.body_tokens.iter() {
+                let atom = match tok {
+                    Token::Number(n) => number_atom(n),
+                    Token::String(s) => {
+                        let mut b = vec![b'S'];
+                        b.extend_from_slice(s.as_bytes());
+                        Atom::Raw(b)
+                    }
+                    Token::Symbol(s) => {
+                        let canon = canonicalize_core_word_name(s);
+                        match self.resolve_word_entry_readonly(&canon) {
+                            Some((resolved, rdef)) => {
+                                if user_set.contains(&resolved) {
+                                    // A user-word dependency: encoded by identity.
+                                    Atom::Ref(resolved)
+                                } else if rdef.is_builtin {
+                                    // Core / module word: stable global vocabulary,
+                                    // encoded by its canonical resolved name.
+                                    let mut b = vec![b'G'];
+                                    b.extend_from_slice(resolved.as_bytes());
+                                    Atom::Raw(b)
+                                } else {
+                                    Atom::Ref(resolved)
+                                }
+                            }
+                            // Free / unresolved symbol: encoded by canonical name.
+                            None => {
+                                let mut b = vec![b'F'];
+                                b.extend_from_slice(canon.as_bytes());
+                                Atom::Raw(b)
+                            }
+                        }
+                    }
+                    Token::VectorStart => structural_atom(b'['),
+                    Token::VectorEnd => structural_atom(b']'),
+                    Token::BlockStart => structural_atom(b'{'),
+                    Token::BlockEnd => structural_atom(b'}'),
+                    Token::Pipeline => structural_atom(b'~'),
+                    Token::NilCoalesce => structural_atom(b'^'),
+                    Token::CondClauseSep => structural_atom(b'|'),
+                    Token::LineBreak => structural_atom(b'\n'),
+                };
+                atoms.push(atom);
+            }
+        }
+        atoms
+    }
+
+    /// Recompute content identities for every user word (Section 8.6). Cheap
+    /// enough to run after any change to the user-word graph.
+    pub(crate) fn recompute_word_identities(&mut self) {
+        // 1. Snapshot all user words: (fully-qualified name, dictionary, def).
+        let mut words: Vec<(String, String, Arc<WordDefinition>)> = Vec::new();
+        for (dict_name, dict) in &self.user_dictionaries {
+            for (name, def) in &dict.words {
+                words.push((
+                    format!("{}@{}", dict_name, name),
+                    dict_name.clone(),
+                    def.clone(),
+                ));
+            }
+        }
+        let user_set: HashSet<String> = words.iter().map(|(fq, _, _)| fq.clone()).collect();
+        let reg_order: HashMap<String, u64> = words
+            .iter()
+            .map(|(fq, _, def)| (fq.clone(), def.registration_order))
+            .collect();
+
+        // 2. Canonical shape of each body; references to other user words are
+        //    captured as Atom::Ref and resolved through the owning dictionary.
+        let prev_ctx = self.owning_dictionary_context.take();
+        let mut shapes: HashMap<String, Vec<Atom>> = HashMap::new();
+        for (fq, dict, def) in &words {
+            self.owning_dictionary_context = Some(dict.clone());
+            let atoms = self.build_word_shape(def, &user_set);
+            shapes.insert(fq.clone(), atoms);
+        }
+        self.owning_dictionary_context = prev_ctx;
+
+        // 3. Dependency graph restricted to user words.
+        let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+        for (fq, atoms) in &shapes {
+            let mut seen = HashSet::new();
+            let mut neighbors = Vec::new();
+            for atom in atoms {
+                if let Atom::Ref(target) = atom {
+                    if user_set.contains(target) && seen.insert(target.clone()) {
+                        neighbors.push(target.clone());
+                    }
+                }
+            }
+            adj.insert(fq.clone(), neighbors);
+        }
+
+        // 4. SCCs in reverse topological order (dependencies first).
+        let sccs = tarjan_sccs(&user_set, &adj);
+
+        // 5. Assign identities component by component.
+        let mut ids: HashMap<String, String> = HashMap::new();
+        for scc in &sccs {
+            let scc_set: HashSet<String> = scc.iter().cloned().collect();
+
+            // Pre-ordering digest: intra-SCC references blanked (so the ordering
+            // does not depend on which member calls which), extra-SCC references
+            // by their already-computed identity.
+            let mut pre: HashMap<String, String> = HashMap::new();
+            for m in scc {
+                let bytes = serialize_shape(&shapes[m], &|target: &str| {
+                    if scc_set.contains(target) {
+                        b"C?".to_vec()
+                    } else {
+                        let mut v = vec![b'I'];
+                        if let Some(id) = ids.get(target) {
+                            v.extend_from_slice(id.as_bytes());
+                        }
+                        v
+                    }
+                });
+                pre.insert(m.clone(), content_digest(&bytes));
+            }
+
+            let mut ordered: Vec<String> = scc.clone();
+            ordered.sort_by(|a, b| {
+                pre[a]
+                    .cmp(&pre[b])
+                    .then_with(|| reg_order.get(a).cmp(&reg_order.get(b)))
+                    .then_with(|| a.cmp(b))
+            });
+            let mut position: HashMap<String, usize> = HashMap::new();
+            for (i, m) in ordered.iter().enumerate() {
+                position.insert(m.clone(), i);
+            }
+
+            // Final shape bytes: intra-SCC references by position, extra-SCC by id.
+            let mut final_bytes: HashMap<String, Vec<u8>> = HashMap::new();
+            for m in scc {
+                let bytes = serialize_shape(&shapes[m], &|target: &str| {
+                    if scc_set.contains(target) {
+                        let mut v = vec![b'P'];
+                        v.extend_from_slice(position[target].to_string().as_bytes());
+                        v
+                    } else {
+                        let mut v = vec![b'I'];
+                        if let Some(id) = ids.get(target) {
+                            v.extend_from_slice(id.as_bytes());
+                        }
+                        v
+                    }
+                });
+                final_bytes.insert(m.clone(), bytes);
+            }
+
+            // Combined digest over members in canonical position order.
+            let mut combined_input = Vec::new();
+            for (i, m) in ordered.iter().enumerate() {
+                combined_input.extend_from_slice(i.to_string().as_bytes());
+                combined_input.push(0x1d);
+                combined_input.extend_from_slice(&final_bytes[m]);
+                combined_input.push(0x1c);
+            }
+            let combined = content_digest(&combined_input);
+
+            for m in scc {
+                let pos = position[m];
+                let mut id_bytes = combined.clone().into_bytes();
+                id_bytes.push(b':');
+                id_bytes.extend_from_slice(pos.to_string().as_bytes());
+                ids.insert(m.clone(), content_digest(&id_bytes));
+            }
+        }
+
+        self.word_identities = ids;
+    }
+}

--- a/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
@@ -105,6 +105,26 @@ impl AjisaiInterpreter {
         js_array.into()
     }
 
+    /// Content identity (Section 8.6) of each user word, as `[fqName, id]`
+    /// pairs. The host uses these to deduplicate identical definitions on
+    /// import and to key shared word groups by content rather than by name.
+    #[wasm_bindgen]
+    pub fn collect_word_identities(&self) -> JsValue {
+        let js_array = js_sys::Array::new();
+        for dict_name in self.interpreter.user_dictionary_names() {
+            for (name, _def) in self.interpreter.user_dictionary_words(&dict_name) {
+                let fq_name = format!("{}@{}", dict_name, name);
+                if let Some(id) = self.interpreter.word_identity(&fq_name) {
+                    let item = js_sys::Array::new();
+                    item.push(&fq_name.clone().into());
+                    item.push(&id.clone().into());
+                    js_array.push(&item);
+                }
+            }
+        }
+        js_array.into()
+    }
+
     pub(crate) fn collect_imported_modules_array(&self) -> JsValue {
         let arr = js_sys::Array::new();
         for name in self.interpreter.import_table.modules.keys() {


### PR DESCRIPTION
Implements the §8.6 model whose spec landed in #1099 (merged). Four stages.

## 1 — Owning-dictionary resolution
Bare names in a user word's body resolve through that word's **own** dictionary first (definition-time dependency scanning, dependency rebuild, and execution, incl. before plan compilation). `resolve_short_name` order: Core → modules → own dictionary → other user dictionaries; resolve cache keyed by owning-dictionary context. Fixes the reported bug: a `Test` group imported alongside `Example` is self-referential and runs its own words.

## 2 — Content-hash identity engine
`interpreter/word_identity.rs`: canonical body serialization (exact-rational numbers, structural tokens, core/module refs by canonical name, **user-word refs by identity**), a deterministic 256-bit-class digest, and SCC-based assignment (Tarjan, reverse-topological) with **cycle hashing** for self/mutual recursion. `word_identities` recomputed after DEF/DEL/rebuild; `collect_word_identities()` over the WASM boundary. Identity is name-independent, so identical content shares one identity.

## 3 — Identity-keyed export / import dedup
Export writes a versioned document carrying each word's content identity. Import recognises re-imported unchanged content as **deduplicated** (before/after identity comparison), **verifies** embedded identities against locally recomputed ones (surfacing definitions edited without re-export), and still reads legacy v1 array files.

## 4 — Content store for definition bodies
Definition bodies are interned by canonical content key: textually identical bodies share one `Arc<[ExecutionLine]>`, so copying or re-importing a word group no longer duplicates its code in memory — real storage deduplication.

## Tests / checks
1287 Rust lib tests pass; `cargo check --features wasm` clean. New tests: self-referential import; identity dedup; name-independent identity; reproducible recursive identity; shared stored body.

## Follow-up (separate PR, recommended)
Whole-definition **record store** with a `name → id` naming layer and an **identity-keyed execution-plan cache**, collapsing differently-named identical content into one record. It reaches the execution hot path (`store_execution_plan_set_for_word`), child runtime, and persistence, so it needs WASM/GUI/perf validation that this environment can't run — best done as its own reviewed change. Explicit `update` propagation (pin semantics) also remains.

https://claude.ai/code/session_01XhcgjtY8dzTLLJbqfMgbHz