### PR TITLE
docs: Semantic Spine migration plan

### DIFF
--- a/docs/dev/INDEX.md
+++ b/docs/dev/INDEX.md
@@ -25,6 +25,7 @@ Status: non-canonical. この索引を含め、`docs/dev/` 配下の全文書は
 | 文書 | 説明 | 状態 |
 | --- | --- | --- |
 | `concept-reduction-2026-07.md` | 十概念への削減。何を捨て、何を残し、実装削減がどの順で進むか | `[設計根拠]` |
+| `semantic-spine-migration-plan.md` | 整理後正典と整理前実装の乖離を収束させる Semantic Spine 移行計画（9 Phase） | `[方針記録]` |
 | `ajisai-minimal-core-identity.md` | 何が変われば Ajisai でなくなるか——同一性の幹の切り分け | `[方針記録]` |
 | `ajisai-self-hosting-design.md` | セルフホスティングの位置づけ（新しい権威層を作らない） | `[方針記録]` |
 | `vector-nesting-role-redefinition.md` | Vector ネストの役割（Lisp 的動機の廃止） | `[方針記録]` |

--- a/docs/dev/semantic-spine-migration-plan.md
+++ b/docs/dev/semantic-spine-migration-plan.md
@@ -1,0 +1,337 @@
+# Semantic Spine — 意味論・実装・Host Protocol の再統合計画
+
+> Status: **Non-canonical / 設計メモ（`[方針記録]`）.** 本書は Ajisai の意味論・
+> 互換性方針を定義しない。正典は `spec/` 配下の各ソースと、そこから生成される
+> `SPECIFICATION.html` のみ。本書は「整理後の正典」と「整理前の実装座標系」の乖離を
+> 記述し、その収束点（Semantic Spine）を作る移行手続きを定める。既存コードの一括削除を
+> 先に行わないこと、まず構造上の収束点を作ることを原則とする。
+>
+> 前提文書: `concept-reduction-2026-07.md`（十概念への削減）、
+> `reduction-consistency-audit-2026-07.md`（削減後整合監査）。本書はその実装側続編である。
+
+---
+
+## 0. 結論の要約
+
+正典側は6値領域・二値論理・二階層辞書・最小 NIL・機械可読 Word 契約へ収束済みだが、
+Rust 実装は**削減前の座標系**をまだ主軸に使っている。個別削除ではなく、意味論が存在
+できる場所を1箇所（Semantic Spine）へ限定し、旧概念を「意味」から「内部実装 / 表示 /
+互換 adapter」へ降格させることで複数の問題を同時に解く。
+
+移行は9フェーズ。**Phase 1〜7 で新構造を並存させ、Phase 8 で consumer を切替え、
+Phase 9 で到達不能になった旧型・旧ファイルを一括削除する。** 旧コードの削除を最初に
+行わない。
+
+---
+
+## 1. 現在の semantic value model の実体
+
+中心は `rust/src/types/mod.rs`。
+
+### 1.1 `ValueData`（`mod.rs:371-390`）— 7 variant
+
+```rust
+pub enum ValueData {
+    Boolean(bool),
+    Scalar(Fraction),
+    ExactScalar(ExactReal),                 // ← 正典6領域に無い
+    Vector(Arc<Vec<Value>>),
+    Tensor { data: Arc<DenseTensor>, shape: Arc<Vec<usize>> }, // ← 正典6領域に無い
+    Nil,
+    CodeBlock(Vec<Token>),
+}
+```
+
+`String` variant は**存在しない**。
+
+### 1.2 `Interpretation`（`mod.rs:346-369`）— 第二の型系, 8 role
+
+```rust
+pub enum Interpretation {
+    Unassigned, RawNumber, Interval, Text, TruthValue,
+    Timestamp, Nil, ContinuedFraction,
+}
+```
+
+### 1.3 `Value`（`mod.rs:502-507`）
+
+```rust
+pub struct Value {
+    pub data: ValueData,
+    pub hint: Interpretation,               // ← 第二型系を値に添付
+    pub absence: Option<AbsenceMetadata>,   // ← NIL の経緯を値に添付
+}
+```
+
+### 1.4 派生軸（`semantic/value_axes.rs`）
+
+`SemanticKind`（Number/Collection/Record/Code/Process/Supervisor/Absence/**Unknown**）、
+`ValueShape`（Scalar/Vector/**Tensor**/Record/CodeBlock/Handle/Absence/**Unknown**）、
+`ValueOrigin`（…/**ModuleWord**/…/**Unknown**）。いずれも正典6領域より広い分類を持つ。
+
+---
+
+## 2. 正典6領域との不一致一覧
+
+正典（`spec/language-semantics.md`, `SPECIFICATION.html`）: `Scalar / Boolean / String /
+Vector / NIL / CodeBlock`。
+
+| 正典領域 | Rust 実装の実体 | 不一致の性質 | 降格先 |
+| --- | --- | --- | --- |
+| Scalar | `Scalar(Fraction)` + `ExactScalar(ExactReal)` | 内部表現の別 variant が意味型に昇格 | `ScalarRepr::{Float/Exact}`（B） |
+| Boolean | `Boolean(bool)` | 一致 | — |
+| **String** | variant 無し。`Vector`+`Interpretation::Text`、または scalar codepoint（`value_protocol.rs:75, 194-198`） | 第一級値が欠落し、第二型系で代替 | `KernelValue::String`（A へ昇格） |
+| Vector | `Vector(Arc<Vec<Value>>)` + `Tensor{..}` | 最適化表現が意味型に昇格。等価判定で相互変換（`mod.rs:409-411`） | `VectorRepr::{General/DenseNumeric}`（B） |
+| NIL | `Nil` + `Value.absence: AbsenceMetadata` | reason 以外の経緯（origin/recoverability/diagnosis）を値に添付 | trace/diagnostic（C） |
+| CodeBlock | `CodeBlock(Vec<Token>)` | 一致 | — |
+| （無し） | `Interpretation`（Interval/Text/Timestamp/…） | dispatch を変える第二型系 | presentation metadata（C） |
+| （無し） | `SemanticKind/ValueShape/ValueOrigin` の Unknown/Tensor/Record/Process/Supervisor/ModuleWord | 観測分類が6領域を超過 | host/legacy metadata（C/D） |
+
+**要点**: 「6領域 vs 7 variant」だけでなく、`Interpretation` という第二型系と、
+`Value.absence` に添付された NIL 経緯が、値モデルの実質的な座標系になっている。
+
+---
+
+## 3. Tensor / Interpretation / UNKNOWN / NIL metadata / module の依存グラフ
+
+検索結果を削除リストにはしない。**意味論の境界を越える入口**を特定する。
+
+### 3.1 Tensor
+- 定義: `types/mod.rs` `DenseTensor`(:31-207) / `SparseTensor`(:209-321) / `TensorLaneId`+`NilReasonRegistry`(:323-329) / `ValueData::Tensor`(:384-387)。
+- 越境入口（★ = ここを塞げば意味論から消える）:
+  - ★ `ValueData::Tensor` variant 自体（`mod.rs:384`）。
+  - ★ 等価判定の Vector↔Tensor 相互変換（`mod.rs:409-411, 420-500`）。
+  - ★ `ValueShape::Tensor` / protocol 文字列 `"tensor"`（`value_axes.rs:17`, `protocol.rs:25`）。
+  - `value_protocol.rs:212-223`（Tensor→protocol children 展開）。
+- 純内部（残してよい）: `interpreter/tensor_ops.rs`, `tensor_cmds.rs`, `simd_ops.rs`, `compiled_plan.rs`, dense/sparse storage。
+
+### 3.2 Interpretation
+- 定義: `types/mod.rs:346-369`。
+- 越境入口:
+  - ★ `Value.hint`（`mod.rs:505`）— 値に添付され `PartialEq` にも参加（`mod.rs:511`）。
+  - ★ dispatch を変える箇所: `value_protocol.rs` `scalar_to_protocol`(:71-78) が `TruthValue/Timestamp/Text` で type を分岐、`value_to_protocol`(:152-232) が `Text/TruthValue/ContinuedFraction` で構造分岐。
+  - `SemanticRegistry.flow_hints: HashMap<u64, Interpretation>`（`mod.rs:519-521`）。
+- 表示専用（C へ）: 実際に必要なのは String 化と timestamp/interval の**表示**のみ。
+
+### 3.3 UNKNOWN（削減済みのはずの残骸）
+- `SemanticKind::Unknown`, `ValueShape::Unknown`, `ValueOrigin::Unknown`（`value_axes.rs`）。
+- `UnknownBehavior::{NeverCreates, MayCreate}`（`word_contract.rs:82-86`）と `widen_unknown`。
+- `value_to_protocol` の `is_unknown()` 早期 return コメント（`value_protocol.rs:169-177`）。
+- 越境入口: ★ `UnknownBehavior` を `WordContract` が公開フィールドに持つこと、★ `SemanticKind/ValueShape::Unknown` が protocol 文字列に出ること。
+
+### 3.4 NIL metadata
+- `AbsenceMetadata { reason, origin, recoverability, diagnosis }`（`semantic/absence.rs:52-58`）。
+- `AbsenceOrigin`（16 variant, `absence.rs:4-42`）、`Recoverability`（`absence.rs:44-50`）。
+- `NilReasonRegistry = HashMap<TensorLaneId, NilReason>`（`mod.rs:329`）。
+- 越境入口: ★ `Value.absence`（`mod.rs:506`）が値に添付され、★ golden protocol の `semantics.absence.{origin,recoverability,diagnosis}` として観測可能（`spec/freeze/host-protocol-v1.golden.json`）。
+- 正典 NIL は reason 中心の最小モデル。origin/recoverability/diagnosis は診断・trace（C）へ。
+
+### 3.5 module
+- Interpreter フィールド: `module_state`, `import_table: ImportTable`, `module_vocabulary: HashMap<String, ModuleDictionary>`, `module_epoch`（`interpreter_core.rs:62-84,90`）。型: `ModuleDictionary`(:67-70), `ImportedModule`(:72-76), `ImportTable`(:78-81)。
+- `Capability::{ModuleOwned, CoreOwned}`（`protocol.rs:47-48`）、`ValueOrigin::ModuleWord`（`value_axes.rs:31`）。
+- golden protocol の `importedModules`（`host-protocol-v1.golden.json`）。
+- **重要な観察**: `spec/words.json` と `spec/language-semantics.md` に IMPORT / module の**語彙は存在しない**（§1 の grep で 0 件）。つまり module は正典から既に消えており、実装と V1 protocol にのみ残る **legacy 概念（D）**。`module_state` は実際には汎用スクラッチ（Word contract cache の格納先, `word_contract.rs:27,318-339`）としても使われており、名前が誤解を招く。
+- 越境入口: ★ Interpreter が module 系フィールドを**辞書解決**に使う箇所（`resolve_word.rs`, `execute_del.rs`, `session_lifecycle.rs`）。Kernel の辞書は Core/User のみにする。
+
+---
+
+## 4. `words.json` と Rust Word 定義の重複箇所
+
+### 4.1 現状
+- `spec/words.json`: 69 entry。各 entry に `name, aliases, family, stack{inputs,outputs},
+  consumption, nilPolicy, projection, errorWhen, purity, determinism, capability,
+  hostedEffect, interpretationRole, clauses, documentation, executorKey, effects`。
+- **`words.json` を読む Rust は無い**（`build.rs` 無し、`rust/` 内に `words.json` 参照 0）。
+  consumer は JS スクリプトのみ: `generate-word-reference.mjs`, `generate-word-manifest.mjs`,
+  `generate-core-word-docs.mjs`, `generate-skill-md.mjs`, `check-semantic-kernel.mjs`,
+  `check-word-schema-migration.mjs`, `check-reading-surfaces.mjs`。
+- Rust 側は `builtins/builtin_word_definitions.rs` の `BUILTIN_SPECS`（`BuiltinSpec`,
+  約1340行）に**手書き**で並列定義。`BuiltinSpec` フィールド（`:7-52`）は
+  `name, category, hover_*, executor_key, mass(=stack), summary, role, stack_effect,
+  stability, purity, effects, deterministic, safe_preview, partiality, nil_policy,
+  safety_level, execution_form`。
+
+### 4.2 二重管理されている意味情報（1事実・複数記述）
+
+| 意味情報 | `spec/words.json` | Rust |
+| --- | --- | --- |
+| 正規名 | `name` | `BuiltinSpec.name` |
+| alias | `aliases` | `core_word_aliases.rs`（別の手書き表） |
+| stack 契約 | `stack{inputs,outputs}` | `BuiltinSpec.mass`（`MassContract`） |
+| consumption | `consumption` | （`ConsumptionMode` 実装側） |
+| NIL 方針 | `nilPolicy` | `BuiltinSpec.nil_policy`（`NilPolicy`） |
+| purity | `purity` | `BuiltinSpec.purity`（`WordPurity`） |
+| determinism | `determinism` | `BuiltinSpec.deterministic` |
+| executor 対応 | `executorKey` | `BuiltinExecutorKey`（`builtin_word_types.rs:1-70`, 手書き enum）+ `execute_builtin.rs` の巨大 `match` |
+| docs | `documentation` | `generated_core_word_docs.rs`（既に生成済）+ `BuiltinSpec.summary/role/...` |
+
+**既に片側生成されているのは docs のみ**（`generated_core_word_docs.rs`）。契約本体
+（stack/nil/purity/alias/executorKey）は spec と Rust で独立に手書きされ、乖離を
+`check-*` スクリプトで**事後照合**している。これを「JSON→Rust 生成」に反転させる。
+
+---
+
+## 5. HostProtocolV1 と runtime model の結合点
+
+- serializer: `wasm_interpreter_bindings/wasm_value_conversion.rs`（Value→JsValue）,
+  `wasm_interpreter_state.rs`（stack/dict/status/absence）。両者は `types/value_protocol.rs`
+  の `ProtocolNode`（pure (Value,hint)→wire）を共有し、`semantic/protocol.rs` の
+  `as_protocol_str` で enum→文字列化。
+- V1 が Kernel 内部型に**直結**している箇所（golden `host-protocol-v1.golden.json`）:
+  - `semantics.semanticKind`（`SemanticKind`）, `semantics.shape`（`ValueShape`, `"tensor"` 含む）。
+  - `semantics.capabilities`（`Capability`, `moduleOwned/coreOwned` 含む）。
+  - `semantics.origin` / `semantics.absence.{reason,origin,recoverability,diagnosis}`（`AbsenceMetadata` 直写し）。
+  - `importedModules`（module state 直写し）。
+  - `collect_hedged_trace`（`wasm_interpreter_state.rs:451-455`, 既に no-op だが V1 が pin）。
+- V1 の互換ポリシー: field 削除・改名・意味変更は breaking。よって**V1 は掃除せず凍結**し、
+  V1 固有概念（module/tensor/unknown/absence-origin/recoverability/hedged）は adapter 内に閉じる。
+
+---
+
+## 6. Semantic Spine を導入する最小の seam
+
+既存構造にある「くびれ」を再利用する。新しい経路を無から作らない。
+
+1. **`types/value_protocol.rs::value_to_protocol`** — コメント自身が
+   「the single source of truth for the machine-facing value wire format」（`:1-9,149-151`）。
+   これが既に Value→観測の narrow waist。**Observation / HostProtocolV2 はここを起点**にする。
+2. **`BuiltinExecutorKey` + `execute_builtin.rs` の `match`**（`:161-...`）— 既に
+   「executor key → primitive」表であり、§11 が求める primitive executor テーブルそのもの。
+   `BuiltinExecutorKey` を `words.json.executorKey` から**生成 enum**にすれば、Word 追加時の
+   登録漏れがコンパイルエラーになる。
+3. **`coreword_registry` / `BuiltinSpec`** — 契約メタデータの集約点。ここを
+   `words.json` からの生成物に置換する。
+4. **`interpreter/word_contract.rs::WordContract`** — 契約推論は既に存在するが用途は
+   検証のみ。runtime はまだ消費していない。§12 の execute wrapper 化の接続先。
+
+最小 seam の結論: **新規 `rust/src/kernel/` を作り、既存 `types`/`interpreter` を
+`From`/`Into` adapter で橋渡しする。`value_to_protocol` の入力を `KernelValue` 由来の
+`Observation` に差し替えるのが最初の1本。**
+
+---
+
+## 7. 新規ファイル構成案
+
+```text
+rust/src/kernel/                     # Semantic Spine（public 型はここだけ）
+  mod.rs            # 再エクスポート。仕様6領域外の型を pub にしない invariant の番人
+  value.rs          # KernelValue（6 variant）, ScalarRepr, VectorRepr（private repr）
+  scalar.rs         # ScalarRepr::{Float(Fraction)/Exact(ExactReal)}（旧 ExactScalar 内部化）
+  vector.rs         # VectorRepr::{General/DenseNumeric(DenseTensor)}（旧 Tensor 内部化）
+  string.rs         # KernelValue::String(Arc<str>) の正規化・codepoint 変換
+  nil.rs            # Nil(NilReason) 最小モデル
+  state.rs          # KernelState（Core/User 二層辞書のみ, module 無し）
+  observation.rs    # Observation / ObservedValue / PresentationHint（旧 Interpretation の表示分）
+  word_contract.rs  # runtime が消費する WordContract（generated から供給）
+  execute.rs        # execute_word wrapper（arity/nil/keep/lift/primitive/projection）
+  diagnostic.rs     # ExecutionTrace / DiagnosticContext（旧 absence origin/recoverability）
+
+rust/src/kernel/generated/           # words.json からの生成物（build.rs 出力 or チェックイン）
+  word_id.rs        # WordId enum
+  executor_key.rs   # ExecutorKey enum（現 BuiltinExecutorKey を生成化）
+  word_contracts.rs # 各 Word の stack/nil/consumption/purity 契約
+  aliases.rs        # alias 表（現 core_word_aliases.rs を生成化）
+
+rust/src/host/
+  protocol_v2.rs    # HostProtocolV2（KernelValue/Observation に一致）
+  protocol_v1_adapter.rs # Legacy V1 anti-corruption layer（module/tensor/unknown を adapter 内で構築）
+
+rust/build.rs                        # spec/words.json → kernel/generated/*.rs
+```
+
+対応する生成器（既存 `.mjs` 群と役割分担）: Rust 契約生成は `build.rs`（または
+`scripts/generate-word-registry.mjs` + チェックイン）で行い、JS 側の docs/manifest 生成は現状維持。
+
+---
+
+## 8. 移行 Phase ごとの変更対象ファイル
+
+原則: **Phase 1〜7 は追加のみ（旧構造と並存）。削除は Phase 9。**
+
+| Phase | 目的 | 追加/変更 | 触らない（並存） |
+| --- | --- | --- | --- |
+| 1. Spine 骨格 | `kernel/` 新設 | `kernel/{mod,value,nil,state,observation,word_contract,execute}.rs`（型と署名のみ） | 既存 runtime 全て |
+| 2. 6領域化 | `KernelValue` 6 variant + repr | `kernel/{value,scalar,vector,string}.rs`, `From<ValueData>`/`Into<ValueData>` adapter | `types/mod.rs`（変更なし） |
+| 3. registry 生成 | words.json→Rust | `build.rs`, `kernel/generated/*`, `scripts/generate-word-registry.mjs` | 手書き `BuiltinSpec`（当面 oracle） |
+| 4. execute wrapper | 契約を runtime が消費 | `kernel/execute.rs`（ADD/SUB/MUL/DIV から横展開）, `word_contract.rs` を runtime 接続 | 既存 `execute_builtin.rs`（fallback） |
+| 5. Observation | 内部/観測の分離 | `kernel/observation.rs`, `value_protocol.rs` の入力を Observation へ | golden 出力は不変 |
+| 6. HostProtocolV2 | Spine 直写し | `host/protocol_v2.rs`, `spec/host-protocol-v2.schema.json`, 新 golden | V1 serializer |
+| 7. V1 adapter | V1 を Spine から生成 | `host/protocol_v1_adapter.rs`（module/tensor/unknown を adapter 内で構築） | golden `host-protocol-v1.golden.json`（不変） |
+| 8. GUI/WASM 切替 | consumer を V2/Observation へ | `src/wasm-interpreter-types.ts`, `src/gui/*`, worker | 旧 V1 consumer は adapter 経由で維持 |
+| 9. 旧モデル一括削除 | 到達不能型の除去 | §10 参照 | — |
+
+---
+
+## 9. 各 Phase で維持すべき既存テスト
+
+これらは移行中も緑を保ち、Observation 等価の回帰網とする。
+
+- `rust/src/conformance_tests.rs`（conformance corpus）— 全 Phase で不変。
+- `spec/freeze/host-protocol-v1.golden.json` + `src/host-protocol-v1.contract.test.ts` — Phase 7 まで完全一致を維持（V1 凍結の証明）。
+- `types/value_protocol_tests.rs`（wire format の MC/DC）— Phase 5 で Observation 経由に付け替え後も同一出力。
+- `interpreter/word_contract_tests.rs`, `word_space_tests.rs` — Phase 4 で runtime 接続後も契約不変。
+- `interpreter/nil_conformance_tests.rs`, `nil_reason_tests.rs`, `nil_diagnostics_tests.rs` — 最小 NIL の reason 保存を Phase 5 で担保。
+- `interpreter/scalar_fastpath_tests.rs`, `simd_ops`, `compiled_plan_tests.rs`, `types/exact/*` — 内部最適化が Observation を壊さないことの担保（Phase 2/5）。
+- `scripts/check-semantic-kernel.mjs`（69 語/16 alias/12 family 上限）, `check-semantic-firewall.sh`, `check-conformance-coverage.mjs` — CI ゲートとして全 Phase 維持。
+- `types/value_persist_tests.rs`（snapshot 往復）— Phase 2 の repr 変更で往復不変を担保。
+
+---
+
+## 10. Semantic Spine 完成後に削除可能になる型・ファイル一覧（Phase 9 候補）
+
+**到達不能になった時点で削除**する。個別書換えではなく「新構造から届かなくなった型/ファイルをまとめて消す」。
+
+意味論から降格・除去できる型:
+- `ValueData::Tensor`（variant）, `TensorLaneId`, `NilReasonRegistry`, Vector↔Tensor 等価分岐（`mod.rs:409-500`）。
+- `ValueData::ExactScalar`（variant; `ExactReal` 実装は `ScalarRepr::Exact` として内部保持）。
+- `Interpretation` enum と `Value.hint`（表示分は `PresentationHint` へ移送）。
+- `Value.absence` フィールド, `AbsenceMetadata`, `AbsenceOrigin`, `Recoverability`（reason 以外; trace へ）。
+- `SemanticKind::Unknown`, `ValueShape::{Tensor,Unknown}`, `ValueOrigin::{ModuleWord,Unknown}`。
+- `UnknownBehavior`, `WaterSensitivity` を `WordContract` の public から除去（内部/legacy へ）。
+- `Capability::{ModuleOwned, CoreOwned}`（V1 adapter 内へ）。
+- Interpreter の `module_vocabulary`, `import_table`, `ModuleDictionary`, `ImportedModule`, `ImportTable`, `module_epoch`（辞書は Core/User のみ）。`module_state` は用途明確化のためリネーム（例 `runtime_scratch`）。
+
+重複記述として削除できるもの:
+- 手書き `BuiltinSpec` の契約フィールド（stack/nil/purity/determinism/executor_key）→ `kernel/generated/*` に置換。
+- 手書き `BuiltinExecutorKey`（`builtin_word_types.rs`）→ 生成 `ExecutorKey`。
+- 手書き alias 表（`core_word_aliases.rs`）→ 生成 `aliases.rs`。
+
+保持（非目標・§28）: `DenseTensor/SparseTensor` storage, `simd_ops`, `compiled_plan`,
+`types/exact/*`（exact arithmetic）, tensor 最適化本体。これらは `VectorRepr`/`ScalarRepr`
+の private 実装として残す。
+
+---
+
+## 11. 最重要 invariant（CI 最優先ルール）
+
+> **Ajisai の言語仕様に存在しない概念は、Semantic Spine（`kernel/` の public API）に
+> 存在してはならない。** Spine より下の private 実装には最適化のための複雑さを許容する。
+
+実装手段の段階:
+1. 型閉包（最終防衛線）: `kernel::KernelValue` が正典6 variant のみ。`Tensor`/`ExactScalar`/
+   `Interpretation`/`Unknown`/module を public 型として**表現不能**にする。
+2. テキスト checker（補助・既存維持）: `check-semantic-firewall.sh` に、`kernel/mod.rs` の
+   public re-export に禁止語（Tensor/ExactScalar/Interpretation/Unknown/module/…）が現れないことを追加。
+3. Observation 比較: conformance は内部表現でなく `Observation` を比較（§18）。
+
+---
+
+## 12. 設計判断の優先順位（迷ったとき）
+
+1. 正典仕様　2. Semantic Spine の単純さ　3. 機械検証可能な single source of truth　
+4. external behavior 互換（V1 golden）　5. 内部実装互換　6. 局所的変更量。
+
+短期的に差分が増えても、意味論の重複を残さない方を優先する
+（**One semantic fact, one authoritative representation.**）。
+
+---
+
+## 13. 最初の1コミットの提案（Phase 1 の入口）
+
+1. `rust/src/kernel/` を新設し、`KernelValue`（6 variant, repr は未実装 stub）と
+   `Nil(NilReason)`、`Observation` の**型と署名のみ**を置く。既存 runtime からは未参照。
+2. `check-semantic-firewall.sh` に kernel public 閉包チェックを1件追加（禁止語 grep）。
+3. 本書を `docs/dev/INDEX.md` に登録。
+
+この時点でビルド・全既存テストは不変。以降 Phase 2 で `From<ValueData>`/`Into<ValueData>`
+adapter を足し、旧構造と並存させながら consumer を1本ずつ Spine へ寄せる。


### PR DESCRIPTION
## Summary

Records the repository investigation requested for the Semantic Spine initiative and the migration plan derived from it, as a non-canonical design memo under `docs/dev/` (plus its `INDEX.md` entry). No runtime, spec, or protocol behavior changes — this is a planning document to seed the refactor before any code is touched.

The document delivers the requested survey, grounded in concrete file/line references:

1. **Current semantic value model** — `ValueData` (7 variants incl. `ExactScalar`, `Tensor`) + `Interpretation` (a second, dispatch-affecting type system) + `Value.absence` (NIL metadata attached to values).
2. **Mismatch with the canonical six domains** — `String` is missing (represented as `Vector`+`Interpretation::Text`); `ExactScalar`/`Tensor` are optimization representations promoted into the semantic type.
3. **Dependency graph** for Tensor / Interpretation / UNKNOWN / NIL-metadata / module, scoped to the *boundary-crossing entry points* (not raw usage counts). Notably: `module`/`import` vocabulary is already absent from the canonical `words.json` and `language-semantics.md` — it survives only in the implementation and in HostProtocolV1, i.e. it is legacy (D), not semantics.
4. **`words.json` vs Rust duplication** — `words.json` (69 entries, `executorKey`, stack/nil/purity contracts) drives JS docs/manifest generation only; the Rust `BuiltinSpec` table and `BuiltinExecutorKey`/alias tables are hand-authored in parallel and reconciled by after-the-fact `check-*` scripts.
5. **HostProtocolV1 coupling points** — `value_protocol.rs` / `semantic/protocol.rs` serialize Kernel-internal types (`SemanticKind`, `ValueShape::tensor`, `Capability::moduleOwned`, `AbsenceMetadata`, `importedModules`) directly into the frozen V1 golden.
6. **Minimal seam** — reuse the existing narrow waists: `value_to_protocol` (already the single source of truth for the wire format), the `BuiltinExecutorKey` → primitive `match`, and the existing `WordContract` inference.
7. **New file layout** — `rust/src/kernel/` for the spine + `kernel/generated/` from `words.json` via `build.rs`.
8. **Per-phase change targets** — 9 phases; add-and-coexist through Phase 7, switch consumers in Phase 8, bulk-delete unreachable types in Phase 9.
9. **Tests to keep green** at each phase (conformance corpus, V1 golden, `value_protocol` MC/DC, NIL conformance, semantic-kernel/firewall gates).
10. **Types/files that become deletable** once the spine is complete, separated from the optimization internals that stay (dense/sparse tensor storage, SIMD, exact arithmetic).

The plan's governing principle: **concepts absent from the language specification must be inexpressible in the Semantic Spine's public API**, while optimization complexity is permitted below it. Old code is *not* deleted first — the convergence point is built alongside the existing runtime and the legacy model is removed only once it is unreachable.

## Quality Classification

- Highest impacted level: QL-D (documentation only; no code paths changed)

## Traceability

- Requirement(s): n/a — planning document; no requirement behavior is added or modified.
- Verification evidence: no code change. Existing CI gates (`check-semantic-kernel.mjs`, `check-semantic-firewall.sh`, conformance corpus, V1 golden) remain the baseline the plan commits to keeping green through every phase.

## Quality Checklist

- [x] Relevant requirements/objectives are identified. (None impacted — docs-only.)
- [x] Traceability links were added/updated. (`docs/dev/INDEX.md` entry added.)
- [ ] `cargo fmt --check` (in `rust/`) — n/a, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — n/a, no Rust changed
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — n/a, no Rust changed
- [ ] `npm run check`, if applicable — n/a, no source changed
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a
- [x] MC/DC-like checklist reviewed for modified boolean logic — n/a, no boolean logic changed
- [x] Release checklist impact considered — none; non-canonical doc under `docs/dev/`

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgfADL96PiTPzhiZYqvjfK)_