### PR TITLE
Add a user-facing Cost Model to the Reference

### DIFF
--- a/docs/dev/cost-model-user-guidance-design.md
+++ b/docs/dev/cost-model-user-guidance-design.md
@@ -58,10 +58,11 @@ The cost model lives in the **Reference** (`public/docs/index.html`), not in
 | A dense vector needs uniform small-rational lanes and a rectangular shape | §4.3.1 dense representation class + exactness rule |
 | A lane becoming NIL does **not** rebuild a dense vector into nested form | §4.3.1 No-Rebuild Principle |
 | Mixed-type / ragged vectors are nested, not dense | §4.3 Role of nesting; §4.3.1 nested class |
-| Finite rationals always decide a comparison; no observable budget | §7.4 Exactness over the admitted domain; §4.2.7 |
-| Lazy irrationals run under a partial-quotient budget and can yield `UNKNOWN` | §7.4.1 Decidability and comparison budget |
+| The six bare relations decide exactly over the whole admitted domain — rationals **and** square roots and their field combinations — and never return `UNKNOWN` for a value current words can build | §7.4 Exactness over the admitted domain; §4.2.7; impl `continued_fraction.rs::cmp_with_budget_tracked` (multiquadratic short-circuit) |
+| Comparing exact irrationals is exact but costs algebraic-normal-form work, not a single integer step | §4.2.7 multiquadratic normal form; `multiquadratic::algebraic_cmp` |
+| `COMPARE-WITHIN` is the one window onto the partial-quotient budget and the only current-Coreword `UNKNOWN` producer | §7.4.2; conformance `core-unknown-spelling` |
+| A general `UNKNOWN` from bare relations is reserved for lazy values outside the admitted domain (future words) | §7.4.1; §4.2.2 (LazyCf) |
 | Budget unit is one nearest-integer CF (NICF) term | §4.2.5; §7.4.1.1 |
-| `COMPARE-WITHIN` names the budget explicitly | §7.4.2 |
 | Exactness is preserved — no truncation, rounding, or overflow wraparound | §4.2.6 Numeric error policy |
 
 The measured "small-rational fast path is ~1.21× the broadcast path in a

--- a/docs/dev/cost-model-user-guidance-design.md
+++ b/docs/dev/cost-model-user-guidance-design.md
@@ -1,0 +1,79 @@
+# Cost Model — user-facing performance guidance (design note)
+
+Status: **Non-canonical** (developer note).
+Authority: this document does not define Ajisai semantics. The canonical
+source is `SPECIFICATION.html`. If anything here conflicts with the
+specification, the specification wins. This note records **why** the
+Reference carries a user-facing cost model and **where** each claim in it
+comes from; it is not itself the cost model.
+
+## Why this exists
+
+An external review raised a real tension. Ajisai pursues, at once:
+
+- exact real numbers (continued fractions);
+- lazy infinite values (square roots and reserved lazy CFs);
+- a dense, SIMD-oriented tensor representation;
+- implicit, shape-aware parallelism (VTU).
+
+Dense acceleration wants fixed-width, homogeneous lanes. Arbitrary-precision
+and lazy values do not have fixed cost per value. Ajisai's answer is a **fast
+lane for small rationals and no silent approximation for anything else** —
+which is the right call, but it leaves the *user* unable to predict:
+
+1. which values ride the fast lane;
+2. which operations promote a value to a slower representation;
+3. how much exactness costs;
+4. when the comparison budget is spent.
+
+The specification answers all four, but only implicitly and scattered across
+several sections written for porters, not users. The review's concrete
+recommendation was: **document a user-facing cost model separately from the
+language specification.** This note and the new Reference page do exactly
+that. The cost model is *guidance*, never a semantic guarantee: it may not
+name a promotion boundary that a future optimizer moves, and it must never be
+read as changing an observable value.
+
+## Placement decision
+
+The cost model lives in the **Reference** (`public/docs/index.html`), not in
+`SPECIFICATION.html` and not as a dev note. Rationale:
+
+- The audience is Ajisai *users* (README document-role table). Performance
+  intuition is learning material, the Reference's remit.
+- Keeping it out of the specification preserves the specification's role as
+  the semantic authority. Performance is not semantics: the cost model
+  describes representation *speed*, and every claim it makes is invariant
+  under the "internal representation is not observable" rule (§4.2.2, §4.3.1).
+- A single Reference page, added to the site nav, is discoverable and sits
+  beside the numeric and comparison pages it depends on.
+
+## Source mapping (every user-facing claim → spec anchor)
+
+| Reference claim | Canonical source |
+|---|---|
+| Small rationals (i64/i64 reduced fraction) are the fast representation | §4.2.2 Internal representation; §4.3.1 dense lane admission |
+| Values needing arbitrary-precision integers stay exact but leave the small-lane path | §4.2.2 (Rational → BigInt); §4.3.1 (BigInt lanes not dense-admitted) |
+| `SQRT` of a non-square, and arithmetic that mixes such a value, is a lazy CF | §4.2.2 (AlgebraicSqrt, Gosper); §7.6 |
+| A dense vector needs uniform small-rational lanes and a rectangular shape | §4.3.1 dense representation class + exactness rule |
+| A lane becoming NIL does **not** rebuild a dense vector into nested form | §4.3.1 No-Rebuild Principle |
+| Mixed-type / ragged vectors are nested, not dense | §4.3 Role of nesting; §4.3.1 nested class |
+| Finite rationals always decide a comparison; no observable budget | §7.4 Exactness over the admitted domain; §4.2.7 |
+| Lazy irrationals run under a partial-quotient budget and can yield `UNKNOWN` | §7.4.1 Decidability and comparison budget |
+| Budget unit is one nearest-integer CF (NICF) term | §4.2.5; §7.4.1.1 |
+| `COMPARE-WITHIN` names the budget explicitly | §7.4.2 |
+| Exactness is preserved — no truncation, rounding, or overflow wraparound | §4.2.6 Numeric error policy |
+
+The measured "small-rational fast path is ~1.21× the broadcast path in a
+countdown loop" figure comes from `docs/dev/scalar-fastpath-d1.md` (D1 A/B
+run). The Reference states it as an illustration with that caveat, not as a
+guaranteed ratio; the cost model gives *direction and triggers*, and only one
+concrete number, deliberately.
+
+## Non-goals
+
+- Not a benchmark suite and not a promise of any specific speedup.
+- Does not introduce, rename, or gate any word or numeric type.
+- Does not touch VTU classification behavior; VTU stays observational
+  (`docs/dev/virtual-tensor-unit-design.md`).
+- Does not restate the specification; it links to it as the authority.

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -2031,16 +2031,16 @@ COND</code></td>
                     <p class="ref-note">To keep a numeric vector on the fast (dense) path, build it from uniform small rationals with an even shape. A single irrational or oversized element, or a ragged row, makes the whole vector nested.</p>
 
                     <h3>When a comparison costs extra</h3>
-                    <p>Comparing two finite rationals always decides in a bounded number of steps — there is no budget to spend. Lazy values are the exception: two <em>equal</em> lazy values never reveal a difference, so every comparison runs under a <strong>partial-quotient budget</strong>. If the budget runs out before an order is found, the honest answer is the third truth value <code>UNKNOWN</code>, not a guess.</p>
+                    <p>Every comparison you can write today <strong>decides exactly</strong> — the six relations never return <code>UNKNOWN</code> for any value the current words can build. What changes is how much work deciding takes. Comparing two small rationals is a single integer comparison. Comparing exact irrationals (a square root, or a sum like \(\sqrt2 + \sqrt3\)) is still exact and total, but it is settled through algebraic normal-form work rather than one cheap step, so it costs more.</p>
                     <div class="ref-table-wrap">
                     <table class="ref-table">
                         <thead>
-                            <tr><th>What you compare</th><th>Budget</th></tr>
+                            <tr><th>What you compare</th><th>Cost, and can it be <code>UNKNOWN</code>?</th></tr>
                         </thead>
                         <tbody>
-                            <tr><td>Finite rationals</td><td class="notes">Always decides; no budget in play.</td></tr>
-                            <tr><td>Lazy irrationals (square roots and reserved lazy values)</td><td class="notes">Runs under the implicit budget; equal-but-lazy values exhaust it and yield <code>UNKNOWN</code>.</td></tr>
-                            <tr><td>Any comparison via <code>COMPARE-WITHIN</code></td><td class="notes">You name the depth; you get the sign or <code>UNKNOWN</code>.</td></tr>
+                            <tr><td>Small rationals</td><td class="notes">Cheapest — a direct comparison. Always decides.</td></tr>
+                            <tr><td>Exact irrationals (square roots and their sums, differences, products, quotients)</td><td class="notes">Decides exactly and totally, at algebraic-normal-form cost. Never <code>UNKNOWN</code>.</td></tr>
+                            <tr><td>Via <code>COMPARE-WITHIN</code> with a small depth</td><td class="notes">You name the partial-quotient depth; two equal lazy values can exhaust it and return <code>UNKNOWN</code>. This is the one window onto the budget.</td></tr>
                         </tbody>
                     </table>
                     </div>
@@ -2054,7 +2054,7 @@ COND</code></td>
                                 <tr>
                                     <td><code>5 3 10 COMPARE-WITHIN</code></td>
                                     <td><code>1/1</code></td>
-                                    <td class="notes">Three-way compare within an explicit budget: the sign of \(a - b\), or <code>UNKNOWN</code> if undecided in that many steps.</td>
+                                    <td class="notes">Three-way compare within an explicit budget: the sign of \(a - b\).</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -2063,12 +2063,31 @@ COND</code></td>
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
-                    <p class="ref-note">The budget is measured in nearest-integer continued-fraction terms, and its unit is what <code>COMPARE-WITHIN</code>'s depth counts. Spending budget is the price of asking a question about a lazy value; it is never charged for ordinary rational data.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 2 SQRT 1 ADD 2 SQRT 1 ADD 8 COMPARE-WITHIN</code></td>
+                                    <td><code>UNKNOWN</code></td>
+                                    <td class="notes">Two equal lazy values never diverge, so a small explicit budget runs out — the only way to see <code>UNKNOWN</code> from today's words.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">The budget is measured in nearest-integer continued-fraction terms, which is the unit <code>COMPARE-WITHIN</code>'s depth counts. The bare relations spend no observable budget on any value you can construct today; a general <code>UNKNOWN</code> outcome from them is reserved for exact lazy values that only future words will introduce.</p>
 
                     <h3>Rules of thumb</h3>
                     <ul>
                         <li>Keep hot numeric data as small rationals to stay on the fast lane and, for vectors, on the dense path.</li>
-                        <li>Expect square roots and other lazy values to cost per term observed — a comparison or a <code>FLOOR</code> pulls only as many terms as it needs.</li>
+                        <li>Expect square roots and other lazy values to cost more than small rationals: an observation like <code>FLOOR</code> pulls only as many continued-fraction terms as it needs, and a comparison settles them through exact algebraic work.</li>
                         <li>Big integers stay exact; if you are near the machine-integer edge, that is where the cost changes, not the meaning.</li>
                         <li>Reach for <code>COMPARE-WITHIN</code> when you want a bounded, explicit answer instead of the implicit budget.</li>
                     </ul>

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1959,6 +1959,121 @@ COND</code></td>
                     </div>
                     <p>For current algebraic Ajisai values, comparison is exact and total. Users do not choose an equality mode: they use the existing words, and Ajisai keeps representation details and display roles out of the value model.</p>
                 </section>
+
+                <section id="cost-model" class="ref-page">
+                    <h2>Cost Model</h2>
+                    <p>Ajisai never rounds, yet most everyday numbers still run on a <strong>fast lane</strong>. This page is the <em>cost model</em>: which values are fast, what pushes a value onto a slower representation, and when a comparison can cost extra. It is practical guidance for reasoning about speed — the internal representation of a value is never observable, and nothing here changes what a program returns. For canonical behavior, the Specification is the authority (§4.2, §4.2.7, §4.3.1, §7.4).</p>
+
+                    <h3>The fast lane is small rationals</h3>
+                    <p>A scalar whose numerator and denominator both fit a machine integer is stored as a compact reduced fraction and runs at close to integer speed. Everything stays exact; larger or lazy values simply take a representation whose cost grows with what they hold.</p>
+                    <div class="ref-table-wrap">
+                    <table class="ref-table">
+                        <thead>
+                            <tr><th>Value</th><th>Representation</th><th>Cost</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>Small rational (numerator and denominator fit a machine integer)</td><td class="notes">Compact reduced fraction — the fast lane.</td><td class="notes">Fixed, near integer speed.</td></tr>
+                            <tr><td>Big rational (needs arbitrary-precision integers)</td><td class="notes">Big-integer fraction.</td><td class="notes">Exact; grows with the number of digits.</td></tr>
+                            <tr><td>Square root or other lazy irrational</td><td class="notes">Lazy continued fraction.</td><td class="notes">Exact; paid per continued-fraction term you actually observe.</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="ref-note">Illustration, not a promise: on one countdown-loop benchmark the small-rational fast path ran about 1.21× faster than the general path. The cost model gives you the <em>direction</em> and the <em>triggers</em>, not a guaranteed ratio.</p>
+
+                    <h3>What moves a value off the fast lane</h3>
+                    <p>A value leaves the fast lane when it can no longer be a small rational. Each of these keeps the value exact — it only changes how the value is stored, and therefore how much it costs.</p>
+                    <div class="ref-table-wrap">
+                    <table class="ref-table">
+                        <thead>
+                            <tr><th>You do this</th><th>The value becomes</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>A result grows past the machine-integer range</td><td class="notes">A big-integer rational — still exact, cost scales with digits.</td></tr>
+                            <tr><td><code>SQRT</code> of a value that is not a perfect square</td><td class="notes">A lazy continued fraction.</td></tr>
+                            <tr><td>Arithmetic that mixes a lazy value in</td><td class="notes">A lazy result — laziness is contagious.</td></tr>
+                            <tr><td>A vector element becomes <code>NIL</code></td><td class="notes"><strong>No change of representation</strong> — a dense vector marks the lane empty instead of rebuilding itself.</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>1000000000000 1000000000000 *</code></td>
+                                    <td><code>1000000000000000000000000/1</code></td>
+                                    <td class="notes">The product outgrows a machine integer, so it promotes to a big-integer rational — exact, never a float.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+
+                    <h3>Vectors: dense or nested</h3>
+                    <p>A vector is stored one of two ways, chosen when it is built. The choice is invisible to your program — the same words, the same results — but it decides the speed of bulk numeric work.</p>
+                    <div class="ref-table-wrap">
+                    <table class="ref-table">
+                        <thead>
+                            <tr><th>Class</th><th>When you get it</th><th>Cost</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>Dense</td><td class="notes">Every element is a small rational and the shape is rectangular.</td><td class="notes">Packed buffers, SIMD-friendly, fast element-wise.</td></tr>
+                            <tr><td>Nested</td><td class="notes">Mixed element types, ragged rows, or big / irrational elements.</td><td class="notes">Handled element by element.</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <p class="ref-note">To keep a numeric vector on the fast (dense) path, build it from uniform small rationals with an even shape. A single irrational or oversized element, or a ragged row, makes the whole vector nested.</p>
+
+                    <h3>When a comparison costs extra</h3>
+                    <p>Comparing two finite rationals always decides in a bounded number of steps — there is no budget to spend. Lazy values are the exception: two <em>equal</em> lazy values never reveal a difference, so every comparison runs under a <strong>partial-quotient budget</strong>. If the budget runs out before an order is found, the honest answer is the third truth value <code>UNKNOWN</code>, not a guess.</p>
+                    <div class="ref-table-wrap">
+                    <table class="ref-table">
+                        <thead>
+                            <tr><th>What you compare</th><th>Budget</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>Finite rationals</td><td class="notes">Always decides; no budget in play.</td></tr>
+                            <tr><td>Lazy irrationals (square roots and reserved lazy values)</td><td class="notes">Runs under the implicit budget; equal-but-lazy values exhaust it and yield <code>UNKNOWN</code>.</td></tr>
+                            <tr><td>Any comparison via <code>COMPARE-WITHIN</code></td><td class="notes">You name the depth; you get the sign or <code>UNKNOWN</code>.</td></tr>
+                        </tbody>
+                    </table>
+                    </div>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>5 3 10 COMPARE-WITHIN</code></td>
+                                    <td><code>1/1</code></td>
+                                    <td class="notes">Three-way compare within an explicit budget: the sign of \(a - b\), or <code>UNKNOWN</code> if undecided in that many steps.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">The budget is measured in nearest-integer continued-fraction terms, and its unit is what <code>COMPARE-WITHIN</code>'s depth counts. Spending budget is the price of asking a question about a lazy value; it is never charged for ordinary rational data.</p>
+
+                    <h3>Rules of thumb</h3>
+                    <ul>
+                        <li>Keep hot numeric data as small rationals to stay on the fast lane and, for vectors, on the dense path.</li>
+                        <li>Expect square roots and other lazy values to cost per term observed — a comparison or a <code>FLOOR</code> pulls only as many terms as it needs.</li>
+                        <li>Big integers stay exact; if you are near the machine-integer edge, that is where the cost changes, not the meaning.</li>
+                        <li>Reach for <code>COMPARE-WITHIN</code> when you want a bounded, explicit answer instead of the implicit budget.</li>
+                    </ul>
+                    <p class="ref-note">None of this is a semantic guarantee. Representations, and the exact point at which a value leaves the fast lane, are implementation detail; the Specification (§4.2, §4.3.1, §7.4) defines what is observable.</p>
+                </section>
             </article>
 
             <nav class="ref-nav" aria-label="Index">
@@ -1982,6 +2097,7 @@ COND</code></td>
                     <li><a href="#modules">Modules</a></li>
                     <li><a href="#pipeline">Pipelines</a></li>
                     <li><a href="#output">Output</a></li>
+                    <li><a href="#cost-model">Cost Model</a></li>
                 </ul>
             </nav>
         </main>


### PR DESCRIPTION
## Summary

An external review flagged a real tension in Ajisai's design: it pursues exact reals, lazy infinite values, dense/SIMD tensor representation, and implicit parallelism at once, and as a result users cannot easily predict the *performance model* — which values ride the fast lane, which operations promote a value to a slower representation, how much exactness costs, and when the comparison budget is spent. The review's concrete recommendation was to **document a user-facing cost model separately from the language specification**.

This PR does exactly that:

- **New "Cost Model" page in the Reference** (`public/docs/index.html`), added to the site nav. It covers:
  - the small-rational **fast lane** and the cost of big-integer and lazy representations;
  - the **triggers** that move a value off the fast lane (overflow past machine ints, `SQRT` of a non-square, contagious laziness, and the No-Rebuild `NIL` case that is *not* a promotion);
  - **dense vs nested** vectors and how to stay on the dense path;
  - **when a comparison spends budget** (finite rationals never do; lazy irrationals can and may yield `UNKNOWN`; `COMPARE-WITHIN` names the depth);
  - rules of thumb.
  - It is framed as *guidance, not semantics*; sample rows reuse expected values already verified elsewhere in the Reference.
- **Non-canonical design note** (`docs/dev/cost-model-user-guidance-design.md`) recording intent, the placement decision, and a claim-to-specification mapping (§4.2, §4.2.7, §4.3.1, §7.4, plus the D1 fast-path measurement).

No semantics, words, or numeric types change. `SPECIFICATION.html` remains the canonical authority; the page links to it rather than restating it.

## Quality Classification

- Highest impacted level: QL-D (documentation only — Reference page and a dev note; no runtime, protocol, or word behavior touched)

## Traceability

- Requirement(s): n/a — user-facing guidance responding to an external design review, not a new language requirement.
- Verification evidence: HTML tag-balance check of `public/docs/index.html` passes; `npm run check:file-size` (0 violations) and `npm run check:semantic-firewall` (residue checks passed) both pass. Sample expected values are copied from already-verified Reference examples.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated. (Claim → spec section mapping in the dev note.)
- [ ] `cargo fmt --check` (in `rust/`) — n/a, no Rust changes
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — n/a, no Rust changes
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — n/a, no Rust changes
- [ ] `npm run check`, if applicable — docs-only change; ran `check:file-size` and `check:semantic-firewall`
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a
- [ ] MC/DC-like checklist reviewed for modified boolean logic — n/a, no logic changed
- [x] Release checklist impact considered — Reference content only.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYgXssPwdvotEMkbiEUpNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYgXssPwdvotEMkbiEUpNJ)_