### PR TITLE
spec: state the kernel in the present tense

### DIFF
--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -199,12 +199,12 @@ This document defines the correspondence between Ajisai source programs and obse
 </p>
 
 <p>
-Ajisai is built from ten concepts and nothing else. Everything below is one of them, or a consequence of one of them.
+Ajisai is built from ten concepts. Everything below is one of them, or a consequence of one of them.
 </p>
 
 <ol>
 <li>Exact rational arithmetic, closed under square roots, with no rounding.</li>
-<li>Three outcomes and no fourth: a value, a reasoned absence, or an error.</li>
+<li>Three outcomes: a value, a reasoned absence, or an error.</li>
 <li>A stack of values and vectors of values.</li>
 <li>Code blocks, evaluated only when a Word asks for it.</li>
 <li>One modifier axis: consume or keep.</li>
@@ -303,7 +303,7 @@ A code block is a tagged value containing source for later evaluation. Producing
 </p>
 
 <p>
-Quoted code is not eagerly executed. A vector is data and is never executable; Ajisai makes no claim to homoiconicity.
+Quoted code is not eagerly executed. Code and data are distinct value domains: executable source lives in a CodeBlock, and a Vector is data and is never executable.
 </p>
 
 <h2 id="lang-values">3. Value Domains</h2>
@@ -325,7 +325,7 @@ Every scalar denotes an exact element of the field \(\mathbb{Q}(\sqrt{d_1},\dots
 </p>
 
 <p>
-Arithmetic performs no intermediate rounding, and coefficients are arbitrary-precision, so overflow is impossible rather than wrapped. Comparison over this domain is <strong>total and decidable</strong>: every comparison of two scalars yields TRUE or FALSE in finite time, with no budget, no refinement limit, and no undecided outcome. Values built through different histories compare equal when they denote the same real — \(\sqrt{8}\) and \(\sqrt{2}+\sqrt{2}\) are one value.
+Arithmetic performs no intermediate rounding, and coefficients are arbitrary-precision, so a coefficient grows to whatever size the value requires. Comparison over this domain is <strong>total and decidable</strong>: every comparison of two scalars yields TRUE or FALSE in finite time. Values built through different histories compare equal when they denote the same real — \(\sqrt{8}\) and \(\sqrt{2}+\sqrt{2}\) are one value.
 </p>
 
 <p>
@@ -335,11 +335,11 @@ The internal representation is unobservable. Canonical continued-fraction displa
 <h3 id="lang-values-truth">LANG.VALUES.TRUTH — Two-valued truth</h3>
 
 <p>
-Truth values are TRUE and FALSE. <code>AND</code>, <code>OR</code>, and <code>NOT</code> are the ordinary Boolean operations, and every comparison decides.
+The Boolean domain has exactly two values, TRUE and FALSE. <code>AND</code>, <code>OR</code>, and <code>NOT</code> are the ordinary Boolean operations, and every comparison decides.
 </p>
 
 <p>
-There is no third truth value. An operation that cannot produce a value produces NIL, which is absence and not undecidability; an operation that is malformed raises ERROR.
+Absence and misuse live outside this domain: an operation that cannot produce a value produces NIL, which is absence rather than undecidability, and an operation that is malformed raises ERROR.
 </p>
 
 <h3 id="lang-values-nil">LANG.VALUES.NIL — Diagnostic absence</h3>
@@ -349,7 +349,7 @@ NIL is a value representing absence from a well-formed partial operation. It car
 </p>
 
 <p>
-NIL carries the reason and nothing else. Origin, recoverability, and structured diagnosis records are not part of the value; an implementation may emit richer diagnostics on the host channel, and no program behavior may depend on them.
+The reason is the entire observable content of a NIL: two NILs with the same reason are the same value. An implementation may emit richer diagnostics on the host channel, and no program behavior may depend on them.
 </p>
 
 <h3 id="lang-values-vector">LANG.VALUES.VECTOR — Vectors</h3>
@@ -359,7 +359,7 @@ A Vector is an ordered finite collection of values. Indexing is 0-origin and neg
 </p>
 
 <p>
-Vector length is semantic even when storage is flattened, shared, or lazily materialized. There is no separate rank, shape, or reshape algebra: a vector is a sequence, not a tensor.
+Vector length is semantic even when storage is flattened, shared, or lazily materialized. Order and length are a Vector's whole observable structure, and a nested Vector is an element like any other.
 </p>
 
 <h2 id="lang-machine">4. Machine State and Evaluation</h2>
@@ -416,7 +416,7 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <p>Every attempted operation ends in exactly one of three categories. Success yields its registered outputs. Well-formed partial failure yields NIL with a reason. Malformed use yields ERROR.</p>
 
-<p>An implementation must not convert malformed use to NIL and must not raise ERROR merely because a registered partial projection has no value. There is no mode or modifier that converts an ERROR into a value.</p>
+<p>An implementation must not convert malformed use to NIL and must not raise ERROR merely because a registered partial projection has no value. Recovery operates on absence alone: <code>VENT</code> acts on a NIL top, while an ERROR propagates and halts evaluation.</p>
 
 <h3 id="lang-failure-project">LANG.FAILURE.PROJECT — Projection</h3>
 
@@ -466,7 +466,7 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <p>The dictionary has two tiers. <strong>Core</strong> holds the 69 canonical Words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds definitions made by <code>DEF</code>. Resolution is a deterministic function of the normalized name and the current dictionary, and User never shadows Core.</p>
 
-<p>There is no module system, no import state, and no third tier. <code>LOOKUP</code>, hover, the Reference, and execution must identify the same canonical entry.</p>
+<p>Those two tiers are the whole dictionary: a name resolves in Core or in User, and a Core name is reachable by itself. <code>LOOKUP</code>, hover, the Reference, and execution must identify the same canonical entry.</p>
 
 <h3 id="lang-dictionary-mutation">LANG.DICTIONARY.MUTATION — User Words</h3>
 

--- a/scripts/check-word-schema-migration.mjs
+++ b/scripts/check-word-schema-migration.mjs
@@ -8,24 +8,6 @@ const rust = readFileSync('rust/src/builtins/builtin_word_definitions.rs', 'utf8
 const aliasesSource = readFileSync('rust/src/core_word_aliases.rs', 'utf8');
 const compiledPlanSource = readFileSync('rust/src/interpreter/compiled_plan.rs', 'utf8');
 const language = readFileSync('spec/language-semantics.md', 'utf8');
-const moduleBuiltins = readFileSync('rust/src/interpreter/modules/module_builtins.rs', 'utf8');
-const moduleDocs = readFileSync('rust/src/interpreter/modules/module_word_docs.rs', 'utf8');
-
-function moduleWordBlock(moduleName, shortName) {
-  const arrayStart = moduleBuiltins.indexOf(`const ${moduleName}_WORDS`);
-  const arrayEnd = moduleBuiltins.indexOf('\n];', arrayStart);
-  if (arrayStart < 0 || arrayEnd < 0) return undefined;
-  const body = moduleBuiltins.slice(arrayStart, arrayEnd);
-  return [...body.matchAll(/module_word!\(([\s\S]*?)\n\s*\),/g)]
-    .map((match) => match[1])
-    .find((block) => block.match(/^\s*"([^"]+)"/)?.[1] === shortName);
-}
-
-function moduleDocBlock(moduleName, shortName) {
-  return [...moduleDocs.matchAll(/ModuleWordDoc\s*\{([\s\S]*?)\n\s*\},/g)]
-    .map((match) => match[1])
-    .find((block) => block.includes(`module: "${moduleName}"`) && block.includes(`word: "${shortName}"`));
-}
 
 const errors = [];
 const fail = (message) => errors.push(message);
@@ -44,21 +26,6 @@ for (const word of words.entries) {
   if (!manifestNames.has(word.name)) fail(`${word.name} is absent from the frozen manifest`);
   for (const clause of word.clauses) if (!language.includes(`${clause} —`)) fail(`${word.name} references missing clause ${clause}`);
 
-  if (word.module) {
-    const [moduleName, shortName] = word.name.split('@');
-    if (moduleName !== word.module || !shortName) fail(`${word.name} has inconsistent module ownership`);
-    const block = moduleWordBlock(moduleName, shortName);
-    if (!block || !block.includes(word.executorKey)) fail(`${word.name} module executorKey drift`);
-    const doc = moduleDocBlock(moduleName, shortName);
-    if (!doc) fail(`${word.name} has no module documentation`);
-    else if (!doc.includes(`summary: "${word.documentation.summary}"`)) fail(`${word.name} summary drift`);
-    for (const effect of word.effects) {
-      const rustEffect = effect.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
-      if (!block?.includes(`"${rustEffect}"`)) fail(`${word.name} effect drift: ${effect}`);
-    }
-    continue;
-  }
-
   const escaped = word.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const start = rust.search(new RegExp(`name: "${escaped}"`));
   if (start < 0) {
@@ -66,7 +33,7 @@ for (const word of words.entries) {
     continue;
   }
   const block = rust.slice(start, rust.indexOf('..SPEC_DEFAULT', start));
-  const compiledModifiers = new Set(['TOP', 'STAK', 'EAT', 'KEEP']);
+  const compiledModifiers = new Set(['EAT', 'KEEP']);
   const directive = new Set(['VENT', 'FLOW']);
   if (compiledModifiers.has(word.name)) {
     if (!compiledPlanSource.includes(`CompiledOp::${word.executorKey}`)) fail(`${word.name} compiled executorKey drift`);
@@ -93,18 +60,15 @@ for (const word of words.entries) {
   }
 }
 
-const canonicalManifestEntries = manifest.entries
-  .filter((entry) => entry.kind === 'coreword' || entry.kind === 'moduleword');
+const canonicalManifestEntries = manifest.entries.filter((entry) => entry.kind === 'coreword');
 const expected = new Set(canonicalManifestEntries.map((entry) => entry.canonical));
-for (const name of expected) if (!names.has(name)) fail(`migration scope omits ${name}`);
-for (const name of names) if (!expected.has(name)) fail(`migration scope contains unexpected Word ${name}`);
-if (names.size !== expected.size) fail(`migration scope has ${names.size} entries; expected ${expected.size}`);
+for (const name of expected) if (!names.has(name)) fail(`contract scope omits ${name}`);
+for (const name of names) if (!expected.has(name)) fail(`contract scope contains unexpected Word ${name}`);
+if (names.size !== expected.size) fail(`contract scope has ${names.size} entries; expected ${expected.size}`);
 
 if (errors.length) {
   for (const error of errors) console.error(`[word-schema] ${error}`);
   process.exitCode = 1;
 } else {
-  const coreCount = canonicalManifestEntries.filter((entry) => entry.kind === 'coreword').length;
-  const moduleCount = canonicalManifestEntries.filter((entry) => entry.kind === 'moduleword').length;
-  console.log(`[word-schema] all ${coreCount} Core and ${moduleCount} Module contracts cover the ${manifest.entries.length}-surface manifest and current executors.`);
+  console.log(`[word-schema] all ${canonicalManifestEntries.length} Core contracts cover the ${manifest.entries.length}-surface manifest and current executors.`);
 }

--- a/spec/language-semantics.md
+++ b/spec/language-semantics.md
@@ -11,12 +11,12 @@ This document defines the correspondence between Ajisai source programs and obse
 </p>
 
 <p>
-Ajisai is built from ten concepts and nothing else. Everything below is one of them, or a consequence of one of them.
+Ajisai is built from ten concepts. Everything below is one of them, or a consequence of one of them.
 </p>
 
 <ol>
 <li>Exact rational arithmetic, closed under square roots, with no rounding.</li>
-<li>Three outcomes and no fourth: a value, a reasoned absence, or an error.</li>
+<li>Three outcomes: a value, a reasoned absence, or an error.</li>
 <li>A stack of values and vectors of values.</li>
 <li>Code blocks, evaluated only when a Word asks for it.</li>
 <li>One modifier axis: consume or keep.</li>
@@ -115,7 +115,7 @@ A code block is a tagged value containing source for later evaluation. Producing
 </p>
 
 <p>
-Quoted code is not eagerly executed. A vector is data and is never executable; Ajisai makes no claim to homoiconicity.
+Quoted code is not eagerly executed. Code and data are distinct value domains: executable source lives in a CodeBlock, and a Vector is data and is never executable.
 </p>
 
 <h2 id="lang-values">3. Value Domains</h2>
@@ -137,7 +137,7 @@ Every scalar denotes an exact element of the field \(\mathbb{Q}(\sqrt{d_1},\dots
 </p>
 
 <p>
-Arithmetic performs no intermediate rounding, and coefficients are arbitrary-precision, so overflow is impossible rather than wrapped. Comparison over this domain is <strong>total and decidable</strong>: every comparison of two scalars yields TRUE or FALSE in finite time, with no budget, no refinement limit, and no undecided outcome. Values built through different histories compare equal when they denote the same real — \(\sqrt{8}\) and \(\sqrt{2}+\sqrt{2}\) are one value.
+Arithmetic performs no intermediate rounding, and coefficients are arbitrary-precision, so a coefficient grows to whatever size the value requires. Comparison over this domain is <strong>total and decidable</strong>: every comparison of two scalars yields TRUE or FALSE in finite time. Values built through different histories compare equal when they denote the same real — \(\sqrt{8}\) and \(\sqrt{2}+\sqrt{2}\) are one value.
 </p>
 
 <p>
@@ -147,11 +147,11 @@ The internal representation is unobservable. Canonical continued-fraction displa
 <h3 id="lang-values-truth">LANG.VALUES.TRUTH — Two-valued truth</h3>
 
 <p>
-Truth values are TRUE and FALSE. <code>AND</code>, <code>OR</code>, and <code>NOT</code> are the ordinary Boolean operations, and every comparison decides.
+The Boolean domain has exactly two values, TRUE and FALSE. <code>AND</code>, <code>OR</code>, and <code>NOT</code> are the ordinary Boolean operations, and every comparison decides.
 </p>
 
 <p>
-There is no third truth value. An operation that cannot produce a value produces NIL, which is absence and not undecidability; an operation that is malformed raises ERROR.
+Absence and misuse live outside this domain: an operation that cannot produce a value produces NIL, which is absence rather than undecidability, and an operation that is malformed raises ERROR.
 </p>
 
 <h3 id="lang-values-nil">LANG.VALUES.NIL — Diagnostic absence</h3>
@@ -161,7 +161,7 @@ NIL is a value representing absence from a well-formed partial operation. It car
 </p>
 
 <p>
-NIL carries the reason and nothing else. Origin, recoverability, and structured diagnosis records are not part of the value; an implementation may emit richer diagnostics on the host channel, and no program behavior may depend on them.
+The reason is the entire observable content of a NIL: two NILs with the same reason are the same value. An implementation may emit richer diagnostics on the host channel, and no program behavior may depend on them.
 </p>
 
 <h3 id="lang-values-vector">LANG.VALUES.VECTOR — Vectors</h3>
@@ -171,7 +171,7 @@ A Vector is an ordered finite collection of values. Indexing is 0-origin and neg
 </p>
 
 <p>
-Vector length is semantic even when storage is flattened, shared, or lazily materialized. There is no separate rank, shape, or reshape algebra: a vector is a sequence, not a tensor.
+Vector length is semantic even when storage is flattened, shared, or lazily materialized. Order and length are a Vector's whole observable structure, and a nested Vector is an element like any other.
 </p>
 
 <h2 id="lang-machine">4. Machine State and Evaluation</h2>
@@ -228,7 +228,7 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <p>Every attempted operation ends in exactly one of three categories. Success yields its registered outputs. Well-formed partial failure yields NIL with a reason. Malformed use yields ERROR.</p>
 
-<p>An implementation must not convert malformed use to NIL and must not raise ERROR merely because a registered partial projection has no value. There is no mode or modifier that converts an ERROR into a value.</p>
+<p>An implementation must not convert malformed use to NIL and must not raise ERROR merely because a registered partial projection has no value. Recovery operates on absence alone: <code>VENT</code> acts on a NIL top, while an ERROR propagates and halts evaluation.</p>
 
 <h3 id="lang-failure-project">LANG.FAILURE.PROJECT — Projection</h3>
 
@@ -278,7 +278,7 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <p>The dictionary has two tiers. <strong>Core</strong> holds the 69 canonical Words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds definitions made by <code>DEF</code>. Resolution is a deterministic function of the normalized name and the current dictionary, and User never shadows Core.</p>
 
-<p>There is no module system, no import state, and no third tier. <code>LOOKUP</code>, hover, the Reference, and execution must identify the same canonical entry.</p>
+<p>Those two tiers are the whole dictionary: a name resolves in Core or in User, and a Core name is reachable by itself. <code>LOOKUP</code>, hover, the Reference, and execution must identify the same canonical entry.</p>
 
 <h3 id="lang-dictionary-mutation">LANG.DICTIONARY.MUTATION — User Words</h3>
 

--- a/spec/words.json
+++ b/spec/words.json
@@ -742,7 +742,7 @@
         "lookup": "Absolute value of a number.",
         "syntax": "-2 ABS"
       },
-      "executorKey": "math_ops::op_abs",
+      "executorKey": "Abs",
       "effects": []
     },
     {
@@ -779,7 +779,7 @@
         "lookup": "Numeric negation.",
         "syntax": "2 NEG"
       },
-      "executorKey": "math_ops::op_neg",
+      "executorKey": "Neg",
       "effects": []
     },
     {
@@ -816,7 +816,7 @@
         "lookup": "Sign of a number: -1, 0, or 1.",
         "syntax": "-2 SIGN"
       },
-      "executorKey": "math_ops::op_sign",
+      "executorKey": "Sign",
       "effects": []
     },
     {
@@ -853,7 +853,7 @@
         "lookup": "Smaller of two numbers.",
         "syntax": "1 2 MIN"
       },
-      "executorKey": "math_ops::op_min",
+      "executorKey": "Min",
       "effects": []
     },
     {
@@ -890,7 +890,7 @@
         "lookup": "Larger of two numbers.",
         "syntax": "1 2 MAX"
       },
-      "executorKey": "math_ops::op_max",
+      "executorKey": "Max",
       "effects": []
     },
     {
@@ -928,7 +928,7 @@
         "lookup": "Exact square root of a non-negative rational. The result is carried in multiquadratic normal form and compares with no rounding. A negative radicand projects to NIL.",
         "syntax": "2 SQRT"
       },
-      "executorKey": "math_ops::op_sqrt",
+      "executorKey": "Sqrt",
       "effects": []
     },
     {
@@ -1443,7 +1443,7 @@
         "lookup": "Return a copy of a vector sorted in ascending order.",
         "syntax": "[ 3 1 2 ] SORT"
       },
-      "executorKey": "sort::op_sort",
+      "executorKey": "Sort",
       "effects": []
     },
     {
@@ -1480,7 +1480,7 @@
         "lookup": "Return a copy of a vector with duplicates removed, preserving first-occurrence order.",
         "syntax": "[ 1 2 1 ] UNIQUE"
       },
-      "executorKey": "algo_ops::op_unique",
+      "executorKey": "Unique",
       "effects": []
     },
     {
@@ -1517,7 +1517,7 @@
         "lookup": "True if a vector contains an element equal to the given value.",
         "syntax": "[ 1 2 ] 2 CONTAINS"
       },
-      "executorKey": "algo_ops::op_contains",
+      "executorKey": "Contains",
       "effects": []
     },
     {
@@ -1554,7 +1554,7 @@
         "lookup": "Index of the first element equal to the value; Bubble/NIL if absent.",
         "syntax": "[ 1 2 ] 2 INDEX-OF"
       },
-      "executorKey": "algo_ops::op_index_of",
+      "executorKey": "IndexOf",
       "effects": []
     },
     {


### PR DESCRIPTION
## Summary

Follow-up to #1378, which did this for the README and the Reference. The semantic kernel still framed parts of the language against an earlier, larger design — "ten concepts **and nothing else**", "three outcomes **and no fourth**", "**no budget, no refinement limit, and no undecided outcome**", "**there is no third truth value**", "**no separate rank, shape, or reshape algebra**", "**no module system, no import state, and no third tier**". Each asks the reader to know what Ajisai is not. The kernel now says what it is.

**Normative content is unchanged.** Every prohibition that constrains an implementation is preserved; where a bare negation was carrying the normative weight, it is restated positively so the closure claim survives:

| Was | Now |
| --- | --- |
| "There is no third truth value." | "The Boolean domain has exactly two values, TRUE and FALSE." |
| "There is no separate rank, shape, or reshape algebra: a vector is a sequence, not a tensor." | "Order and length are a Vector's whole observable structure, and a nested Vector is an element like any other." |
| "There is no module system, no import state, and no third tier." | "Those two tiers are the whole dictionary: a name resolves in Core or in User, and a Core name is reachable by itself." |
| "There is no mode or modifier that converts an ERROR into a value." | "Recovery operates on absence alone: `VENT` acts on a NIL top, while an ERROR propagates and halts evaluation." |
| "NIL carries the reason and nothing else. Origin, recoverability, and structured diagnosis records are not part of the value" | "The reason is the entire observable content of a NIL: two NILs with the same reason are the same value." |

Untouched: the `must not` clauses in `LANG.FAILURE.TRICHOTOMY`, the ERROR-lane rule in `LANG.COLLECTIONS.LIFT`, the HostProtocolV1 field prohibitions in `LANG.OBSERVATION.PROTOCOL`, and the `cannot verify` conformance rule in `LANG.CONTRACT.CHECK`. No clause ID changed, so every conformance link still resolves.

## A dead gate, and the drift it was hiding

`word-schema:check` read two module source files deleted in the reduction, so it had been **crashing on startup instead of checking anything** — it is not in the CI quality gate, so nothing noticed. Removing the module branch, the `TOP`/`STAK` compiled-modifier cases, and the `moduleword` manifest kind makes it run again (−36 lines).

It then immediately reported real drift it had been unable to see: the ten Words promoted out of modules — `ABS` `NEG` `SIGN` `MIN` `MAX` `SQRT` `SORT` `UNIQUE` `CONTAINS` `INDEX-OF` — still declared **module-style executor keys** in `spec/words.json`:

```
"executorKey": "math_ops::op_abs"     ← module convention
"executorKey": "Abs"                  ← what the Rust registry binds, and what the other 59 Core Words use
```

Corrected to the variant names, so all 69 contracts now agree with their executors. This was my error in the reduction, introduced when those words were flattened into Core.

## Quality Classification

- Highest impacted level: QL-C (canonical spec prose and a contract-registry field; no runtime behavior changes)

## Traceability

- Requirement(s): the canonical spec must define the current language on its own terms; `spec/words.json` must agree with the Rust registry (`LANG.CONTRACT.REGISTRY`, `LANG.MACHINE.WORD`).
- Verification evidence:
  - `word-schema:check`: **all 69 Core contracts cover the 93-surface manifest and current executors** (previously: crash)
  - `cargo test --all-targets`: 777 lib + 83 integration tests, **0 failed**
  - `npm run check`, `npm run lint`, `npm test` (226 tests) pass
  - `specification:check`, `semantic-kernel:check` (352 lines, 39 clauses, 11 families, 69 Words, 16 aliases), `word:reference:check`, `core-word-docs:check`, `word:manifest:check`, `check:formalization-coverage` (101 entries), `check:semantic-firewall`, `check:file-size`, `check:skill`, `primitive:test-map` all pass
  - All 57 Reference samples and 5 README samples executed against `ajisai run` — 0 failing
  - Every `SPECIFICATION.html` anchor cited by the README resolves

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable, no Rust changed
- [x] `cargo test --all-targets --verbose` (in `rust/`)
- [x] `npm run check`
- [ ] `cargo llvm-cov --branch --workspace` — not applicable, no executable code changed
- [ ] MC/DC-like checklist reviewed for modified boolean logic — not applicable, no boolean logic changed
- [x] Release checklist impact considered

## Note for a follow-up

The CI quality gate does not run `word-schema:check`, `specification:check`, `semantic-kernel:check`, `word:reference:check`, or `core-word-docs:check`. That is why a broken gate and a hand-edit-vs-generator drift could both go unnoticed. Adding them is a small workflow change, kept out of this PR so the spec change stays reviewable on its own.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ4YawbB4Pt7smaooW2HJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ4YawbB4Pt7smaooW2HJX)_