### PR TITLE
Fix Reference: square-root comparisons decide exactly, not UNKNOWN

### DIFF
--- a/docs/dev/reference-sqrt-unknown-drift.md
+++ b/docs/dev/reference-sqrt-unknown-drift.md
@@ -1,0 +1,76 @@
+# Reference drift: square-root comparisons wrongly shown as UNKNOWN
+
+Status: **Non-canonical** (developer note / drift record).
+Authority: this document defines no semantics. The canonical source is
+`SPECIFICATION.html`; the conformance suite (`tests/conformance/index.html`)
+is the tie-breaker below it in the §2.5 authority order. This note records a
+corrected divergence in the **Reference** (`public/docs/index.html`), a
+Derived document.
+
+## The divergence
+
+The Reference taught, in the Comparison and the Three-Valued Logic pages,
+that an ordinary relation over square roots can return `UNKNOWN`:
+
+| Reference example (before) | Reference showed | Correct value |
+|---|---|---|
+| `'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ` | `UNKNOWN` | `TRUE` |
+| `'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ TRUE AND` | `UNKNOWN` | `TRUE` |
+
+with a concept note claiming "every comparison runs under a budget" and that
+"equal irrationals exhaust it and yield `UNKNOWN`."
+
+## Why the Reference was wrong (not the implementation)
+
+This is **not** spec/implementation drift. All three authorities above the
+Reference already agree that the value is `TRUE`:
+
+- **Specification.** §4.2.7 defines the admitted domain \(D\) — rationals,
+  `SQRT` of rationals, closed under \(+\,-\,\times\,\div\) — and §7.4
+  ("Exactness over the admitted domain") makes the six relations *total and
+  exact* over \(D\); `U` is reserved for exact lazy values outside \(D\)
+  (future words) and for `COMPARE-WITHIN`. §2.3.1.1 gives this exact program
+  as a worked example evaluating to `TRUE`.
+- **Conformance suite.** `core-sqrt2-minus-sqrt2-eq-zero`
+  (`tests/conformance/index.html`) pins `2 SQRT 2 SQRT SUB 0 EQ` → `TRUE`.
+  Its comment states the six bare relations "can no longer produce UNKNOWN"
+  over `SQRT`-built values, and names `COMPARE-WITHIN` as the current
+  `UNKNOWN` producer (`core-unknown-spelling`,
+  `core-unknown-propagation`).
+- **Implementation.** `continued_fraction.rs::cmp_with_budget_tracked`
+  short-circuits any Gosper operand through the multiquadratic normal form
+  (`multiquadratic::algebraic_cmp`) *before* spending a partial quotient, so
+  admitted-domain comparisons decide exactly. Unit tests assert
+  `2 SQRT 2 SQRT EQ` → `TRUE` and `2 SQRT 2 SQRT SUB SIGN` / `... SUB ABS`
+  → `0` (`arithmetic_operation_tests.rs`, `math_ops_tests.rs`).
+
+The Reference examples were stale — a snapshot of behavior from before the
+admitted-domain exact comparison landed. Per the §2.5 order (spec ▷ math ▷
+conformance ▷ generated ▷ Reference ▷ style ▷ impl), the Reference is the
+lowest doc surface here and simply had to be brought into line.
+
+## Resolution
+
+`public/docs/index.html`:
+
+- Comparison page: `2 SQRT 2 SQRT SUB 0 EQ` now shows `TRUE`; the note
+  explains that square roots and their field combinations compare exactly
+  with no budget. A genuine `UNKNOWN` example was added using the
+  conformance-verified `2 SQRT 1 ADD 2 SQRT 1 ADD 8 COMPARE-WITHIN`, and the
+  section note now attributes `UNKNOWN` to `COMPARE-WITHIN` and to reserved
+  future lazy values, not to the bare relations.
+- Three-Valued Logic page: the Kleene-AND propagation example now derives its
+  `UNKNOWN` from `... COMPARE-WITHIN TRUE AND` (fixture
+  `core-unknown-propagation`) instead of the sqrt relation.
+
+Every expected value now equals a conformance-suite observation.
+
+## Related
+
+- The Cost Model page and `docs/dev/cost-model-user-guidance-design.md`
+  carried the same wrong framing when first drafted and were corrected in the
+  same spirit (bare relations decide the admitted domain exactly;
+  `COMPARE-WITHIN` is the budget window).
+- Drift-handling policy: `docs/dev/spec-impl-drift-tactic.md`
+  ("observable behavior must trace to a canonical anchor; the suite breaks
+  ties").

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -884,8 +884,8 @@
                             <tbody>
                                 <tr>
                                     <td><code>'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ</code></td>
-                                    <td><code>UNKNOWN</code></td>
-                                    <td class="notes">\(\sqrt{2} - \sqrt{2}\) cannot be told apart from 0 within the comparison budget, so the honest answer is the third truth value.</td>
+                                    <td><code>TRUE</code></td>
+                                    <td class="notes">\(\sqrt{2} - \sqrt{2}\) is exactly 0. Square roots and their sums, differences, products, and quotients are compared exactly, so the six relations decide them without a budget.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -913,7 +913,26 @@
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
-                    <p class="ref-note">Comparing exact lazy values (like square roots) cannot always terminate, so every comparison runs under a budget. Equal irrationals exhaust it and yield <code>UNKNOWN</code> — a logical truth value, distinct from <code>NIL</code>.</p>
+                    <div class="sample">
+                        <div class="ref-table-wrap">
+                        <table class="ref-table">
+                            <thead>
+                                <tr><th>Sample code</th><th>Expected value</th><th>Notes</th></tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><code>'math' IMPORT 2 SQRT 1 ADD 2 SQRT 1 ADD 8 COMPARE-WITHIN</code></td>
+                                    <td><code>UNKNOWN</code></td>
+                                    <td class="notes">Two equal lazy values never diverge, so a small explicit budget runs out and returns the third truth value. <code>COMPARE-WITHIN</code> is the one word today that can produce <code>UNKNOWN</code>.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="sample-actions">
+                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
+                        </div>
+                    </div>
+                    <p class="ref-note">The six relations decide exactly over every value the current words can build — rationals and square roots alike — so they never return <code>UNKNOWN</code>. The budget lives behind <code>COMPARE-WITHIN</code>, which lets you name a partial-quotient depth and returns <code>UNKNOWN</code> — a logical truth value, distinct from <code>NIL</code> — when two lazy values do not diverge within it. A general <code>UNKNOWN</code> from the bare relations is reserved for exact lazy values that only future words will introduce.</p>
                 </section>
 
                 <section id="logic" class="ref-page">
@@ -984,9 +1003,9 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ TRUE AND</code></td>
+                                    <td><code>'math' IMPORT 2 SQRT 1 ADD 2 SQRT 1 ADD 8 COMPARE-WITHIN TRUE AND</code></td>
                                     <td><code>UNKNOWN</code></td>
-                                    <td class="notes">Unknown flows through the Kleene tables: true AND unknown is unknown.</td>
+                                    <td class="notes">A budget-exhausted <code>COMPARE-WITHIN</code> yields unknown, which flows through the Kleene tables: true AND unknown is unknown.</td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
## Summary

The Reference (`public/docs/index.html`) taught that an ordinary relation over square roots can return `UNKNOWN` — e.g. `'math' IMPORT 2 SQRT 2 SQRT SUB 0 EQ` → `UNKNOWN`, with a note claiming "every comparison runs under a budget." That contradicts the canonical specification, the conformance suite, **and** the implementation, which all agree the value is `TRUE`.

This is a stale **Reference** (Derived doc) snapshot from before admitted-domain exact comparison landed — **not** spec/implementation drift. The implementation is fully conformant:

- **Specification** §4.2.7 / §7.4: the six relations are *total and exact* over the admitted domain \(D\) (rationals, `SQRT` of rationals, closed under `+ - * /`); `UNKNOWN` is reserved for exact lazy values outside \(D\) (future words) and for `COMPARE-WITHIN`. §2.3.1.1 gives this exact program as a `TRUE` worked example.
- **Conformance** `core-sqrt2-minus-sqrt2-eq-zero` pins `2 SQRT 2 SQRT SUB 0 EQ` → `TRUE`, and names `COMPARE-WITHIN` as the current `UNKNOWN` producer (`core-unknown-spelling`, `core-unknown-propagation`).
- **Implementation** `continued_fraction.rs::cmp_with_budget_tracked` decides any admitted-domain (Gosper) operand via the multiquadratic normal form before spending a partial quotient. Unit tests assert `2 SQRT 2 SQRT EQ → TRUE` and `2 SQRT 2 SQRT SUB SIGN / SUB ABS → 0`.

Per the §2.5 authority order (spec ▷ math ▷ conformance ▷ generated ▷ Reference ▷ style ▷ impl), the Reference is the lowest doc surface here and was brought into line.

## Changes

- **Comparison page**: `2 SQRT 2 SQRT SUB 0 EQ` now shows `TRUE` with a corrected note (square roots and their field combinations compare exactly, no budget). Added a genuine `UNKNOWN` example using the conformance-verified `2 SQRT 1 ADD 2 SQRT 1 ADD 8 COMPARE-WITHIN`; the section note now attributes `UNKNOWN` to `COMPARE-WITHIN` and to reserved future lazy values, not to the bare relations.
- **Three-Valued Logic page**: the Kleene-AND propagation example derives its `UNKNOWN` from `... COMPARE-WITHIN TRUE AND` (fixture `core-unknown-propagation`) instead of the sqrt relation.
- **`docs/dev/reference-sqrt-unknown-drift.md`**: non-canonical note recording the divergence, why the implementation was already correct, and the resolution.

Every edited expected value now equals a conformance-suite observation.

## Relationship to #1270

Companion to #1270 (the Cost Model Reference page). This PR fixes the **pre-existing** Comparison/Logic pages; #1270's own new Cost Model page carried the same wrong framing when first drafted and was corrected there. The two PRs edit non-overlapping regions of `public/docs/index.html`.

## Quality Classification

- Highest impacted level: QL-D (Reference documentation only; no runtime, protocol, or word behavior changes)

## Traceability

- Requirement(s): n/a — Reference correction aligning a Derived doc with the specification and conformance suite.
- Verification evidence: expected values matched against `tests/conformance/index.html` fixtures (`core-sqrt2-minus-sqrt2-eq-zero`, `core-unknown-spelling`, `core-unknown-propagation`, `core-compare-within-gt`); HTML tag-balance check of `public/docs/index.html` passes.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated. (Drift note maps each example to its conformance fixture and spec section.)
- [ ] `cargo fmt --check` (in `rust/`) — n/a, no Rust changes
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — n/a, no Rust changes
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — n/a, no Rust changes; existing tests already assert the correct behavior
- [ ] `npm run check`, if applicable — docs-only change
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a
- [ ] MC/DC-like checklist reviewed for modified boolean logic — n/a, no logic changed
- [x] Release checklist impact considered — Reference content only.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYgXssPwdvotEMkbiEUpNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYgXssPwdvotEMkbiEUpNJ)_