### PR TITLE
kernel: add HostProtocolV2 rendered from the Observation (Phase 6)

### DIFF
--- a/rust/src/kernel/host_protocol_v2.rs
+++ b/rust/src/kernel/host_protocol_v2.rs
@@ -1,0 +1,214 @@
+//! HostProtocolV2 — the host wire format rendered directly from the Semantic
+//! Spine (migration plan §15).
+//!
+//! V2 reflects the six canonical value domains and the outward-observable
+//! [`Observation`], and nothing else. It carries no legacy concept — no module
+//! catalog, no tensor shape, no logical-unknown axis, no absence
+//! origin/recoverability, no capability set — because those cannot be expressed
+//! by the spine types it serializes. That is the whole point of a second
+//! protocol: the frozen [`HostProtocolV1`](crate::semantic::protocol) keeps its
+//! legacy surface for existing consumers, while V2 stays in lockstep with the
+//! language as it is now.
+//!
+//! This module is a pure `Observation -> serde_json::Value` mapping; no consumer
+//! reads it yet. Phase 8 routes new GUI/WASM paths onto it.
+
+use serde_json::{json, Value as Json};
+
+use super::observation::{Observation, ObservedValue, PresentationHint};
+use super::value::KernelValue;
+
+/// The protocol identifier carried by every V2 document.
+pub const PROTOCOL_VERSION: &str = "ajisai.host.v2";
+
+fn presentation_str(hint: PresentationHint) -> &'static str {
+    match hint {
+        PresentationHint::Structural => "structural",
+        PresentationHint::Text => "text",
+        PresentationHint::Interval => "interval",
+        PresentationHint::Timestamp => "timestamp",
+    }
+}
+
+/// Render a [`KernelValue`] into its V2 value node. Total over the six domains;
+/// no legacy field can appear because the spine cannot express one.
+pub fn value_to_v2(value: &KernelValue) -> Json {
+    match value {
+        KernelValue::Scalar(scalar) => match scalar.as_fraction() {
+            Some(fraction) => json!({
+                "type": "scalar",
+                "numerator": fraction.numerator().to_string(),
+                "denominator": fraction.denominator().to_string(),
+            }),
+            // An exact-real scalar's rational backing is not part of the public
+            // spine API; V2 marks the representation and defers its wire value
+            // to a later phase that widens the exact-real surface.
+            None => json!({ "type": "scalar", "exact": true }),
+        },
+        KernelValue::Boolean(value) => json!({ "type": "boolean", "value": value }),
+        KernelValue::String(text) => json!({ "type": "string", "value": text.as_ref() }),
+        KernelValue::Vector(items) => json!({
+            "type": "vector",
+            "items": items.iter().map(value_to_v2).collect::<Vec<_>>(),
+        }),
+        KernelValue::Nil(reason) => json!({
+            "type": "nil",
+            "reason": reason.as_ref().map(|reason| reason.as_protocol_str()),
+        }),
+        KernelValue::CodeBlock(_) => json!({ "type": "codeBlock" }),
+    }
+}
+
+fn observed_to_v2(observed: &ObservedValue) -> Json {
+    json!({
+        "value": value_to_v2(&observed.value),
+        "presentation": presentation_str(observed.presentation),
+    })
+}
+
+/// Render an [`Observation`] into a complete HostProtocolV2 document.
+pub fn observation_to_v2(observation: &Observation) -> Json {
+    json!({
+        "protocol": PROTOCOL_VERSION,
+        "stack": observation
+            .stack
+            .iter()
+            .map(observed_to_v2)
+            .collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::NilReason;
+    use crate::kernel::scalar::Scalar;
+    use crate::kernel::value::CodeBlock;
+    use crate::types::fraction::Fraction;
+    use std::sync::Arc;
+
+    const GOLDEN_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../spec/freeze/host-protocol-v2.golden.json"
+    );
+
+    /// One value of each of the six domains plus a display-hinted vector, so the
+    /// golden exercises the whole wire surface.
+    fn canonical_observation() -> Observation {
+        fn scalar(n: i64) -> KernelValue {
+            KernelValue::Scalar(Scalar::from_fraction(Fraction::from(n)))
+        }
+        Observation {
+            stack: vec![
+                ObservedValue {
+                    value: scalar(3),
+                    presentation: PresentationHint::Structural,
+                },
+                ObservedValue {
+                    value: KernelValue::Boolean(true),
+                    presentation: PresentationHint::Structural,
+                },
+                ObservedValue {
+                    value: KernelValue::String(Arc::from("hi")),
+                    presentation: PresentationHint::Text,
+                },
+                ObservedValue {
+                    value: KernelValue::Vector(Arc::from([scalar(1), scalar(2)])),
+                    presentation: PresentationHint::Interval,
+                },
+                ObservedValue {
+                    value: KernelValue::Nil(Some(NilReason::DivisionByZero)),
+                    presentation: PresentationHint::Structural,
+                },
+                ObservedValue {
+                    value: KernelValue::Nil(None),
+                    presentation: PresentationHint::Structural,
+                },
+                ObservedValue {
+                    value: KernelValue::CodeBlock(CodeBlock::new(Arc::from(Vec::new()))),
+                    presentation: PresentationHint::Structural,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn v2_document_matches_the_frozen_golden() {
+        let document = observation_to_v2(&canonical_observation());
+        let golden: Json = serde_json::from_str(
+            &std::fs::read_to_string(GOLDEN_PATH).expect("V2 golden is present"),
+        )
+        .expect("V2 golden is valid JSON");
+        assert_eq!(
+            document, golden,
+            "V2 output drifted from the golden; regenerate with \
+             `cargo test regenerate_v2_golden -- --ignored`"
+        );
+    }
+
+    #[test]
+    fn v2_carries_no_legacy_field() {
+        // The V1-only concepts the spine dropped must never surface in a V2
+        // document, by construction. This is a belt-and-braces check over the
+        // serialized text alongside the type-level guarantee.
+        let text = serde_json::to_string(&observation_to_v2(&canonical_observation())).unwrap();
+        for legacy in [
+            "module",
+            "tensor",
+            "unknown",
+            "origin",
+            "recoverab",
+            "capabilit",
+            "importedModules",
+            "semanticKind",
+        ] {
+            assert!(!text.contains(legacy), "V2 leaked a legacy field: {legacy}");
+        }
+    }
+
+    #[test]
+    fn v2_value_types_conform_to_the_schema() {
+        // Keep the schema and the serializer from drifting: every value node the
+        // serializer emits must use a `type` the schema declares. Reads the
+        // domain enum straight from spec/host-protocol-v2.schema.json.
+        const SCHEMA_PATH: &str = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../spec/host-protocol-v2.schema.json"
+        );
+        let schema: Json =
+            serde_json::from_str(&std::fs::read_to_string(SCHEMA_PATH).expect("schema present"))
+                .expect("schema is valid JSON");
+        let allowed: Vec<&str> = schema["$defs"]["value"]["properties"]["type"]["enum"]
+            .as_array()
+            .expect("schema declares a value type enum")
+            .iter()
+            .map(|entry| entry.as_str().expect("type enum entries are strings"))
+            .collect();
+
+        fn walk(node: &Json, allowed: &[&str]) {
+            let type_str = node["type"].as_str().expect("value node has a type");
+            assert!(
+                allowed.contains(&type_str),
+                "value type `{type_str}` is not declared in the schema"
+            );
+            if let Some(items) = node["items"].as_array() {
+                for item in items {
+                    walk(item, allowed);
+                }
+            }
+        }
+
+        let document = observation_to_v2(&canonical_observation());
+        for observed in document["stack"].as_array().unwrap() {
+            walk(&observed["value"], &allowed);
+        }
+    }
+
+    #[test]
+    #[ignore = "regenerates the V2 golden; run with `-- --ignored`"]
+    fn regenerate_v2_golden() {
+        let document = observation_to_v2(&canonical_observation());
+        let pretty = serde_json::to_string_pretty(&document).unwrap();
+        std::fs::write(GOLDEN_PATH, format!("{pretty}\n")).unwrap();
+    }
+}

--- a/rust/src/kernel/mod.rs
+++ b/rust/src/kernel/mod.rs
@@ -26,6 +26,7 @@
 pub mod arithmetic;
 pub mod execute;
 pub mod generated;
+pub mod host_protocol_v2;
 pub mod nil;
 pub mod observation;
 pub mod scalar;

--- a/spec/freeze/host-protocol-v2.golden.json
+++ b/spec/freeze/host-protocol-v2.golden.json
@@ -1,0 +1,65 @@
+{
+  "protocol": "ajisai.host.v2",
+  "stack": [
+    {
+      "presentation": "structural",
+      "value": {
+        "denominator": "1",
+        "numerator": "3",
+        "type": "scalar"
+      }
+    },
+    {
+      "presentation": "structural",
+      "value": {
+        "type": "boolean",
+        "value": true
+      }
+    },
+    {
+      "presentation": "text",
+      "value": {
+        "type": "string",
+        "value": "hi"
+      }
+    },
+    {
+      "presentation": "interval",
+      "value": {
+        "items": [
+          {
+            "denominator": "1",
+            "numerator": "1",
+            "type": "scalar"
+          },
+          {
+            "denominator": "1",
+            "numerator": "2",
+            "type": "scalar"
+          }
+        ],
+        "type": "vector"
+      }
+    },
+    {
+      "presentation": "structural",
+      "value": {
+        "reason": "divisionByZero",
+        "type": "nil"
+      }
+    },
+    {
+      "presentation": "structural",
+      "value": {
+        "reason": null,
+        "type": "nil"
+      }
+    },
+    {
+      "presentation": "structural",
+      "value": {
+        "type": "codeBlock"
+      }
+    }
+  ]
+}

--- a/spec/host-protocol-v2.schema.json
+++ b/spec/host-protocol-v2.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ajisai.dev/spec/host-protocol-v2.schema.json",
+  "title": "Ajisai HostProtocolV2",
+  "description": "The host wire format rendered directly from the Semantic Spine. It reflects the six canonical value domains and the outward-observable stack, and carries no legacy concept (module catalog, tensor shape, logical-unknown axis, absence origin/recoverability, capability set). The frozen HostProtocolV1 remains the compatibility surface; V2 stays in lockstep with the language as it is now.",
+  "type": "object",
+  "required": ["protocol", "stack"],
+  "additionalProperties": false,
+  "properties": {
+    "protocol": {
+      "const": "ajisai.host.v2",
+      "description": "Protocol identifier carried by every V2 document."
+    },
+    "stack": {
+      "type": "array",
+      "description": "Observed stack values, bottom to top.",
+      "items": { "$ref": "#/$defs/observedValue" }
+    }
+  },
+  "$defs": {
+    "observedValue": {
+      "type": "object",
+      "required": ["value", "presentation"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "$ref": "#/$defs/value" },
+        "presentation": {
+          "description": "Presentation-only display intent; never changes execution semantics.",
+          "enum": ["structural", "text", "interval", "timestamp"]
+        }
+      }
+    },
+    "value": {
+      "type": "object",
+      "required": ["type"],
+      "description": "One of the six canonical value domains, discriminated by `type`.",
+      "properties": {
+        "type": {
+          "description": "The value domain.",
+          "enum": ["scalar", "boolean", "string", "vector", "nil", "codeBlock"]
+        },
+        "numerator": {
+          "type": "string",
+          "description": "scalar: rational numerator (arbitrary precision, decimal string)."
+        },
+        "denominator": {
+          "type": "string",
+          "description": "scalar: rational denominator (arbitrary precision, decimal string)."
+        },
+        "exact": {
+          "type": "boolean",
+          "description": "scalar: present and true when the value is backed by an exact real rather than a rational."
+        },
+        "value": {
+          "description": "boolean: the truth value; string: the text.",
+          "type": ["boolean", "string"]
+        },
+        "items": {
+          "type": "array",
+          "description": "vector: the element values.",
+          "items": { "$ref": "#/$defs/value" }
+        },
+        "reason": {
+          "description": "nil: the absence reason, or null for a bare literal NIL. The reason is the only absence datum the spine observes; origin/recoverability are diagnostic state, not wire fields.",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 6 of `docs/dev/semantic-spine-migration-plan.md`: introduce **HostProtocolV2**, a host wire format serialized directly from the Semantic Spine (plan §15). V2 reflects the six canonical value domains and the outward-observable `Observation` — and **nothing else**: no module catalog, tensor shape, logical-unknown axis, absence origin/recoverability, or capability set, because the spine types it serializes cannot express them. The frozen `HostProtocolV1` is **untouched** and remains the compatibility surface; V2 stands alongside it. Additive — no consumer reads V2 yet (Phase 8 routes GUI/WASM onto it).

- **`host_protocol_v2.rs`** — `observation_to_v2` / `value_to_v2`, a pure `Observation → serde_json::Value` mapping, total over `KernelValue`. Scalars render `numerator`/`denominator` (exact scalars mark `exact: true`, wire value deferred); `nil` renders its reason via the shared `NilReason::as_protocol_str` — **reason only**; origin/recoverability are diagnostic state, not wire fields (§9).
- **`spec/host-protocol-v2.schema.json`** — the V2 contract (draft-07), modeled on the six domains.
- **`spec/freeze/host-protocol-v2.golden.json`** — a frozen document exercising every domain plus a display-hinted (`interval`) vector.

### Validation

- The serializer reproduces the golden byte-for-byte (regenerate with the ignored `regenerate_v2_golden` test).
- Every emitted value `type` conforms to the schema's declared domain enum — a live cross-check that keeps schema and serializer in lockstep.
- A document **carries no legacy field** (`module`/`tensor`/`unknown`/`origin`/`recoverab`/`capabilit`/`importedModules`/`semanticKind`) — belt-and-braces over the type-level guarantee.

## Quality Classification

- Highest impacted level: QL-C — new serializer + spec artifacts, no consumer; V1 path and golden unchanged. No behavior change.

## Traceability

- Requirement(s): migration plan `docs/dev/semantic-spine-migration-plan.md` §14 (V1 frozen), §15 (V2 from the spine), §16 (no legacy reflux), §23 Phase 6.
- Verification evidence: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (809 passing + 1 ignored regenerator), `scripts/check-semantic-firewall.sh` (spine closure + residue green), `npm run check:file-size` (green) — all run locally.

## Quality Checklist

- [x] Relevant requirements/objectives are identified. (Migration plan Phase 6.)
- [x] Traceability links were added/updated. (Plan references in module docs, schema `description`, this PR.)
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — `cargo test --lib`: 809 passing, 0 failing.
- [ ] `npm run check`, if applicable — n/a, no TypeScript changed; the V2 schema/golden are consumed by the Rust tests.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a while off live serializers; coverage lands when a consumer reads V2.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the value/presentation serialization is a total match over closed enums, covered by the golden + schema-conformance tests.
- [x] Release checklist impact considered — none; V1 golden untouched, V2 has no consumer yet.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgfADL96PiTPzhiZYqvjfK)_