### PR TITLE
feat: style ref-tagline as version badge on reference page

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -152,8 +152,14 @@
         }
 
         .ref-tagline {
-            font-size: 0.875rem;
-            color: var(--color-text-light);
+            display: inline-block;
+            font-size: 0.75rem;
+            color: oklch(100% 0 0);
+            background: oklch(51.1% 0.091 295.7);
+            border: 1px solid oklch(51.1% 0.091 295.7);
+            border-radius: 6px;
+            padding: 0.125rem 0.5rem;
+            line-height: 1.5;
         }
 
         .header-actions {


### PR DESCRIPTION
## Summary

リファレンスページの「Reference」タグライン（`.ref-tagline`）にバージョンバッジと同じスタイルを適用します。

- 白文字・`--color-primary`（紫陽花パープル）背景
- `border-radius: 6px`
- アプリ本体の `.version` バッジと視覚的に統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg4PBCdV1jSs1E6zD7WuY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lg4PBCdV1jSs1E6zD7WuY1)_