### PR TITLE
kernel: route the arithmetic family through the execute wrapper (Phase 4)

### DIFF
--- a/rust/src/kernel/arithmetic.rs
+++ b/rust/src/kernel/arithmetic.rs
@@ -1,0 +1,145 @@
+//! Spine-level arithmetic primitives for the `ADD`/`SUB`/`MUL`/`DIV` family
+//! (migration plan §12, Phase 4).
+//!
+//! These are the first Words routed through the shared [`execute_word`] wrapper.
+//! A primitive computes only: the wrapper has already applied arity and NIL
+//! policy, so a primitive receives its operands and returns its results.
+//!
+//! Scope: Phase 4 covers the rational-scalar domain, computed with the same
+//! [`Fraction`] arithmetic the legacy executor uses, so results agree by
+//! construction (the differential tests confirm this against the live
+//! interpreter). Operands outside that domain — exact-real scalars, vectors,
+//! tensors — are left to the legacy executor until a later phase widens the
+//! primitives; here they yield a reasonless NIL rather than a wrong number.
+//!
+//! [`execute_word`]: super::execute::execute_word
+
+use super::scalar::Scalar;
+use super::value::KernelValue;
+use crate::error::NilReason;
+use crate::types::fraction::Fraction;
+
+fn scalar_fraction(value: &KernelValue) -> Option<Fraction> {
+    match value {
+        KernelValue::Scalar(scalar) => scalar.as_fraction().cloned(),
+        _ => None,
+    }
+}
+
+/// Apply a binary rational operation to two operands. `op` returns `None` when
+/// the operation projects to NIL (division by zero); a non-rational operand
+/// yields a reasonless NIL (out of Phase 4 scope).
+fn binary(
+    operands: &[KernelValue],
+    op: impl Fn(&Fraction, &Fraction) -> Option<Fraction>,
+) -> Vec<KernelValue> {
+    let result = match (operands.first(), operands.get(1)) {
+        (Some(a), Some(b)) => match (scalar_fraction(a), scalar_fraction(b)) {
+            (Some(a), Some(b)) => match op(&a, &b) {
+                Some(value) => KernelValue::Scalar(Scalar::from_fraction(value)),
+                None => KernelValue::Nil(Some(NilReason::DivisionByZero)),
+            },
+            _ => KernelValue::Nil(None),
+        },
+        _ => KernelValue::Nil(None),
+    };
+    vec![result]
+}
+
+pub fn add(operands: &[KernelValue]) -> Vec<KernelValue> {
+    binary(operands, |a, b| Some(a.add(b)))
+}
+
+pub fn sub(operands: &[KernelValue]) -> Vec<KernelValue> {
+    binary(operands, |a, b| Some(a.sub(b)))
+}
+
+pub fn mul(operands: &[KernelValue]) -> Vec<KernelValue> {
+    binary(operands, |a, b| Some(a.mul(b)))
+}
+
+pub fn div(operands: &[KernelValue]) -> Vec<KernelValue> {
+    binary(
+        operands,
+        |a, b| if b.is_zero() { None } else { Some(a.div(b)) },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::execute::{execute_word, Consumption, KernelStack, Primitive};
+    use crate::kernel::generated::GENERATED_WORDS;
+    use crate::kernel::word_contract::WordContract;
+
+    fn contract(name: &str) -> WordContract {
+        let word = GENERATED_WORDS
+            .iter()
+            .find(|word| word.name == name)
+            .expect("word present in generated registry");
+        WordContract::from_generated(word).expect("arithmetic Words are fixed-arity")
+    }
+
+    /// Evaluate an Ajisai program on a fresh interpreter and lower its
+    /// top-of-stack value onto the spine.
+    async fn eval_top(program: &str) -> KernelValue {
+        let mut interp = crate::interpreter::Interpreter::new();
+        interp.execute(program).await.expect("program runs");
+        assert_eq!(interp.stack.len(), 1, "program leaves one value: {program}");
+        KernelValue::from(&interp.stack[0])
+    }
+
+    /// The spine wrapper and the live executor must agree, operand-for-operand.
+    /// Operands are produced by the same interpreter, so the comparison isolates
+    /// the Word's computation rather than literal parsing.
+    async fn assert_agrees(word: &str, primitive: Primitive, a: &str, b: &str) {
+        let operands = vec![eval_top(a).await, eval_top(b).await];
+        let mut stack = KernelStack::from_values(operands);
+        execute_word(&contract(word), primitive, Consumption::Eat, &mut stack).unwrap();
+        assert_eq!(stack.len(), 1);
+        let spine = stack.as_slice()[0].clone();
+
+        let legacy = eval_top(&format!("{a} {b} {word}")).await;
+        assert_eq!(
+            spine, legacy,
+            "spine and legacy disagree on `{a} {word} {b}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_matches_the_live_executor() {
+        assert_agrees("ADD", add, "3", "4").await;
+        assert_agrees("ADD", add, "1/2", "1/3").await;
+        assert_agrees("ADD", add, "-5", "2").await;
+    }
+
+    #[tokio::test]
+    async fn sub_matches_the_live_executor() {
+        assert_agrees("SUB", sub, "10", "3").await;
+        assert_agrees("SUB", sub, "1/2", "1/3").await;
+    }
+
+    #[tokio::test]
+    async fn mul_matches_the_live_executor() {
+        assert_agrees("MUL", mul, "6", "7").await;
+        assert_agrees("MUL", mul, "0.6", "0.8").await;
+    }
+
+    #[tokio::test]
+    async fn div_matches_the_live_executor() {
+        assert_agrees("DIV", div, "20", "4").await;
+        assert_agrees("DIV", div, "1", "3").await;
+    }
+
+    #[tokio::test]
+    async fn div_by_zero_projects_to_the_same_nil() {
+        // Both paths project division by zero to NIL(DivisionByZero).
+        assert_agrees("DIV", div, "3", "0").await;
+        let mut stack = KernelStack::from_values(vec![eval_top("3").await, eval_top("0").await]);
+        execute_word(&contract("DIV"), div, Consumption::Eat, &mut stack).unwrap();
+        assert_eq!(
+            stack.as_slice()[0],
+            KernelValue::Nil(Some(NilReason::DivisionByZero))
+        );
+    }
+}

--- a/rust/src/kernel/execute.rs
+++ b/rust/src/kernel/execute.rs
@@ -1,0 +1,201 @@
+//! The shared Word execution wrapper (migration plan §12).
+//!
+//! Every Word's shared concerns — arity, NIL policy, consumption — are applied
+//! here, once, from the [`WordContract`]. A Word's own code (a [`Primitive`])
+//! only computes: given its operands, it returns the values to push. This is
+//! the entry point the plan converges every Word onto; Phase 4 routes the
+//! arithmetic family through it and validates the result against the live
+//! executor, without yet rewiring the runtime's dispatch.
+
+use super::value::KernelValue;
+use super::word_contract::WordContract;
+
+/// A minimal value stack the wrapper operates on. The runtime's own stack keeps
+/// its optimizations; this is the spine-level view a Word sees.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct KernelStack {
+    items: Vec<KernelValue>,
+}
+
+impl KernelStack {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    /// Build a stack from values in bottom-to-top order.
+    pub fn from_values(items: Vec<KernelValue>) -> Self {
+        Self { items }
+    }
+
+    pub fn push(&mut self, value: KernelValue) {
+        self.items.push(value);
+    }
+
+    pub fn pop(&mut self) -> Option<KernelValue> {
+        self.items.pop()
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn as_slice(&self) -> &[KernelValue] {
+        &self.items
+    }
+}
+
+/// How the wrapper treats the consumed operands.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Consumption {
+    /// Consume the operands (the default `EAT` mode).
+    Eat,
+    /// Keep the operands and append the results (`KEEP`).
+    Keep,
+}
+
+/// Why a Word could not run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecError {
+    /// Fewer operands on the stack than the contract's arity requires.
+    StackUnderflow,
+}
+
+/// A Word's own computation: given its operands in stack order (bottom → top),
+/// return the values to push. The wrapper has already applied arity and NIL
+/// policy, so a primitive only computes.
+pub type Primitive = fn(&[KernelValue]) -> Vec<KernelValue>;
+
+fn is_nil(value: &KernelValue) -> bool {
+    matches!(value, KernelValue::Nil(_))
+}
+
+/// Run a Word through the shared wrapper: validate arity, apply the NIL policy,
+/// run the primitive if it is not short-circuited, then consume operands and
+/// push results per the consumption mode.
+pub fn execute_word(
+    contract: &WordContract,
+    primitive: Primitive,
+    consumption: Consumption,
+    stack: &mut KernelStack,
+) -> Result<(), ExecError> {
+    let consumes = contract.arity.consumes as usize;
+    if stack.items.len() < consumes {
+        return Err(ExecError::StackUnderflow);
+    }
+
+    let operand_start = stack.items.len() - consumes;
+    let operands = &stack.items[operand_start..];
+
+    // NIL policy: a NIL operand short-circuits the Word to a NIL result,
+    // propagating the first NIL's reason, without running the primitive.
+    let results = if contract.nil_policy.passes_nil_through() && operands.iter().any(is_nil) {
+        let propagated = operands
+            .iter()
+            .find(|value| is_nil(value))
+            .cloned()
+            .unwrap_or(KernelValue::Nil(None));
+        vec![propagated]
+    } else {
+        primitive(operands)
+    };
+
+    if consumption == Consumption::Eat {
+        stack.items.truncate(operand_start);
+    }
+    stack.items.extend(results);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::scalar::Scalar;
+    use crate::kernel::word_contract::{Arity, NilPolicy};
+    use crate::types::fraction::Fraction;
+
+    fn passthrough_contract() -> WordContract {
+        WordContract {
+            arity: Arity {
+                consumes: 2,
+                produces: 1,
+            },
+            nil_policy: NilPolicy::Passthrough,
+        }
+    }
+
+    fn scalar(n: i64) -> KernelValue {
+        KernelValue::Scalar(Scalar::from_fraction(Fraction::from(n)))
+    }
+
+    // A primitive that would panic if a NIL operand ever reached it, so the
+    // passthrough test proves the wrapper short-circuited before the primitive.
+    fn sum_or_panic(operands: &[KernelValue]) -> Vec<KernelValue> {
+        let mut total = 0_i64;
+        for operand in operands {
+            match operand {
+                KernelValue::Scalar(s) => {
+                    total += s.as_fraction().and_then(Fraction::to_i64).unwrap()
+                }
+                other => panic!("primitive received a non-scalar operand: {other:?}"),
+            }
+        }
+        vec![scalar(total)]
+    }
+
+    #[test]
+    fn eat_consumes_operands_and_pushes_the_result() {
+        let mut stack = KernelStack::from_values(vec![scalar(2), scalar(3)]);
+        execute_word(
+            &passthrough_contract(),
+            sum_or_panic,
+            Consumption::Eat,
+            &mut stack,
+        )
+        .unwrap();
+        assert_eq!(stack.as_slice(), &[scalar(5)]);
+    }
+
+    #[test]
+    fn keep_preserves_operands_and_appends_the_result() {
+        let mut stack = KernelStack::from_values(vec![scalar(2), scalar(3)]);
+        execute_word(
+            &passthrough_contract(),
+            sum_or_panic,
+            Consumption::Keep,
+            &mut stack,
+        )
+        .unwrap();
+        assert_eq!(stack.as_slice(), &[scalar(2), scalar(3), scalar(5)]);
+    }
+
+    #[test]
+    fn a_nil_operand_short_circuits_before_the_primitive() {
+        let mut stack = KernelStack::from_values(vec![scalar(2), KernelValue::Nil(None)]);
+        // sum_or_panic would panic on the NIL; reaching here proves passthrough
+        // ran instead of the primitive.
+        execute_word(
+            &passthrough_contract(),
+            sum_or_panic,
+            Consumption::Eat,
+            &mut stack,
+        )
+        .unwrap();
+        assert_eq!(stack.as_slice(), &[KernelValue::Nil(None)]);
+    }
+
+    #[test]
+    fn too_few_operands_is_an_underflow() {
+        let mut stack = KernelStack::from_values(vec![scalar(2)]);
+        let result = execute_word(
+            &passthrough_contract(),
+            sum_or_panic,
+            Consumption::Eat,
+            &mut stack,
+        );
+        assert_eq!(result, Err(ExecError::StackUnderflow));
+    }
+}

--- a/rust/src/kernel/mod.rs
+++ b/rust/src/kernel/mod.rs
@@ -23,11 +23,14 @@
 //! the two models coexist while consumers migrate onto the spine one at a time.
 //! See `docs/dev/semantic-spine-migration-plan.md`.
 
+pub mod arithmetic;
+pub mod execute;
 pub mod generated;
 pub mod nil;
 pub mod observation;
 pub mod scalar;
 pub mod value;
+pub mod word_contract;
 
 // The temporary legacy <-> spine bridge. A private module: its `From` impls are
 // coherent crate-wide regardless, and keeping it unexported holds the spine's

--- a/rust/src/kernel/word_contract.rs
+++ b/rust/src/kernel/word_contract.rs
@@ -1,0 +1,121 @@
+//! The spine's typed view of a Word's contract, derived from the generated
+//! registry (migration plan §12). The execution wrapper reads this — arity,
+//! nil policy — so the shared concerns of every Word are applied from one
+//! machine-checked source (`spec/words.json`) rather than re-encoded per Word.
+
+use super::generated::GeneratedWord;
+
+/// Fixed stack arity: how many operands a Word consumes and how many results it
+/// produces under the default consume mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Arity {
+    pub consumes: u8,
+    pub produces: u8,
+}
+
+/// How a Word treats a NIL operand, projected from the spec `nilPolicy`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NilPolicy {
+    /// A NIL operand passes through: the Word yields NIL without running.
+    Passthrough,
+    /// A NIL operand passes through, and the Word may itself project a result
+    /// to NIL (e.g. `DIV` by zero).
+    PassthroughThenProject,
+    /// The Word may create a NIL from non-NIL operands.
+    CreatesNil,
+    /// The Word preserves an operand's NIL reason unchanged.
+    PreservesReason,
+    /// The Word rejects a NIL operand as an error rather than passing it.
+    RejectsNil,
+    /// The Word consumes a NIL operand as ordinary input.
+    ConsumeNil,
+    /// The Word inspects NIL-ness without propagating it.
+    InspectNil,
+}
+
+impl NilPolicy {
+    fn from_spec(spec: &str) -> Option<Self> {
+        Some(match spec {
+            "passthrough" => NilPolicy::Passthrough,
+            "passthroughThenProject" => NilPolicy::PassthroughThenProject,
+            "createsNil" => NilPolicy::CreatesNil,
+            "preserveReason" => NilPolicy::PreservesReason,
+            "rejectNil" => NilPolicy::RejectsNil,
+            "consumeNil" => NilPolicy::ConsumeNil,
+            "inspectNil" => NilPolicy::InspectNil,
+            _ => return None,
+        })
+    }
+
+    /// Whether a NIL operand short-circuits the Word to a NIL result without
+    /// running its primitive.
+    pub fn passes_nil_through(self) -> bool {
+        matches!(
+            self,
+            NilPolicy::Passthrough | NilPolicy::PassthroughThenProject
+        )
+    }
+}
+
+/// A Word's static contract as the execution wrapper consumes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WordContract {
+    pub arity: Arity,
+    pub nil_policy: NilPolicy,
+}
+
+impl WordContract {
+    /// Build a fixed-arity contract from a generated Word. Returns `None` when
+    /// the Word's stack arity is data-dependent (`"variable"`/`"control"`) or
+    /// its nil policy is unrecognized — such Words do not flow through the
+    /// fixed-arity wrapper (yet).
+    pub fn from_generated(word: &GeneratedWord) -> Option<Self> {
+        let consumes = word.stack_inputs.parse::<u8>().ok()?;
+        let produces = word.stack_outputs.parse::<u8>().ok()?;
+        let nil_policy = NilPolicy::from_spec(word.nil_policy)?;
+        Some(WordContract {
+            arity: Arity { consumes, produces },
+            nil_policy,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::generated::GENERATED_WORDS;
+
+    fn word(name: &str) -> &'static GeneratedWord {
+        GENERATED_WORDS
+            .iter()
+            .find(|word| word.name == name)
+            .expect("word present in generated registry")
+    }
+
+    #[test]
+    fn fixed_arity_word_yields_a_contract() {
+        let contract = WordContract::from_generated(word("ADD")).expect("ADD is fixed-arity");
+        assert_eq!(
+            contract.arity,
+            Arity {
+                consumes: 2,
+                produces: 1
+            }
+        );
+        assert!(contract.nil_policy.passes_nil_through());
+    }
+
+    #[test]
+    fn div_passes_nil_through_then_projects() {
+        let contract = WordContract::from_generated(word("DIV")).expect("DIV is fixed-arity");
+        assert_eq!(contract.nil_policy, NilPolicy::PassthroughThenProject);
+        assert!(contract.nil_policy.passes_nil_through());
+    }
+
+    #[test]
+    fn data_dependent_arity_has_no_fixed_contract() {
+        // COND's stack arity is "variable" in spec/words.json, so it does not
+        // flow through the fixed-arity wrapper.
+        assert!(WordContract::from_generated(word("COND")).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of `docs/dev/semantic-spine-migration-plan.md`: introduce the shared Word **execution wrapper** and run `ADD`/`SUB`/`MUL`/`DIV` through it, validated against the live executor (plan §12). This is the first phase to put the spine on an execution path — kept **off the runtime's live dispatch**: the wrapper is exercised and differential-tested, not yet wired in, so behavior cannot change.

- **`word_contract.rs`** — `WordContract` (`Arity` + `NilPolicy`) built from the generated registry via `WordContract::from_generated`. The wrapper's shared behavior is therefore derived from `spec/words.json`, the single source established in Phase 3. Data-dependent-arity Words (`COND`, …) and unrecognized nil policies yield `None` and stay off the fixed-arity wrapper.
- **`execute.rs`** — `KernelStack` + `execute_word(contract, primitive, consumption, stack)`. The wrapper applies:
  - **arity** — fewer operands than the contract requires → `StackUnderflow`;
  - **NIL policy** — a NIL operand short-circuits to a propagated NIL *without running the primitive* (bubble passthrough);
  - **consumption** — `Eat` consumes operands; `Keep` appends the result.
  A `Primitive` is a pure `fn(&[KernelValue]) -> Vec<KernelValue>` that only computes.
- **`arithmetic.rs`** — `add`/`sub`/`mul`/`div` over the **rational-scalar domain**, computed with the same `Fraction` arithmetic the legacy executor uses (div-by-zero → `NIL(DivisionByZero)`). Operands outside that domain (exact-real, vectors, tensors) yield a reasonless NIL and stay with the legacy executor until a later phase widens the primitives.

### Validation: differential against the live executor

The arithmetic tests spin up a fresh `Interpreter`, feed the **same operands** to the wrapper, and assert the spine and live results agree operand-for-operand — including fractions (`1/2 1/3 +`), negatives, decimal literals (`0.6 0.8 *`), and division-by-zero projection (`3 0 /` → the same `NIL(DivisionByZero)`). Because both paths use the same `Fraction` arithmetic, agreement is by construction; the tests pin it.

## Quality Classification

- Highest impacted level: QL-C — new library code on no live execution path; the arithmetic primitives are differential-tested against the runtime, but the runtime's dispatch is unchanged. No behavior change.

## Traceability

- Requirement(s): migration plan `docs/dev/semantic-spine-migration-plan.md` §12 (runtime consumes WordContract), §23 Phase 4 (ADD/SUB/MUL/DIV first).
- Verification evidence: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (802 passing, incl. 12 new: wrapper unit + contract + differential), `scripts/check-semantic-firewall.sh` (spine closure green), `npm run check:file-size` (green) — all run locally.

## Quality Checklist

- [x] Relevant requirements/objectives are identified. (Migration plan Phase 4.)
- [x] Traceability links were added/updated. (Plan references in module docs + this PR.)
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — `cargo test --lib`: 802 passing, 0 failing.
- [ ] `npm run check`, if applicable — n/a, no TypeScript changed.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a while off live dispatch; coverage lands when the runtime routes through the wrapper.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the wrapper's NIL-passthrough / arity branches are covered by dedicated unit tests (passthrough short-circuit, eat/keep, underflow).
- [x] Release checklist impact considered — none; wrapper is off live dispatch, no observable behavior change.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgfADL96PiTPzhiZYqvjfK)_