### PR TITLE
Stabilize content identity for free symbols

### DIFF
--- a/rust/src/interpreter/dictionary_operation_tests.rs
+++ b/rust/src/interpreter/dictionary_operation_tests.rs
@@ -163,6 +163,38 @@ mod tests {
         assert_eq!(first, second, "recursive identity must be reproducible");
     }
 
+    /// Section 8.6: adding a later word with the same spelling as a formerly
+    /// unresolved reference must not recapture the existing body or change its
+    /// content identity. Dependencies are fixed at definition time.
+    #[tokio::test]
+    async fn test_unresolved_reference_identity_is_not_recaptured() {
+        let mut interp = Interpreter::new();
+        interp.active_user_dictionary = "A".to_string();
+        interp.execute("{ MISSING } 'CALLER' DEF").await.unwrap();
+        let before = interp
+            .word_identity("A@CALLER")
+            .cloned()
+            .expect("identity should be computed for caller");
+
+        interp.execute("{ [ 1 ] } 'MISSING' DEF").await.unwrap();
+
+        let after = interp
+            .word_identity("A@CALLER")
+            .cloned()
+            .expect("identity should remain computed for caller");
+        assert_eq!(
+            before, after,
+            "a later definition must not recapture a previously free symbol"
+        );
+        assert!(
+            !interp
+                .dependents
+                .get("A@MISSING")
+                .is_some_and(|deps| deps.contains("A@CALLER")),
+            "the existing caller must not become dependent on the later word"
+        );
+    }
+
     /// Section 8.6 content store: textually identical bodies defined under
     /// different names/dictionaries share a single stored body in memory rather
     /// than being duplicated.
@@ -224,7 +256,11 @@ mod tests {
         // Identical body in another dictionary shares one store entry.
         interp.active_user_dictionary = "B".to_string();
         interp.execute("{ [ 1 ] } 'Y' DEF").await.unwrap();
-        assert_eq!(interp.body_store.len(), 1, "identical bodies share one entry");
+        assert_eq!(
+            interp.body_store.len(),
+            1,
+            "identical bodies share one entry"
+        );
 
         // Redefining A@X keeps [1] (still used by B@Y) and adds [9].
         interp.active_user_dictionary = "A".to_string();

--- a/rust/src/interpreter/word_identity.rs
+++ b/rust/src/interpreter/word_identity.rs
@@ -257,14 +257,24 @@ impl Interpreter {
                         let canon = canonicalize_core_word_name(s);
                         match self.resolve_word_entry_readonly(&canon) {
                             Some((resolved, rdef)) => {
-                                if user_set.contains(&resolved) {
-                                    // A user-word dependency: encoded by identity.
+                                if def.dependencies.contains(&resolved) {
+                                    // A user-word dependency fixed at definition time:
+                                    // encode the recorded target rather than treating a
+                                    // later same-named word as a fresh capture.
                                     Atom::Ref(resolved)
                                 } else if rdef.is_builtin {
                                     // Core / module word: stable global vocabulary,
                                     // encoded by its canonical resolved name.
                                     let mut b = vec![b'G'];
                                     b.extend_from_slice(resolved.as_bytes());
+                                    Atom::Raw(b)
+                                } else if user_set.contains(&resolved) {
+                                    // A user word not recorded in this definition's
+                                    // dependency set was not resolved when the word was
+                                    // authored. Keep it as a free symbol so adding an
+                                    // unrelated word cannot recapture existing content.
+                                    let mut b = vec![b'F'];
+                                    b.extend_from_slice(canon.as_bytes());
                                     Atom::Raw(b)
                                 } else {
                                     Atom::Ref(resolved)


### PR DESCRIPTION
### Motivation
- Prevent later same-named user words from changing the content identity of previously defined bodies that referenced them as unresolved/free symbols, in accordance with Section 8.6 (dependencies fixed at definition time).

### Description
- Prefer the dependencies recorded at definition time when serializing a word body by checking `def.dependencies` in `build_word_shape` (`rust/src/interpreter/word_identity.rs`) so recorded user-word targets are encoded by identity rather than recaptured by later names.
- Treat a user word that exists in the environment but was not recorded in the defining word's `dependencies` as a free symbol and encode it as a free/canonical symbol (`F`) to avoid recapture.
- Add a regression test `test_unresolved_reference_identity_is_not_recaptured` in `rust/src/interpreter/dictionary_operation_tests.rs` that defines a caller with an unresolved symbol, later defines that symbol, and asserts the caller's identity and dependency graph remain unchanged.

### Testing
- Ran `git diff --check` which completed without issues.
- Ran `cargo test --manifest-path rust/Cargo.toml dictionary_operation_tests` and observed the suite succeed with all tests passing (`29 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc0036a648326b5296cd33f90e579)