### PR TITLE
kernel: delete the unreachable legacy semantic model (Phase 9, first pass)

### DIFF
--- a/docs/dev/semantic-spine-migration-plan.md
+++ b/docs/dev/semantic-spine-migration-plan.md
@@ -300,6 +300,34 @@ rust/build.rs                        # spec/words.json → kernel/generated/*.rs
 `types/exact/*`（exact arithmetic）, tensor 最適化本体。これらは `VectorRepr`/`ScalarRepr`
 の private 実装として残す。
 
+### 10.1 Phase 9 実施記録（第1次削除）
+
+到達可能性を実測し、**到達不能なものだけ**を削除した。削除済み:
+
+| 削除対象 | 到達可能性の実測 |
+| --- | --- |
+| `TensorLaneId`, `NilReasonRegistry` | 定義のみ。参照 0 |
+| `SemanticRegistry`（`flow_hints`/`flow_extensions`）, `ValueExt` | `Interpreter` が構築するのみで read/write 0（フィールドの doc 自身が "no readers yet" と明記） |
+| `UnknownBehavior`, `widen_unknown` | `WordContract` に計算・格納されるが観測者 0。UNKNOWN は削減済み概念 |
+| `WaterSensitivity`, `widen_water` | 同上 |
+| `SemanticKind::{Record,Process,Supervisor,Unknown}` | 構築 0（`as_protocol_str` の arm のみ） |
+| `ValueShape::{Record,Handle,Unknown}` | 構築 0 |
+| `ValueOrigin::{Computed,CoreWord,BuiltinWord,ModuleWord,UserWord,Optimizer}` | 構築 0。`Value::origin` は Literal/NilPropagation/HostEnvironment/Unknown のみ返す |
+| `Capability::{ModuleOwned,CoreOwned}` | 構築 0。V1 golden にも現れない |
+
+削除できなかったもの（**まだ live**）とその理由:
+
+- `ValueData::Tensor` / `ExactScalar` / `Interpretation` / `Value.hint` / `Value.absence`,
+  `AbsenceMetadata` / `AbsenceOrigin` / `Recoverability`, module 系
+  （`module_vocabulary` / `ImportTable` / …）, `ValueShape::Tensor`。
+- 理由: Spine は runtime と**並存**しているだけで、まだ**置換されていない**。実行器・
+  `value_to_protocol`・V1 serializer は今も旧 `ValueData` 上で動作しており、これらの型は
+  live path から到達可能である。
+
+したがって次の削除には、Phase 4〜8 で作成・検証済みの Spine 経路を**実際に consumer へ
+配線する**作業（execute wrapper を dispatch へ、`Observation` を serializer へ、V2 producer を
+wasm へ）が先行する。§23 の原則どおり、**到達不能になってから削除する**。
+
 ---
 
 ## 11. 最重要 invariant（CI 最優先ルール）

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::types::{Interpretation, SemanticRegistry, Stack, Token, Value, WordDefinition};
+use crate::types::{Interpretation, Stack, Token, Value, WordDefinition};
 use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -209,13 +209,6 @@ pub struct Interpreter {
     pub(crate) module_epoch: u64,
     pub(crate) execution_epoch: u64,
 
-    /// Flow-plane scaffolding (value-id-keyed `flow_hints` / `flow_extensions`).
-    /// Top-level stack-position roles moved onto [`Stack`] in Phase 4, leaving
-    /// this registry with only the flow-plane fields, which have no readers yet
-    /// and are explicitly out of scope for the Phase 4 migration. Retained for
-    /// that future use; `dead_code` is expected until a reader lands.
-    #[allow(dead_code)]
-    pub(crate) semantic_registry: SemanticRegistry,
     pub(crate) monitor_notifications: Vec<Vec<Value>>,
     pub(crate) next_supervisor_id: u64,
 
@@ -350,7 +343,6 @@ impl Interpreter {
             dictionary_epoch: 0,
             module_epoch: 0,
             execution_epoch: 0,
-            semantic_registry: SemanticRegistry::new(),
             monitor_notifications: Vec::new(),
             next_supervisor_id: 1,
             runtime_metrics: RuntimeMetrics::default(),

--- a/rust/src/interpreter/word_contract.rs
+++ b/rust/src/interpreter/word_contract.rs
@@ -14,8 +14,7 @@ use crate::coreword_registry::{get_coreword_metadata, MassContract, NilPolicy, W
 use crate::types::{Capabilities, Token, WordDefinition};
 
 use super::word_contract_lattice::{
-    widen_confidence, widen_determinism, widen_nil, widen_order, widen_purity, widen_unknown,
-    widen_water,
+    widen_confidence, widen_determinism, widen_nil, widen_order, widen_purity,
 };
 use super::word_space::{DepSpace, SpaceBound, SpaceClass, SpaceSim};
 use super::Interpreter;
@@ -35,8 +34,6 @@ pub struct WordContract {
     pub determinism: ContractDeterminism,
     pub order_sensitivity: OrderSensitivity,
     pub nil_behavior: NilBehavior,
-    pub unknown_behavior: UnknownBehavior,
-    pub water_sensitivity: WaterSensitivity,
     /// Sound upper bound on the word's space growth (Phase 2.2; `word_space`).
     pub space: SpaceClass,
     /// True when the bound is provably attained, licensing a declaration error.
@@ -80,18 +77,6 @@ pub enum NilBehavior {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum UnknownBehavior {
-    NeverCreates,
-    MayCreate,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum WaterSensitivity {
-    NotWaterSensitive,
-    WaterSensitive,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ContractConfidence {
     Complete,
     Conservative,
@@ -115,8 +100,6 @@ impl WordContract {
             determinism: ContractDeterminism::NonDeterministic,
             order_sensitivity: OrderSensitivity::OrderSensitive,
             nil_behavior: NilBehavior::MayCreate,
-            unknown_behavior: UnknownBehavior::MayCreate,
-            water_sensitivity: WaterSensitivity::WaterSensitive,
             space: SpaceClass::Unbounded,
             space_exact: false,
             confidence: ContractConfidence::Conservative,
@@ -142,8 +125,6 @@ impl WordContract {
             determinism: ContractDeterminism::Deterministic,
             order_sensitivity: OrderSensitivity::OrderIndependent,
             nil_behavior: NilBehavior::NeverCreates,
-            unknown_behavior: UnknownBehavior::NeverCreates,
-            water_sensitivity: WaterSensitivity::NotWaterSensitive,
             space: SpaceClass::Const,
             space_exact: true,
             confidence: ContractConfidence::Complete,
@@ -221,8 +202,6 @@ struct AccumulatedContract {
     determinism: ContractDeterminism,
     order_sensitivity: OrderSensitivity,
     nil_behavior: NilBehavior,
-    unknown_behavior: UnknownBehavior,
-    water_sensitivity: WaterSensitivity,
     confidence: ContractConfidence,
 }
 
@@ -236,8 +215,6 @@ impl AccumulatedContract {
             determinism: contract.determinism,
             order_sensitivity: contract.order_sensitivity,
             nil_behavior: contract.nil_behavior,
-            unknown_behavior: contract.unknown_behavior,
-            water_sensitivity: contract.water_sensitivity,
             confidence: contract.confidence,
         }
     }
@@ -253,8 +230,6 @@ impl AccumulatedContract {
         self.determinism = widen_determinism(self.determinism, other.determinism);
         self.order_sensitivity = widen_order(self.order_sensitivity, other.order_sensitivity);
         self.nil_behavior = widen_nil(self.nil_behavior, other.nil_behavior);
-        self.unknown_behavior = widen_unknown(self.unknown_behavior, other.unknown_behavior);
-        self.water_sensitivity = widen_water(self.water_sensitivity, other.water_sensitivity);
         self.confidence = widen_confidence(self.confidence, other.confidence);
     }
 }
@@ -276,16 +251,6 @@ fn static_word_contract(name: &str, def: &WordDefinition) -> WordContract {
         NilPolicy::ConsumesNil => NilBehavior::ConsumesNil,
     };
     let (space, space_exact) = super::word_space::builtin_space_for(name);
-    let unknown_behavior = if name.eq_ignore_ascii_case("COMPARE-WITHIN") {
-        UnknownBehavior::MayCreate
-    } else {
-        UnknownBehavior::NeverCreates
-    };
-    let water_sensitivity = if name.eq_ignore_ascii_case("COMPARE-WITHIN") {
-        WaterSensitivity::WaterSensitive
-    } else {
-        WaterSensitivity::NotWaterSensitive
-    };
     WordContract {
         flow: meta.mass.into(),
         purity: meta.purity.into(),
@@ -298,8 +263,6 @@ fn static_word_contract(name: &str, def: &WordDefinition) -> WordContract {
         },
         order_sensitivity: OrderSensitivity::OrderIndependent,
         nil_behavior,
-        unknown_behavior,
-        water_sensitivity,
         space,
         space_exact,
         confidence: ContractConfidence::Complete,
@@ -440,8 +403,6 @@ impl Interpreter {
             determinism: acc.determinism,
             order_sensitivity: acc.order_sensitivity,
             nil_behavior: acc.nil_behavior,
-            unknown_behavior: acc.unknown_behavior,
-            water_sensitivity: acc.water_sensitivity,
             space,
             space_exact,
             confidence: acc.confidence,

--- a/rust/src/interpreter/word_contract_lattice.rs
+++ b/rust/src/interpreter/word_contract_lattice.rs
@@ -2,7 +2,6 @@
 
 use super::word_contract::{
     ContractConfidence, ContractDeterminism, ContractPurity, NilBehavior, OrderSensitivity,
-    UnknownBehavior, WaterSensitivity,
 };
 
 pub(super) fn widen_purity(a: ContractPurity, b: ContractPurity) -> ContractPurity {
@@ -48,24 +47,6 @@ pub(super) fn widen_nil(a: NilBehavior, b: NilBehavior) -> NilBehavior {
         (ConsumesNil, _) | (_, ConsumesNil) => ConsumesNil,
         (Propagates, _) | (_, Propagates) => Propagates,
         _ => NeverCreates,
-    }
-}
-
-pub(super) fn widen_unknown(a: UnknownBehavior, b: UnknownBehavior) -> UnknownBehavior {
-    if matches!(a, UnknownBehavior::MayCreate) || matches!(b, UnknownBehavior::MayCreate) {
-        UnknownBehavior::MayCreate
-    } else {
-        UnknownBehavior::NeverCreates
-    }
-}
-
-pub(super) fn widen_water(a: WaterSensitivity, b: WaterSensitivity) -> WaterSensitivity {
-    if matches!(a, WaterSensitivity::WaterSensitive)
-        || matches!(b, WaterSensitivity::WaterSensitive)
-    {
-        WaterSensitivity::WaterSensitive
-    } else {
-        WaterSensitivity::NotWaterSensitive
     }
 }
 

--- a/rust/src/semantic/capability.rs
+++ b/rust/src/semantic/capability.rs
@@ -11,8 +11,6 @@ pub enum Capability {
     Serializable,
     Displayable,
     UserEditable,
-    ModuleOwned,
-    CoreOwned,
     AiExplainable,
     /// The value is a three-valued truth value (true / false / unknown,
     /// SPEC §7.5). Signals consumers to read the `truthValue` axis.

--- a/rust/src/semantic/protocol.rs
+++ b/rust/src/semantic/protocol.rs
@@ -5,12 +5,8 @@ impl SemanticKind {
         match self {
             SemanticKind::Number => "number",
             SemanticKind::Collection => "collection",
-            SemanticKind::Record => "record",
             SemanticKind::Code => "code",
-            SemanticKind::Process => "process",
-            SemanticKind::Supervisor => "supervisor",
             SemanticKind::Absence => "absence",
-            SemanticKind::Unknown => "unknown",
         }
     }
 }
@@ -21,11 +17,8 @@ impl ValueShape {
             ValueShape::Scalar => "scalar",
             ValueShape::Vector => "vector",
             ValueShape::Tensor => "tensor",
-            ValueShape::Record => "record",
             ValueShape::CodeBlock => "codeBlock",
-            ValueShape::Handle => "handle",
             ValueShape::Absence => "absence",
-            ValueShape::Unknown => "unknown",
         }
     }
 }
@@ -44,8 +37,6 @@ impl Capability {
             Capability::Serializable => "serializable",
             Capability::Displayable => "displayable",
             Capability::UserEditable => "userEditable",
-            Capability::ModuleOwned => "moduleOwned",
-            Capability::CoreOwned => "coreOwned",
             Capability::AiExplainable => "aiExplainable",
             Capability::TruthValued => "truthValued",
         }
@@ -56,14 +47,8 @@ impl ValueOrigin {
     pub fn as_protocol_str(&self) -> &'static str {
         match self {
             ValueOrigin::Literal => "literal",
-            ValueOrigin::Computed => "computed",
-            ValueOrigin::CoreWord => "coreWord",
-            ValueOrigin::BuiltinWord => "builtinWord",
-            ValueOrigin::ModuleWord { .. } => "moduleWord",
-            ValueOrigin::UserWord => "userWord",
             ValueOrigin::NilPropagation => "nilPropagation",
             ValueOrigin::HostEnvironment => "hostEnvironment",
-            ValueOrigin::Optimizer => "optimizer",
             ValueOrigin::Unknown => "unknown",
         }
     }

--- a/rust/src/semantic/protocol_string_tests.rs
+++ b/rust/src/semantic/protocol_string_tests.rs
@@ -13,7 +13,11 @@ fn semantic_axes_use_lower_camel_case_protocol_strings() {
         Capability::NilPassthrough.as_protocol_str(),
         "nilPassthrough"
     );
-    assert_eq!(ValueOrigin::Computed.as_protocol_str(), "computed");
+    // A live origin: `Value::origin` still produces this one.
+    assert_eq!(
+        ValueOrigin::NilPropagation.as_protocol_str(),
+        "nilPropagation"
+    );
 }
 
 #[test]

--- a/rust/src/semantic/value_axes.rs
+++ b/rust/src/semantic/value_axes.rs
@@ -2,12 +2,8 @@
 pub enum SemanticKind {
     Number,
     Collection,
-    Record,
     Code,
-    Process,
-    Supervisor,
     Absence,
-    Unknown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,23 +11,14 @@ pub enum ValueShape {
     Scalar,
     Vector,
     Tensor,
-    Record,
     CodeBlock,
-    Handle,
     Absence,
-    Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValueOrigin {
     Literal,
-    Computed,
-    CoreWord,
-    BuiltinWord,
-    ModuleWord { module: Option<String> },
-    UserWord,
     NilPropagation,
     HostEnvironment,
-    Optimizer,
     Unknown,
 }

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -21,11 +21,9 @@ mod value_protocol_tests;
 
 use self::fraction::Fraction;
 pub use self::stack::Stack;
-use crate::error::NilReason;
 use crate::semantic::AbsenceMetadata;
 use crate::types::exact::ExactReal;
-use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Eq)]
@@ -320,26 +318,6 @@ impl SparseTensor {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TensorLaneId {
-    pub tensor_id: u64,
-    pub lane: usize,
-}
-
-pub type NilReasonRegistry = HashMap<TensorLaneId, NilReason>;
-
-pub trait ValueExt: std::fmt::Debug + Send + 'static {
-    fn clone_box(&self) -> Box<dyn ValueExt>;
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
-impl Clone for Box<dyn ValueExt> {
-    fn clone(&self) -> Self {
-        self.clone_box()
-    }
-}
-
 /// Semantic interpretation role assigned to a stack value. This is the
 /// meaning the runtime attaches to a value, not a formatting switch:
 /// rendering for humans and AI is derived from (data, role).
@@ -509,39 +487,6 @@ pub struct Value {
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         self.data == other.data && self.hint == other.hint
-    }
-}
-
-/// Flow-plane semantic metadata that is keyed by value identity rather than by
-/// stack position. Top-level stack-position roles moved to [`Stack`] in Phase 4
-/// (single authority, SPEC §12); this registry retains only the value-id-keyed
-/// nested extensions, which are out of scope for that migration.
-pub struct SemanticRegistry {
-    pub flow_hints: HashMap<u64, Interpretation>,
-    pub flow_extensions: HashMap<u64, Box<dyn ValueExt>>,
-}
-
-impl std::fmt::Debug for SemanticRegistry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SemanticRegistry")
-            .field("flow_hints_len", &self.flow_hints.len())
-            .field("flow_extensions_len", &self.flow_extensions.len())
-            .finish()
-    }
-}
-
-impl Default for SemanticRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SemanticRegistry {
-    pub fn new() -> Self {
-        SemanticRegistry {
-            flow_hints: HashMap::new(),
-            flow_extensions: HashMap::new(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 9 of `docs/dev/semantic-spine-migration-plan.md`. I measured reachability across the §10 deletion candidates and removed **only what is genuinely unreachable**, per the plan's rule that deletion *follows* unreachability rather than leading it. **155 lines removed, 8 added.**

### Deleted (reachability measured, not assumed)

| Removed | Why it was unreachable |
| --- | --- |
| `TensorLaneId`, `NilReasonRegistry` | Defined; referenced nowhere. |
| `SemanticRegistry` (`flow_hints`/`flow_extensions`) + the `ValueExt` trait it held | Constructed once by `Interpreter`, never read or written. The field's own doc comment recorded it had "no readers yet". |
| `UnknownBehavior` + `widen_unknown`, `WaterSensitivity` + `widen_water` | Computed into `WordContract` and widened through the lattice, but **never observed** by any consumer. UNKNOWN is a retired concept, and the `COMPARE-WITHIN` special case producing them names a Word that no longer exists. |
| `SemanticKind::{Record,Process,Supervisor,Unknown}`, `ValueShape::{Record,Handle,Unknown}`, `ValueOrigin::{Computed,CoreWord,BuiltinWord,ModuleWord,UserWord,Optimizer}`, `Capability::{ModuleOwned,CoreOwned}` | Never constructed — their only remaining reachability was their own `as_protocol_str` arm. `Value::origin` only ever returns `Literal`/`NilPropagation`/`HostEnvironment`/`Unknown`, and the V1 golden contains none of the removed capability strings, so **no wire output changes**. |

These are exactly the "removed concepts" residue: module, record, process, supervisor, handle, and the logical unknown.

### Deliberately NOT deleted — still reachable from live code

`ValueData::{Tensor, ExactScalar}`, `Interpretation`/`Value.hint`, `Value.absence` + `AbsenceMetadata`/`AbsenceOrigin`/`Recoverability`, the module state, and `ValueShape::Tensor`.

**The spine coexists with the runtime but has not yet been substituted into it** — the executor, `value_to_protocol`, and the V1 serializers still run on the legacy model, so these types remain live. Deleting them now would break the build, not reduce the system. Phases 4–8 built and validated the spine paths but intentionally left them off live dispatch to keep each step zero-risk; the next deletion pass depends on actually wiring those consumers (execute wrapper → dispatch, `Observation` → serializers, V2 producer → wasm). Recorded in the plan as **§10.1** together with the wiring each future deletion depends on.

### Coverage note

A protocol-string test that only covered *dead* `ValueOrigin` variants now covers a live one (`NilPropagation`) instead, so the axis keeps its coverage rather than silently losing it.

## Quality Classification

- Highest impacted level: QL-C — removes unreachable code from library and observation-axis surfaces; no live path changes and no wire output changes.

## Traceability

- Requirement(s): migration plan `docs/dev/semantic-spine-migration-plan.md` §10 (deletable inventory), §10.1 (new: first-pass record), §23 Phase 9.
- Verification evidence: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (810 passing), `npm test` (231 passing), `scripts/check-semantic-firewall.sh`, `npm run check:file-size` — all green locally. The frozen V1 golden is **byte-unchanged** (`git diff` touches no golden file).

## Quality Checklist

- [x] Relevant requirements/objectives are identified. (Migration plan Phase 9.)
- [x] Traceability links were added/updated. (Plan §10.1 records what was deleted, what was not, and why.)
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — `cargo test --lib`: 810 passing, 0 failing.
- [x] `npm run check`, if applicable — vitest 231 passing; no TS source changed.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — n/a; this removes code rather than adding branches.
- [x] MC/DC-like checklist reviewed for modified boolean logic — no boolean logic modified; the removed `widen_unknown`/`widen_water` joins had no observers, and remaining lattice joins are untouched.
- [x] Release checklist impact considered — none; V1 golden byte-unchanged, no live path or wire output altered.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgfADL96PiTPzhiZYqvjfK)_