### PR TITLE
docs(reference): document the dictionary / word-identity mechanism

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -243,6 +243,12 @@
 
         .ref-article p { margin: 0.5rem 0; }
 
+        .ref-article ol.ref-list {
+            margin: 0.5rem 0;
+            padding-left: 1.5rem;
+        }
+        .ref-article ol.ref-list li { margin: 0.25rem 0; }
+
         .ref-article code {
             font-family: var(--font-stack-mono);
             font-size: 0.9em;
@@ -1711,7 +1717,54 @@ COND</code></td>
                     </div>
                     <h3>Managing words</h3>
                     <p><code>DEL</code> deletes a user word by quoted name. Dependencies are tracked: redefining or deleting a word that other words depend on requires the force modifier <code>FORC</code> (<code>!</code>). Built-in words can never be redefined or deleted. <code>LOOKUP</code> (<code>?</code>) shows the definition of a word — for a user word it returns the original source for editing.</p>
-                    <p class="ref-note">Word names are case-insensitive (<code>add10</code> and <code>ADD10</code> are the same word) and conventionally follow an action-object style such as <code>APPLY-GAIN</code>.</p>
+                    <p class="ref-note">Word names are case-insensitive (<code>add10</code> and <code>ADD10</code> are the same word) and conventionally follow an action-object style such as <code>APPLY-GAIN</code>. How a name is matched to a definition is the subject of <a href="#dictionaries">Dictionaries and Word Identity</a>.</p>
+                </section>
+
+                <section id="dictionaries" class="ref-page">
+                    <h2>Dictionaries and Word Identity</h2>
+                    <p>User words live in a <strong>dictionary</strong>. The words you define in the Playground go into the bundled <code>EXAMPLE</code> dictionary, and an imported word group forms its own dictionary named after the group. A dictionary is simply a map from names to definitions; the same name may exist in more than one dictionary at once.</p>
+
+                    <h3>Qualified names</h3>
+                    <p>A bare name like <code>ADD10</code> is resolved for you (see below), but you can always name a word unambiguously by qualifying it with its dictionary: <code>DICT@WORD</code>. The qualified form bypasses resolution and points straight at one dictionary's entry.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>{ [ 10 ] + } 'ADD10' DEF
+5 EXAMPLE@ADD10</code></td>
+                                    <td><code>[ 15/1 ]</code></td>
+                                    <td class="notes">A word you define lives in <code>EXAMPLE</code>, so <code>EXAMPLE@ADD10</code> names the same word as the bare <code>ADD10</code>.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+
+                    <h3>Words are identified by content</h3>
+                    <p>Ajisai is <strong>content-addressed</strong>: a user word's identity is computed from its content — its normalized body together with the identities of the words it calls — not from its name. Renaming a word, or defining an identical body in another dictionary, produces the very same identity, while changing the body produces a new one. A word's name is a label for an identity, not the word itself.</p>
+                    <p>Two consequences follow directly. Defining the same body twice does not store it twice — identical definitions share one identity and deduplicate. And because each word's dependencies are pinned to the <em>identities</em> they referenced at definition time, adding a core word, importing a module, or loading another dictionary later can never silently recapture an existing reference.</p>
+
+                    <h3>Resolving a bare name</h3>
+                    <p>A bare name is looked up in a fixed order, and the first match wins:</p>
+                    <ol class="ref-list">
+                        <li>Core words (the built-ins) — they are never shadowed by anything you define.</li>
+                        <li>Words from modules you have imported.</li>
+                        <li>The dictionary that the currently running word belongs to (so an imported group calls its own words).</li>
+                        <li>Any other user dictionary.</li>
+                    </ol>
+                    <p>The last step is where a name can match several dictionaries at once, and here the content-addressed model decides the outcome. If every match is the <em>same word</em> — the matches share one content identity — the bare name resolves to it, exactly as before. If the matches are <em>different words</em> — they carry distinct identities — the bare name is <strong>ambiguous</strong> and does not resolve; Ajisai reports the conflict and asks you to qualify it:</p>
+                    <p class="ref-note">For example, if a <code>GREET</code> with one body exists in <code>EXAMPLE</code> and a different <code>GREET</code> exists in an imported <code>AUDIOLIB</code>, calling the bare <code>GREET</code> raises <code>Ambiguous word 'GREET': found in EXAMPLE@GREET, AUDIOLIB@GREET. Use a qualified path to specify which one you mean.</code> Writing <code>EXAMPLE@GREET</code> or <code>AUDIOLIB@GREET</code> resolves it. Ambiguity is about a difference in <em>content</em>, not merely a shared name — two dictionaries holding the identical word are not in conflict.</p>
+
+                    <h3>Importing word groups</h3>
+                    <p>You can export a word group, edit the file, rename it, and import it again. Import is a <strong>merge by identity</strong>, never a destructive overwrite. Identical definitions deduplicate automatically, so re-importing an unchanged group is a no-op. If you edited a word and import it under a name that already exists, the name is re-pointed to the new identity while the previous identity stays in place — any words that referenced the old version remain pinned to it, so nothing breaks. The bundled <code>EXAMPLE</code> dictionary is treated exactly like any other in this respect; there is no special name to protect.</p>
+                    <p class="ref-note">Because identity is content-addressed, an imported group behaves identically in every environment, regardless of which other dictionaries or modules happen to be loaded.</p>
                 </section>
 
                 <section id="modules" class="ref-page">
@@ -1860,6 +1913,7 @@ COND</code></td>
                     <li><a href="#cond">Conditionals</a></li>
                     <li><a href="#strings">Strings</a></li>
                     <li><a href="#define">Defining Words</a></li>
+                    <li><a href="#dictionaries">Dictionaries and Word Identity</a></li>
                     <li><a href="#modules">Modules</a></li>
                     <li><a href="#pipeline">Pipelines</a></li>
                     <li><a href="#output">Output</a></li>


### PR DESCRIPTION
Adds a thorough Reference section documenting the dictionary mechanism shipped in #1113 (content-addressed user-word resolution).

## What's added
A new **"Dictionaries and Word Identity"** section in `public/docs/index.html`, placed between *Defining Words* and *Modules*, covering:
- **Qualified names** (`DICT@WORD`) — with a runnable Playground sample (`EXAMPLE@ADD10`).
- **Words are identified by content** — identity derived from content, not name; identical bodies deduplicate; references pinned to identities.
- **Resolving a bare name** — the fixed lookup order (Core → imported modules → owning dictionary → other user dictionaries) and the rule that same-content matches resolve while distinct-content matches are *ambiguous* (with the actual error text and the `DICT@WORD` fix).
- **Importing word groups** — non-destructive merge by identity; re-import dedups; editing then re-importing coexists; no special-casing of `EXAMPLE`.

Also adds the section to the index nav and a small ordered-list style.

## Terminology
Per the request, this deliberately avoids **"content-first"**, which would collide with Ajisai's core **AI-first** concept (the intro already uses "AI-first"). It uses **"content-addressed" / "identified by content"** instead — the vocabulary already established in `SPECIFICATION.html` §8.6 — keeping the Reference and the canonical spec consistent.

## Verification
- HTML tag balance and nav/section parity checked (17 sections / 17 nav items / 17 `ref-page`s).
- The page's pagination JS is generic (`querySelectorAll('.ref-page')` + nav links), so the new section integrates with no JS change.
- `npm run provenance:check` clean (reference docs are presentation-layer, not in the tracked canonical set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEYRs4PcAoRnUgtZcoGwyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEYRs4PcAoRnUgtZcoGwyx)_