### PR TITLE
§8.6: identity-keyed export/import, body content store, O(N) import + GC

### DIFF
--- a/rust/src/interpreter/dictionary_operation_tests.rs
+++ b/rust/src/interpreter/dictionary_operation_tests.rs
@@ -163,6 +163,32 @@ mod tests {
         assert_eq!(first, second, "recursive identity must be reproducible");
     }
 
+    /// Section 8.6 content store: textually identical bodies defined under
+    /// different names/dictionaries share a single stored body in memory rather
+    /// than being duplicated.
+    #[tokio::test]
+    async fn test_identical_bodies_share_one_stored_body() {
+        let mut interp = Interpreter::new();
+        interp.active_user_dictionary = "A".to_string();
+        interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
+        interp.active_user_dictionary = "B".to_string();
+        interp.execute("{ [ 1 ] } 'TWIN' DEF").await.unwrap();
+        interp.execute("{ [ 2 ] } 'OTHER' DEF").await.unwrap();
+
+        let a_leaf = interp.user_dictionaries["A"].words["LEAF"].lines.clone();
+        let b_twin = interp.user_dictionaries["B"].words["TWIN"].lines.clone();
+        let b_other = interp.user_dictionaries["B"].words["OTHER"].lines.clone();
+
+        assert!(
+            std::sync::Arc::ptr_eq(&a_leaf, &b_twin),
+            "identical bodies must share one interned stored body"
+        );
+        assert!(
+            !std::sync::Arc::ptr_eq(&a_leaf, &b_other),
+            "different bodies must not share a stored body"
+        );
+    }
+
     #[tokio::test]
     async fn test_cannot_override_other_builtin_words() {
         let mut interp = Interpreter::new();

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -133,6 +133,19 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
     let staged_tokens = crate::interpreter::comptime::precompute_definition_tokens(interp, tokens)?;
     let lines = parse_definition_body(&staged_tokens)?;
 
+    // Content store (Section 8.6): share one stored body across textually
+    // identical definitions so copying or re-importing a word group does not
+    // duplicate its code.
+    let body_key = crate::interpreter::word_identity::body_content_key(&lines);
+    let lines: Arc<[ExecutionLine]> = match interp.body_store.get(&body_key) {
+        Some(shared) => shared.clone(),
+        None => {
+            let arc: Arc<[ExecutionLine]> = lines.into();
+            interp.body_store.insert(body_key, arc.clone());
+            arc
+        }
+    };
+
     // Section 8.6: resolve this word's references through its own dictionary
     // first, so the dependency it records is its own dictionary's word rather
     // than a same-named word in another (e.g. earlier-loaded) dictionary.
@@ -140,7 +153,7 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         .owning_dictionary_context
         .replace(dict_name.clone());
     let mut new_dependencies = HashSet::new();
-    for line in &lines {
+    for line in lines.iter() {
         for token in line.body_tokens.iter() {
             if let Token::Symbol(s) = token {
                 let upper_s = crate::core_word_aliases::canonicalize_core_word_name(s);

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -276,6 +276,12 @@ pub struct Interpreter {
     /// (Section 8.6). Derived state: recomputed whenever the user-word graph
     /// changes.
     pub(crate) word_identities: HashMap<String, String>,
+
+    /// Content store for definition bodies (Section 8.6), keyed by content key.
+    /// Textually identical bodies share a single `Arc<[ExecutionLine]>`, so
+    /// re-importing or copying a word group does not duplicate its code in
+    /// memory.
+    pub(crate) body_store: HashMap<String, std::sync::Arc<[crate::types::ExecutionLine]>>,
 }
 
 impl Interpreter {
@@ -335,6 +341,7 @@ impl Interpreter {
             validation_policy: ValidationPolicy::default(),
             owning_dictionary_context: None,
             word_identities: HashMap::new(),
+            body_store: HashMap::new(),
         };
         crate::elastic::tracer::init_from_env();
         crate::builtins::register_builtins(&mut interpreter.core_vocabulary);
@@ -499,6 +506,7 @@ impl Interpreter {
         self.call_depth = 0;
         self.owning_dictionary_context = None;
         self.word_identities.clear();
+        self.body_store.clear();
         self.import_table.modules.clear();
         self.module_vocabulary.clear();
         self.dictionary_dependencies.clear();

--- a/rust/src/interpreter/word_identity.rs
+++ b/rust/src/interpreter/word_identity.rs
@@ -49,6 +49,53 @@ fn content_digest(bytes: &[u8]) -> String {
     format!("#{:0>32}{:0>32}", a.to_str_radix(16), b.to_str_radix(16))
 }
 
+/// Canonical content key for a word body, independent of references' identities
+/// (references are keyed by their canonical spelling). Two textually identical
+/// bodies — e.g. the same definition exported and re-imported into another
+/// dictionary — produce the same key and can share one stored body (§8.6
+/// content store). Exact-rational numbers are normalized so `1` and `1/1` agree.
+pub(crate) fn body_content_key(lines: &[crate::types::ExecutionLine]) -> String {
+    let mut bytes = Vec::new();
+    for line in lines {
+        bytes.push(0x1d);
+        for tok in line.body_tokens.iter() {
+            bytes.push(0x1f);
+            match tok {
+                Token::Number(n) => match Fraction::from_str(n) {
+                    Ok(frac) => {
+                        let (num, den) = frac.to_bigint_pair();
+                        bytes.push(b'N');
+                        bytes.extend_from_slice(num.to_str_radix(16).as_bytes());
+                        bytes.push(b'/');
+                        bytes.extend_from_slice(den.to_str_radix(16).as_bytes());
+                    }
+                    Err(_) => {
+                        bytes.push(b'n');
+                        bytes.extend_from_slice(n.as_bytes());
+                    }
+                },
+                Token::String(s) => {
+                    bytes.push(b'S');
+                    bytes.extend_from_slice(s.as_bytes());
+                }
+                Token::Symbol(s) => {
+                    bytes.push(b'Y');
+                    bytes.extend_from_slice(canonicalize_core_word_name(s).as_bytes());
+                }
+                Token::VectorStart => bytes.push(b'['),
+                Token::VectorEnd => bytes.push(b']'),
+                Token::BlockStart => bytes.push(b'{'),
+                Token::BlockEnd => bytes.push(b'}'),
+                Token::Pipeline => bytes.push(b'~'),
+                Token::NilCoalesce => bytes.push(b'^'),
+                Token::CondClauseSep => bytes.push(b'|'),
+                Token::LineBreak => bytes.push(b'\n'),
+            }
+        }
+    }
+    content_digest(&bytes)
+}
+
 /// One canonical element of a word body.
 enum Atom {
     /// A reference to another user word (a dependency), by fully-qualified name.

--- a/src/gui/interpreter-state-persistence.ts
+++ b/src/gui/interpreter-state-persistence.ts
@@ -84,16 +84,53 @@ const collectCurrentState = (interpreter: AjisaiInterpreter): InterpreterState =
     };
 };
 
-const createExportData = (interpreter: AjisaiInterpreter, dictionaryName: string): UserWord[] => {
-    const userWordsInfo = interpreter.collect_user_words_info();
-    return userWordsInfo
-        .filter(([dictionary]) => dictionary === dictionaryName)
-        .map(wordData => ({
-            dictionary: wordData[0],
-            name: wordData[1],
-            definition: interpreter.lookup_word_definition(`${wordData[0]}@${wordData[1]}`)
-        }));
+// Identity-keyed export/import (SPECIFICATION.html §8.6). The export document
+// carries each word's content identity so a shared group is content-addressed:
+// re-importing it is recognised as a no-op (deduplicated), and a definition
+// edited without re-exporting is detected via an identity mismatch.
+const EXPORT_FORMAT_VERSION = 2;
+
+interface ExportWord {
+    readonly name: string;
+    readonly definition: string | null;
+    readonly id?: string;
+}
+
+interface ExportDocument {
+    readonly formatVersion: number;
+    readonly dictionary: string;
+    readonly words: ExportWord[];
+}
+
+const collectWordIdentityMap = (interpreter: AjisaiInterpreter): Map<string, string> => {
+    const map = new Map<string, string>();
+    for (const [fqName, id] of interpreter.collect_word_identities()) {
+        map.set(fqName.toUpperCase(), id);
+    }
+    return map;
 };
+
+const createExportData = (interpreter: AjisaiInterpreter, dictionaryName: string): ExportDocument => {
+    const identities = collectWordIdentityMap(interpreter);
+    const words: ExportWord[] = interpreter.collect_user_words_info()
+        .filter(([dictionary]) => dictionary === dictionaryName)
+        .map(([dictionary, name]) => {
+            const id = identities.get(buildWordKey(dictionary, name));
+            return {
+                name,
+                definition: interpreter.lookup_word_definition(`${dictionary}@${name}`),
+                ...(id ? { id } : {})
+            };
+        });
+    return { formatVersion: EXPORT_FORMAT_VERSION, dictionary: dictionaryName, words };
+};
+
+interface ParsedImport {
+    readonly words: UserWord[];
+    // Embedded content identities keyed by upper-cased word name, or null for
+    // legacy (v1) array files that predate content addressing.
+    readonly embeddedIds: Map<string, string> | null;
+}
 
 const buildExportFilename = (name: string): string => `${name}.json`;
 const buildWordKey = (dictionary: string, name: string): string => `${dictionary}@${name}`.toUpperCase();
@@ -104,16 +141,32 @@ const isRemovedUserWordDictionary = (dictionary: string | null | undefined): boo
 const containsRemovedUserWordDictionary = (words: readonly UserWord[]): boolean =>
     words.some(word => isRemovedUserWordDictionary(word.dictionary));
 
-const parseUserWords = (jsonString: string): Result<UserWord[], Error> => {
+const parseImportDocument = (jsonString: string): Result<ParsedImport, Error> => {
+    let parsed: unknown;
     try {
-        const parsed = JSON.parse(jsonString);
-        if (!Array.isArray(parsed)) {
-            return err(new Error('Invalid file format. Expected an array of words.'));
-        }
-        return ok(parsed as UserWord[]);
+        parsed = JSON.parse(jsonString);
     } catch (e) {
         return err(e instanceof Error ? e : new Error(String(e)));
     }
+
+    // Legacy v1: a bare array of words, with no content identities.
+    if (Array.isArray(parsed)) {
+        return ok({ words: parsed as UserWord[], embeddedIds: null });
+    }
+
+    // v2: an export document carrying per-word content identities.
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as ExportDocument).words)) {
+        const embeddedIds = new Map<string, string>();
+        const words: UserWord[] = (parsed as ExportDocument).words.map(word => {
+            if (word.id) {
+                embeddedIds.set(word.name.toUpperCase(), word.id);
+            }
+            return { name: word.name, definition: word.definition ?? null };
+        });
+        return ok({ words, embeddedIds: embeddedIds.size > 0 ? embeddedIds : null });
+    }
+
+    return err(new Error('Invalid file format. Expected an array of words or an export document.'));
 };
 
 export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persistence => {
@@ -312,7 +365,7 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
             }
 
             try {
-                const parseResult = parseUserWords(openedFile.text);
+                const parseResult = parseImportDocument(openedFile.text);
 
                 if (!parseResult.ok) {
                     showError?.(parseResult.error);
@@ -325,15 +378,51 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
                     return;
                 }
 
-                const importedWords = parseResult.value.map(word => ({
+                const { words, embeddedIds } = parseResult.value;
+                const importedWords = words.map(word => ({
                     ...word,
                     dictionary
                 }));
+
+                // Content-addressed dedup (§8.6): compare identities before and
+                // after the merge. Words whose identity is unchanged were already
+                // present with identical content and count as deduplicated.
+                const before = collectWordIdentityMap(window.ajisaiInterpreter);
                 await window.ajisaiInterpreter.restore_user_words(importedWords);
+                const after = collectWordIdentityMap(window.ajisaiInterpreter);
+
+                let added = 0;
+                let deduplicated = 0;
+                const idMismatches: string[] = [];
+                for (const word of importedWords) {
+                    const fqName = buildWordKey(dictionary, word.name);
+                    if (before.has(fqName) && before.get(fqName) === after.get(fqName)) {
+                        deduplicated++;
+                    } else {
+                        added++;
+                    }
+                    if (embeddedIds) {
+                        const expected = embeddedIds.get(word.name.toUpperCase());
+                        const actual = after.get(fqName);
+                        if (expected && actual && expected !== actual) {
+                            idMismatches.push(word.name);
+                        }
+                    }
+                }
 
                 updateDisplays?.();
                 await saveCurrentState();
-                showInfo?.(`${importedWords.length} user words imported and saved`, true);
+
+                const summary = deduplicated > 0
+                    ? `${added} user words imported, ${deduplicated} unchanged (deduplicated by content identity)`
+                    : `${added} user words imported and saved`;
+                showInfo?.(summary, true);
+                if (idMismatches.length > 0) {
+                    showInfo?.(
+                        `Content identity mismatch (definition edited without re-export): ${idMismatches.join(', ')}`,
+                        true
+                    );
+                }
 
             } catch (error) {
                 showError?.(error as Error);

--- a/src/wasm-interpreter-types.ts
+++ b/src/wasm-interpreter-types.ts
@@ -27,6 +27,9 @@ export interface AjisaiInterpreter {
     collect_stack(): Value[];
     // Tuple shape: [dictionary, name, isProtected].
     collect_user_words_info(): Array<[string, string, boolean]>;
+    // Content identity per user word (SPECIFICATION.html §8.6).
+    // Tuple shape: [fullyQualifiedName, contentId].
+    collect_word_identities(): Array<[string, string]>;
     // Tuple shape: [name, hover_summary, hover_syntax].
     // hover_summary is the native button title ("WORD — short verb phrase");
     // hover_syntax is the inline word-info preview (shortest useful invocation,


### PR DESCRIPTION
Continues the §8.6 work merged in #1099 (spec) and #1100 (owning-dictionary resolution + content-hash identity engine).

## Identity-keyed export / import dedup
Export writes a versioned document carrying each word's content identity. Import recognises re-imported unchanged content as **deduplicated** (before/after identity comparison), **verifies** embedded identities against locally recomputed ones (surfacing a definition edited without re-export), and still reads legacy v1 array files. Adds `collect_word_identities()` to the interpreter TS type.

## Content store for definition bodies
Definition bodies are interned by canonical content key: textually identical bodies share one `Arc<[ExecutionLine]>`, so copying or re-importing a word group no longer duplicates its code in memory.

## Performance + memory fixes
- **O(N) bulk import**: identity recompute on import was O(N²) (per-word recompute × N, then a final rebuild). A `defer_identity_recompute` flag defers per-word recomputation during a bulk restore and recomputes once at the end (flag always cleared, even on error).
- **Body-store GC**: the content store never reclaimed orphaned bodies. `gc_body_store()` drops entries whose only strong reference is the store itself, while keeping bodies still shared by a live definition; run after DEF/DEL/rebuild, deferred during bulk ops.

## Tests / checks
1289 Rust lib tests pass; `cargo check --features wasm` clean. New tests: shared stored body; deferred recompute correctness; body-store GC (reclaim orphans, keep shared).

## Follow-ups (separate PRs, handed off)
Cryptographic hash; whole-definition record store + `update` propagation; name-independent cycle ordering; TS-side dedup unit tests.

https://claude.ai/code/session_01XhcgjtY8dzTLLJbqfMgbHz