### PR TITLE
docs(d1): mark scalar fast-path handoff as implemented

### DIFF
--- a/docs/dev/handoff-d1-scalar-fastpath.md
+++ b/docs/dev/handoff-d1-scalar-fastpath.md
@@ -1,6 +1,16 @@
 # Handoff: D1 — scalar–scalar arithmetic fast path (bypass the tensor wrapper)
 
-Status: **not implemented**. This is a handoff spec for whoever picks up D1.
+Status: **implemented and landed**. The completed work is documented in
+`scalar-fastpath-d1.md`; this file is retained as the original handoff spec and
+as the record of the invariants the implementation had to preserve. The fast
+path is guarded by `Interpreter::set_scalar_fastpath_enabled(bool)` /
+`AJISAI_NO_SCALAR_FASTPATH`, covers `+ - * /` and `< <= > >= = !=` for bare
+scalars and same-shape singleton tensor/vector operands in `StackTop` mode
+(`Consume` and `Keep`), and is pinned by the ON/OFF differential suite in
+`rust/src/interpreter/scalar_fastpath_tests.rs`. Measured win on the
+`tail_call_bench` countdown: **~1.19x** (8426.7 → 7081.7 ns/iter; 2,004,000
+fast-path hits ON, 0 OFF).
+
 It is a *value-model* optimization adjacent to the arithmetic kernel, not a
 change to the exact-arithmetic algorithms. The canonical language definition is
 `SPECIFICATION.html`; D1 must not change any observable result.


### PR DESCRIPTION
## Summary

The D1 scalar–scalar fast path that Codex was iterating on **already landed** in `main` (final squash merge of PR #1179). I verified the full implementation end-to-end and found that the one genuinely dangling artifact was the handoff spec itself: `docs/dev/handoff-d1-scalar-fastpath.md` still read **"Status: not implemented"**, which makes the work look pending to anyone reading the repo. This PR fixes that stale status.

## What I verified (no code changes needed — it was already correct)

- **Arithmetic + comparison fast paths** present and guarded by `Interpreter::set_scalar_fastpath_enabled(bool)` / `AJISAI_NO_SCALAR_FASTPATH`, with a `scalar_fastpath_count` metric.
- **Differential tests** (`rust/src/interpreter/scalar_fastpath_tests.rs`) — ON vs OFF identical stack value + rendered form + hint across bare scalar, singleton tensor, singleton vector, mixed/Text/NIL fallback, division-by-zero, and KEEP mode. All 8 pass.
- **Benchmark reproduces**: `cargo run --release --example tail_call_bench` → D1 toggle gives **~1.19x** (8426.7 → 7081.7 ns/iter), 2,004,000 fast-path hits ON / 0 OFF.
- **Design note** `docs/dev/scalar-fastpath-d1.md` already documents the work; `provenance:check` is green (docs/ is outside the attested surface, so this doc-only change needs no re-attestation).

## Change

Single doc edit: flip the handoff status from "not implemented" to "implemented and landed", cross-link the design note, and record the verified benchmark numbers and invariant coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLRwPdMfjXKCrA7ABLVvCi)_