### PR TITLE
spec: require the reading surfaces to describe the present language

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,24 @@ jobs:
         # may not grow by >=10%. See scripts/check-file-size-budget.mjs.
         run: npm run check:file-size
 
+      - name: Reading surfaces describe the present language (LANG.AUTHORITY.PRESENT)
+        # The README, the Reference, and the Specification may name only Words the
+        # vocabulary registry still holds. Derived from the registry rather than a
+        # blocklist, so deleting a Word is enough to keep prose honest about it.
+        run: npm run check:reading-surfaces
+
+      - name: Verify generated specification surfaces are in sync
+        # SPECIFICATION.html is generated from spec/ and must never be hand-edited;
+        # the Word reference and Core hover contracts are generated from
+        # spec/words.json. None of these were gated in CI, which is how a stale
+        # generated surface and a broken word-schema checker both went unnoticed.
+        run: |
+          npm run specification:check
+          npm run semantic-kernel:check
+          npm run word-schema:check
+          npm run word:reference:check
+          npm run core-word-docs:check
+
       - name: Generate conformance manifest
         run: npm run conformance:manifest
 

--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -241,7 +241,17 @@ This Language Semantics is authoritative for program meaning. <code>spec/words.j
 </p>
 
 <p>
-Neither implementation layout nor explanatory text can override an observable contract. A document that is not in the list above defines nothing.
+Neither implementation layout nor explanatory text can override an observable contract. A document that is not in the list above defines nothing; <code>docs/dev/</code> holds design notes and history on those terms.
+</p>
+
+<h3 id="lang-authority-present">LANG.AUTHORITY.PRESENT — Present-tense description</h3>
+
+<p>
+Ajisai has three reading surfaces: the <strong>README</strong>, the <strong>Reference</strong>, and this <strong>Specification</strong>. Each describes the language as it currently is. A definition, an example, or an explanation may rest only on concepts the language has, and every Word it names must exist in the vocabulary registry.
+</p>
+
+<p>
+Superseded designs, migration history, and the reasoning behind a change are recorded outside these three surfaces, in notes that define nothing. A negative statement belongs on a reading surface only when it constrains an implementation — "an implementation must not convert malformed use to NIL" is such a constraint — and not when its only content is a contrast with a design the language does not have.
 </p>
 
 <h3 id="lang-authority-identity">LANG.AUTHORITY.IDENTITY — Language identity</h3>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:tauri-frontend": "AJISAI_BUILD_TARGET=tauri vite build",
     "check:semantic-firewall": "bash ./scripts/check-semantic-firewall.sh",
     "check:file-size": "node scripts/check-file-size-budget.mjs",
+    "check:reading-surfaces": "node scripts/check-reading-surfaces.mjs",
     "hooks:install": "git config core.hooksPath .githooks",
     "specification:generate": "node scripts/generate-specification.mjs",
     "specification:check": "node scripts/generate-specification.mjs --check",

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1223,7 +1223,7 @@
                                 <tr>
                                     <td><code>[ 3 1 2 ] SORT</code></td>
                                     <td><code>[ 1/1 2/1 3/1 ]</code></td>
-                                    <td class="notes">Ascending sort. <code>SORT</code> is owned by the <code>ALGO</code> module.</td>
+                                    <td class="notes">Ascending sort over the whole vector.</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/scripts/check-reading-surfaces.mjs
+++ b/scripts/check-reading-surfaces.mjs
@@ -1,0 +1,82 @@
+// LANG.AUTHORITY.PRESENT — the vocabulary half of the clause.
+//
+// The README, the Reference, and the Specification describe the language as it
+// currently is, and "every Word it names must exist in the vocabulary
+// registry". This gate reads the registry rather than a hand-kept blocklist, so
+// a Word deleted from spec/words.json can never be left behind in prose: the
+// check fails the moment a reading surface names something the language does
+// not have.
+//
+// It found `<code>ALGO</code>` ("SORT is owned by the ALGO module") surviving
+// three manual review passes of the Reference, which is the case it exists for.
+
+import { readFileSync } from 'node:fs';
+
+const manifest = JSON.parse(readFileSync('docs/word-manifest.json', 'utf8'));
+
+const known = new Set();
+for (const entry of manifest.entries) {
+  known.add(entry.canonical);
+  for (const surface of entry.surfaces ?? []) known.add(surface);
+}
+
+// Names the documents introduce themselves: user-defined words and dictionaries
+// from worked examples, and string contents that happen to be upper-case. These
+// are the documents' own inventions, not vocabulary claims, so each is listed
+// deliberately. A new example word is a one-line addition here.
+const EXAMPLE_NAMES = new Set([
+  // user words defined in the Reference's own examples
+  'ADD10', 'GREET', 'APPLY-GAIN', 'SAY-HELLO', 'SAY-WORLD', 'SAY-BANG', 'FIZZBUZZ',
+  // dictionaries and qualified paths from the resolution examples
+  'EXAMPLE', 'AUDIOLIB', 'DICT@WORD', 'EXAMPLE@ADD10', 'EXAMPLE@GREET', 'AUDIOLIB@GREET',
+  // literal string contents shown on the stack
+  'TEST', "T'ES'T", 'AB', 'CD',
+]);
+
+const SURFACES = ['README.md', 'public/docs/index.html', 'SPECIFICATION.html'];
+
+// Word-shaped: upper-case initial, then the characters an Ajisai name may use.
+// Anything else inside <code> is a literal, a fragment, or punctuation.
+const WORD_SHAPED = /^[A-Z][A-Z0-9@?!'-]*$/;
+
+const errors = [];
+
+for (const path of SURFACES) {
+  const source = readFileSync(path, 'utf8');
+  const seen = new Map();
+
+  // A backticked markdown link label is a repository path, not a program
+  // token — [`LICENSE`](LICENSE) names a file. Drop those spans first.
+  const prose = source.replace(/\[`[^`]+`\]\([^)]*\)/g, '');
+
+  // Markdown backticks and HTML <code> mark a token as belonging to the
+  // program, so both are vocabulary claims.
+  const spans = [
+    ...[...prose.matchAll(/<code>([^<]+)<\/code>/g)].map((m) => m[1]),
+    ...[...prose.matchAll(/`([^`\n]+)`/g)].map((m) => m[1]),
+  ];
+
+  for (const span of spans) {
+    // A span may hold a whole program (`2 SQRT 2 LT`), so check every token.
+    for (const token of span.trim().split(/\s+/)) {
+      if (!WORD_SHAPED.test(token)) continue;
+      if (known.has(token) || EXAMPLE_NAMES.has(token)) continue;
+      seen.set(token, (seen.get(token) ?? 0) + 1);
+    }
+  }
+
+  for (const [token, count] of [...seen].sort()) {
+    errors.push(`${path} names ${token} (${count}x), which is not in the vocabulary registry`);
+  }
+}
+
+if (errors.length) {
+  for (const error of errors) console.error(`[reading-surfaces] ${error}`);
+  console.error('[reading-surfaces] LANG.AUTHORITY.PRESENT: a reading surface may name only Words the language has.');
+  console.error('[reading-surfaces] If the name is a new worked example, add it to EXAMPLE_NAMES in this script.');
+  process.exitCode = 1;
+} else {
+  console.log(
+    `[reading-surfaces] ${SURFACES.length} surfaces name only the ${manifest.entries.length} registered surfaces and ${EXAMPLE_NAMES.size} declared example names.`,
+  );
+}

--- a/scripts/check-semantic-firewall.sh
+++ b/scripts/check-semantic-firewall.sh
@@ -81,6 +81,18 @@ check_user_visible_absent 'epoch vocabulary' '[Ee]poch'
 check_user_visible_absent 'internal roadmap phase numbers' '[Pp]hase [0-9]'
 check_user_visible_absent 'memoization vocabulary' '[Mm]emoiz'
 
+# ── Reading surfaces describe the present language ────────────────────────
+# LANG.AUTHORITY.PRESENT: the README, the Reference, and the Specification
+# describe Ajisai as it currently is. History and superseded designs live in
+# docs/dev/, which defines nothing. This catches the framing half of the
+# clause; check-reading-surfaces.mjs catches the vocabulary half.
+READING_SURFACES=(README.md public/docs/index.html SPECIFICATION.html spec/language-semantics.md spec/gui-semantics.md)
+
+check_absent \
+  'history framing on a reading surface (LANG.AUTHORITY.PRESENT)' \
+  '\b([Nn]o longer|[Uu]sed to be|[Ff]ormerly|[Pp]reviously|[Dd]eprecated|[Ll]egacy|[Ee]arlier versions?|[Oo]nce (had|carried|supported)|has been removed|was removed|reserved for future)\b' \
+  "${READING_SURFACES[@]}"
+
 if [[ "$failed" -ne 0 ]]; then
   echo "[semantic-firewall] residue checks failed" >&2
   exit 1

--- a/spec/language-semantics.md
+++ b/spec/language-semantics.md
@@ -53,7 +53,17 @@ This Language Semantics is authoritative for program meaning. <code>spec/words.j
 </p>
 
 <p>
-Neither implementation layout nor explanatory text can override an observable contract. A document that is not in the list above defines nothing.
+Neither implementation layout nor explanatory text can override an observable contract. A document that is not in the list above defines nothing; <code>docs/dev/</code> holds design notes and history on those terms.
+</p>
+
+<h3 id="lang-authority-present">LANG.AUTHORITY.PRESENT — Present-tense description</h3>
+
+<p>
+Ajisai has three reading surfaces: the <strong>README</strong>, the <strong>Reference</strong>, and this <strong>Specification</strong>. Each describes the language as it currently is. A definition, an example, or an explanation may rest only on concepts the language has, and every Word it names must exist in the vocabulary registry.
+</p>
+
+<p>
+Superseded designs, migration history, and the reasoning behind a change are recorded outside these three surfaces, in notes that define nothing. A negative statement belongs on a reading surface only when it constrains an implementation — "an implementation must not convert malformed use to NIL" is such a constraint — and not when its only content is a contrast with a design the language does not have.
 </p>
 
 <h3 id="lang-authority-identity">LANG.AUTHORITY.IDENTITY — Language identity</h3>


### PR DESCRIPTION
## Summary

#1378 and #1379 applied a rule by hand: the README, the Reference, and the Specification describe the language as it currently is, and history lives in `docs/dev/`. This makes that rule the specification's own, as **`LANG.AUTHORITY.PRESENT`** in §1, where document authority is already defined:

> Ajisai has three reading surfaces: the **README**, the **Reference**, and this **Specification**. Each describes the language as it currently is. A definition, an example, or an explanation may rest only on concepts the language has, and every Word it names must exist in the vocabulary registry.

The second paragraph places superseded designs and migration history outside the three surfaces, and carves out the one negation that still belongs on a reading surface: one that **constrains an implementation** — "an implementation must not convert malformed use to NIL". A negation whose only content is a contrast with a design the language does not have is what the clause forbids.

## Two gates, because a rule with no gate is decoration

**`scripts/check-reading-surfaces.mjs`** — the vocabulary half. It derives the permitted names from `docs/word-manifest.json` rather than a hand-kept blocklist, so **deleting a Word is by itself enough to keep prose honest about it**. Worked-example names the documents invent (`ADD10`, `GREET`, `EXAMPLE@GREET`, …) are declared explicitly, and a backticked markdown link label is treated as a repository path rather than a program token.

**The semantic firewall** — the framing half: `no longer`, `formerly`, `previously`, `deprecated`, `legacy`, `was removed`, `reserved for future` and their kin, across all five reading-surface files.

Both were negative-tested rather than assumed:

```
$ printf 'A vector has a `RANK` and you can `RESHAPE` it, and `TOP` targets the stack.\n' >> README.md
[reading-surfaces] README.md names RANK (1x), which is not in the vocabulary registry
[reading-surfaces] README.md names RESHAPE (1x), which is not in the vocabulary registry
[reading-surfaces] README.md names TOP (1x), which is not in the vocabulary registry

$ printf 'The `COMPARE-WITHIN` word was removed and modules are no longer supported.\n' >> README.md
[semantic-firewall] FAIL: history framing on a reading surface (LANG.AUTHORITY.PRESENT)
```

The vocabulary gate earned its place immediately: it found residue that three manual review passes of the Reference had missed — a `SORT` note still read *"`SORT` is owned by the `ALGO` module"*. Fixed here.

One consequence worth noting: the clause's own text tripped the framing gate (it said "a design Ajisai **once had**"), so it is reworded to "a design the language does not have" — which is the better rule anyway, since it covers any absent design rather than only an earlier one.

## CI additions

The quality gate now runs `check:reading-surfaces`, plus the **five drift checks it had never run**: `specification:check`, `semantic-kernel:check`, `word-schema:check`, `word:reference:check`, `core-word-docs:check`. Their absence is exactly why a hand-edit could diverge from the generator and why `word-schema:check` could sit broken through the whole reduction (see #1379). `SPECIFICATION.html` is generated from `spec/` and is now verified as such on every push.

## Quality Classification

- Highest impacted level: QL-C (canonical spec clause plus CI gates; no runtime behavior changes)

## Traceability

- Requirement(s): new clause `LANG.AUTHORITY.PRESENT`, enforcing what #1378 and #1379 did by hand.
- Verification evidence:
  - `check:reading-surfaces`: 3 surfaces name only the 93 registered surfaces and 17 declared example names — and fails as shown above when a deleted Word is reintroduced
  - `check:semantic-firewall`: residue checks pass — and fails as shown above on injected history framing
  - `semantic-kernel:check`: 362 lines, 40 clauses, 11 families, 69 Words, 16 aliases (line ceiling 400)
  - `specification:check`, `word-schema:check`, `word:reference:check`, `core-word-docs:check`, `word:manifest:check`, `check:formalization-coverage`, `check:file-size`, `check:skill` all pass
  - All 57 Reference samples and 5 README samples executed against `ajisai run` — 0 failing
  - `npm run check`, `npm run lint`, `npm test` (226 tests) pass

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — unchanged from the base; left to CI on this SHA
- [x] `npm run check`
- [ ] `cargo llvm-cov --branch --workspace` — not applicable, no executable code changed
- [ ] MC/DC-like checklist reviewed for modified boolean logic — not applicable, no boolean logic changed
- [x] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ4YawbB4Pt7smaooW2HJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ4YawbB4Pt7smaooW2HJX)_