### PR TITLE
docs: describe only the language as it stands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Ajisai is an AI-first, vector-oriented dataflow language for **auditable, exact vector computation with machine-readable contracts** — built so that both people and agents can check a computation *before* it runs.
 
-Its central promise is **value integrity first**: numbers stay exact, structure stays visible, partial failure stays diagnosable, and every built-in word is expected to have a machine-readable contract that a user word's declaration can be checked against ahead of execution (`ajisai check --contract`) — a conservative, partial check: declarations are verified within the syntactic fragment the inference can analyze, and anything it cannot prove (higher-order bodies, dynamic control, child runtimes) is reported as "cannot verify", never silently passed.
+Its central promise is **value integrity first**: numbers stay exact, structure stays visible, partial failure stays diagnosable, and every built-in Word carries a machine-readable contract that a user word's declaration can be checked against ahead of execution (`ajisai check --contract`). That check is deliberately conservative — it verifies declarations within the syntactic fragment its inference can analyze, and reports anything it cannot prove as "cannot verify".
 
-**Ten concepts.** Ajisai is deliberately small: exact rationals closed under `SQRT`; three outcomes and no fourth (a value, a reasoned absence, an error); a stack and vectors; code blocks evaluated only on request; one modifier axis; a sealed-Core / User dictionary with content-addressed identity; a machine-readable contract per Word; a pre-execution check of user declarations against those contracts; one host protocol; and an executable conformance corpus. The vocabulary is **69 Words** in one flat dictionary. Anything not on that list is not part of the language — see [`docs/dev/concept-reduction-2026-07.md`](docs/dev/concept-reduction-2026-07.md) for what was cut and why.
+**Ten concepts.** Ajisai is built from ten concepts and nothing else: exact rationals closed under `SQRT`; three outcomes (a value, a reasoned absence, an error); a stack and vectors; code blocks evaluated only on request; one modifier axis; a sealed-Core / User dictionary with content-addressed identity; a machine-readable contract per Word; a pre-execution check of user declarations against those contracts; one host protocol; and an executable conformance corpus. The vocabulary is **69 Words** in one flat dictionary.
 
-**Numeric scope.** Numbers are *exact by default*: exact rationals and the multiquadratic field they generate under `SQRT` — square roots of non-negative rationals, closed under field arithmetic, in a normal form \(\sum_d c_d\sqrt d\). Arithmetic never rounds, coefficients are arbitrary-precision, and **comparison is total**: every comparison of two scalars decides, with no budget and no undecided outcome. General computable reals (π, e, log, …) are outside the language.
+**Numeric scope.** Numbers are *exact by default*: exact rationals and the multiquadratic field they generate under `SQRT` — square roots of non-negative rationals, closed under field arithmetic, in a normal form \(\sum_d c_d\sqrt d\). Arithmetic never rounds, coefficients are arbitrary-precision, and **comparison is total**: every comparison of two scalars decides in finite time. That field is the whole numeric domain, so π, e, and logarithms are not Ajisai values.
 
 The name *Ajisai* comes from hydrangea, often interpreted as a “water vessel.” Ajisai uses water as its main metaphor: values flow through channels, operations shape those channels, and exceptional situations remain visible instead of disappearing into hidden runtime state.
 
@@ -36,7 +36,7 @@ The HTML source of the specification lives at [`SPECIFICATION.html`](SPECIFICATI
 | Bubble | a well-formed operation could not produce a value | `NIL`, carrying a machine-readable reason |
 | Channel error | the operation or input shape is malformed | raised error that propagates and halts evaluation |
 
-Ajisai keeps these three cases separate, and there is no fourth. A bubble is absence, not falsehood. An error is not a value in the stream. Truth is two-valued: every comparison decides, so the language never has to represent "undecided".
+Ajisai keeps these three cases separate. A bubble is absence, not falsehood; an error is not a value in the stream. Truth is two-valued — `TRUE` and `FALSE` — and every comparison decides.
 
 Spec links: [Value Domains](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-values), [Diagnostic absence](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-values-nil), [Partiality and Failure](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-failure)
 
@@ -44,25 +44,25 @@ Spec links: [Value Domains](https://masamoto1982.github.io/Ajisai/SPECIFICATION.
 
 ## Why Ajisai exists
 
-### 1) Exact numbers: no hidden detour through floating point
+### 1) Exact numbers
 
 Every numeric value is **exact**. Integer, fraction, decimal, and scientific-notation literals are convenient source forms for exact rationals, and `SQRT` produces exact algebraic irrationals carried in a multiquadratic normal form \(\sum_d c_d\sqrt d\). That is the whole numeric domain: rationals plus the `SQRT` closure over them.
 
-Arithmetic never rounds, and coefficients are arbitrary-precision, so overflow is impossible rather than wrapped. Canonical AI-readable display uses a nested continued-fraction form derived from the value, rather than remembering the original source literal.
+Arithmetic works directly on those values, so a result is either the exact answer or a reasoned absence. Coefficients are arbitrary-precision, so a number grows as large as the value requires. Canonical AI-readable display uses a nested continued-fraction form derived from the value, rather than remembering the original source literal.
 
-**Comparison is total.** Every comparison of two scalars answers `TRUE` or `FALSE` in finite time — no budget, no refinement limit, no undecided outcome. Values built through different histories are the same value when they denote the same real: `8 SQRT` equals `2 SQRT 2 SQRT +`.
+**Comparison is total.** Every comparison of two scalars answers `TRUE` or `FALSE` in finite time. Values built through different histories are the same value when they denote the same real: `8 SQRT` equals `2 SQRT 2 SQRT +`.
 
 Spec links: [Exact scalars](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-values-exact), [Two-valued truth](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-values-truth), [Work limits](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-machine-limits)
 
 ### 2) Bubble: partial failure stays visible
 
-Ajisai distinguishes three outcomes and nothing else. A **value** is ordinary success. A **bubble** is `NIL`: a well-formed operation that could not produce a value — division by zero, a failed `NUM` parse, an invalid `CHR` code point, an out-of-range `GET`. A **channel error** is malformed use, which propagates and halts evaluation.
+Ajisai distinguishes three outcomes. A **value** is ordinary success. A **bubble** is `NIL`: a well-formed operation that could not produce a value — division by zero, a failed `NUM` parse, an invalid `CHR` code point, an out-of-range `GET`. A **channel error** is malformed use, which propagates and halts evaluation.
 
-A bubble carries a machine-readable **reason** and flows downstream, so absence stays diagnosable instead of disappearing into a sentinel. `NIL` is not `FALSE` and an error is not a value.
+A bubble carries a machine-readable **reason** and flows downstream, so absence stays diagnosable. `NIL` is not `FALSE`, and an error is not a value.
 
 - `NIL` means "the value is absent", and `^` (`VENT`) turns it into a fallback at the end of a pipeline.
-- `AND` / `OR` / `NOT` pass a `NIL` operand through rather than absorbing it, so a bubble is never silently swallowed by a definite operand.
-- There is no modifier that converts an error into a value.
+- `AND` / `OR` / `NOT` pass a `NIL` operand through, so a bubble stays visible even when the other operand would settle the answer.
+- A channel error is the one outcome that ends the program: it propagates to the top and halts evaluation, so misuse surfaces where it happened rather than turning into a value.
 
 Spec links: [Diagnostic absence](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-values-nil), [Value, absence, misuse](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-failure-trichotomy), [NIL passthrough](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-failure-passthrough), [Recovery](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-failure-recovery)
 
@@ -70,23 +70,23 @@ Spec links: [Diagnostic absence](https://masamoto1982.github.io/Ajisai/SPECIFICA
 
 Ajisai is vector-oriented. A vector is an ordered, indexable sequence; indexing is 0-origin and negative indices count from the end. Vectors nest, which is how ragged and grouped data is expressed.
 
-Arithmetic and comparison **lift element-wise**: two vectors of equal length combine pairwise, and a scalar combines with every element. Any other pairing is an error rather than a silent reshape.
+Arithmetic and comparison **lift element-wise**: two vectors of equal length combine pairwise, and a scalar combines with every element. Any other pairing raises an error, so a length mismatch is reported at the point it occurs.
 
-A vector is a sequence, not a tensor: there is no rank, shape, or reshape algebra. It is also not a code-as-data mechanism — executable code lives in `{ }` code blocks, a vector is never executable, and Ajisai makes no claim to Lisp-style homoiconicity. Internal storage (nested trees or dense buffers) is unobservable.
+A vector is a sequence: values in order, nested as deeply as the data needs. Executable code is a separate kind of value that lives in `{ }` code blocks, so code and data never occupy the same shape. Internal storage (nested trees or dense buffers) is unobservable.
 
 Spec links: [Vectors](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-values-vector), [Element lifting](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-collections-lift), [Higher-order evaluation](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-collections-higher)
 
 ### 4) One modifier axis: consume or keep
 
-A modifier prefixes the next word only, and there is exactly one axis: **consumption**. `EAT` (`,`, the default) consumes the operands a word reads; `KEEP` (`,,`) leaves them on the stack beneath the result.
+A modifier prefixes the next word only, and the single axis is **consumption**. `EAT` (`,`, the default) consumes the operands a word reads; `KEEP` (`,,`) leaves them on the stack beneath the result.
 
-That is the whole modifier system. There is no target axis, and no error-swallowing modifier: partial failure of a well-formed operation becomes a reasoned `NIL`, and malformed use raises an error that propagates rather than becoming a value.
+That is the whole modifier system: two words, one decision. Everything else about how a Word behaves is in the Word itself, so reading a call means reading a name and at most one prefix.
 
 Spec links: [The consumption axis](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-modifiers-consumption), [Stack observation](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html#lang-stack-order)
 
 ### 5) Words and contracts: searchable channels for humans and AI
 
-The dictionary has two tiers and no more: **Core** holds the 69 canonical Words and is sealed, and **User** holds definitions made by `DEF`. There is no module system and nothing to import — every Word is reachable by its plain name.
+The dictionary has two tiers: **Core** holds the 69 canonical Words and is sealed, and **User** holds definitions made by `DEF`. Every Core Word is reachable by its plain name, so a program starts with the full vocabulary already in scope.
 
 Each Core Word's contract is a machine-readable record in [`spec/words.json`](spec/words.json): arity, consumption, NIL policy, projection reason, error conditions, purity, effects, and documentation. That record is the single place the Word is defined; prose is a projection of it.
 
@@ -96,16 +96,16 @@ Spec links: [Word contracts](https://masamoto1982.github.io/Ajisai/SPECIFICATION
 
 ## Safety model: safe by design
 
-Ajisai does **not** rely on a broad "safe mode" that wraps evaluation. There is no
-global safe/unsafe switch. Ordinary value flow is safe by design:
+Safety in Ajisai is a property of ordinary value flow. Every operation lands in
+one of two places:
 
 - a well-formed operation that cannot produce a value becomes a **bubble** (`NIL`),
 - a malformed use raises a **channel error**.
 
-There is no mode or modifier that converts an error into a value: a channel error
-propagates and halts evaluation, while well-formed partial failure already flows
-as a reasoned bubble that a single `^` (`VENT`) can turn into a fallback at the
-end of a pipeline.
+The two are kept apart on purpose. A bubble carries its reason downstream, and a
+single `^` (`VENT`) turns it into a fallback at the end of a pipeline. A channel
+error propagates to the top and halts evaluation, so misuse is reported rather
+than absorbed into the result.
 
 Two limits bound how much a program may do, and they mean different things:
 

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -456,7 +456,7 @@
             <article class="ref-article">
                 <section id="intro" class="ref-page">
                     <h2>Introduction</h2>
-                    <p>Ajisai is an AI-first, vector-oriented, fractional-dataflow stack language. A program is a sequence of <strong>words</strong>: values are pushed onto a single stack, and each word consumes operands from the stack and pushes its results. Every number is <strong>exact</strong> — exact rationals and the algebraic <code>SQRT</code> closure (a multiquadratic normal form), compared with no rounding — so arithmetic never rounds. Its continued-fraction form is a canonical display <em>derived from</em> the value, not its internal storage.</p>
+                    <p>Ajisai is an AI-first, vector-oriented dataflow language. A program is a sequence of <strong>words</strong>: values are pushed onto a single stack, and each word consumes operands from the stack and pushes its results. Every number is <strong>exact</strong> — exact rationals and the algebraic <code>SQRT</code> closure over them, carried in a multiquadratic normal form — so arithmetic and comparison both work without rounding. A number's continued-fraction form is a canonical display <em>derived from</em> the value, not its internal storage.</p>
                     <p>This reference introduces each feature with short, verified examples. Every example has an <strong>"Open in Playground"</strong> button; pressing it loads the code into the app's editor so you can run it and see how it behaves.</p>
                     <p><strong>The Reference is for using Ajisai.</strong> If you are implementing or porting the language, the single design authority is the <a href="../SPECIFICATION.html">Specification</a>; this page is derived from it for learners and day-to-day users.</p>
                     <h3>How to read the examples</h3>
@@ -497,7 +497,7 @@
                                 <tr>
                                     <td><code>[ [ 1 2 ] [ 3 4 ] ]</code></td>
                                     <td><code>[ [ 1/1 2/1 ] [ 3/1 4/1 ] ]</code></td>
-                                    <td class="notes">Nesting is preserved; nested vectors act as tensors.</td>
+                                    <td class="notes">Nesting is preserved, and nesting is how grouped and ragged data is expressed.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -530,7 +530,7 @@
 
                 <section id="numbers" class="ref-page">
                     <h2>Exact Numbers</h2>
-                    <p>Every numeric value is exact; its continued-fraction form is a canonical display <em>derived</em> from the value, not its internal storage. Integer, fraction, decimal, and scientific-notation literals are all surface forms of the same exact value — <code>0.5</code> <em>is</em> one half, not a binary approximation. The implemented domain is exact rationals and the algebraic <code>SQRT</code> closure; general computable reals (π, e, log, …) are reserved for future words.</p>
+                    <p>Every numeric value is exact; its continued-fraction form is a canonical display <em>derived</em> from the value, not its internal storage. Integer, fraction, decimal, and scientific-notation literals are all surface forms of the same exact value — <code>0.5</code> <em>is</em> one half, not a binary approximation. The numeric domain is exact rationals together with the algebraic <code>SQRT</code> closure over them, and every number you can build is one of those.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -650,7 +650,7 @@
 
                 <section id="stack" class="ref-page">
                     <h2>Stack and Modifiers</h2>
-                    <p>Words take their operands from the stack and push their results back. Two pairs of <strong>modifiers</strong>, written before a word, control where the operands come from and whether they survive:</p>
+                    <p>Words take their operands from the stack and push their results back. A <strong>modifier</strong>, written before a word, controls whether the operands survive the call:</p>
                     <div class="ref-table-wrap word-table">
                         <table class="ref-table">
                             <thead>
@@ -854,12 +854,12 @@
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
-                    <p class="ref-note">The six relations decide exactly over every value the words can build — rationals and square roots alike — so a comparison always answers <code>TRUE</code> or <code>FALSE</code>. There is no budget to run out of and no undecided outcome.</p>
+                    <p class="ref-note">The six relations decide exactly over every value the words can build — rationals and square roots alike — so a comparison always answers <code>TRUE</code> or <code>FALSE</code> in finite time.</p>
                 </section>
 
                 <section id="logic" class="ref-page">
                     <h2>Logic</h2>
-                    <p><code>AND</code> (<code>&amp;</code>) and <code>OR</code> and <code>NOT</code> are the ordinary Boolean operations over <code>TRUE</code> and <code>FALSE</code>. There is no third truth value: every comparison decides, so logic never has to represent "undecided". An absent operand passes through rather than being absorbed — <code>NIL</code> in, <code>NIL</code> out — so a bubble stays visible instead of being swallowed by a definite operand.</p>
+                    <p><code>AND</code> (<code>&amp;</code>) and <code>OR</code> and <code>NOT</code> are the Boolean operations over the two truth values <code>TRUE</code> and <code>FALSE</code>. An absent operand passes through: <code>NIL</code> in, <code>NIL</code> out, so a bubble stays visible in the result even when the other operand would settle the answer.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -927,7 +927,7 @@
                                 <tr>
                                     <td><code>1 0 DIV TRUE AND</code></td>
                                     <td><code>NIL</code></td>
-                                    <td class="notes">The left operand bubbled, so the absence flows to the result instead of being absorbed. Recover it with <code>^</code> where it matters.</td>
+                                    <td class="notes">The left operand bubbled, so the absence flows through to the result. Recover it with <code>^</code> where it matters.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -1400,7 +1400,7 @@ COND</code></td>
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
-                    <p class="ref-note">Every guard decides, so a clause either fires or does not. If no clause matches and there is no else clause, <code>COND</code> raises an error.</p>
+                    <p class="ref-note">Each guard answers <code>TRUE</code> or <code>FALSE</code>, so a clause either fires or does not. If no clause matches and no else clause is present, <code>COND</code> raises an error.</p>
                 </section>
 
                 <section id="strings" class="ref-page">
@@ -1638,7 +1638,7 @@ COND</code></td>
 
                     <h3>Words are identified by content</h3>
                     <p>Ajisai is <strong>content-addressed</strong>: a user word's identity is computed from its content — its normalized body together with the identities of the words it calls — not from its name. Renaming a word, or defining an identical body in another dictionary, produces the very same identity, while changing the body produces a new one. A word's name is a label for an identity, not the word itself.</p>
-                    <p>Two consequences follow directly. Defining the same body twice does not store it twice — identical definitions share one identity and deduplicate. And because each word's dependencies are pinned to the <em>identities</em> they referenced at definition time, adding a core word, importing a module, or loading another dictionary later can never silently recapture an existing reference.</p>
+                    <p>Two consequences follow directly. Defining the same body twice does not store it twice — identical definitions share one identity and deduplicate. And because each word's dependencies are pinned to the <em>identities</em> they referenced at definition time, defining a new word or loading another dictionary later can never silently recapture an existing reference.</p>
 
                     <h3>Resolving a bare name</h3>
                     <p>A bare name is looked up in a fixed order, and the first match wins:</p>
@@ -1653,7 +1653,7 @@ COND</code></td>
 
                     <h3>Importing word groups</h3>
                     <p>You can export a word group, edit the file, rename it, and import it again. Import is a <strong>merge by identity</strong>, never a destructive overwrite. Identical definitions deduplicate automatically, so re-importing an unchanged group is a no-op. If you edited a word and import it under a name that already exists, the name is re-pointed to the new identity while the previous identity stays in place — any words that referenced the old version remain pinned to it, so nothing breaks. The bundled <code>EXAMPLE</code> dictionary is treated exactly like any other in this respect; there is no special name to protect.</p>
-                    <p class="ref-note">Because identity is content-addressed, an imported group behaves identically in every environment, regardless of which other dictionaries or modules happen to be loaded.</p>
+                    <p class="ref-note">Because identity is content-addressed, an imported group behaves identically in every environment, regardless of which other dictionaries happen to be loaded.</p>
                 </section>
 
 
@@ -1737,7 +1737,7 @@ COND</code></td>
                         </tbody>
                     </table>
                     </div>
-                    <p>For current algebraic Ajisai values, comparison is exact and total. Users do not choose an equality mode: they use the existing words, and Ajisai keeps representation details and display roles out of the value model.</p>
+                    <p>Comparison words work at the top layer only: over every Ajisai value they are exact and total, and they answer the mathematical question. The layers below stay out of the value model, so representation and display never affect what a comparison says.</p>
                 </section>
 
             </article>


### PR DESCRIPTION
## Summary

The README and the Reference still described Ajisai partly **by contrast with an earlier, larger design** — "no third truth value", "no budget to run out of", "no target axis", "no module system", "not a tensor". A reader who never saw that design gets nothing from those sentences, and in a few places the contrast had gone stale and stated the opposite of current behavior. Both documents now state the current shape directly.

**Stale statements corrected:**

| Where | Was | Now |
| --- | --- | --- |
| Reference, Stack and Modifiers | "Two pairs of modifiers … control where the operands come from and whether they survive" — the table below lists one pair | one modifier, one axis: whether the operands survive the call |
| Reference, Values and Vectors | "nested vectors act as tensors" | nesting is how grouped and ragged data is expressed |
| Reference, Exact Numbers | "general computable reals (π, e, log, …) are reserved for future words" | the numeric domain is the rationals and their `SQRT` closure |
| Reference, Word Identity | "adding a core word, **importing a module**, or loading another dictionary"; "which other dictionaries **or modules** happen to be loaded" | module mentions dropped |
| README, contract paragraph | listed "child runtimes" among what the inference cannot prove | that concept does not exist |

**Rephrasings, same meaning:** logic is introduced as the Boolean operations over two truth values with `NIL` passing through; comparison as deciding in finite time; the modifier axis as two words and one decision; the dictionary as two tiers with every Core Word in scope by plain name; the safety model as a property of value flow, with bubbles and channel errors described by what each does rather than by what Ajisai lacks.

The README no longer points at `docs/dev/concept-reduction-2026-07.md`. That note stays in the repository as a design record and a reminder of what the language once carried; it is simply not part of the language's description.

Prose and notes only — no sample code, no section structure, and no markup changed.

## Quality Classification

- Highest impacted level: QL-D (documentation only; no runtime, spec, or vocabulary surface is touched)

## Traceability

- Requirement(s): the README and the Reference must present the current language on its own terms; history belongs in `docs/dev/`.
- Verification evidence:
  - **All 57 Reference samples** executed against `ajisai run` — 57 passing, 0 failing.
  - **All 5 README samples** executed against `ajisai run` — 5 passing, 0 failing.
  - Every `SPECIFICATION.html#…` anchor cited by the README resolves to an `id` in the generated spec.
  - `check:semantic-firewall`, `semantic-kernel:check` (352 lines, 39 clauses, 11 families, 69 Words, 16 aliases), `specification:check`, `word:reference:check`, `core-word-docs:check` all pass.
  - `npm run check` and `npm run test` (226 tests) pass.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — unchanged from the base; left to CI on this SHA
- [x] `npm run check`
- [ ] `cargo llvm-cov --branch --workspace` — not applicable, no executable code changed
- [ ] MC/DC-like checklist reviewed for modified boolean logic — not applicable, no boolean logic changed
- [x] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ4YawbB4Pt7smaooW2HJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ4YawbB4Pt7smaooW2HJX)_