### PR TITLE
Bring back the playground, on the other side of the boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,46 @@ jobs:
       - name: Core alone
         run: cargo test -p ajisai-core
 
-      # The dependency edge only ever runs package -> Core. If this fails, the
-      # package boundary has been inverted.
-      - name: Core has no package dependency
+      # The dependency edge only ever runs package -> Core, and the playground's
+      # WebAssembly binding is a host like any other. If this fails, a boundary
+      # has been inverted.
+      - name: Core has no package or host dependency
         run: |
           if cargo tree -p ajisai-core --prefix none --no-dedupe \
-               | grep -qE '^ajisai-(music|audit)'; then
-            echo "ajisai-core depends on a package"
+               | grep -qE '^ajisai-(music|audit|wasm)'; then
+            echo "ajisai-core depends on a package or a host"
             exit 1
           fi
-          echo "ajisai-core depends on no package"
+          echo "ajisai-core depends on no package and no host"
 
       - name: Vocabulary manifest is generatable
         run: cargo run -q -p ajisai-core --bin ajisai -- words > /dev/null
+
+  playground:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build the WebAssembly module
+        run: |
+          cargo build -p ajisai-wasm --target wasm32-unknown-unknown --release
+          cp target/wasm32-unknown-unknown/release/ajisai_wasm.wasm playground/ajisai.wasm
+
+      - name: Install the browser
+        working-directory: playground
+        run: |
+          npm install --no-audit --no-fund
+          npx playwright install --with-deps chromium
+
+      # The presentation rules, the WebAssembly boundary, and the real
+      # interface driven in a real browser.
+      - name: Test
+        working-directory: playground
+        run: npm test

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Playground
+
+# Builds the WebAssembly module and publishes the playground to GitHub Pages.
+# The module is a build artifact and is not committed, so this workflow is the
+# only place it is produced for deployment.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build the WebAssembly module
+        run: cargo build -p ajisai-wasm --target wasm32-unknown-unknown --release
+
+      - name: Assemble the site
+        run: |
+          mkdir -p site
+          cp playground/index.html playground/app.css playground/app.js \
+             playground/presentation.js playground/worker.js site/
+          cp target/wasm32-unknown-unknown/release/ajisai_wasm.wasm site/ajisai.wasm
+          cp CNAME site/CNAME
+          # GitHub Pages runs Jekyll unless told not to.
+          touch site/.nojekyll
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ajisai.tech

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ajisai-wasm"
+version = "1.0.0"
+dependencies = [
+ "ajisai-core",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/ajisai-core",
     "crates/ajisai-music",
     "crates/ajisai-audit",
+    "crates/ajisai-wasm",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ JSON, generated from the live registry.
 
 ## Try it
 
+**In a browser: [ajisai.tech](https://ajisai.tech)** — the playground, with the
+flow, the dictionary, and a stack that shows you which values the armed modes
+would take as operands before you run.
+
+Or on the command line:
+
 ```sh
 cargo run -p ajisai-core --bin ajisai -- eval '1 2 3 4 STAK ADD'
 cargo run -p ajisai-core --bin ajisai -- repl
@@ -128,9 +134,17 @@ SPECIFICATION.md        the language — canonical
 crates/ajisai-core/     the language: library and CLI
 crates/ajisai-music/    exact just intonation, as an external package
 crates/ajisai-audit/    content addressing and receipts, as an external package
+crates/ajisai-wasm/     a raw-ABI WebAssembly binding, for browser hosts
+playground/             the web playground — a host, not the language
 docs/                   the Semantic Plane, the ontology, contracts, migration,
                         implementation notes, and the playground specification
 ```
+
+The playground is deliberately outside the language. `docs/playground-ui.md`
+specifies it, `SPECIFICATION.md` never refers to it, and a headless
+implementation that provides none of it is fully conforming. It is built from
+five files and one WebAssembly module — no bundler, no framework, and no
+runtime dependency.
 
 Ajisai Core has three dependencies, all of them exact integer arithmetic. It has
 one execution path, no feature flag that changes what a program means, and no
@@ -147,6 +161,14 @@ cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all --check
 cargo build --workspace --release
+```
+
+The playground:
+
+```sh
+cargo build -p ajisai-wasm --target wasm32-unknown-unknown --release
+cp target/wasm32-unknown-unknown/release/ajisai_wasm.wasm playground/ajisai.wasm
+cd playground && npm install && npm test
 ```
 
 ## Coming from an earlier Ajisai

--- a/crates/ajisai-wasm/Cargo.toml
+++ b/crates/ajisai-wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ajisai-wasm"
+description = "A raw-ABI WebAssembly binding for Ajisai Core, for browser hosts."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# No wasm-bindgen, no wasm-pack, no npm. The whole interface is strings in and
+# JSON out, which a hand-written C ABI over linear memory covers in a hundred
+# lines — and that keeps `cargo build --target wasm32-unknown-unknown` the only
+# build step there is.
+[dependencies]
+ajisai-core = { path = "../ajisai-core" }

--- a/crates/ajisai-wasm/src/lib.rs
+++ b/crates/ajisai-wasm/src/lib.rs
@@ -1,0 +1,516 @@
+//! # ajisai-wasm
+//!
+//! A WebAssembly binding for Ajisai Core, for browser hosts.
+//!
+//! **This is a host, not part of the language.** Ajisai Core does not depend on
+//! this crate and does not know it exists; nothing here changes what a program
+//! means. Everything below is presentation plumbing in the sense of
+//! `SPECIFICATION.md` §14 and `docs/playground-ui.md`: it moves strings across
+//! the WebAssembly boundary and says what changed, so a user interface can
+//! decide what to show.
+//!
+//! ## Why there is no `wasm-bindgen`
+//!
+//! The whole interface is a string in and a JSON string out. That needs an
+//! allocator, a pointer, and a length — which is a hand-written C ABI over
+//! linear memory, about a hundred lines on each side. Taking `wasm-bindgen`
+//! instead would mean a proc-macro dependency, a `wasm-pack`/`wasm-bindgen-cli`
+//! build step, and a generated JavaScript shim, in exchange for ergonomics this
+//! interface does not need. `cargo build --target wasm32-unknown-unknown` is
+//! the only build step there is.
+//!
+//! ## The protocol
+//!
+//! Every call follows the same shape:
+//!
+//! 1. JS calls [`ajisai_alloc`] and writes UTF-8 source into linear memory.
+//! 2. JS calls one of the entry points with that pointer and length. The call
+//!    returns the byte length of a JSON reply.
+//! 3. JS reads that many bytes from [`ajisai_reply`] and decodes UTF-8.
+//! 4. JS calls [`ajisai_free`] on the argument buffer.
+//!
+//! The reply buffer belongs to this module and stays valid until the next call.
+
+use std::alloc::{alloc, dealloc, Layout};
+use std::cell::RefCell;
+
+use ajisai_core::lint::{self, Severity};
+use ajisai_core::{manifest, syntax, Interpreter};
+
+/// The longest rendering of one value the host will be handed.
+///
+/// `0 1000000 RANGE` is a legal program and its vector renders to megabytes of
+/// text that no panel can show. Truncating is a presentation decision and it
+/// belongs here rather than in the renderer: the value is untouched, and only
+/// the string crossing the boundary is shortened.
+const RENDER_LIMIT: usize = 4000;
+
+thread_local! {
+    static SESSION: RefCell<Interpreter> = RefCell::new(Interpreter::new());
+    static REPLY: RefCell<String> = const { RefCell::new(String::new()) };
+}
+
+// --------------------------------------------------------------- memory
+
+/// Allocate `len` bytes of linear memory for the caller to write into.
+///
+/// # Safety
+/// The caller must pass the same `len` to [`ajisai_free`], and must not use the
+/// pointer afterwards.
+#[no_mangle]
+pub unsafe extern "C" fn ajisai_alloc(len: usize) -> *mut u8 {
+    if len == 0 {
+        return std::ptr::null_mut();
+    }
+    match Layout::from_size_align(len, 1) {
+        Ok(layout) => alloc(layout),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Release a buffer from [`ajisai_alloc`].
+///
+/// # Safety
+/// `ptr` must have come from [`ajisai_alloc`] with the same `len`.
+#[no_mangle]
+pub unsafe extern "C" fn ajisai_free(ptr: *mut u8, len: usize) {
+    if ptr.is_null() || len == 0 {
+        return;
+    }
+    if let Ok(layout) = Layout::from_size_align(len, 1) {
+        dealloc(ptr, layout);
+    }
+}
+
+/// A pointer to the JSON reply from the most recent call.
+#[no_mangle]
+pub extern "C" fn ajisai_reply() -> *const u8 {
+    REPLY.with(|reply| reply.borrow().as_ptr())
+}
+
+// ------------------------------------------------------------ entry points
+
+/// Run a source fragment against the session, and describe what happened.
+///
+/// # Safety
+/// `ptr` must point to `len` bytes of UTF-8.
+#[no_mangle]
+pub unsafe extern "C" fn ajisai_execute(ptr: *const u8, len: usize) -> usize {
+    let source = read_source(ptr, len);
+    reply(SESSION.with(|session| execute_json(&mut session.borrow_mut(), &source)))
+}
+
+/// Lint a source fragment. The session is not touched.
+///
+/// # Safety
+/// `ptr` must point to `len` bytes of UTF-8.
+#[no_mangle]
+pub unsafe extern "C" fn ajisai_lint(ptr: *const u8, len: usize) -> usize {
+    let source = read_source(ptr, len);
+    reply(SESSION.with(|session| lint_json(&session.borrow(), &source)))
+}
+
+/// Render a fragment in canonical form — the formatter, over the boundary.
+///
+/// # Safety
+/// `ptr` must point to `len` bytes of UTF-8.
+#[no_mangle]
+pub unsafe extern "C" fn ajisai_format(ptr: *const u8, len: usize) -> usize {
+    let source = read_source(ptr, len);
+    reply(match syntax::parse(&source) {
+        Ok(program) => object(&[
+            ("ok", "true".to_string()),
+            ("text", quote(&syntax::render_program(&program))),
+        ]),
+        Err(error) => object(&[
+            ("ok", "false".to_string()),
+            ("error", quote(&error.to_string())),
+        ]),
+    })
+}
+
+/// Split a fragment into the steps a host can run one at a time.
+///
+/// A step is one source unit, using [`ajisai_core::interpreter::unit_len`] —
+/// the same rule `VENT` uses. That matters: splitting `TRUE VENT { 1 }` into
+/// three steps would hand `VENT` a body with no unit to release, so a stepper
+/// that segmented naively would fail on programs that run perfectly.
+///
+/// # Safety
+/// `ptr` must point to `len` bytes of UTF-8.
+#[no_mangle]
+pub unsafe extern "C" fn ajisai_steps(ptr: *const u8, len: usize) -> usize {
+    let source = read_source(ptr, len);
+    reply(match syntax::parse(&source) {
+        Err(error) => object(&[
+            ("ok", "false".to_string()),
+            ("error", quote(&error.to_string())),
+        ]),
+        Ok(program) => {
+            let mut steps = Vec::new();
+            let mut index = 0;
+            while index < program.len() {
+                let span = match ajisai_core::interpreter::unit_len(&program, index) {
+                    Ok(span) => span,
+                    // A trailing `VENT` has no unit. Hand the remainder over as
+                    // one step and let the evaluator raise the real error.
+                    Err(_) => program.len() - index,
+                };
+                let end = (index + span).min(program.len());
+                steps.push(quote(&syntax::render_program(&program[index..end])));
+                index = end;
+            }
+            object(&[("ok", "true".to_string()), ("steps", array(&steps))])
+        }
+    })
+}
+
+/// The vocabulary manifest: every registered word's contract, as JSON.
+#[no_mangle]
+pub extern "C" fn ajisai_vocabulary() -> usize {
+    reply(SESSION.with(|session| manifest::vocabulary_json(&session.borrow())))
+}
+
+/// Discard the session and start a fresh one.
+#[no_mangle]
+pub extern "C" fn ajisai_reset() -> usize {
+    SESSION.with(|session| *session.borrow_mut() = Interpreter::new());
+    reply(SESSION.with(|session| snapshot_json(&session.borrow())))
+}
+
+/// The session's current state, without running anything.
+#[no_mangle]
+pub extern "C" fn ajisai_snapshot() -> usize {
+    reply(SESSION.with(|session| snapshot_json(&session.borrow())))
+}
+
+// ------------------------------------------------------------------ inner
+
+unsafe fn read_source(ptr: *const u8, len: usize) -> String {
+    if ptr.is_null() || len == 0 {
+        return String::new();
+    }
+    let bytes = std::slice::from_raw_parts(ptr, len);
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn reply(json: String) -> usize {
+    REPLY.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        *slot = json;
+        slot.len()
+    })
+}
+
+fn execute_json(interpreter: &mut Interpreter, source: &str) -> String {
+    match interpreter.execute(source) {
+        Ok(()) => {
+            let mut fields = vec![("ok", "true".to_string()), ("error", "null".to_string())];
+            fields.extend(state_fields(interpreter));
+            object(&fields)
+        }
+        Err(error) => {
+            let mut fields = vec![
+                ("ok", "false".to_string()),
+                ("error", quote(&error.to_string())),
+            ];
+            fields.extend(state_fields(interpreter));
+            object(&fields)
+        }
+    }
+}
+
+fn snapshot_json(interpreter: &Interpreter) -> String {
+    let mut fields = vec![("ok", "true".to_string()), ("error", "null".to_string())];
+    fields.extend(state_fields(interpreter));
+    object(&fields)
+}
+
+/// The two observable surfaces a run can change: the flow, and the dictionary.
+fn state_fields(interpreter: &Interpreter) -> Vec<(&'static str, String)> {
+    let stack: Vec<String> = interpreter
+        .stack()
+        .iter()
+        .map(|value| quote(&truncate(&value.to_string())))
+        .collect();
+    let definitions: Vec<String> = interpreter
+        .definitions()
+        .iter()
+        .map(|(name, body)| {
+            object(&[
+                ("name", quote(name)),
+                (
+                    "body",
+                    quote(&truncate(&format!(
+                        "{{ {} }}",
+                        syntax::render_program(body)
+                    ))),
+                ),
+            ])
+        })
+        .collect();
+    vec![
+        ("stack", array(&stack)),
+        ("definitions", array(&definitions)),
+    ]
+}
+
+fn lint_json(interpreter: &Interpreter, source: &str) -> String {
+    match lint::lint(interpreter, source) {
+        Ok(findings) => {
+            let items: Vec<String> = findings
+                .iter()
+                .map(|finding| {
+                    object(&[
+                        (
+                            "severity",
+                            quote(match finding.severity {
+                                Severity::Error => "error",
+                                Severity::Advisory => "advisory",
+                            }),
+                        ),
+                        ("message", quote(&finding.message)),
+                    ])
+                })
+                .collect();
+            object(&[("ok", "true".to_string()), ("findings", array(&items))])
+        }
+        Err(error) => object(&[
+            ("ok", "false".to_string()),
+            ("error", quote(&error.to_string())),
+        ]),
+    }
+}
+
+fn truncate(text: &str) -> String {
+    if text.chars().count() <= RENDER_LIMIT {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(RENDER_LIMIT).collect();
+    format!("{head}…")
+}
+
+// ------------------------------------------------------------------- JSON
+//
+// Written out rather than pulled in, for the same reason `ajisai-core` writes
+// its own manifest: the shape is small and fixed.
+
+fn object(fields: &[(&str, String)]) -> String {
+    let body: Vec<String> = fields
+        .iter()
+        .map(|(key, value)| format!("{}:{}", quote(key), value))
+        .collect();
+    format!("{{{}}}", body.join(","))
+}
+
+fn array(items: &[String]) -> String {
+    format!("[{}]", items.join(","))
+}
+
+fn quote(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for c in text.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pull the `steps` array out of a reply. Written properly rather than by
+    /// splitting on `","`, because a step like `"DOUBLE"` carries escaped
+    /// quotes of its own.
+    fn decode_steps(json: &str) -> Vec<String> {
+        let body = json
+            .split(r#""steps":["#)
+            .nth(1)
+            .expect("a steps array")
+            .trim_end_matches("]}");
+        let mut steps = Vec::new();
+        let mut chars = body.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c != '"' {
+                continue;
+            }
+            let mut step = String::new();
+            while let Some(c) = chars.next() {
+                match c {
+                    '\\' => step.push(chars.next().expect("an escape")),
+                    '"' => break,
+                    other => step.push(other),
+                }
+            }
+            steps.push(step);
+        }
+        steps
+    }
+
+    fn call(source: &str, entry: unsafe extern "C" fn(*const u8, usize) -> usize) -> String {
+        let bytes = source.as_bytes();
+        let len = unsafe { entry(bytes.as_ptr(), bytes.len()) };
+        REPLY.with(|reply| reply.borrow()[..len].to_string())
+    }
+
+    #[test]
+    fn execute_reports_the_flow() {
+        let json = call("1 2 ADD", ajisai_execute);
+        assert!(json.contains("\"ok\":true"), "{json}");
+        assert!(json.contains("\"stack\":[\"3\"]"), "{json}");
+        ajisai_reset();
+    }
+
+    #[test]
+    fn execute_reports_an_error_and_the_flow_it_left() {
+        ajisai_reset();
+        let json = call("7 1 0 DIV", ajisai_execute);
+        assert!(json.contains("\"ok\":false"), "{json}");
+        assert!(json.contains("division by zero"), "{json}");
+        // Word-level atomicity is visible across the boundary too.
+        assert!(json.contains("\"stack\":[\"7\",\"1\",\"0\"]"), "{json}");
+        ajisai_reset();
+    }
+
+    #[test]
+    fn definitions_come_back_as_source() {
+        ajisai_reset();
+        let json = call("{ 2 MUL } \"DOUBLE\" DEF", ajisai_execute);
+        assert!(json.contains("\"name\":\"DOUBLE\""), "{json}");
+        assert!(json.contains("\"body\":\"{ 2 MUL }\""), "{json}");
+        ajisai_reset();
+    }
+
+    #[test]
+    fn the_session_persists_between_calls() {
+        ajisai_reset();
+        call("1 2", ajisai_execute);
+        let json = call("ADD", ajisai_execute);
+        assert!(json.contains("\"stack\":[\"3\"]"), "{json}");
+        ajisai_reset();
+    }
+
+    #[test]
+    fn reset_empties_the_session() {
+        call("{ 1 } \"X\" DEF 9", ajisai_execute);
+        let len = ajisai_reset();
+        let json = REPLY.with(|reply| reply.borrow()[..len].to_string());
+        assert!(json.contains("\"stack\":[]"), "{json}");
+        assert!(json.contains("\"definitions\":[]"), "{json}");
+    }
+
+    #[test]
+    fn lint_and_format_do_not_touch_the_session() {
+        ajisai_reset();
+        call("1 2", ajisai_execute);
+        let findings = call("[ 1 ] 2 ADD", ajisai_lint);
+        assert!(findings.contains("\"severity\":\"error\""), "{findings}");
+        let formatted = call("1 2 & +", ajisai_format);
+        assert!(formatted.contains("1 2 KEEP ADD"), "{formatted}");
+        let snapshot = {
+            let len = ajisai_snapshot();
+            REPLY.with(|reply| reply.borrow()[..len].to_string())
+        };
+        assert!(snapshot.contains("\"stack\":[\"1\",\"2\"]"), "{snapshot}");
+        ajisai_reset();
+    }
+
+    #[test]
+    fn the_vocabulary_crosses_the_boundary() {
+        let len = ajisai_vocabulary();
+        let json = REPLY.with(|reply| reply.borrow()[..len].to_string());
+        assert!(json.contains("\"name\": \"VENT\""), "{json}");
+        assert!(json.contains("\"name\": \"STAK\""), "{json}");
+    }
+
+    /// A legal program can render to megabytes. The value is untouched; only
+    /// the string crossing the boundary is shortened.
+    #[test]
+    fn an_enormous_rendering_is_truncated() {
+        ajisai_reset();
+        let json = call("0 200000 RANGE", ajisai_execute);
+        assert!(json.contains('…'), "should be truncated");
+        assert!(json.len() < RENDER_LIMIT * 4, "reply stayed bounded");
+        ajisai_reset();
+    }
+
+    #[test]
+    fn text_and_quotes_survive_json_encoding() {
+        ajisai_reset();
+        let json = call("\"a\\\"b\" { 1 ADD }", ajisai_execute);
+        assert!(json.contains("\\\\\\\""), "quote should be escaped: {json}");
+        ajisai_reset();
+    }
+
+    /// A step is one source unit — so a vent and the unit it governs stay
+    /// together, and a mode word stays with the word it governs. Splitting them
+    /// would break programs that run perfectly.
+    #[test]
+    fn steps_respect_the_source_unit_rule() {
+        let json = call("1 2 ADD", ajisai_steps);
+        assert!(json.contains(r#"["1","2","ADD"]"#), "{json}");
+
+        let json = call("TRUE VENT { 1 0 DIV } 7", ajisai_steps);
+        assert!(
+            json.contains(r#"["TRUE","VENT { 1 0 DIV }","7"]"#),
+            "a vent must keep its unit: {json}"
+        );
+
+        let json = call("1 2 3 STAK ADD", ajisai_steps);
+        assert!(
+            json.contains(r#"["1","2","3","STAK ADD"]"#),
+            "a mode must keep its word: {json}"
+        );
+
+        let json = call("TRUE VENT", ajisai_steps);
+        assert!(json.contains("\"ok\":true"), "{json}");
+    }
+
+    /// Stepping a program produces the same flow as running it whole.
+    #[test]
+    fn stepping_and_running_agree() {
+        for source in [
+            "1 2 ADD 3 MUL",
+            "1 2 3 STAK ADD",
+            "5 0 GT KEEP VENT { 1 } NOT VENT { 2 }",
+            "{ 2 MUL } \"DOUBLE\" DEF 21 DOUBLE",
+            "[ 1 2 3 ] { 2 MUL } MAP",
+        ] {
+            ajisai_reset();
+            let whole = call(source, ajisai_execute);
+
+            ajisai_reset();
+            let steps_json = call(source, ajisai_steps);
+            let steps = decode_steps(&steps_json);
+            let mut stepped = String::new();
+            for step in steps {
+                stepped = call(&step, ajisai_execute);
+            }
+            let flow = |json: &str| json.split(r#""stack":"#).nth(1).unwrap().to_string();
+            assert_eq!(flow(&whole), flow(&stepped), "`{source}` disagreed");
+        }
+        ajisai_reset();
+    }
+
+    #[test]
+    fn allocation_round_trips() {
+        unsafe {
+            let ptr = ajisai_alloc(8);
+            assert!(!ptr.is_null());
+            std::ptr::write_bytes(ptr, b'x', 8);
+            assert_eq!(std::slice::from_raw_parts(ptr, 8), b"xxxxxxxx");
+            ajisai_free(ptr, 8);
+            assert!(ajisai_alloc(0).is_null());
+        }
+    }
+}

--- a/docs/playground-ui.md
+++ b/docs/playground-ui.md
@@ -1,71 +1,176 @@
 # The Presentation Profile
 
-A specification for a user interface to Ajisai.
+The specification of the Ajisai playground.
 
 **This document is not part of the language.** It may refer to
 `SPECIFICATION.md`; `SPECIFICATION.md` may not refer to it. A headless
 implementation that provides none of this is fully conforming
-(`SPECIFICATION.md` §14), and no behaviour described here may change the result
-of any program.
+(`SPECIFICATION.md` §14), and nothing described here changes the result of any
+program.
 
-## Status
+That separation is the point of having this file. Panel reachability, screen
+transitions, and idempotent selection were once written into the language
+specification as if they were conformance conditions. They are not: they are
+this, and they belong here.
 
-There is no playground in this repository at present. The web playground that
-existed before 1.0 was built against a language that no longer exists — its
-vocabulary, value shapes, and interpreter API are all gone — and it was removed
-rather than left to rot against an API it no longer matched.
-`docs/migration.md` records this.
+## What it is
 
-This document is the specification a replacement should be written against. The
-interpreter is embeddable today: `ajisai-core` is an ordinary Rust library, and
-`ajisai` is a CLI with `run`, `eval`, `lint`, `fmt`, `words`, and `repl`.
+A single page at `playground/`, built from four files and one WebAssembly
+module. No bundler, no framework, no runtime dependency:
 
-## The four panels
+```
+playground/
+  index.html         the four surfaces
+  app.css            appearance
+  app.js             wiring: elements, keys, gestures
+  presentation.js    the transition rules, free of the DOM
+  worker.js          the session, in a worker
+  ajisai.wasm        built from crates/ajisai-wasm
+```
 
-A playground presents four surfaces.
+`presentation.js` holds every rule below as a pure function, so the rules are
+tested without a browser (`presentation.test.mjs`) and the wiring is tested
+with one (`browser.test.mjs`).
 
-**Input.** Where source is written. It may offer completion from the vocabulary
-manifest (`ajisai words`) and formatting via `ajisai fmt`. Both surfaces must
-use the canonical word names the manifest and formatter produce; a playground
-must not invent a display name for a word.
+## The four surfaces
 
-**Output.** Diagnostics — errors and lint findings. A lint finding must be
-presented as a report, never as a refusal to run: the language's position is
-that findings do not block execution, and a UI that greys out the run button on
-an advisory has changed the language.
+**Input** — where source is written. Carries the run controls, the word
+palette, and the suggestion list.
 
-**Stack.** The flow's cross-section, bottom first, rendered as the language
-renders it. **A value's rendering is determined by its role**
-(`SPECIFICATION.md` §6): a `TEXT` vector shows as `"hi"`, an `INTERVAL` as
-`1..3`. A playground must not re-guess a reading the language did not assign —
-if the role is `RAW`, the value renders structurally, however number-like or
-text-like it looks.
+**Output** — diagnostics: errors, and lint findings. Ajisai Core has no I/O
+words, so nothing else appears here.
 
-**Dictionary.** The vocabulary: Ajisai Core's words, any registered package's
-words, and the user's definitions. Package words should be shown as belonging to
-their package, which the manifest records.
+**Stack** — the flow's cross-section, bottom of the flow at the bottom of the
+panel. Rendered exactly as the language renders it: a value's role decides its
+appearance (`SPECIFICATION.md` §6), so a `TEXT` vector shows as `"hi"` and an
+`INTERVAL` as `1..3`. **The playground never re-guesses a reading the language
+did not assign** — a `RAW` vector renders structurally however text-like it
+looks.
 
-## Rules for a playground
+**Dictionary** — two sheets, Ajisai Core and your own words, with a filter.
+Clicking a word puts it in the editor.
+
+## Layout
+
+Above 768px, two columns: Input **or** Output on the left, Stack **or**
+Dictionary on the right. At 768px and below, one surface at a time.
+
+## Manual selection
+
+Two coupling rules, and both are about intent rather than tidiness:
+
+- **Choosing Output pulls the right column to Stack.** You asked what a run
+  said; the flow is the other half of that answer.
+- **Choosing Dictionary pulls the left column to Input.** The reason to open
+  the dictionary is to put a word into the editor.
+
+Together they keep Output and Dictionary — whose intents conflict — out of the
+reachable configurations. Selection is idempotent, and every surface is
+reachable. `presentation.test.mjs` proves all three by exploring the whole
+reachable space.
+
+## Execution-driven transition
+
+Where the layout moves after a run is decided by **what the run touched**:
+
+| touched | two columns | one surface |
+|---|---|---|
+| the flow | right → Stack | Stack |
+| diagnostics | left → Output | Output |
+| the dictionary | right → Dictionary, on the new word's sheet | Dictionary |
+| nothing | stay | stay |
+
+Dictionary outranks Stack: defining a word is the more notable change. A run
+that changed nothing observable moves nothing — a program that did nothing
+should not rearrange the screen.
+
+A failure always counts as touching diagnostics, so a failing program never
+leaves you looking at an unchanged screen.
+
+## Keyboard
+
+| | |
+|---|---|
+| `Shift+Enter` | run |
+| `Ctrl+Enter` | run one source unit, and take it out of the editor |
+| `Shift+Alt+F` | format to canonical words |
+| `Ctrl+Space` | suggest words by prefix |
+| `Ctrl+Alt+Enter` | reset the session, after confirming |
+| `Escape` | abort a run; otherwise dismiss suggestions, or return to the editor |
+
+**A step is one source unit** — the same definition `VENT` uses
+(`SPECIFICATION.md` §9.2). `TRUE VENT { 1 2 ADD }` steps as `TRUE` and then
+`VENT { 1 2 ADD }`, never splitting the vent from the unit it governs, because
+a stepper that split them would fail on programs that run perfectly.
+
+## Touch
+
+| | |
+|---|---|
+| triple-tap the editor | run |
+| double-tap the Stack | go to Output |
+| double-tap Output | go back to the editor |
+| swipe left or right | cycle `input → output → stack → dictionary`, wrapping |
+| tap a palette word | insert it |
+
+## The mode hint
+
+The Stack panel tints the cells the armed modes would treat as operands. Two
+independent axes, mirroring `SPECIFICATION.md` §8.1:
+
+- **Which cells are filled** — the target. `STAK` (or `:`) anywhere in the
+  editor fills every cell; otherwise only the surface cell.
+- **The fill colour** — the fate. `KEEP` (or `&`) is a pale teal-green
+  (operands are retained); the default `EAT` is a pale warm red (operands are
+  consumed). The two tints differ in lightness as well as hue, so they read
+  apart without colour vision, and both are fills rather than text colours, so
+  they never compete with the value's own ink.
+
+This is a **hint about the source being written, not a simulation**: a mode
+governs one word, and the hint summarises which modes the fragment uses. It
+reads whole tokens only, so `.5` and `5.` are numbers and never a `TOP`.
+
+## Abort
+
+The interpreter runs in a worker, so a long program never freezes the page and
+`Escape` can abort by terminating the worker outright.
+
+The session is then rebuilt by **replaying the journal** — the fragments that
+already ran without error. The fragment that was running is not in the journal,
+so it is the one thing that does not come back, which is what abort means.
+
+## Rules a playground must not break
 
 1. **Presentation never changes computation.** The same program produces the
-   same flow whether it is run in a playground, from the CLI, or from a library
-   call. There is no display mode, no rendering option, and no panel state that
-   any word can observe.
-2. **Rendering is the language's, not the UI's.** Use the renderer; do not
-   reimplement it.
-3. **A session is a flow.** The flow persists across submissions
-   (`SPECIFICATION.md` §5.1). A playground that silently clears the flow between
-   runs is showing a different language.
-4. **Errors leave the flow where the failing word left it**
+   same flow in the playground, from the CLI, and from a library call. There is
+   no display mode any word can observe.
+2. **Rendering is the language's.** Use the renderer; do not reimplement it.
+3. **A session is a flow.** It persists across submissions
+   (`SPECIFICATION.md` §5.1).
+4. **A lint finding is a report, not a refusal.** Findings never block a run —
+   greying out the run button on an advisory would have changed the language.
+5. **Errors leave the flow where the failing word left it**
    (`SPECIFICATION.md` §5.7). Show it; do not reset it.
-5. **Packages are opt-in.** A playground chooses which packages to register and
-   must say which it did. Registering `ajisai-music` does not make its words
-   part of Ajisai.
+6. **Packages are opt-in.** The playground registers none, so it presents
+   Ajisai Core exactly.
 
-## What this document does not do
+## Building and testing
 
-It does not define screen transitions, panel reachability, selection state,
-which panel is shown after execution, whether an empty panel is permitted, or
-any other interaction rule. Those are product decisions for whoever builds the
-playground, and putting them in a language specification is what made them look
-like conformance conditions in the first place.
+```sh
+cargo build -p ajisai-wasm --target wasm32-unknown-unknown --release
+cp target/wasm32-unknown-unknown/release/ajisai_wasm.wasm playground/ajisai.wasm
+
+cd playground
+npm install          # playwright, for the browser test only
+npm test             # rules, WebAssembly boundary, and the real interface
+```
+
+`ajisai.wasm` is a build artifact and is not committed. The deployment workflow
+builds it.
+
+## What this document does not define
+
+Fonts, spacing, and colour beyond the two meaningful stack tints; which
+surface a brand-new visitor sees first; whether there is a footer. Those are
+product decisions, and writing them down as if they were requirements is what
+made them look like conformance conditions in the first place.

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+ajisai.wasm

--- a/playground/app.css
+++ b/playground/app.css
@@ -1,0 +1,507 @@
+/* The playground's appearance.
+ *
+ * Ajisai is a hydrangea, and the palette follows one: blue-violet, with the
+ * pale acid-and-alkali shift the flower is known for. Nothing here is
+ * decorative for its own sake — the one place colour carries meaning is the
+ * stack, where two independent tints say which cells are operands and what
+ * becomes of them.
+ */
+
+:root {
+  color-scheme: light dark;
+
+  --ink: #16181d;
+  --ink-soft: #5a6072;
+  --paper: #f7f8fb;
+  --panel: #ffffff;
+  --edge: #dfe3ec;
+  --accent: #5a4fcf;
+  --accent-soft: #ebe9fb;
+
+  /* The two consumption tints. Separated in lightness as well as hue, so they
+   * read apart without relying on colour vision. */
+  --eat: #fdeaea;
+  --eat-edge: #d98b8b;
+  --keep: #dff2ee;
+  --keep-edge: #4f9c8b;
+
+  --error: #b3261e;
+  --advisory: #8a6100;
+
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  --sans: ui-sans-serif, system-ui, "Helvetica Neue", "Hiragino Sans", "Noto Sans JP", sans-serif;
+
+  --radius: 10px;
+  --gap: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e6e8ef;
+    --ink-soft: #99a0b3;
+    --paper: #12141a;
+    --panel: #1a1d25;
+    --edge: #2c313d;
+    --accent: #a79bff;
+    --accent-soft: #262244;
+
+    --eat: #3a2224;
+    --eat-edge: #cf8383;
+    --keep: #16332f;
+    --keep-edge: #63b7a3;
+
+    --error: #ff9a92;
+    --advisory: #e0b558;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+/* `hidden` is how this interface hides a surface, and a `display` rule further
+ * down would otherwise win against the user agent's `[hidden] { display: none }`
+ * — which is exactly what left an empty suggestion list showing. */
+[hidden] {
+  display: none !important;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+}
+.skip-link:focus {
+  left: var(--gap);
+  top: var(--gap);
+  z-index: 10;
+  padding: 8px 12px;
+  background: var(--panel);
+  border-radius: var(--radius);
+}
+
+/* ---------------------------------------------------------------- chrome */
+
+.chrome {
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--edge);
+  background: var(--panel);
+}
+
+footer.chrome {
+  border-bottom: none;
+  border-top: 1px solid var(--edge);
+  font-size: 13px;
+}
+
+.brand {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.brand-mark {
+  color: var(--accent);
+  font-size: 20px;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.chrome-actions {
+  display: flex;
+  gap: var(--gap);
+  margin-left: auto;
+}
+
+.selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.status {
+  margin: 0;
+  color: var(--ink-soft);
+  min-height: 1.5em;
+}
+
+.links {
+  margin: 0 0 0 auto;
+  display: flex;
+  gap: var(--gap);
+}
+
+a {
+  color: var(--accent);
+}
+
+/* ------------------------------------------------------------------ main */
+
+main {
+  display: grid;
+  gap: var(--gap);
+  padding: var(--gap);
+  min-height: 0;
+}
+
+body[data-layout='desktop'] main {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+body[data-layout='mobile'] main {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+body[data-layout='desktop'] [data-mobile],
+body[data-layout='mobile'] [data-desktop] {
+  display: none;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--panel);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--edge);
+}
+
+.panel-head h2 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-soft);
+}
+
+.panel-tools {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
+.panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 10px 12px;
+}
+
+.hint {
+  margin: 0 0 0 auto;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-soft);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--eat);
+  border: 1px solid var(--eat-edge);
+}
+
+.hint[data-retention='keep'] {
+  background: var(--keep);
+  border-color: var(--keep-edge);
+}
+
+/* --------------------------------------------------------------- controls */
+
+button,
+select,
+input[type='search'] {
+  font: inherit;
+  color: inherit;
+  background: var(--paper);
+  border: 1px solid var(--edge);
+  border-radius: 8px;
+  padding: 5px 10px;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ---------------------------------------------------------------- editor */
+
+.editor-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+#editor {
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  resize: none;
+  border: none;
+  padding: 12px;
+  background: transparent;
+  color: inherit;
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.7;
+  tab-size: 2;
+}
+
+#editor::placeholder {
+  color: var(--ink-soft);
+  opacity: 0.75;
+}
+
+#editor:focus {
+  outline: none;
+}
+
+.suggestions {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  max-width: calc(100% - 24px);
+  background: var(--panel);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgb(0 0 0 / 0.12);
+}
+
+.suggestions button {
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 3px 8px;
+}
+
+.palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--edge);
+  max-height: 30%;
+  overflow: auto;
+}
+
+.palette button {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 3px 7px;
+}
+
+/* ----------------------------------------------------------------- stack */
+
+.stack {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 4px;
+  align-items: stretch;
+}
+
+.cell {
+  font-family: var(--mono);
+  font-size: 14px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* The two axes. Which cells are filled says *which values are the operands*;
+ * the fill colour says *what becomes of them*. A fill rather than a text
+ * colour, so it never competes with the value's own ink. */
+.cell[data-operand='eat'] {
+  background: var(--eat);
+  border-color: var(--eat-edge);
+}
+
+.cell[data-operand='keep'] {
+  background: var(--keep);
+  border-color: var(--keep-edge);
+}
+
+.empty,
+.ok {
+  color: var(--ink-soft);
+  font-style: italic;
+  list-style: none;
+}
+
+/* ----------------------------------------------------------- diagnostics */
+
+.diagnostics {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.diagnostics li {
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border-left: 3px solid transparent;
+  white-space: pre-wrap;
+}
+
+.diagnostics .error {
+  color: var(--error);
+  border-left-color: var(--error);
+  background: color-mix(in srgb, var(--error) 8%, transparent);
+}
+
+.diagnostics .advisory {
+  color: var(--advisory);
+  border-left-color: var(--advisory);
+  background: color-mix(in srgb, var(--advisory) 10%, transparent);
+}
+
+/* ------------------------------------------------------------ dictionary */
+
+.search {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--edge);
+}
+
+.search input {
+  width: 100%;
+}
+
+.dictionary {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.word {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: baseline;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: 8px;
+}
+
+.word:hover {
+  background: var(--accent-soft);
+}
+
+.word-name {
+  font-family: var(--mono);
+  font-weight: 650;
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  color: var(--accent);
+}
+
+.word-aliases {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+.word-effect {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-soft);
+  overflow-x: auto;
+}
+
+.word-summary {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+/* ----------------------------------------------------------------- small */
+
+@media (max-width: 768px) {
+  .tagline {
+    display: none;
+  }
+  .chrome {
+    padding: 8px 12px;
+  }
+  main {
+    padding: 8px;
+  }
+  body {
+    font-size: 16px;
+  }
+}

--- a/playground/app.js
+++ b/playground/app.js
@@ -1,0 +1,605 @@
+// The playground.
+//
+// Everything here is presentation. The rules that decide *which* surface you
+// are looking at live in `presentation.js`, free of the DOM and tested on their
+// own; this file wires them to elements, keys, and gestures.
+
+import {
+  MOBILE_BREAKPOINT,
+  SWIPE_THRESHOLD,
+  analyzeModes,
+  applyRun,
+  applyRunMobile,
+  cycle,
+  detectChanges,
+  operandCells,
+  selectSurface,
+} from './presentation.js';
+
+const $ = (id) => document.getElementById(id);
+
+const el = {
+  body: document.body,
+  editor: $('editor'),
+  suggestions: $('suggestions'),
+  palette: $('palette'),
+  output: $('output'),
+  stack: $('stack'),
+  modeHint: $('mode-hint'),
+  dictionary: $('dictionary'),
+  search: $('search'),
+  sheet: $('sheet-select'),
+  status: $('status'),
+  leftSelect: $('left-select'),
+  rightSelect: $('right-select'),
+  mobileSelect: $('mobile-select'),
+  areas: {
+    input: $('input-area'),
+    output: $('output-area'),
+    stack: $('stack-area'),
+    dictionary: $('dictionary-area'),
+  },
+};
+
+// ------------------------------------------------------------------ session
+
+let worker = null;
+let pending = new Map();
+let nextId = 0;
+let running = false;
+
+/** Fragments that ran without error, in order. Replayed after an abort. */
+const journal = [];
+
+const spawn = () => {
+  worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' });
+  worker.onmessage = (event) => {
+    const { id, ok, reply, error } = event.data;
+    const settle = pending.get(id);
+    if (!settle) return;
+    pending.delete(id);
+    if (ok) settle.resolve(reply);
+    else settle.reject(new Error(error));
+  };
+};
+
+const ask = (kind, source, extra) =>
+  new Promise((resolve, reject) => {
+    const id = (nextId += 1);
+    pending.set(id, { resolve, reject });
+    worker.postMessage({ id, kind, source, ...extra });
+  });
+
+/**
+ * Abort by terminating the worker, then rebuild the session by replaying the
+ * journal. The fragment that was running is not in the journal, so it is the
+ * one thing that does not come back — which is what abort means.
+ */
+const abort = async () => {
+  if (!running) return false;
+  worker.terminate();
+  for (const { reject } of pending.values()) reject(new Error('aborted'));
+  pending = new Map();
+  running = false;
+  spawn();
+  const snapshot = await ask('replay', null, { journal: [...journal] });
+  render(snapshot);
+  say('Aborted. The session was rebuilt from what had already run.');
+  return true;
+};
+
+// -------------------------------------------------------------------- state
+
+let layout = { left: 'input', right: 'stack' };
+let mobileSurface = 'input';
+let snapshot = { stack: [], definitions: [] };
+let vocabulary = [];
+let sheet = 'core';
+
+const isMobile = () => window.innerWidth <= MOBILE_BREAKPOINT;
+
+const say = (text) => {
+  el.status.textContent = text;
+};
+
+// ------------------------------------------------------------------- layout
+
+const applyLayout = () => {
+  const mobile = isMobile();
+  el.body.dataset.layout = mobile ? 'mobile' : 'desktop';
+  if (mobile) {
+    for (const [name, node] of Object.entries(el.areas)) {
+      node.hidden = name !== mobileSurface;
+    }
+    el.body.dataset.activeArea = mobileSurface;
+    el.mobileSelect.value = mobileSurface;
+  } else {
+    el.areas.input.hidden = layout.left !== 'input';
+    el.areas.output.hidden = layout.left !== 'output';
+    el.areas.stack.hidden = layout.right !== 'stack';
+    el.areas.dictionary.hidden = layout.right !== 'dictionary';
+    el.body.dataset.activeArea = layout.right;
+    el.leftSelect.value = layout.left;
+    el.rightSelect.value = layout.right;
+  }
+};
+
+const show = (surface) => {
+  if (isMobile()) {
+    mobileSurface = surface;
+  } else {
+    layout = selectSurface(layout, surface);
+  }
+  applyLayout();
+};
+
+// ----------------------------------------------------------------- rendering
+
+const renderStack = () => {
+  const modes = analyzeModes(el.editor.value);
+  const operands = new Set(operandCells(snapshot.stack.length, modes));
+  el.stack.replaceChildren(
+    ...snapshot.stack.map((text, index) => {
+      const item = document.createElement('li');
+      item.className = 'cell';
+      item.textContent = text;
+      if (operands.has(index)) {
+        item.dataset.operand = modes.retention;
+      }
+      return item;
+    }),
+  );
+  if (snapshot.stack.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'empty';
+    empty.textContent = 'the flow is empty';
+    el.stack.replaceChildren(empty);
+  }
+  const target = modes.target === 'stak' ? 'the whole flow' : 'the surface';
+  const fate = modes.retention === 'keep' ? 'kept' : 'eaten';
+  el.modeHint.textContent = `${target} · ${fate}`;
+  el.modeHint.dataset.retention = modes.retention;
+};
+
+const renderDiagnostics = (items) => {
+  if (items.length === 0) {
+    const ok = document.createElement('li');
+    ok.className = 'ok';
+    ok.textContent = 'nothing to report';
+    el.output.replaceChildren(ok);
+    return;
+  }
+  el.output.replaceChildren(
+    ...items.map(({ severity, message }) => {
+      const line = document.createElement('li');
+      line.className = severity;
+      line.textContent = message;
+      return line;
+    }),
+  );
+};
+
+const wordEntry = (word) => {
+  const item = document.createElement('li');
+  item.className = 'word';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'word-name';
+  button.textContent = word.name;
+  button.addEventListener('click', () => insert(word.name));
+  item.append(button);
+
+  if (word.aliases?.length) {
+    const aliases = document.createElement('span');
+    aliases.className = 'word-aliases';
+    aliases.textContent = word.aliases.join(' ');
+    item.append(aliases);
+  }
+  const effect = document.createElement('code');
+  effect.className = 'word-effect';
+  effect.textContent = word.stack_effect ?? word.body ?? '';
+  item.append(effect);
+
+  if (word.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'word-summary';
+    summary.textContent = word.summary;
+    item.append(summary);
+  }
+  return item;
+};
+
+const renderDictionary = () => {
+  const filter = el.search.value.trim().toUpperCase();
+  const source =
+    sheet === 'user'
+      ? snapshot.definitions.map((word) => ({ ...word, summary: '' }))
+      : vocabulary;
+  const shown = source.filter(
+    (word) =>
+      !filter ||
+      word.name.includes(filter) ||
+      (word.aliases ?? []).some((alias) => alias.includes(filter)),
+  );
+  if (shown.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'empty';
+    empty.textContent =
+      sheet === 'user' ? 'no words defined yet' : 'no word matches that filter';
+    el.dictionary.replaceChildren(empty);
+    return;
+  }
+  el.dictionary.replaceChildren(...shown.map(wordEntry));
+};
+
+const render = (reply) => {
+  snapshot = { stack: reply.stack ?? [], definitions: reply.definitions ?? [] };
+  renderStack();
+  renderDictionary();
+};
+
+// -------------------------------------------------------------------- editor
+
+const insert = (text) => {
+  const editor = el.editor;
+  const at = editor.selectionStart ?? editor.value.length;
+  const end = editor.selectionEnd ?? at;
+  const before = editor.value.slice(0, at);
+  const after = editor.value.slice(end);
+  const lead = before && !/\s$/.test(before) ? ' ' : '';
+  editor.value = `${before}${lead}${text} ${after}`;
+  const caret = before.length + lead.length + text.length + 1;
+  editor.setSelectionRange(caret, caret);
+  editor.focus();
+  renderStack();
+  if (!isMobile()) show('input');
+};
+
+const currentPrefix = () => {
+  const at = el.editor.selectionStart ?? 0;
+  const before = el.editor.value.slice(0, at);
+  const match = before.match(/(\S+)$/);
+  return match ? match[1].toUpperCase() : '';
+};
+
+const hideSuggestions = () => {
+  el.suggestions.hidden = true;
+  el.suggestions.replaceChildren();
+};
+
+const showSuggestions = () => {
+  const prefix = currentPrefix();
+  if (!prefix) return hideSuggestions();
+  const names = [
+    ...vocabulary.map((word) => word.name),
+    ...snapshot.definitions.map((word) => word.name),
+  ];
+  const matches = names.filter((name) => name.startsWith(prefix) && name !== prefix).slice(0, 8);
+  if (matches.length === 0) return hideSuggestions();
+  el.suggestions.replaceChildren(
+    ...matches.map((name) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = name;
+      button.addEventListener('click', () => {
+        const at = el.editor.selectionStart ?? 0;
+        const before = el.editor.value.slice(0, at).replace(/\S+$/, '');
+        const after = el.editor.value.slice(at);
+        el.editor.value = `${before}${name} ${after}`;
+        const caret = before.length + name.length + 1;
+        el.editor.setSelectionRange(caret, caret);
+        el.editor.focus();
+        hideSuggestions();
+        renderStack();
+      });
+      item.append(button);
+      return item;
+    }),
+  );
+  el.suggestions.hidden = false;
+};
+
+// ------------------------------------------------------------------- actions
+
+/** Run a fragment, then let what it touched decide where the layout goes. */
+const runFragment = async (source, label) => {
+  const trimmed = source.trim();
+  if (!trimmed) return;
+  const before = snapshot;
+  running = true;
+  say(`${label}…`);
+  let reply;
+  try {
+    reply = await ask('execute', trimmed);
+  } catch (error) {
+    if (error.message === 'aborted') return;
+    say(String(error.message));
+    return;
+  } finally {
+    running = false;
+  }
+  if (reply.ok) journal.push(trimmed);
+
+  const after = { stack: reply.stack, definitions: reply.definitions };
+  const changes = detectChanges(before, after, reply);
+  render(reply);
+  renderDiagnostics(reply.ok ? [] : [{ severity: 'error', message: reply.error }]);
+
+  if (isMobile()) {
+    mobileSurface = applyRunMobile(mobileSurface, changes);
+  } else {
+    layout = applyRun(layout, changes);
+  }
+  if (changes.dictionary) {
+    sheet = 'user';
+    el.sheet.value = 'user';
+    renderDictionary();
+  }
+  applyLayout();
+  say(reply.ok ? `${label} complete.` : reply.error);
+};
+
+const run = () => runFragment(el.editor.value, 'Run');
+
+/** Run one source unit and take it out of the editor, so Step can repeat. */
+const step = async () => {
+  const source = el.editor.value.trim();
+  if (!source) return;
+  const reply = await ask('steps', source);
+  if (!reply.ok) {
+    renderDiagnostics([{ severity: 'error', message: reply.error }]);
+    layout = applyRun(layout, { output: true });
+    mobileSurface = applyRunMobile(mobileSurface, { output: true });
+    applyLayout();
+    return;
+  }
+  const [head, ...rest] = reply.steps;
+  if (!head) return;
+  el.editor.value = rest.join(' ');
+  await runFragment(head, `Step ${head}`);
+  renderStack();
+};
+
+const format = async () => {
+  const reply = await ask('format', el.editor.value);
+  if (reply.ok) {
+    el.editor.value = reply.text;
+    renderStack();
+    say('Formatted.');
+  } else {
+    renderDiagnostics([{ severity: 'error', message: reply.error }]);
+    show('output');
+    say(reply.error);
+  }
+};
+
+const runLint = async () => {
+  const reply = await ask('lint', el.editor.value);
+  if (!reply.ok) {
+    renderDiagnostics([{ severity: 'error', message: reply.error }]);
+  } else {
+    renderDiagnostics(reply.findings);
+    say(
+      reply.findings.length === 0
+        ? 'Nothing obviously wrong — this is not a proof of success.'
+        : `${reply.findings.length} finding(s).`,
+    );
+  }
+  show('output');
+};
+
+const reset = async () => {
+  if (!window.confirm('Discard the flow and every word you have defined?')) return;
+  journal.length = 0;
+  const reply = await ask('reset');
+  render(reply);
+  renderDiagnostics([]);
+  el.editor.value = '';
+  sheet = 'core';
+  el.sheet.value = 'core';
+  renderDictionary();
+  // A full reset returns the layout to where a session starts, rather than
+  // leaving you looking at the empty dictionary you just cleared.
+  layout = { left: 'input', right: 'stack' };
+  mobileSurface = 'input';
+  applyLayout();
+  el.editor.focus();
+  say('Session reset.');
+};
+
+// -------------------------------------------------------------------- events
+
+el.editor.addEventListener('input', () => {
+  renderStack();
+  if (!el.suggestions.hidden) showSuggestions();
+});
+el.editor.addEventListener('blur', () => window.setTimeout(hideSuggestions, 150));
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    if (!el.suggestions.hidden) return hideSuggestions();
+    abort().then((aborted) => {
+      if (!aborted && !isMobile()) show('input');
+    });
+    return;
+  }
+  if (event.key === 'Enter' && event.shiftKey && !event.ctrlKey && !event.altKey) {
+    event.preventDefault();
+    run();
+    return;
+  }
+  if (event.key === 'Enter' && event.ctrlKey && event.altKey) {
+    event.preventDefault();
+    reset();
+    return;
+  }
+  if (event.key === 'Enter' && event.ctrlKey) {
+    event.preventDefault();
+    step();
+    return;
+  }
+  if (event.key === ' ' && event.ctrlKey) {
+    event.preventDefault();
+    showSuggestions();
+    return;
+  }
+  if ((event.key === 'f' || event.key === 'F') && event.shiftKey && event.altKey) {
+    event.preventDefault();
+    format();
+  }
+});
+
+$('run').addEventListener('click', run);
+$('step').addEventListener('click', step);
+$('format').addEventListener('click', format);
+$('reset').addEventListener('click', reset);
+$('lint').addEventListener('click', runLint);
+$('copy-output').addEventListener('click', async () => {
+  const text = [...el.output.children].map((line) => line.textContent).join('\n');
+  try {
+    await navigator.clipboard.writeText(text);
+    say('Output copied.');
+  } catch {
+    say('The browser refused clipboard access.');
+  }
+});
+$('export-words').addEventListener('click', async () => {
+  const text = snapshot.definitions
+    .map((word) => `${word.body} "${word.name}" DEF`)
+    .join('\n');
+  try {
+    await navigator.clipboard.writeText(text);
+    say(`Copied ${snapshot.definitions.length} definition(s).`);
+  } catch {
+    say('The browser refused clipboard access.');
+  }
+});
+
+el.leftSelect.addEventListener('change', (event) => show(event.target.value));
+el.rightSelect.addEventListener('change', (event) => show(event.target.value));
+el.mobileSelect.addEventListener('change', (event) => show(event.target.value));
+el.sheet.addEventListener('change', (event) => {
+  sheet = event.target.value;
+  renderDictionary();
+});
+el.search.addEventListener('input', renderDictionary);
+
+// Clicking Output on a two-column layout goes back to editing.
+el.areas.output.addEventListener('click', (event) => {
+  if (isMobile() || event.target.closest('button')) return;
+  show('input');
+  el.editor.focus();
+});
+
+window.addEventListener('resize', applyLayout);
+
+// ------------------------------------------------------------------ gestures
+
+/** Count taps within a short window, so triple-tap and double-tap are distinct. */
+const tapCounter = (node, count, action) => {
+  let taps = 0;
+  let timer = null;
+  node.addEventListener('pointerup', (event) => {
+    if (!isMobile() || event.target.closest('button, select, input')) return;
+    taps += 1;
+    window.clearTimeout(timer);
+    if (taps >= count) {
+      taps = 0;
+      action();
+      return;
+    }
+    timer = window.setTimeout(() => {
+      taps = 0;
+    }, 400);
+  });
+};
+
+tapCounter(el.editor, 3, run);
+tapCounter(el.areas.stack, 2, () => show('output'));
+tapCounter(el.areas.output, 2, () => {
+  show('input');
+  el.editor.focus();
+});
+
+let swipeFrom = null;
+document.addEventListener('pointerdown', (event) => {
+  swipeFrom = { x: event.clientX, y: event.clientY };
+});
+document.addEventListener('pointerup', (event) => {
+  if (!swipeFrom || !isMobile()) return;
+  const dx = event.clientX - swipeFrom.x;
+  const dy = event.clientY - swipeFrom.y;
+  swipeFrom = null;
+  if (Math.abs(dx) <= Math.abs(dy) || Math.abs(dx) <= SWIPE_THRESHOLD) return;
+  show(cycle(mobileSurface, dx > 0 ? 'right' : 'left'));
+});
+
+// --------------------------------------------------------------------- start
+
+const PALETTE = [
+  'ADD', 'SUB', 'MUL', 'DIV', 'EQ', 'LT', 'GT',
+  'NOT', 'AND', 'OR', 'TRUE', 'FALSE', 'NIL', 'UNKNOWN',
+  'DUP', 'DROP', 'SWAP', 'TOP', 'STAK', 'EAT', 'KEEP', 'VENT',
+  'LENGTH', 'NTH', 'FIRST', 'REST', 'APPEND', 'CONCAT', 'RANGE',
+  'MAP', 'FILTER', 'FOLD', 'EXEC', 'DEF',
+];
+
+const buildPalette = () => {
+  el.palette.replaceChildren(
+    ...PALETTE.map((name) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = name;
+      button.addEventListener('click', () => insert(name));
+      return button;
+    }),
+  );
+};
+
+const PLACEHOLDER_DESKTOP = [
+  'Enter code here',
+  '',
+  'Run      → Shift+Enter',
+  'Step     → Ctrl+Enter',
+  'Format   → Shift+Alt+F',
+  'Suggest  → Ctrl+Space',
+  'Reset    → Ctrl+Alt+Enter',
+  'Abort    → Escape',
+].join('\n');
+
+const PLACEHOLDER_MOBILE = [
+  'Enter code here',
+  '',
+  'Run              → triple-tap here',
+  'Stack → Output   → double-tap Stack',
+  'Output → editor  → double-tap Output',
+  'Change panel     → swipe, or use Panel',
+  'Input assist     → tap the words below',
+].join('\n');
+
+const setPlaceholder = () => {
+  el.editor.placeholder = isMobile() ? PLACEHOLDER_MOBILE : PLACEHOLDER_DESKTOP;
+};
+window.addEventListener('resize', setPlaceholder);
+
+const start = async () => {
+  spawn();
+  buildPalette();
+  setPlaceholder();
+  applyLayout();
+  renderDiagnostics([]);
+  try {
+    const manifest = await ask('vocabulary');
+    vocabulary = manifest.words;
+    const reply = await ask('snapshot');
+    render(reply);
+    say(`Ready — ${vocabulary.length} words.`);
+    document.body.dataset.ready = 'true';
+  } catch (error) {
+    say(`Could not start: ${error.message}`);
+  }
+};
+
+start();

--- a/playground/browser.test.mjs
+++ b/playground/browser.test.mjs
@@ -1,0 +1,332 @@
+// The playground, driven in a real browser.
+//
+// The rules live in `presentation.js` and are tested on their own; this checks
+// that they are actually wired to the elements, the keys, and the gestures —
+// the part a pure test cannot see. It found two defects the first time it ran:
+// a `Lint` button that lived on a panel you cannot see while typing, and a
+// `display: flex` that beat `[hidden]`.
+//
+// Requires the module to have been built:
+//   cargo build -p ajisai-wasm --target wasm32-unknown-unknown --release
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('.', import.meta.url));
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.json': 'application/json',
+};
+
+let server;
+let origin;
+let browser;
+let page;
+const complaints = [];
+
+before(async () => {
+  server = createServer(async (request, response) => {
+    const path = normalize(decodeURIComponent(new URL(request.url, 'http://x').pathname));
+    const file = join(root, path === '/' ? 'index.html' : path);
+    if (!file.startsWith(root)) {
+      response.writeHead(403).end();
+      return;
+    }
+    try {
+      const body = await readFile(file);
+      response.writeHead(200, { 'content-type': TYPES[extname(file)] ?? 'application/octet-stream' });
+      response.end(body);
+    } catch {
+      response.writeHead(404).end();
+    }
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+
+  const { chromium } = await import('playwright');
+  browser = await chromium.launch();
+});
+
+after(async () => {
+  await browser?.close();
+  await new Promise((resolve) => server.close(resolve));
+  assert.deepEqual(complaints, [], 'the console should stay quiet');
+});
+
+const open = async ({ width, height, touch = false }) => {
+  page = await browser.newPage({
+    viewport: { width, height },
+    hasTouch: touch,
+    isMobile: touch,
+  });
+  page.on('pageerror', (error) => complaints.push(String(error)));
+  page.on('console', (message) => {
+    if (message.type() === 'error') complaints.push(message.text());
+  });
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.goto(`${origin}/index.html`);
+  await page.waitForSelector('body[data-ready="true"]', { timeout: 30000 });
+  return page;
+};
+
+const visible = async () => {
+  const shown = [];
+  for (const name of ['input', 'output', 'stack', 'dictionary']) {
+    if (!(await page.locator(`#${name}-area`).isHidden())) shown.push(name);
+  }
+  return shown;
+};
+
+const stack = () => page.locator('#stack .cell').allTextContents();
+
+const settle = () => page.waitForTimeout(300);
+
+// --------------------------------------------------------------- two columns
+
+test('a two-column layout starts on Input and Stack', async () => {
+  await open({ width: 1280, height: 800 });
+  assert.equal(await page.getAttribute('body', 'data-layout'), 'desktop');
+  assert.deepEqual(await visible(), ['input', 'stack']);
+  await page.close();
+});
+
+test('Shift+Enter runs, and the flow appears', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '1 2 3 STAK ADD');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  assert.deepEqual(await stack(), ['6']);
+  await page.close();
+});
+
+test('the stack shows which cells are operands and what becomes of them', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '1 2 3');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+
+  // Default: the surface cell is the operand, and it is eaten.
+  await page.fill('#editor', 'ADD');
+  await settle();
+  assert.deepEqual(await page.locator('#stack .cell').evaluateAll((cells) =>
+    cells.map((cell) => cell.dataset.operand ?? null),
+  ), [null, null, 'eat']);
+  assert.equal(await page.textContent('#mode-hint'), 'the surface · eaten');
+
+  // STAK KEEP: every cell is an operand, and they are kept.
+  await page.fill('#editor', ': & +');
+  await settle();
+  assert.deepEqual(await page.locator('#stack .cell').evaluateAll((cells) =>
+    cells.map((cell) => cell.dataset.operand ?? null),
+  ), ['keep', 'keep', 'keep']);
+  assert.equal(await page.textContent('#mode-hint'), 'the whole flow · kept');
+  await page.close();
+});
+
+test('a definition moves the right column to the words you defined', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '{ 2 MUL } "DOUBLE" DEF');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  assert.deepEqual(await visible(), ['input', 'dictionary']);
+  assert.equal(await page.inputValue('#sheet-select'), 'user');
+  assert.deepEqual(await page.locator('#dictionary .word-name').allTextContents(), ['DOUBLE']);
+  await page.close();
+});
+
+test('a failure moves the left column to the diagnostic', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '1 0 DIV');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  assert.ok((await visible()).includes('output'));
+  assert.match(await page.textContent('#output li'), /division by zero/);
+  await page.close();
+});
+
+test('Ctrl+Enter runs one unit, and a vent keeps its unit', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', 'TRUE VENT { 1 2 ADD } 7');
+  await page.locator('#editor').press('Control+Enter');
+  await settle();
+  assert.equal(await page.inputValue('#editor'), 'VENT { 1 2 ADD } 7');
+  await page.locator('#editor').press('Control+Enter');
+  await settle();
+  // The vent released its unit in one step, rather than being split from it.
+  assert.deepEqual(await stack(), ['3']);
+  await page.close();
+});
+
+test('Shift+Alt+F formats to canonical words', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '1 2 & + : ^ { 3 }');
+  await page.keyboard.press('Shift+Alt+KeyF');
+  await settle();
+  assert.equal(await page.inputValue('#editor'), '1 2 KEEP ADD STAK VENT { 3 }');
+  await page.close();
+});
+
+test('Lint reports without refusing to run, and is reachable while typing', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '[ 1 ] 2 ADD');
+  // The button must be on the panel you are typing on.
+  assert.ok(await page.locator('#lint').isVisible());
+  await page.click('#lint');
+  await settle();
+  assert.match(await page.textContent('#output li'), /expected number/);
+  // ...and the program still runs.
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  assert.match(await page.textContent('#status'), /expected number/);
+  await page.close();
+});
+
+test('Ctrl+Space suggests words by prefix', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', 'CON');
+  await page.locator('#editor').press('Control+Space');
+  await settle();
+  const shown = await page.locator('#suggestions button').allTextContents();
+  assert.ok(shown.includes('CONCAT'), shown.join(' '));
+  await page.click('#suggestions button');
+  assert.equal(await page.inputValue('#editor'), 'CONCAT ');
+  await page.close();
+});
+
+test('clicking a dictionary word puts it in the editor', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.selectOption('#right-select', 'dictionary');
+  // Opening the dictionary returns the left column to the editor.
+  assert.deepEqual(await visible(), ['input', 'dictionary']);
+  await page.fill('#search', 'VENT');
+  await settle();
+  await page.locator('#dictionary .word-name').first().click();
+  assert.equal(await page.inputValue('#editor'), 'VENT ');
+  await page.close();
+});
+
+test('Reset clears the flow and the words', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '{ 1 } "X" DEF 9');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  await page.keyboard.press('Control+Alt+Enter');
+  await settle();
+  assert.equal(await page.inputValue('#editor'), '');
+  assert.deepEqual(await stack(), []);
+  assert.deepEqual(await visible(), ['input', 'stack']);
+  await page.close();
+});
+
+test('the session survives across separate runs', async () => {
+  await open({ width: 1280, height: 800 });
+  await page.fill('#editor', '1 2');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  await page.fill('#editor', 'ADD');
+  await page.locator('#editor').press('Shift+Enter');
+  await settle();
+  assert.deepEqual(await stack(), ['3']);
+  await page.close();
+});
+
+// ------------------------------------------------------------ single surface
+
+test('a narrow layout shows one surface at a time', async () => {
+  await open({ width: 390, height: 844, touch: true });
+  assert.equal(await page.getAttribute('body', 'data-layout'), 'mobile');
+  assert.deepEqual(await visible(), ['input']);
+  await page.close();
+});
+
+test('swiping cycles the surfaces both ways', async () => {
+  await open({ width: 390, height: 844, touch: true });
+  await page.selectOption('#mobile-select', 'stack');
+  const box = await page.locator('#main').boundingBox();
+  const swipe = async (direction) => {
+    const y = box.y + box.height / 2;
+    const [from, to] =
+      direction === 'left'
+        ? [box.x + box.width - 30, box.x + 30]
+        : [box.x + 30, box.x + box.width - 30];
+    await page.mouse.move(from, y);
+    await page.mouse.down();
+    await page.mouse.move(to, y, { steps: 8 });
+    await page.mouse.up();
+    await page.waitForTimeout(150);
+  };
+  await swipe('left');
+  assert.deepEqual(await visible(), ['dictionary']);
+  await swipe('left');
+  assert.deepEqual(await visible(), ['input'], 'cycling wraps around');
+  await swipe('right');
+  assert.deepEqual(await visible(), ['dictionary']);
+  await page.close();
+});
+
+test('a run surfaces the most notable change', async () => {
+  await open({ width: 390, height: 844, touch: true });
+  await page.fill('#editor', '1 2 ADD');
+  await page.click('#run');
+  await settle();
+  assert.deepEqual(await visible(), ['stack']);
+
+  await page.selectOption('#mobile-select', 'input');
+  await page.fill('#editor', '{ 2 MUL } "DOUBLE" DEF');
+  await page.click('#run');
+  await settle();
+  assert.deepEqual(await visible(), ['dictionary'], 'a definition outranks the flow');
+  await page.close();
+});
+
+test('the tap gestures move between surfaces', async () => {
+  await open({ width: 390, height: 844, touch: true });
+  await page.fill('#editor', '10 20 ADD');
+
+  // Triple-tap the editor to run.
+  const editor = await page.locator('#editor').boundingBox();
+  for (let i = 0; i < 3; i += 1) {
+    await page.mouse.click(editor.x + editor.width / 2, editor.y + editor.height / 2);
+  }
+  await settle();
+  assert.deepEqual(await visible(), ['stack']);
+  assert.deepEqual(await stack(), ['30']);
+
+  // Double-tap the flow to read the diagnostics.
+  const area = await page.locator('#stack-area').boundingBox();
+  for (let i = 0; i < 2; i += 1) {
+    await page.mouse.click(area.x + area.width / 2, area.y + area.height - 20);
+  }
+  await settle();
+  assert.deepEqual(await visible(), ['output']);
+
+  // Double-tap the diagnostics to get back to the editor.
+  const output = await page.locator('#output-area').boundingBox();
+  for (let i = 0; i < 2; i += 1) {
+    await page.mouse.click(output.x + output.width / 2, output.y + output.height - 20);
+  }
+  await settle();
+  assert.deepEqual(await visible(), ['input']);
+  await page.close();
+});
+
+test('the narrow layout never scrolls sideways', async () => {
+  await open({ width: 320, height: 568, touch: true });
+  for (const surface of ['input', 'output', 'stack', 'dictionary']) {
+    await page.selectOption('#mobile-select', surface);
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth,
+    );
+    assert.equal(overflows, false, `${surface} overflows`);
+  }
+  await page.close();
+});

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Ajisai — playground</title>
+    <meta
+      name="description"
+      content="A playground for Ajisai, a concatenative language in which exact values and vectors flow left to right."
+    />
+    <link rel="stylesheet" href="./app.css" />
+  </head>
+  <body data-active-area="stack" data-layout="desktop">
+    <a class="skip-link" href="#editor">Skip to the editor</a>
+
+    <header class="chrome">
+      <h1 class="brand"><span class="brand-mark" aria-hidden="true">≋</span> Ajisai</h1>
+      <p class="tagline">exact values, flowing left to right</p>
+      <div class="chrome-actions">
+        <label class="selector" data-desktop>
+          <span class="selector-label">Left</span>
+          <select id="left-select">
+            <option value="input">Input</option>
+            <option value="output">Output</option>
+          </select>
+        </label>
+        <label class="selector" data-desktop>
+          <span class="selector-label">Right</span>
+          <select id="right-select">
+            <option value="stack">Stack</option>
+            <option value="dictionary">Dictionary</option>
+          </select>
+        </label>
+        <label class="selector" data-mobile>
+          <span class="selector-label">Panel</span>
+          <select id="mobile-select">
+            <option value="input">Input</option>
+            <option value="output">Output</option>
+            <option value="stack">Stack</option>
+            <option value="dictionary">Dictionary</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="panel" id="input-area" aria-label="Input">
+        <div class="panel-head">
+          <h2>Input</h2>
+          <div class="panel-tools">
+            <button type="button" id="run" class="primary" title="Shift+Enter">Run</button>
+            <button type="button" id="step" title="Ctrl+Enter">Step</button>
+            <button type="button" id="lint" title="Report obvious contract inconsistencies">
+              Lint
+            </button>
+            <button type="button" id="format" title="Shift+Alt+F">Format</button>
+            <button type="button" id="reset" title="Ctrl+Alt+Enter">Reset</button>
+          </div>
+        </div>
+        <div class="editor-wrap">
+          <textarea
+            id="editor"
+            spellcheck="false"
+            autocapitalize="off"
+            autocomplete="off"
+            autocorrect="off"
+            aria-describedby="editor-help"
+          ></textarea>
+          <ul id="suggestions" class="suggestions" hidden></ul>
+        </div>
+        <p id="editor-help" class="visually-hidden">
+          Shift plus Enter runs the program. Control plus Enter runs one step. Escape aborts.
+        </p>
+        <div class="palette" id="palette" aria-label="Input assist"></div>
+      </section>
+
+      <section class="panel" id="output-area" aria-label="Output">
+        <div class="panel-head">
+          <h2>Output</h2>
+          <div class="panel-tools">
+            <button type="button" id="copy-output">Copy</button>
+          </div>
+        </div>
+        <div class="panel-body">
+          <ul id="output" class="diagnostics"></ul>
+        </div>
+      </section>
+
+      <section class="panel" id="stack-area" aria-label="Stack">
+        <div class="panel-head">
+          <h2>Stack</h2>
+          <p class="hint" id="mode-hint"></p>
+        </div>
+        <div class="panel-body">
+          <ol id="stack" class="stack" reversed></ol>
+        </div>
+      </section>
+
+      <section class="panel" id="dictionary-area" aria-label="Dictionary">
+        <div class="panel-head">
+          <h2>Dictionary</h2>
+          <div class="panel-tools">
+            <select id="sheet-select" aria-label="Dictionary sheet">
+              <option value="core">Ajisai Core</option>
+              <option value="user">Your words</option>
+            </select>
+            <button type="button" id="export-words" title="Copy your definitions as source">
+              Export
+            </button>
+          </div>
+        </div>
+        <div class="search">
+          <input
+            type="search"
+            id="search"
+            placeholder="Filter words"
+            aria-label="Filter words"
+            autocomplete="off"
+          />
+        </div>
+        <div class="panel-body">
+          <ul id="dictionary" class="dictionary"></ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="chrome">
+      <p id="status" class="status" role="status" aria-live="polite">Loading…</p>
+      <p class="links">
+        <a href="https://github.com/masamoto1982/Ajisai">Source</a>
+        <a href="https://github.com/masamoto1982/Ajisai/blob/main/SPECIFICATION.md">
+          Specification
+        </a>
+      </p>
+    </footer>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ajisai-playground",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test *.test.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.56.1"
+  }
+}

--- a/playground/presentation.js
+++ b/playground/presentation.js
@@ -1,0 +1,144 @@
+// The presentation profile, as pure functions.
+//
+// This is a user interface, not the language (`SPECIFICATION.md` §14). Nothing
+// here can change what a program means; it decides which of the four surfaces
+// a person is looking at. It lives in its own module, free of the DOM, so the
+// rules can be tested directly — see `playground/presentation.test.mjs`.
+
+/** The four observation surfaces, in the order a single-panel device cycles. */
+export const VIEW_ORDER = ['input', 'output', 'stack', 'dictionary'];
+
+const LEFT_SURFACES = ['input', 'output'];
+const RIGHT_SURFACES = ['stack', 'dictionary'];
+
+/** Width at or below which the layout shows one surface at a time. */
+export const MOBILE_BREAKPOINT = 768;
+/** Horizontal travel that counts as a swipe rather than a tap. */
+export const SWIPE_THRESHOLD = 50;
+
+export const isLeftSurface = (surface) => LEFT_SURFACES.includes(surface);
+export const isRightSurface = (surface) => RIGHT_SURFACES.includes(surface);
+
+/**
+ * Manual selection, two-column layout.
+ *
+ * The two coupling rules are the point of this function, and they are about
+ * intent rather than cosmetics:
+ *
+ *   - choosing Output pulls the right column to Stack, because you asked to
+ *     see what a run said and the flow is the other half of that answer;
+ *   - choosing Dictionary pulls the left column to Input, because the reason
+ *     to open the dictionary is to put a word into the editor.
+ *
+ * Together they keep Output and Dictionary — the two surfaces whose intents
+ * conflict — out of the reachable configurations.
+ */
+export const selectSurface = (layout, surface) => {
+  const next = { ...layout };
+  if (isLeftSurface(surface)) {
+    next.left = surface;
+    if (surface === 'output') next.right = 'stack';
+  }
+  if (isRightSurface(surface)) {
+    next.right = surface;
+    if (surface === 'dictionary') next.left = 'input';
+  }
+  return next;
+};
+
+/**
+ * Execution-driven transition, two-column layout.
+ *
+ * Distinct from manual selection: here the surfaces a run *touched* decide
+ * where the layout moves. Dictionary outranks Stack for the right column,
+ * because defining a word is the more notable structural change. When a run
+ * changed nothing observable, both columns stay where they were — a run that
+ * did nothing should not move the furniture.
+ */
+export const applyRun = (layout, changes) => {
+  const next = { ...layout };
+  if (changes.output) next.left = 'output';
+  if (changes.stack) next.right = 'stack';
+  if (changes.dictionary) next.right = 'dictionary';
+  return next;
+};
+
+/**
+ * Execution-driven transition, single-surface layout.
+ *
+ * One surface can be shown, so the most notable change wins, in the same
+ * priority order the two-column rule implies. Nothing changed means stay put.
+ */
+export const applyRunMobile = (current, changes) => {
+  if (changes.dictionary) return 'dictionary';
+  if (changes.output) return 'output';
+  if (changes.stack) return 'stack';
+  return current;
+};
+
+/** The next surface when cycling — by swipe, or by the selector's arrows. */
+export const cycle = (current, direction) => {
+  const at = VIEW_ORDER.indexOf(current);
+  const from = at === -1 ? 0 : at;
+  const step = direction === 'left' ? 1 : -1;
+  return VIEW_ORDER[(from + step + VIEW_ORDER.length) % VIEW_ORDER.length];
+};
+
+/**
+ * What a run changed, by comparing two snapshots.
+ *
+ * A failed run always counts as changing Output, because the diagnostic is
+ * what the Output surface shows — a program that fails silently would leave
+ * the person looking at an unchanged screen.
+ */
+export const detectChanges = (before, after, result) => {
+  const sameStack = JSON.stringify(before.stack) === JSON.stringify(after.stack);
+  const key = (definitions) =>
+    JSON.stringify(
+      [...definitions]
+        .map(({ name, body }) => [name, body])
+        .sort((a, b) => a[0].localeCompare(b[0])),
+    );
+  const dictionary = key(before.definitions) !== key(after.definitions);
+  const named = after.definitions.find(
+    (word) => !before.definitions.some((had) => had.name === word.name),
+  );
+  return {
+    output: !result.ok || Boolean(result.findings?.length),
+    stack: !sameStack,
+    dictionary,
+    // The word that just appeared, so the dictionary can land on it.
+    reveal: named?.name,
+  };
+};
+
+/**
+ * Which stack cells the armed modes would treat as operands, and what would
+ * become of them.
+ *
+ * This is a *hint about the source being written*, not a simulation: a mode
+ * governs one word, and this summarises which modes the whole fragment uses.
+ * It reads whole tokens only, so `.5` and `5.` are numbers, never a `TOP`.
+ *
+ *   - `target`: `STAK` (or `:`) anywhere means every cell is an operand;
+ *     otherwise only the surface cell is.
+ *   - `retention`: `KEEP` (or `&`) anywhere means operands are retained;
+ *     otherwise they are eaten.
+ */
+export const analyzeModes = (source) => {
+  let target = 'top';
+  let retention = 'eat';
+  for (const raw of source.split(/\s+/)) {
+    const token = raw.toUpperCase();
+    if (token === ':' || token === 'STAK') target = 'stak';
+    if (token === '&' || token === 'KEEP') retention = 'keep';
+  }
+  return { target, retention };
+};
+
+/** The cells `analyzeModes` says are operands, given a flow of `depth` cells. */
+export const operandCells = (depth, modes) => {
+  if (depth === 0) return [];
+  if (modes.target === 'stak') return Array.from({ length: depth }, (_, i) => i);
+  return [depth - 1];
+};

--- a/playground/presentation.test.mjs
+++ b/playground/presentation.test.mjs
@@ -1,0 +1,157 @@
+// The presentation profile's rules, tested without a browser.
+//
+// Run with: node --test playground/
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  VIEW_ORDER,
+  analyzeModes,
+  applyRun,
+  applyRunMobile,
+  cycle,
+  detectChanges,
+  operandCells,
+  selectSurface,
+} from './presentation.js';
+
+const layout = (left, right) => ({ left, right });
+
+test('choosing Output pulls the right column to Stack', () => {
+  assert.deepEqual(selectSurface(layout('input', 'dictionary'), 'output'), {
+    left: 'output',
+    right: 'stack',
+  });
+});
+
+test('choosing Dictionary pulls the left column to Input', () => {
+  assert.deepEqual(selectSurface(layout('output', 'stack'), 'dictionary'), {
+    left: 'input',
+    right: 'dictionary',
+  });
+});
+
+test('Output and Dictionary are never shown together', () => {
+  // Every configuration reachable by any sequence of selections.
+  const seen = new Set();
+  const frontier = [layout('input', 'stack')];
+  while (frontier.length) {
+    const current = frontier.pop();
+    const key = `${current.left}/${current.right}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    for (const surface of VIEW_ORDER) frontier.push(selectSurface(current, surface));
+  }
+  assert.ok(!seen.has('output/dictionary'), [...seen].join(' '));
+  assert.ok(seen.size > 1, 'more than one configuration is reachable');
+});
+
+test('selection is idempotent', () => {
+  for (const surface of VIEW_ORDER) {
+    const once = selectSurface(layout('input', 'stack'), surface);
+    assert.deepEqual(selectSurface(once, surface), once, surface);
+  }
+});
+
+test('every surface is reachable by selection', () => {
+  for (const surface of VIEW_ORDER) {
+    const next = selectSurface(layout('input', 'stack'), surface);
+    assert.ok(next.left === surface || next.right === surface, surface);
+  }
+});
+
+test('a run moves the layout to what it touched', () => {
+  const start = layout('input', 'dictionary');
+  assert.deepEqual(applyRun(start, { stack: true }), { left: 'input', right: 'stack' });
+  assert.deepEqual(applyRun(start, { output: true }), {
+    left: 'output',
+    right: 'dictionary',
+  });
+  assert.deepEqual(applyRun(start, { output: true, stack: true }), {
+    left: 'output',
+    right: 'stack',
+  });
+  // Dictionary outranks Stack: defining a word is the more notable change.
+  assert.deepEqual(applyRun(start, { stack: true, dictionary: true }), {
+    left: 'input',
+    right: 'dictionary',
+  });
+});
+
+test('a run that changed nothing moves nothing', () => {
+  const start = layout('output', 'stack');
+  assert.deepEqual(applyRun(start, {}), start);
+  assert.equal(applyRunMobile('input', {}), 'input');
+});
+
+test('a single-surface layout shows the most notable change', () => {
+  assert.equal(applyRunMobile('input', { stack: true }), 'stack');
+  assert.equal(applyRunMobile('input', { output: true, stack: true }), 'output');
+  assert.equal(
+    applyRunMobile('input', { output: true, stack: true, dictionary: true }),
+    'dictionary',
+  );
+});
+
+test('cycling visits every surface and wraps both ways', () => {
+  let at = 'input';
+  const visited = [at];
+  for (let i = 0; i < 3; i += 1) {
+    at = cycle(at, 'left');
+    visited.push(at);
+  }
+  assert.deepEqual(visited, VIEW_ORDER);
+  assert.equal(cycle('dictionary', 'left'), 'input');
+  assert.equal(cycle('input', 'right'), 'dictionary');
+});
+
+test('a failed run always counts as changing Output', () => {
+  const state = { stack: [], definitions: [] };
+  const changes = detectChanges(state, state, { ok: false, error: 'boom' });
+  assert.equal(changes.output, true);
+  assert.equal(changes.stack, false);
+});
+
+test('a definition is detected and named', () => {
+  const before = { stack: [], definitions: [] };
+  const after = { stack: [], definitions: [{ name: 'DOUBLE', body: '{ 2 MUL }' }] };
+  const changes = detectChanges(before, after, { ok: true });
+  assert.equal(changes.dictionary, true);
+  assert.equal(changes.reveal, 'DOUBLE');
+});
+
+test('the dictionary comparison ignores order', () => {
+  const words = [
+    { name: 'A', body: '{ 1 }' },
+    { name: 'B', body: '{ 2 }' },
+  ];
+  const changes = detectChanges(
+    { stack: [], definitions: words },
+    { stack: [], definitions: [...words].reverse() },
+    { ok: true },
+  );
+  assert.equal(changes.dictionary, false, 'reordering is not a change');
+});
+
+test('modes are read as whole tokens, so numbers never trigger', () => {
+  assert.deepEqual(analyzeModes('1 2 ADD'), { target: 'top', retention: 'eat' });
+  assert.deepEqual(analyzeModes('1 2 3 : +'), { target: 'stak', retention: 'eat' });
+  assert.deepEqual(analyzeModes('1 2 & +'), { target: 'top', retention: 'keep' });
+  assert.deepEqual(analyzeModes('1 2 3 STAK KEEP ADD'), {
+    target: 'stak',
+    retention: 'keep',
+  });
+  // The alias and the word are the same thing here, as everywhere.
+  assert.deepEqual(analyzeModes('1 2 : & +'), analyzeModes('1 2 STAK KEEP ADD'));
+  // Decimals are numbers.
+  assert.deepEqual(analyzeModes('.5 5. 0.5 ADD'), { target: 'top', retention: 'eat' });
+  // Lower case is the same word.
+  assert.deepEqual(analyzeModes('1 2 keep add'), { target: 'top', retention: 'keep' });
+});
+
+test('the operand hint marks the surface cell, or all of them', () => {
+  assert.deepEqual(operandCells(3, { target: 'top' }), [2]);
+  assert.deepEqual(operandCells(3, { target: 'stak' }), [0, 1, 2]);
+  assert.deepEqual(operandCells(0, { target: 'stak' }), []);
+});

--- a/playground/wasm.test.mjs
+++ b/playground/wasm.test.mjs
@@ -1,0 +1,163 @@
+// The WebAssembly boundary, tested without a browser.
+//
+// `ajisai-wasm` has its own Rust tests; these check the other side of the
+// contract — that a JavaScript host can actually drive the raw ABI, and that
+// what comes back is the JSON the playground expects.
+//
+// Requires the module to have been built:
+//   cargo build -p ajisai-wasm --target wasm32-unknown-unknown --release
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const wasmPath = fileURLToPath(new URL('./ajisai.wasm', import.meta.url));
+const { instance } = await WebAssembly.instantiate(readFileSync(wasmPath), {});
+const core = instance.exports;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const takeReply = (length) =>
+  JSON.parse(decoder.decode(new Uint8Array(core.memory.buffer, core.ajisai_reply(), length)));
+
+const call = (entry, source) => {
+  const bytes = encoder.encode(source ?? '');
+  const pointer = core.ajisai_alloc(bytes.length);
+  try {
+    if (bytes.length) new Uint8Array(core.memory.buffer, pointer, bytes.length).set(bytes);
+    return takeReply(entry(pointer, bytes.length));
+  } finally {
+    core.ajisai_free(pointer, bytes.length);
+  }
+};
+
+const reset = () => takeReply(core.ajisai_reset());
+
+test('the module exports the whole protocol', () => {
+  for (const name of [
+    'memory',
+    'ajisai_alloc',
+    'ajisai_free',
+    'ajisai_reply',
+    'ajisai_execute',
+    'ajisai_lint',
+    'ajisai_format',
+    'ajisai_steps',
+    'ajisai_vocabulary',
+    'ajisai_reset',
+    'ajisai_snapshot',
+  ]) {
+    assert.equal(typeof core[name], name === 'memory' ? 'object' : 'function', name);
+  }
+});
+
+test('a program crosses the boundary and comes back exact', () => {
+  reset();
+  assert.deepEqual(call(core.ajisai_execute, '1 3 DIV 3 MUL').stack, ['1']);
+  reset();
+  assert.deepEqual(call(core.ajisai_execute, '0.1 0.2 ADD').stack, ['3/10']);
+  reset();
+});
+
+test('the session persists across calls', () => {
+  reset();
+  call(core.ajisai_execute, '1 2');
+  assert.deepEqual(call(core.ajisai_execute, 'ADD').stack, ['3']);
+  reset();
+});
+
+test('an error reports the flow the failing word left', () => {
+  reset();
+  const reply = call(core.ajisai_execute, '7 1 0 DIV');
+  assert.equal(reply.ok, false);
+  assert.match(reply.error, /division by zero/);
+  assert.deepEqual(reply.stack, ['7', '1', '0']);
+  reset();
+});
+
+test('definitions come back as source a host can show and re-run', () => {
+  reset();
+  const reply = call(core.ajisai_execute, '{ 2 MUL } "DOUBLE" DEF');
+  assert.deepEqual(reply.definitions, [{ name: 'DOUBLE', body: '{ 2 MUL }' }]);
+  // The exported form is a program that recreates the word.
+  reset();
+  const again = call(core.ajisai_execute, '{ 2 MUL } "DOUBLE" DEF 21 DOUBLE');
+  assert.deepEqual(again.stack, ['42']);
+  reset();
+});
+
+test('a step keeps a vent with its unit', () => {
+  const reply = call(core.ajisai_steps, 'TRUE VENT { 1 0 DIV } 7');
+  assert.deepEqual(reply.steps, ['TRUE', 'VENT { 1 0 DIV }', '7']);
+});
+
+test('a step keeps a mode with the word it governs', () => {
+  assert.deepEqual(call(core.ajisai_steps, '1 2 3 STAK ADD').steps, ['1', '2', '3', 'STAK ADD']);
+});
+
+test('the formatter normalizes symbols to canonical words', () => {
+  assert.equal(call(core.ajisai_format, '1 2 & + : ^ { 3 }').text, '1 2 KEEP ADD STAK VENT { 3 }');
+});
+
+test('the lint crosses as findings, not as a refusal to run', () => {
+  reset();
+  const findings = call(core.ajisai_lint, '[ 1 ] 2 ADD').findings;
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'error');
+  // Linting does not touch the session.
+  assert.deepEqual(takeReply(core.ajisai_snapshot()).stack, []);
+});
+
+test('the vocabulary crosses with contracts intact', () => {
+  const { words } = takeReply(core.ajisai_vocabulary());
+  assert.equal(words.length, 54);
+  const add = words.find((word) => word.name === 'ADD');
+  assert.deepEqual(add.aliases, ['+']);
+  assert.equal(add.stack_effect, '( a b -- sum )');
+  assert.equal(add.stak, 'fold-left');
+  assert.equal(words.find((word) => word.name === 'EQ').stak, 'unsupported');
+});
+
+test('an enormous rendering is truncated rather than shipped whole', () => {
+  reset();
+  const reply = call(core.ajisai_execute, '0 200000 RANGE');
+  assert.equal(reply.ok, true);
+  assert.ok(reply.stack[0].endsWith('…'), 'should be truncated');
+  assert.ok(reply.stack[0].length < 5000, 'should stay small');
+  reset();
+});
+
+test('text and quotes survive the JSON encoding', () => {
+  reset();
+  const reply = call(core.ajisai_execute, '"a\\"b\\nc" { 1 ADD }');
+  assert.equal(reply.ok, true);
+  assert.deepEqual(reply.stack, ['"a\\"b\\nc"', '{ 1 ADD }']);
+  reset();
+});
+
+test('non-ASCII source crosses intact', () => {
+  reset();
+  const reply = call(core.ajisai_execute, '{ 2 MUL } "倍" DEF 21 倍');
+  assert.deepEqual(reply.stack, ['42']);
+  assert.equal(reply.definitions[0].name, '倍');
+  reset();
+});
+
+test('reset empties the session', () => {
+  call(core.ajisai_execute, '{ 1 } "X" DEF 9');
+  const reply = reset();
+  assert.deepEqual(reply.stack, []);
+  assert.deepEqual(reply.definitions, []);
+});
+
+test('repeated allocation does not leak into the reply', () => {
+  reset();
+  for (let i = 0; i < 200; i += 1) {
+    const reply = call(core.ajisai_execute, `${i} ${i} ADD DROP`);
+    assert.equal(reply.ok, true, `iteration ${i}`);
+  }
+  assert.deepEqual(takeReply(core.ajisai_snapshot()).stack, []);
+  reset();
+});

--- a/playground/worker.js
+++ b/playground/worker.js
@@ -1,0 +1,72 @@
+// The session, in a worker.
+//
+// The interpreter lives here so that a long-running program never freezes the
+// interface, and so that Escape can abort by terminating the worker outright.
+// The main thread keeps a journal of fragments that ran, and replays it into a
+// fresh worker afterwards — which is why abort can be brutal and still leave
+// the session where it was.
+
+const wasmUrl = new URL('./ajisai.wasm', import.meta.url);
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+let core = null;
+
+const load = async () => {
+  if (core) return core;
+  const response = await fetch(wasmUrl);
+  const { instance } = await WebAssembly.instantiate(await response.arrayBuffer(), {});
+  core = instance.exports;
+  return core;
+};
+
+/** Read the reply buffer the last call left behind. */
+const takeReply = (length) =>
+  JSON.parse(decoder.decode(new Uint8Array(core.memory.buffer, core.ajisai_reply(), length)));
+
+/** Call an entry point that takes source. */
+const withSource = (entry, source) => {
+  const bytes = encoder.encode(source ?? '');
+  const pointer = core.ajisai_alloc(bytes.length);
+  try {
+    if (bytes.length > 0) {
+      new Uint8Array(core.memory.buffer, pointer, bytes.length).set(bytes);
+    }
+    return takeReply(entry(pointer, bytes.length));
+  } finally {
+    core.ajisai_free(pointer, bytes.length);
+  }
+};
+
+const handlers = {
+  execute: (source) => withSource(core.ajisai_execute, source),
+  lint: (source) => withSource(core.ajisai_lint, source),
+  format: (source) => withSource(core.ajisai_format, source),
+  steps: (source) => withSource(core.ajisai_steps, source),
+  snapshot: () => takeReply(core.ajisai_snapshot()),
+  reset: () => takeReply(core.ajisai_reset()),
+  vocabulary: () => takeReply(core.ajisai_vocabulary()),
+  // Rebuild a session by re-running what already ran. Used after an abort,
+  // where the worker was terminated mid-program.
+  replay: (_source, journal) => {
+    core.ajisai_reset();
+    let reply = takeReply(core.ajisai_snapshot());
+    for (const fragment of journal ?? []) {
+      reply = withSource(core.ajisai_execute, fragment);
+    }
+    return reply;
+  },
+};
+
+self.onmessage = async (event) => {
+  const { id, kind, source, journal } = event.data;
+  try {
+    await load();
+    const handler = handlers[kind];
+    if (!handler) throw new Error(`unknown request: ${kind}`);
+    self.postMessage({ id, ok: true, reply: handler(source, journal) });
+  } catch (error) {
+    self.postMessage({ id, ok: false, error: String(error?.message ?? error) });
+  }
+};


### PR DESCRIPTION
## Summary

The web playground is back — and it is outside the language, which is what the review that prompted its removal was actually asking for.

The separation was right; the loss was not. Panel reachability, screen transitions, and idempotent selection had been written into the language specification as if they were conformance conditions. They are not. `docs/playground-ui.md` specifies them now, `SPECIFICATION.md` never refers to it, and a headless implementation that provides none of this is still fully conforming (§14).

**The design is yours, recovered from the old sources rather than invented again** — `docs/dev/gui-current-design-memory.md`, `gui-layout-state.ts`, `mobile-view-switcher.ts`, and `execution-surface-changes.ts` from `01218c5`.

## What it does

**Layout.** Two columns above 768px — Input *or* Output, Stack *or* Dictionary. One surface at a time below it.

**Manual selection**, with the two coupling rules intact:
- choosing Output pulls the right column to Stack — you asked what a run said, and the flow is the other half of that answer;
- choosing Dictionary pulls the left column to Input — the reason to open the dictionary is to put a word in the editor.

A test explores the *whole* reachable configuration space and proves Output and Dictionary are never shown together, that selection is idempotent, and that every surface is reachable.

**Execution-driven transition.** What a run touched decides where the layout moves:

| touched | two columns | one surface |
|---|---|---|
| the flow | right → Stack | Stack |
| diagnostics | left → Output | Output |
| the dictionary | right → Dictionary, on the new word's sheet | Dictionary |
| nothing | stay | stay |

Dictionary outranks Stack. A run that changed nothing moves nothing.

**Keyboard.** `Shift+Enter` run · `Ctrl+Enter` step · `Shift+Alt+F` format · `Ctrl+Space` suggest · `Ctrl+Alt+Enter` reset · `Escape` abort.

**Touch.** Triple-tap the editor to run · double-tap Stack → Output · double-tap Output → editor · swipe to cycle, wrapping.

**The stack mode hint.** The feature the old memo described at length, now mapping onto the actual `TOP`/`STAK` × `EAT`/`KEEP`: **the filled set is the target, the fill colour is the fate.** `:`/`STAK` fills every cell, otherwise only the surface; `&`/`KEEP` is pale teal-green, the default `EAT` pale warm red. Both differ in lightness as well as hue, and both are fills rather than text colours so they never compete with the value's own ink.

**A step is one source unit**, using the same `unit_len` rule `VENT` uses. `TRUE VENT { 1 2 ADD }` steps as `TRUE` then `VENT { 1 2 ADD }` — a stepper that segmented naively would split the vent from its unit and fail on programs that run perfectly.

## The binding

`crates/ajisai-wasm` is a host like any other. Core does not depend on it, and CI now checks that edge alongside the package edges.

**No `wasm-bindgen`, no `wasm-pack`, no npm at runtime.** The whole interface is a string in and JSON out, which is a hand-written C ABI over linear memory — about a hundred lines each side — so `cargo build --target wasm32-unknown-unknown` is the only build step there is. 271 KB.

The playground has no bundler, no framework, and no runtime dependency: five files and one module.

## Testing

The rules live in `presentation.js` as pure functions, free of the DOM, and are tested without a browser. The wiring is tested *with* one.

That second suite earned its place on its first run, finding three defects:

1. a **Lint button on the Output panel** — unreachable while you are typing, which is the only time you want it;
2. `.suggestions { display: flex }` **beating `[hidden]`**, leaving an empty list rendered under the editor;
3. **Reset leaving you looking at the dictionary it had just emptied**.

| suite | tests |
|---|---|
| `presentation.test.mjs` — the rules | 14 |
| `wasm.test.mjs` — the boundary, under node | 15 |
| `browser.test.mjs` — the real interface, in Chromium | 17 |
| Rust (`cargo test --workspace`) | 157 |

## Kind of change

- [ ] Language change — `SPECIFICATION.md` is updated in the same PR
- [x] Implementation change with no language change
- [x] Package (`ajisai-music`, `ajisai-audit`) — a new host crate, `ajisai-wasm`
- [x] Documentation

**No language change.** `SPECIFICATION.md` is untouched by this branch. Nothing here can alter what a program means, and `docs/playground-ui.md` states that as a rule a playground must not break.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 157 passed
- [x] `cargo build --workspace --release`
- [x] `cd playground && npm test` — 46 passed

CI gains a `playground` job that builds the module, installs Chromium, and runs all three suites. A `pages` workflow builds and deploys to GitHub Pages, and **`CNAME` is restored** (`ajisai.tech`).

## Notes

Two things were agreed before building and are worth restating:

1. **The KaTeX math view is not restored.** New Ajisai has six value shapes, no continued fractions and no tensors, so the benefit is much smaller than it was, and it would mean vendoring ~1 MB of fonts, CSS, and JS again. The renderer is not hard-coded against it — if you want it back, it is an additive change.
2. **`Escape` aborts by terminating the worker**, then rebuilds the session by replaying the journal of fragments that already ran. The fragment that was running is the one thing that does not come back, which is what abort means.

`playground/ajisai.wasm` is a build artifact and is gitignored; the Pages workflow produces it. `playground/package.json` declares `playwright` as a devDependency for the browser test only — nothing is needed to *serve* the playground.

---
_Generated by [Claude Code](https://claude.ai/code/session_01119kkJ2P59ZjBtabXfwW9M)_