### PR TITLE
kernel: reconstruct V1 semantic axes via an anti-corruption adapter (Phase 7)

### DIFF
--- a/rust/src/kernel/legacy_v1.rs
+++ b/rust/src/kernel/legacy_v1.rs
@@ -1,0 +1,139 @@
+//! HostProtocolV1 anti-corruption adapter (migration plan §16).
+//!
+//! HostProtocolV1 is frozen: it keeps a legacy surface — `semanticKind`,
+//! `shape`, `capabilities`, an absence `origin`/`recoverability`/`diagnosis`
+//! block, `importedModules` — that the reduced language no longer has. This
+//! module is the boundary that lets V1 keep that surface after the legacy
+//! semantic fields are removed from the kernel path (Phase 9): it reconstructs
+//! the parts of the V1 semantics block that are a pure function of the value
+//! **from the spine's [`KernelValue`]**, so the runtime need not carry them.
+//!
+//! Anti-corruption is one-directional. V1 vocabulary lives here and nowhere
+//! else on the spine side, and it never flows back: the adapter reads a
+//! `KernelValue` and returns V1 protocol strings; it does not — and cannot —
+//! add a module, tensor, or origin field to `KernelValue`.
+//!
+//! Scope. The three axes below (`semanticKind`, `shape`, `capabilities`) are
+//! functions of the value domain, so the spine can supply them. The remaining
+//! V1-only data is not a function of the value and is **not** reconstructed
+//! here: an absence's `origin`/`recoverability`/`diagnosis` is diagnostic state
+//! (§9) and `importedModules` is legacy runtime state (§10). A full V1 document
+//! defaults those in the adapter (origin/recoverability `unknown`, no modules)
+//! or takes them from a legacy annotation passed alongside — never from the
+//! spine value. Only the value-derived axes are modeled in this phase.
+
+use super::value::KernelValue;
+
+/// V1 `semanticKind` for a value, reconstructed from the spine. Mirrors the
+/// legacy `Value::semantic_kind`: a string is a collection (its legacy
+/// representation is a vector), a boolean reports `number` on this coarse axis
+/// for protocol stability (its truth lives in `truthValued`), and a NIL is an
+/// absence.
+pub fn v1_semantic_kind(value: &KernelValue) -> &'static str {
+    match value {
+        KernelValue::Scalar(_) | KernelValue::Boolean(_) => "number",
+        KernelValue::String(_) | KernelValue::Vector(_) => "collection",
+        KernelValue::Nil(_) => "absence",
+        KernelValue::CodeBlock(_) => "code",
+    }
+}
+
+/// V1 `shape` for a value, reconstructed from the spine. Mirrors the legacy
+/// `Value::shape_kind`.
+pub fn v1_shape(value: &KernelValue) -> &'static str {
+    match value {
+        KernelValue::Scalar(_) | KernelValue::Boolean(_) => "scalar",
+        KernelValue::String(_) | KernelValue::Vector(_) => "vector",
+        KernelValue::Nil(_) => "absence",
+        KernelValue::CodeBlock(_) => "codeBlock",
+    }
+}
+
+/// V1 `capabilities` for a value, reconstructed from the spine in the legacy
+/// order. Mirrors the legacy `Value::capabilities`: a base set for every stack
+/// value, then domain-specific capabilities, then `truthValued` for a boolean.
+pub fn v1_capabilities(value: &KernelValue) -> Vec<&'static str> {
+    let mut capabilities = vec!["stackItem", "serializable", "displayable"];
+    match value {
+        KernelValue::Scalar(_) => {
+            capabilities.extend(["numeric", "exactNumeric", "userEditable"]);
+        }
+        KernelValue::String(_) | KernelValue::Vector(_) => {
+            capabilities.extend(["iterable", "indexable", "userEditable"]);
+        }
+        KernelValue::Nil(_) => {
+            capabilities.extend(["nilPassthrough", "diagnosable", "aiExplainable"]);
+        }
+        KernelValue::CodeBlock(_) => capabilities.push("callable"),
+        KernelValue::Boolean(_) => {}
+    }
+    // A boolean is truth-valued; it advertises `truthValued` so consumers read
+    // the `truthValue` axis (SPEC §2.3).
+    if matches!(value, KernelValue::Boolean(_)) {
+        capabilities.push("truthValued");
+    }
+    capabilities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::scalar::Scalar;
+    use crate::kernel::value::CodeBlock;
+    use crate::types::fraction::Fraction;
+    use crate::types::Value;
+    use std::sync::Arc;
+
+    // The legacy `Value` methods are HostProtocolV1's source of truth. Raising a
+    // KernelValue to a Value and reading them back is the oracle the adapter's
+    // spine-side reconstruction must match.
+    fn oracle_semantic_kind(value: &KernelValue) -> &'static str {
+        Value::from(value).semantic_kind().as_protocol_str()
+    }
+    fn oracle_shape(value: &KernelValue) -> &'static str {
+        Value::from(value).shape_kind().as_protocol_str()
+    }
+    fn oracle_capabilities(value: &KernelValue) -> Vec<&'static str> {
+        Value::from(value)
+            .capabilities()
+            .into_iter()
+            .map(|capability| capability.as_protocol_str())
+            .collect()
+    }
+
+    fn representative_values() -> Vec<KernelValue> {
+        vec![
+            KernelValue::Scalar(Scalar::from_fraction(Fraction::from(3_i64))),
+            KernelValue::Boolean(true),
+            KernelValue::Boolean(false),
+            // Non-empty: an empty string raises to NIL in the legacy model.
+            KernelValue::String(Arc::from("hi")),
+            KernelValue::Vector(Arc::from([KernelValue::Scalar(Scalar::from_fraction(
+                Fraction::from(1_i64),
+            ))])),
+            KernelValue::Nil(None),
+            KernelValue::CodeBlock(CodeBlock::new(Arc::from(Vec::new()))),
+        ]
+    }
+
+    #[test]
+    fn adapter_reconstructs_the_v1_semantic_axes_from_the_spine() {
+        for value in representative_values() {
+            assert_eq!(
+                v1_semantic_kind(&value),
+                oracle_semantic_kind(&value),
+                "semanticKind mismatch for {value:?}"
+            );
+            assert_eq!(
+                v1_shape(&value),
+                oracle_shape(&value),
+                "shape mismatch for {value:?}"
+            );
+            assert_eq!(
+                v1_capabilities(&value),
+                oracle_capabilities(&value),
+                "capabilities mismatch for {value:?}"
+            );
+        }
+    }
+}

--- a/rust/src/kernel/mod.rs
+++ b/rust/src/kernel/mod.rs
@@ -27,6 +27,7 @@ pub mod arithmetic;
 pub mod execute;
 pub mod generated;
 pub mod host_protocol_v2;
+pub mod legacy_v1;
 pub mod nil;
 pub mod observation;
 pub mod scalar;


### PR DESCRIPTION
## Summary

Phase 7 of `docs/dev/semantic-spine-migration-plan.md`: add the **HostProtocolV1 anti-corruption adapter** (plan §16). V1 is frozen and keeps a legacy surface the reduced language no longer has (`semanticKind`, `shape`, `capabilities`, absence `origin`/`recoverability`/`diagnosis`, `importedModules`). This module is the boundary that lets V1 keep that surface **after the legacy semantic fields are removed from the kernel path in Phase 9**: it reconstructs the value-derived parts of the V1 semantics block from the spine's `KernelValue`, so the runtime need not carry them.

- **`legacy_v1.rs`** — `v1_semantic_kind` / `v1_shape` / `v1_capabilities` map a `KernelValue` to the V1 protocol strings, mirroring the legacy `Value::semantic_kind` / `shape_kind` / `capabilities` (a string is a collection/vector; a boolean reports `number` on the coarse axis and gains `truthValued`; a NIL is an absence).
- **One-directional by design**: V1 vocabulary lives here and nowhere else on the spine side, and the adapter *cannot* add a module/tensor/origin field back to `KernelValue` — the anti-corruption invariant the firewall's spine-closure check already enforces at the type level.

### Honest scope

Only the **value-derived** axes are reconstructed from the spine. The remaining V1-only data is **not** a function of the value and is deliberately not reconstructed here: an absence's `origin`/`recoverability`/`diagnosis` is diagnostic state (§9) and `importedModules` is legacy runtime state (§10). A full V1 document defaults those in the adapter (`unknown`, no modules) or takes them from a legacy annotation passed alongside — never from the spine value. This PR models the value-derived axes, which are exactly the "legacy semantic fields" Phase 9 removes from the kernel path.

### Validation

The legacy `Value` methods are V1's source of truth. The test raises one `KernelValue` of each domain to a `Value` and asserts the adapter's spine-side output equals the oracle — `semanticKind`, `shape`, and the **ordered** `capabilities` list including `truthValued` for booleans.

## Quality Classification

- Highest impacted level: QL-C — new adapter code, no consumer; V1 serializers and the frozen V1 golden are untouched. No behavior change.

## Traceability

- Requirement(s): migration plan `docs/dev/semantic-spine-migration-plan.md` §14 (V1 frozen), §16 (anti-corruption layer), §23 Phase 7; enables §9 Phase 9 deletion.
- Verification evidence: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (810 passing), `scripts/check-semantic-firewall.sh` (spine closure green), `npm run check:file-size` (green) — all run locally.

## Quality Checklist

- [x] Relevant requirements/objectives are identified. (Migration plan Phase 7.)
- [x] Traceability links were added/updated. (Plan references in module docs + this PR.)
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — `cargo test --lib`: 810 passing, 0 failing.
- [ ] `npm run check`, if applicable — n/a, no TypeScript changed.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a; adapter has no consumer yet.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the three axis mappings are total matches over the closed `KernelValue` enum, checked against the live `Value` oracle for every domain.
- [x] Release checklist impact considered — none; V1 serializers/golden untouched, adapter has no consumer yet.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgfADL96PiTPzhiZYqvjfK)_