### PR TITLE
Witness Minimal Core derivability of MATH@SIGN (Minimal Core step 3)

### DIFF
--- a/docs/dev/ajisai-minimal-core-identity.md
+++ b/docs/dev/ajisai-minimal-core-identity.md
@@ -175,7 +175,20 @@ NIL を受ければ Core の Bubble パススルーに従って NIL を透過し
    と明記——契約は既存 §7.4 で決着済みのため裁定は追認にとどめた。既存の三つの "Core"
    語義(§9.3 Core Words 階層・Core Profile・§7.14 Coreword)との区別、および「新しい
    権威層・実行特権を作らない」ことも明記(self-hosting memo の非目標を引き継ぐ)。
-3. **セルフホスト 1 語実証.** 素材の派生語を 1 つ選び、Core だけを使って Ajisai prelude
-   で再定義し、既存 conformance suite（`core-*`）が緑のままであることを確認する。
+3. **導出可能性の実証 — ✅ 実装済み（当初案は §8.2 により再構成）.**
+   当初の「Ajisai prelude でビルトインを再定義して差し替える」案は **§8.2「ビルトイン語は
+   再定義できない」により不可**。真のセルフホストは独立した別インタプリタ（Python 移植と
+   同格）を意味し、1 語差し替えでは実現しない。代わりに **導出可能性の witness** を採った：
+   素材語 `MATH@SIGN` を Minimal Core の語だけ（`NIL?` `LT` `GT` `COND` `IDLE` とリテラル）で
+   User 語 `SIGN2` として再実装し、有理数域と NIL で両者が一致することを法則テスト
+   （`rust/tests/minimal_core_derivation.rs`, proptest 128 例＋スポット＋NIL）で示した。
+   これは trusted Rust core を縮めるのではなく、**Minimal Core の導出力を裏付ける証拠**。
+   加えて witness は**オラクルとしての発見**を surface した：`SIGN2` は遅延無理数 `2 SQRT` を
+   正しく `1` と符号付けする一方、ビルトイン `MATH@SIGN` は `apply_unary`（有理数限定）の
+   ため同入力を `SIGN: expected a number` で拒否する。派生語は現行ビルトインの**全域拡張**で
+   あり、これは Python 移植が SPEC_GAPS を炙り出したのと同じ機序（`MATH@MIN`/`MAX` は
+   全数域を扱うのに `MATH@SIGN` だけが有理数限定、という §7.4/§7.4.3 との不整合）。この
+   ギャップの是正（`MATH@SIGN` を全数域対応にし、未決時の U 挙動を §7.4.3 に追記するか）は
+   本 witness の範囲外の別課題として記録する。
 4. **移行の計測.** `primitive-test-map` / `word-manifest` から「Core だけで書ける素材語」を
    静的判定し、trusted Rust core 行数をファイルサイズ予算と同じ発想で予算化する。

--- a/rust/tests/minimal_core_derivation.rs
+++ b/rust/tests/minimal_core_derivation.rs
@@ -1,0 +1,164 @@
+//! Minimal Core derivability witness (SPECIFICATION.html §2.6).
+//!
+//! §2.6 declares the *Ajisai Minimal Core* — the `identity` and `flow`
+//! `core_tier`s of `docs/formalization-coverage.json` — and states that the
+//! `material` tier is derivable library that stays bound by the Minimal Core's
+//! propagation disciplines. This file is an executable *witness* of that
+//! derivability claim for one material word: it re-implements the `material`
+//! word `MATH@SIGN` (tier `material`, derived from `algebra.exact-real.budgeted-order`
+//! and `algebra.k3.domain`) as the user word `SIGN2`, written using **only**
+//! Minimal Core words, and asserts the two agree over `MATH@SIGN`'s domain.
+//!
+//! `SIGN2` uses exactly these words, all Minimal Core:
+//!   - `NIL?`   — identity tier (Bubble/NIL observation, §7.15)
+//!   - `LT` `GT`— identity tier (budgeted comparison producing a TruthValue, §7.4)
+//!   - `COND` `IDLE` — flow tier (state-transformer composition/identity, §7.7)
+//!   - `NIL` and numeric literals — identity / sugar
+//! No `material`-tier word (no arithmetic, no vector word, no module word)
+//! appears in the definition, so a green run witnesses that `MATH@SIGN`'s
+//! observable contract is reconstructible from the Minimal Core alone.
+//!
+//! Scope. The equivalence is asserted over `MATH@SIGN`'s actual domain: the
+//! admitted *rational* values (§4.2.7) and NIL. It is deliberately not asserted
+//! over lazy irrationals, because the two diverge there — and that divergence is
+//! itself a finding this witness surfaced, recorded in
+//! `minimal_core_sign_extends_builtin_note` below: the derived `SIGN2` correctly
+//! signs `2 SQRT` (→ `1`) via Core comparison's admitted-domain totality (§7.4),
+//! whereas the built-in `MATH@SIGN` rejects the lazy operand with
+//! `SIGN: expected a number`. The Minimal Core derivation is thus a *total
+//! extension* of the current built-in, in the same way the Python port surfaced
+//! specification gaps — the derivation acts as an oracle for the material word.
+
+use ajisai_core::interpreter::Interpreter;
+use proptest::prelude::*;
+
+/// Run an Ajisai program and render the whole final stack, the same observation
+/// the conformance runner and `algebraic_laws.rs` use. Panics on execution error.
+fn eval(src: &str) -> String {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio current-thread runtime");
+    rt.block_on(async {
+        let mut interp = Interpreter::new();
+        interp
+            .execute(src)
+            .await
+            .unwrap_or_else(|e| panic!("program failed: {src:?}: {e}"));
+        interp
+            .get_stack()
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    })
+}
+
+/// The Minimal-Core-only definition of `SIGN2`. Multi-line body: each newline is
+/// a statement separator (§3.4), so the `|`-style COND clauses are one per line
+/// (§7.7.1).
+const SIGN2_DEF: &str = "{
+{ NIL? | NIL }
+{ 0 LT | -1 }
+{ 0 GT | 1 }
+{ IDLE | 0 }
+COND
+} 'SIGN2' DEF
+";
+
+/// Derived side: define `SIGN2` from the Minimal Core, then apply it to `x`.
+fn derived(x: &str) -> String {
+    eval(&format!("{SIGN2_DEF}{x} SIGN2"))
+}
+
+/// Built-in side: the `material` word under witness.
+fn builtin(x: &str) -> String {
+    eval(&format!("'math' IMPORT {x} MATH@SIGN"))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Over the rational domain, the Minimal-Core `SIGN2` reproduces `MATH@SIGN`
+    /// exactly. `num`/`den` covers integers (den=1), proper fractions, both
+    /// signs, and zero (num=0). The input value is *constructed* with `/`
+    /// (division builds the operand); `SIGN2` itself uses no arithmetic.
+    #[test]
+    fn minimal_core_sign_matches_builtin_over_rationals(
+        num in -50i64..=50,
+        den in 1i64..=50,
+    ) {
+        let x = format!("{num} {den} /");
+        let d = derived(&x);
+        let b = builtin(&x);
+        prop_assert_eq!(
+            &d, &b,
+            "SIGN2 (Minimal Core) and MATH@SIGN disagree on {}/{}: derived={}, builtin={}",
+            num, den, d, b
+        );
+    }
+}
+
+/// NIL propagation: both the derived word and the built-in pass a NIL operand
+/// through to NIL. `SIGN2` inherits this from the `NIL?` guard plus COND's
+/// non-firing on the remaining guards, matching `MATH@SIGN`'s NIL-passthrough.
+#[test]
+fn minimal_core_sign_matches_builtin_on_nil() {
+    let x = "1 0 /"; // divisionByZero → NIL
+    assert_eq!(
+        derived(x),
+        builtin(x),
+        "SIGN2 and MATH@SIGN disagree on NIL"
+    );
+    assert_eq!(derived(x), "NIL");
+}
+
+/// Decided-value spot checks, independent of the generator, pinning the three
+/// signs on both rational integers and rational fractions.
+#[test]
+fn minimal_core_sign_decided_spot_checks() {
+    for (x, want) in [
+        ("7", "1/1"),
+        ("-7", "-1/1"),
+        ("0", "0/1"),
+        ("3 4 /", "1/1"),
+        ("-3 4 /", "-1/1"),
+        ("0 4 /", "0/1"),
+    ] {
+        assert_eq!(derived(x), want, "SIGN2({x})");
+        assert_eq!(builtin(x), want, "MATH@SIGN({x})");
+    }
+}
+
+/// Oracle finding (documented, not a divergence in the witness above). The
+/// Minimal-Core `SIGN2` is a *total extension* of the current built-in: it signs
+/// the lazy irrational `2 SQRT` as `1` through Core comparison's admitted-domain
+/// totality (§7.4), while the built-in `MATH@SIGN` rejects the same operand.
+/// This test pins the current, divergent behavior so that a later fix to
+/// `MATH@SIGN` (making it accept the full numeric domain like `MATH@MIN`/`MAX`)
+/// will flip the built-in branch and flag this note for update.
+#[test]
+fn minimal_core_sign_extends_builtin_note() {
+    // Derived side handles the lazy irrational and reports the correct sign.
+    // `2 SQRT` needs the math module in scope to construct the operand; `SIGN2`
+    // itself still uses only Minimal Core words.
+    let derived_sqrt = eval(&format!("'math' IMPORT {SIGN2_DEF}2 SQRT SIGN2"));
+    assert_eq!(derived_sqrt, "1/1", "SIGN2 should sign 2 SQRT as +1");
+
+    // Built-in side currently errors on the same input. Encode that as an
+    // observed error rather than a value, so the note is self-verifying.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("tokio current-thread runtime");
+    let builtin_errs = rt.block_on(async {
+        let mut interp = Interpreter::new();
+        interp
+            .execute("'math' IMPORT 2 SQRT MATH@SIGN")
+            .await
+            .is_err()
+    });
+    assert!(
+        builtin_errs,
+        "MATH@SIGN now accepts 2 SQRT; the Minimal Core derivation is no longer a \
+         strict extension — update §2.6 witness note in this file"
+    );
+}


### PR DESCRIPTION
## 背景

Minimal Core 手順3(選択肢A: 導出可能性の実証)。当初案「Ajisai prelude でビルトインを再定義して差し替え」は **§8.2「ビルトイン語は再定義できない」により実行不能**と判明したため、代わりに**導出可能性の witness**(User語による等価再実装＋テスト)を採った。

## この PR がすること

`rust/tests/minimal_core_derivation.rs` を追加:

- 素材語 `MATH@SIGN`(tier `material`, `budgeted-order`+`k3.domain` 由来)を、**Minimal Core の語だけ**で User語 `SIGN2` として再実装:
  ```
  { { NIL? | NIL } { 0 LT | -1 } { 0 GT | 1 } { IDLE | 0 } COND } 'SIGN2' DEF
  ```
  使用語は `NIL?`/`LT`/`GT`(identity)・`COND`/`IDLE`(flow)・リテラルのみ。**素材語(算術・ベクトル・モジュール語)を一切使わない**。
- `SIGN2` ≡ `MATH@SIGN` を `MATH@SIGN` の定義域で検証:
  - proptest 128 例(有理数 `num/den`、整数・分数・両符号・ゼロ)
  - スポット確認(±整数・±分数・ゼロ)
  - NIL パススルー(`1 0 /` → NIL)
- 緑の実行が、素材語の可観測契約が **Minimal Core(identity+flow)だけから再構成可能**であることを witness する(§2.6 の裏付け)。

## オラクルとしての発見(重要)

witness は副産物として、Python 移植が SPEC_GAPS を炙り出したのと同じ機序で**ビルトインの不整合**を surface した(`minimal_core_sign_extends_builtin_note` で固定):

- 派生 `SIGN2` は遅延無理数 `2 SQRT` を正しく `1` と符号付けする(Core 比較の域D全域性, §7.4)。
- 一方ビルトイン `MATH@SIGN` は同入力を **`SIGN: expected a number` で拒否**する。原因は `op_sign` が `apply_unary`(有理数 `Fraction` 限定)で実装されているため。
- 対照的に `MATH@MIN`/`MAX` は `apply_selecting` で「遅延連分数を含む全数域」を扱うと明記(§7.4.3)。**`MATH@SIGN` だけが有理数限定**で、文書契約「Sign of a number」とも §7.4 とも不整合。
- したがって派生語は現行ビルトインの**全域拡張**。

このギャップの是正(`MATH@SIGN` を全数域対応にし、未決時の U 挙動を §7.4.3 に規定するか)は **本 witness の範囲外の別課題**として記録。テストは現行の分岐挙動を固定しており、将来ビルトインが修正されればこのノートが更新を促す。

## スコープ / トレードオフ

- これは **trusted Rust core を縮小しない** — Minimal Core の*導出力の証拠*であって実装削減ではない(実装削減には §8 に self-host prelude 機構を新設する選択肢Bが必要)。
- 変更はテスト新規追加のみ。製品挙動は不変。`rust/tests` は provenance 追跡対象外のため再attest不要。

## 検証

- `cargo test --test minimal_core_derivation` → 4 tests pass(proptest 128 例含む)✅
- `rustfmt --check`(当該ファイル)clean ✅
- `check:file-size` 0 violations ✅

## 次

`MATH@SIGN` 全域化ギャップの扱い(修正するか、有理数限定を契約として明文化するか)は要判断。手順4(移行の計測)は選択肢B採用時に意味を持つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeFsRCndiGDREbHh8Z5DQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeFsRCndiGDREbHh8Z5DQQ)_