### PR TITLE
perf(interpreter): O(N) bulk import + GC the body content store (§8.6)

### DIFF
--- a/rust/src/interpreter/dictionary_operation_tests.rs
+++ b/rust/src/interpreter/dictionary_operation_tests.rs
@@ -189,6 +189,54 @@ mod tests {
         );
     }
 
+    /// Deferring identity recomputation during a bulk operation skips per-word
+    /// recomputes; a single recompute at the end (here via rebuild) restores
+    /// correctness. This is what makes import O(N) rather than O(N^2).
+    #[tokio::test]
+    async fn test_deferred_identity_recompute() {
+        let mut interp = Interpreter::new();
+        interp.active_user_dictionary = "A".to_string();
+
+        interp.defer_identity_recompute = true;
+        interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
+        assert!(
+            interp.word_identity("A@LEAF").is_none(),
+            "identity recompute should be deferred"
+        );
+
+        interp.defer_identity_recompute = false;
+        interp.rebuild_dependencies().unwrap();
+        assert!(
+            interp.word_identity("A@LEAF").is_some(),
+            "identity should be computed once after the batch"
+        );
+    }
+
+    /// Section 8.6 content store: bodies orphaned by a redefine are reclaimed,
+    /// while bodies still shared by a live definition are kept.
+    #[tokio::test]
+    async fn test_body_store_gc() {
+        let mut interp = Interpreter::new();
+        interp.active_user_dictionary = "A".to_string();
+        interp.execute("{ [ 1 ] } 'X' DEF").await.unwrap();
+        assert_eq!(interp.body_store.len(), 1);
+
+        // Identical body in another dictionary shares one store entry.
+        interp.active_user_dictionary = "B".to_string();
+        interp.execute("{ [ 1 ] } 'Y' DEF").await.unwrap();
+        assert_eq!(interp.body_store.len(), 1, "identical bodies share one entry");
+
+        // Redefining A@X keeps [1] (still used by B@Y) and adds [9].
+        interp.active_user_dictionary = "A".to_string();
+        interp.execute("{ [ 9 ] } 'X' DEF").await.unwrap();
+        assert_eq!(interp.body_store.len(), 2, "shared [1] kept, [9] added");
+
+        // Redefining B@Y away orphans [1]; it is reclaimed, leaving [9] and [8].
+        interp.active_user_dictionary = "B".to_string();
+        interp.execute("{ [ 8 ] } 'Y' DEF").await.unwrap();
+        assert_eq!(interp.body_store.len(), 2, "orphaned [1] reclaimed");
+    }
+
     #[tokio::test]
     async fn test_cannot_override_other_builtin_words() {
         let mut interp = Interpreter::new();

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -205,6 +205,7 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         .insert(upper_name.clone(), Arc::new(new_def));
     interp.sync_user_words_cache();
     interp.recompute_word_identities();
+    interp.gc_body_store();
     interp
         .output_buffer
         .push_str(&format!("Defined word: {}@{}\n", dict_name, name));

--- a/rust/src/interpreter/execute_del.rs
+++ b/rust/src/interpreter/execute_del.rs
@@ -132,6 +132,7 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         .push_str(&format!("Deleted word: {}\n", fq_name));
 
     interp.recompute_word_identities();
+    interp.gc_body_store();
     interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -282,6 +282,11 @@ pub struct Interpreter {
     /// re-importing or copying a word group does not duplicate its code in
     /// memory.
     pub(crate) body_store: HashMap<String, std::sync::Arc<[crate::types::ExecutionLine]>>,
+
+    /// When set, `recompute_word_identities` is a no-op. Bulk operations (e.g.
+    /// restoring or importing many words) set this for the duration of the
+    /// batch and recompute once at the end, avoiding O(N^2) identity hashing.
+    pub(crate) defer_identity_recompute: bool,
 }
 
 impl Interpreter {
@@ -342,6 +347,7 @@ impl Interpreter {
             owning_dictionary_context: None,
             word_identities: HashMap::new(),
             body_store: HashMap::new(),
+            defer_identity_recompute: false,
         };
         crate::elastic::tracer::init_from_env();
         crate::builtins::register_builtins(&mut interpreter.core_vocabulary);
@@ -507,6 +513,7 @@ impl Interpreter {
         self.owning_dictionary_context = None;
         self.word_identities.clear();
         self.body_store.clear();
+        self.defer_identity_recompute = false;
         self.import_table.modules.clear();
         self.module_vocabulary.clear();
         self.dictionary_dependencies.clear();

--- a/rust/src/interpreter/resolve_word.rs
+++ b/rust/src/interpreter/resolve_word.rs
@@ -341,6 +341,7 @@ impl Interpreter {
 
         self.sync_user_words_cache();
         self.recompute_word_identities();
+        self.gc_body_store();
         Ok(())
     }
 

--- a/rust/src/interpreter/word_identity.rs
+++ b/rust/src/interpreter/word_identity.rs
@@ -225,6 +225,22 @@ impl Interpreter {
         self.word_identities.get(fq_name)
     }
 
+    /// Reclaim content-store bodies no longer referenced by any definition.
+    /// An entry whose only remaining strong reference is the store itself
+    /// (`strong_count == 1`) is orphaned — deleted or replaced by a redefine —
+    /// and is dropped. A body still shared by one or more live definitions has
+    /// a higher count and is kept. Run only at quiescent points (after a
+    /// definition, deletion, or dependency rebuild), where no transient body
+    /// clones are in flight; deferred during bulk operations like the rest of
+    /// the content-store maintenance.
+    pub(crate) fn gc_body_store(&mut self) {
+        if self.defer_identity_recompute {
+            return;
+        }
+        self.body_store
+            .retain(|_, body| std::sync::Arc::strong_count(body) > 1);
+    }
+
     fn build_word_shape(&self, def: &WordDefinition, user_set: &HashSet<String>) -> Vec<Atom> {
         let mut atoms = Vec::new();
         for line in def.lines.iter() {
@@ -280,6 +296,11 @@ impl Interpreter {
     /// Recompute content identities for every user word (Section 8.6). Cheap
     /// enough to run after any change to the user-word graph.
     pub(crate) fn recompute_word_identities(&mut self) {
+        // Deferred during bulk operations; the batch recomputes once at the end.
+        if self.defer_identity_recompute {
+            return;
+        }
+
         // 1. Snapshot all user words: (fully-qualified name, dictionary, def).
         let mut words: Vec<(String, String, Arc<WordDefinition>)> = Vec::new();
         for (dict_name, dict) in &self.user_dictionaries {

--- a/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
@@ -561,6 +561,25 @@ impl AjisaiInterpreter {
         let words: Vec<UserWordData> = serde_wasm_bindgen::from_value(words_js)
             .map_err(|e| format!("Failed to deserialize words: {}", e))?;
 
+        // Defer per-word identity recomputation during the bulk restore and
+        // recompute once below via rebuild_dependencies. This turns O(N^2)
+        // identity hashing on import into O(N). The flag is always cleared,
+        // even on error, so later interactive definitions recompute normally.
+        self.interpreter.defer_identity_recompute = true;
+        let restore_result = self.define_restored_words(words);
+        self.interpreter.defer_identity_recompute = false;
+        restore_result?;
+
+        self.interpreter
+            .rebuild_dependencies()
+            .map_err(|e| e.to_string())?;
+
+        let _ = self.interpreter.collect_output();
+
+        Ok(())
+    }
+
+    fn define_restored_words(&mut self, words: Vec<UserWordData>) -> Result<(), String> {
         for word in words {
             self.interpreter.active_user_dictionary = word
                 .dictionary
@@ -578,13 +597,6 @@ impl AjisaiInterpreter {
             interpreter::execute_def::op_def_inner(&mut self.interpreter, &word.name, &tokens)
                 .map_err(|e| format!("Failed to restore word {}: {}", word.name, e))?;
         }
-
-        self.interpreter
-            .rebuild_dependencies()
-            .map_err(|e| e.to_string())?;
-
-        let _ = self.interpreter.collect_output();
-
         Ok(())
     }
 }


### PR DESCRIPTION
#1 Identity recompute on import was O(N^2): restore_user_words calls op_def_inner per word, each recomputing all identities, then rebuild recomputed again. Add a defer_identity_recompute flag; the bulk restore defers per-word recomputation and recomputes once via rebuild_dependencies (O(N)). The flag is always cleared, even on error.

#2 The body content store never reclaimed orphaned bodies, growing unboundedly across edits/deletes. Add gc_body_store(): an entry whose only strong reference is the store itself is dropped; bodies still shared by a live definition are kept. Run at quiescent points (after DEF, DEL, and dependency rebuild) and deferred during bulk operations.

Tests: deferred recompute correctness; body-store GC reclaims orphans and keeps shared bodies.

## Summary

<!-- Describe the change and intent. -->

## Quality Classification

- Highest impacted level: <!-- QL-A / QL-B / QL-C / QL-D -->

## Traceability

- Requirement(s): <!-- e.g., AQ-REQ-00X -->
- Verification evidence: <!-- tests, CI jobs, checklists -->

## Quality Checklist

- [ ] Relevant requirements/objectives are identified.
- [ ] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [ ] `cargo test --all-targets --verbose` (in `rust/`)
- [ ] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [ ] MC/DC-like checklist reviewed for modified boolean logic
- [ ] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.
