### PR TITLE
Remove the legacy module runtime

### DIFF
--- a/docs/dev/semantic-spine-migration-plan.md
+++ b/docs/dev/semantic-spine-migration-plan.md
@@ -328,6 +328,23 @@ rust/build.rs                        # spec/words.json → kernel/generated/*.rs
 配線する**作業（execute wrapper を dispatch へ、`Observation` を serializer へ、V2 producer を
 wasm へ）が先行する。§23 の原則どおり、**到達不能になってから削除する**。
 
+### 10.2 Phase 9 実施記録（module runtime の削除）
+
+正典から削除済みで、登録経路も既に存在しなかった module runtime を削除した:
+
+- `ModuleDictionary` / `ImportedModule` / `ImportTable` と `Interpreter` の
+  `module_vocabulary` / `import_table` を削除。
+- bare name、修飾名、resolve cache、dependency graph、`DEL` に残っていた module 分岐を削除。
+- module の変更元が無いにもかかわらず cache と compiled plan の invalidation に残っていた
+  `module_epoch` を削除。
+- Word contract cache が借用していた `module_state` は、実際の責務を表す
+  `runtime_scratch` に改名。
+- 凍結済み V1 / wasm 互換 API は anti-corruption boundary として署名を保持し、module catalog、
+  import state、imported module の各結果を常に空として返す。restore は no-op のままとする。
+
+これにより module は Kernel の解決・実行状態から到達不能になり、空の legacy wire shape のみが
+host boundary に残る。
+
 ---
 
 ## 11. 最重要 invariant（CI 最優先ルール）

--- a/rust/src/interpreter/compiled_plan.rs
+++ b/rust/src/interpreter/compiled_plan.rs
@@ -62,7 +62,6 @@ pub enum CompiledOp {
 
 pub fn is_plan_valid(plan: &CompiledPlan, interp: &Interpreter) -> bool {
     plan.compiled_at.dictionary_epoch == interp.dictionary_epoch
-        && plan.compiled_at.module_epoch == interp.module_epoch
 }
 
 fn compile_symbol(token: &Token, symbol: &str, interp: &Interpreter) -> CompiledOp {

--- a/rust/src/interpreter/control_cond.rs
+++ b/rust/src/interpreter/control_cond.rs
@@ -323,7 +323,6 @@ fn restore_cond_eval_state(
     interp.stack = saved_stack;
     interp.consumption_mode = saved_consumption_mode;
     interp.dictionary_epoch = saved_epoch.dictionary_epoch;
-    interp.module_epoch = saved_epoch.module_epoch;
     interp.execution_epoch = saved_epoch.execution_epoch;
     interp.global_epoch = saved_epoch.global_epoch;
 }

--- a/rust/src/interpreter/epoch.rs
+++ b/rust/src/interpreter/epoch.rs
@@ -2,6 +2,5 @@
 pub struct EpochSnapshot {
     pub global_epoch: u64,
     pub dictionary_epoch: u64,
-    pub module_epoch: u64,
     pub execution_epoch: u64,
 }

--- a/rust/src/interpreter/execute_builtin.rs
+++ b/rust/src/interpreter/execute_builtin.rs
@@ -289,15 +289,6 @@ impl Interpreter {
                     dict.words
                         .insert(word.to_string(), std::sync::Arc::new(updated));
                     self.sync_user_words_cache();
-                    return;
-                }
-            }
-            if let Some(module) = self.module_vocabulary.get_mut(ns) {
-                let qualified = format!("{}@{}", ns, word);
-                if let Some(old_def) = module.words.get(&qualified).cloned() {
-                    let mut updated = (*old_def).clone();
-                    updated.execution_plans = Some(plan_set);
-                    module.words.insert(qualified, std::sync::Arc::new(updated));
                 }
             }
         }

--- a/rust/src/interpreter/execute_del.rs
+++ b/rust/src/interpreter/execute_del.rs
@@ -23,58 +23,19 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
-    if target_dict.is_none() {
-        if interp.user_dictionaries.contains_key(&word_name) {
-            interp.user_dictionaries.remove(&word_name);
-            interp.sync_user_words_cache();
-            interp.rebuild_dependencies()?;
-            interp
-                .output_buffer
-                .push_str(&format!("Deleted dictionary: {}\n", word_name));
-            interp.bump_dictionary_epoch();
-            interp.force_flag = false;
-            return Ok(());
-        }
-
-        if false {
-            interp.force_flag = false;
-            return Err(AjisaiError::from(format!(
-                "Cannot delete module dictionary {}. Use '{}' UNIMPORT to hide imported module words.",
-                word_name, word_name
-            )));
-        }
-
-        if let Some(module_name) = find_imported_module_item(interp, &word_name) {
-            interp.force_flag = false;
-            return Err(AjisaiError::from(format!(
-                "Cannot delete module word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
-                module_name, word_name, module_name, word_name
-            )));
-        }
-    }
-
-    if let Some(module_name) = target_dict.as_deref() {
-        if let Some(module) = interp.module_vocabulary.get(module_name) {
-            let qualified = format!("{}@{}", module_name, word_name);
-            if module.words.contains_key(&qualified) {
-                interp.force_flag = false;
-                return Err(AjisaiError::from(format!(
-                    "Cannot delete module word {}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
-                    qualified, module_name, word_name
-                )));
-            }
-        }
-    }
-
-    let (owner_name, is_module) = find_word_owner(interp, target_dict.as_deref(), &word_name)?;
-
-    if is_module {
+    if target_dict.is_none() && interp.user_dictionaries.contains_key(&word_name) {
+        interp.user_dictionaries.remove(&word_name);
+        interp.sync_user_words_cache();
+        interp.rebuild_dependencies()?;
+        interp
+            .output_buffer
+            .push_str(&format!("Deleted dictionary: {}\n", word_name));
+        interp.bump_dictionary_epoch();
         interp.force_flag = false;
-        return Err(AjisaiError::from(format!(
-            "Cannot delete module word {}@{}. Use '{}' [ '{}' ] UNIMPORT-ONLY to hide it.",
-            owner_name, word_name, owner_name, word_name
-        )));
+        return Ok(());
     }
+
+    let owner_name = find_word_owner(interp, target_dict.as_deref(), &word_name)?;
 
     let fq_name = format!("{}@{}", owner_name, word_name);
     let dependents = interp.collect_dependents(&fq_name);
@@ -87,17 +48,10 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         )));
     }
 
-    let removed_def = if is_module {
-        interp
-            .user_dictionaries
-            .get_mut(&owner_name)
-            .and_then(|dict| dict.words.remove(&word_name))
-    } else {
-        interp
-            .user_dictionaries
-            .get_mut(&owner_name)
-            .and_then(|dict| dict.words.remove(&word_name))
-    };
+    let removed_def = interp
+        .user_dictionaries
+        .get_mut(&owner_name)
+        .and_then(|dict| dict.words.remove(&word_name));
 
     if let Some(removed_def) = removed_def {
         interp.sync_user_words_cache();
@@ -131,30 +85,15 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
     Ok(())
 }
 
-fn find_imported_module_item(interp: &Interpreter, word_name: &str) -> Option<String> {
-    for (module_name, module) in &interp.module_vocabulary {
-        let Some(imported) = interp.import_table.modules.get(module_name) else {
-            continue;
-        };
-        let qualified = format!("{}@{}", module_name, word_name);
-        if module.words.contains_key(&qualified)
-            && (imported.import_all_public || imported.imported_words.contains(word_name))
-        {
-            return Some(module_name.clone());
-        }
-    }
-    None
-}
-
 fn find_word_owner(
     interp: &Interpreter,
     target_dict: Option<&str>,
     word_name: &str,
-) -> Result<(String, bool)> {
+) -> Result<String> {
     if let Some(dict_name) = target_dict {
         if let Some(dict) = interp.user_dictionaries.get(dict_name) {
             if dict.words.contains_key(word_name) {
-                return Ok((dict_name.to_string(), false));
+                return Ok(dict_name.to_string());
             }
         }
         Err(AjisaiError::from(format!(
@@ -164,7 +103,7 @@ fn find_word_owner(
     } else {
         for (dict_name, dict) in &interp.user_dictionaries {
             if dict.words.contains_key(word_name) {
-                return Ok((dict_name.clone(), false));
+                return Ok(dict_name.clone());
             }
         }
         Err(AjisaiError::from(format!(

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -64,22 +64,6 @@ pub(crate) struct UserDictionary {
     pub words: HashMap<String, Arc<WordDefinition>>,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ModuleDictionary {
-    pub words: HashMap<String, Arc<WordDefinition>>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ImportedModule {
-    pub import_all_public: bool,
-    pub imported_words: HashSet<String>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct ImportTable {
-    pub modules: HashMap<String, ImportedModule>,
-}
-
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DictionaryDependencyInfo {
     pub depends_on: HashSet<String>,
@@ -90,7 +74,6 @@ pub(crate) struct DictionaryDependencyInfo {
 pub struct ResolveCacheEntry {
     pub resolved_name: String,
     pub dictionary_epoch: u64,
-    pub module_epoch: u64,
     pub registration_order: u64,
 }
 
@@ -178,8 +161,8 @@ pub struct Interpreter {
     pub(crate) disable_no_change_check: bool,
     pub(crate) pending_tokens: Option<Vec<Token>>,
     pub(crate) pending_token_index: usize,
-    pub(crate) module_state: HashMap<String, Box<dyn std::any::Any + Send>>,
-    pub(crate) import_table: ImportTable,
+    /// Type-erased caches owned by runtime subsystems.
+    pub(crate) runtime_scratch: HashMap<String, Box<dyn std::any::Any + Send>>,
     pub(crate) call_stack: SmallVec<[String; 5]>,
     /// User-word call depth. Incremented on entry to a user-word body in
     /// `execute_word_core_inner`, decremented on exit. Compared against
@@ -199,14 +182,12 @@ pub struct Interpreter {
     /// than running for minutes. Reset per top-level `execute`.
     pub(crate) numeric_work_used: u64,
 
-    pub(crate) module_vocabulary: HashMap<String, ModuleDictionary>,
     pub(crate) dictionary_dependencies: HashMap<String, DictionaryDependencyInfo>,
     pub(crate) next_registration_order: u64,
     pub(crate) active_user_dictionary: String,
 
     pub(crate) global_epoch: u64,
     pub(crate) dictionary_epoch: u64,
-    pub(crate) module_epoch: u64,
     pub(crate) execution_epoch: u64,
 
     pub(crate) monitor_notifications: Vec<Vec<Value>>,
@@ -327,21 +308,18 @@ impl Interpreter {
             disable_no_change_check: true,
             pending_tokens: None,
             pending_token_index: 0,
-            module_state: HashMap::new(),
-            import_table: ImportTable::default(),
+            runtime_scratch: HashMap::new(),
             call_stack: SmallVec::new(),
             call_depth: 0,
             execution_step_count: 0,
             max_execution_steps: DEFAULT_MAX_EXECUTION_STEPS,
             runtime_limits: super::runtime_limits::RuntimeLimits::default(),
             numeric_work_used: 0,
-            module_vocabulary: HashMap::new(),
             dictionary_dependencies: HashMap::new(),
             next_registration_order: 1,
             active_user_dictionary: "EXAMPLE".to_string(),
             global_epoch: 0,
             dictionary_epoch: 0,
-            module_epoch: 0,
             execution_epoch: 0,
             monitor_notifications: Vec::new(),
             next_supervisor_id: 1,
@@ -426,7 +404,6 @@ impl Interpreter {
         EpochSnapshot {
             global_epoch: self.global_epoch,
             dictionary_epoch: self.dictionary_epoch,
-            module_epoch: self.module_epoch,
             execution_epoch: self.execution_epoch,
         }
     }

--- a/rust/src/interpreter/resolve_cache.rs
+++ b/rust/src/interpreter/resolve_cache.rs
@@ -20,9 +20,7 @@ impl Interpreter {
     pub(crate) fn lookup_resolve_cache(&mut self, name: &str) -> Option<String> {
         let key = self.contextual_resolve_cache_key(name);
         let entry = self.resolve_cache.get(&key)?;
-        if entry.dictionary_epoch == self.dictionary_epoch
-            && entry.module_epoch == self.module_epoch
-        {
+        if entry.dictionary_epoch == self.dictionary_epoch {
             self.runtime_metrics.resolve_cache_hit_count += 1;
             Some(entry.resolved_name.clone())
         } else {
@@ -43,7 +41,6 @@ impl Interpreter {
             ResolveCacheEntry {
                 resolved_name: resolved_name.to_string(),
                 dictionary_epoch: self.dictionary_epoch,
-                module_epoch: self.module_epoch,
                 registration_order,
             },
         );

--- a/rust/src/interpreter/resolve_word.rs
+++ b/rust/src/interpreter/resolve_word.rs
@@ -75,29 +75,11 @@ impl Interpreter {
             .unwrap_or_default();
     }
 
-    fn is_module_word_imported(&self, module_name: &str, short_name: &str) -> bool {
-        self.import_table
-            .modules
-            .get(module_name)
-            .map(|m| m.import_all_public || m.imported_words.contains(short_name))
-            .unwrap_or(false)
-    }
-
     pub(crate) fn resolve_short_name(&self, name: &str) -> Option<(String, Arc<WordDefinition>)> {
         let upper = name.to_uppercase();
 
         if let Some(def) = self.core_vocabulary.get(&upper) {
             return Some((upper, def.clone()));
-        }
-
-        for (module_name, module) in &self.module_vocabulary {
-            if !self.is_module_word_imported(module_name, &upper) {
-                continue;
-            }
-            let qualified = format!("{}@{}", module_name, upper);
-            if let Some(def) = module.words.get(&qualified) {
-                return Some((qualified, def.clone()));
-            }
         }
 
         // Section 8.6: a bare name resolves through the owning dictionary's
@@ -174,7 +156,7 @@ impl Interpreter {
     pub(crate) fn check_ambiguity(&self, name: &str) -> Vec<String> {
         let upper = name.to_uppercase();
 
-        // Core / Module words win the bare-name ladder and are never ambiguous.
+        // Core words win the bare-name ladder and are never ambiguous.
         if self.core_vocabulary.contains_key(&upper) {
             return vec![];
         }
@@ -204,15 +186,6 @@ impl Interpreter {
                         .cloned()
                         .map(|def| (word.clone(), def));
                 }
-                if let Some(module_dict) = self.module_vocabulary.get(ns.as_str()) {
-                    let qualified = format!("{}@{}", ns, word);
-                    if self.is_module_word_imported(ns, &word) {
-                        if let Some(def) = module_dict.words.get(&qualified) {
-                            return Some((qualified, def.clone()));
-                        }
-                    }
-                    return None;
-                }
                 if let Some(user_dict) = self.user_dictionaries.get(ns.as_str()) {
                     if let Some(def) = user_dict.words.get(&word) {
                         return Some((format!("{}@{}", ns, word), def.clone()));
@@ -229,22 +202,12 @@ impl Interpreter {
                             return Some((format!("{}@{}", second, word), def.clone()));
                         }
                     }
-                } else if first == "DICT" {
-                    if second == "CORE" {
-                        return self
-                            .core_vocabulary
-                            .get(&word)
-                            .cloned()
-                            .map(|def| (word.clone(), def));
-                    }
-                    if let Some(module_dict) = self.module_vocabulary.get(second.as_str()) {
-                        let qualified = format!("{}@{}", second, word);
-                        if self.is_module_word_imported(second, &word) {
-                            if let Some(def) = module_dict.words.get(&qualified) {
-                                return Some((qualified, def.clone()));
-                            }
-                        }
-                    }
+                } else if first == "DICT" && second == "CORE" {
+                    return self
+                        .core_vocabulary
+                        .get(&word)
+                        .cloned()
+                        .map(|def| (word.clone(), def));
                 }
                 None
             }
@@ -282,12 +245,6 @@ impl Interpreter {
                 if let Some(dict) = self.user_dictionaries.get(ns.as_str()) {
                     if let Some(def) = dict.words.get(&word).cloned() {
                         return Some((format!("{}@{}", ns, word), def));
-                    }
-                }
-                if let Some(module) = self.module_vocabulary.get(ns.as_str()) {
-                    let qualified = format!("{}@{}", ns, word);
-                    if let Some(def) = module.words.get(&qualified).cloned() {
-                        return Some((qualified, def));
                     }
                 }
             }
@@ -375,11 +332,6 @@ impl Interpreter {
         self.owning_dictionary_context = None;
 
         for dict in self.user_dictionaries.keys() {
-            self.dictionary_dependencies
-                .entry(dict.clone())
-                .or_default();
-        }
-        for dict in self.module_vocabulary.keys() {
             self.dictionary_dependencies
                 .entry(dict.clone())
                 .or_default();

--- a/rust/src/interpreter/session_lifecycle.rs
+++ b/rust/src/interpreter/session_lifecycle.rs
@@ -35,7 +35,7 @@ impl Interpreter {
         self.force_flag = false;
         self.pending_tokens = None;
         self.pending_token_index = 0;
-        self.module_state.clear();
+        self.runtime_scratch.clear();
         self.call_stack.clear();
         self.call_depth = 0;
         self.tail_self_word = None;
@@ -47,8 +47,6 @@ impl Interpreter {
         self.word_identities.clear();
         self.body_store.clear();
         self.defer_identity_recompute = false;
-        self.import_table.modules.clear();
-        self.module_vocabulary.clear();
         self.dictionary_dependencies.clear();
         self.next_registration_order = 1;
         self.active_user_dictionary = "EXAMPLE".to_string();

--- a/rust/src/interpreter/word_contract.rs
+++ b/rust/src/interpreter/word_contract.rs
@@ -278,7 +278,7 @@ impl Interpreter {
     }
 
     pub(crate) fn clear_word_contract_cache(&mut self) {
-        self.module_state.remove(WORD_CONTRACT_CACHE_STATE_KEY);
+        self.runtime_scratch.remove(WORD_CONTRACT_CACHE_STATE_KEY);
     }
 
     #[cfg(test)]
@@ -288,13 +288,13 @@ impl Interpreter {
     }
 
     fn word_contract_cache_ref(&self) -> Option<&WordContractCache> {
-        self.module_state
+        self.runtime_scratch
             .get(WORD_CONTRACT_CACHE_STATE_KEY)
             .and_then(|cache| cache.downcast_ref::<WordContractCache>())
     }
 
     fn word_contract_cache_mut(&mut self) -> &mut WordContractCache {
-        self.module_state
+        self.runtime_scratch
             .entry(WORD_CONTRACT_CACHE_STATE_KEY.to_string())
             .or_insert_with(|| Box::<WordContractCache>::default())
             .downcast_mut::<WordContractCache>()

--- a/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
@@ -10,17 +10,6 @@ use crate::types::arena::{arena_to_value, json_to_arena_node, ValueArena};
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 
-fn js_string_array(value: &JsValue) -> Vec<String> {
-    let arr = js_sys::Array::from(value);
-    let mut out = Vec::with_capacity(arr.length() as usize);
-    for i in 0..arr.length() {
-        if let Some(s) = arr.get(i).as_string() {
-            out.push(s);
-        }
-    }
-    out
-}
-
 fn diagnosis_to_js(diagnosis: &DebugDiagnosis) -> JsValue {
     let obj = js_sys::Object::new();
 
@@ -125,11 +114,7 @@ impl AjisaiInterpreter {
     }
 
     pub(crate) fn collect_imported_modules_array(&self) -> JsValue {
-        let arr = js_sys::Array::new();
-        for name in self.interpreter.import_table.modules.keys() {
-            arr.push(&JsValue::from_str(name));
-        }
-        arr.into()
+        js_sys::Array::new().into()
     }
 
     pub(crate) fn collect_user_words_for_state(&self) -> JsValue {
@@ -158,11 +143,7 @@ impl AjisaiInterpreter {
         to_value(&builtins::collect_core_builtin_definitions()).unwrap_or(JsValue::NULL)
     }
 
-    /// Returns Core-listed words (canonical core + Canonical Module words
-    /// that are core-listed, e.g. SORT). This is the listing-based Core
-    /// view defined by the redesigned vocabulary system; bare module words
-    /// are surfaced for visibility only — invoking SORT bare still requires
-    /// `'ALGO' IMPORT` per current execution semantics.
+    /// Returns the canonical Core-listed words.
     ///
     /// Tuple shape: `(name, description, syntax)` — same as
     /// `collect_core_words_info` so the GUI can render either list with the
@@ -174,13 +155,6 @@ impl AjisaiInterpreter {
                 .into_iter()
                 .map(|(n, d, s)| (n.to_string(), d.to_string(), s.to_string()))
                 .collect();
-
-        for word in crate::coreword_registry::get_core_listed_words() {
-            if word.is_canonical_core() {
-                continue;
-            }
-            continue;
-        }
 
         to_value(&entries).unwrap_or(JsValue::NULL)
     }
@@ -207,11 +181,7 @@ impl AjisaiInterpreter {
 
     #[wasm_bindgen]
     pub fn collect_imported_modules(&self) -> JsValue {
-        let arr = js_sys::Array::new();
-        for name in self.interpreter.import_table.modules.keys() {
-            arr.push(&JsValue::from_str(name));
-        }
-        arr.into()
+        js_sys::Array::new().into()
     }
 
     /// All importable module names, in specification order. Drives the GUI's
@@ -240,68 +210,18 @@ impl AjisaiInterpreter {
     /// `collect_imported_modules` (module names only) cannot represent.
     #[wasm_bindgen]
     pub fn collect_import_state(&self) -> JsValue {
-        let arr = js_sys::Array::new();
-        for (name, entry) in &self.interpreter.import_table.modules {
-            let item = js_sys::Array::new();
-            item.push(&JsValue::from_str(name));
-            item.push(&entry.import_all_public.into());
-            let words = js_sys::Array::new();
-            for w in &entry.imported_words {
-                words.push(&JsValue::from_str(w));
-            }
-            item.push(&words.into());
-            item.push(&js_sys::Array::new().into());
-            arr.push(&item);
-        }
-        arr.into()
+        js_sys::Array::new().into()
     }
 
-    /// Restore a detailed import state previously captured by
-    /// `collect_import_state`. Reinstates partial imports exactly, unlike
-    /// `restore_imported_modules` which forces a full IMPORT per module.
+    /// Accept a legacy import-state snapshot. Modules are no longer runtime
+    /// vocabulary, so restoration intentionally has no effect.
     #[wasm_bindgen]
-    pub fn restore_import_state(&mut self, state_js: JsValue) {
-        let arr = js_sys::Array::from(&state_js);
-        for i in 0..arr.length() {
-            let entry = js_sys::Array::from(&arr.get(i));
-            let Some(module) = entry.get(0).as_string() else {
-                continue;
-            };
-            let import_all_public = entry.get(1).as_bool().unwrap_or(false);
-            let words = js_string_array(&entry.get(2));
-            let samples = js_string_array(&entry.get(3));
-        }
-    }
+    pub fn restore_import_state(&mut self, _state_js: JsValue) {}
 
     /// Tuple shape: `(name, description)`.
     #[wasm_bindgen]
-    pub fn collect_module_words_info(&self, module_name: &str) -> JsValue {
-        let upper = module_name.to_uppercase();
-        let arr = js_sys::Array::new();
-        let Some(imported) = self.interpreter.import_table.modules.get(&upper) else {
-            return arr.into();
-        };
-        if let Some(module_dict) = self.interpreter.module_vocabulary.get(&upper) {
-            for (name, def) in &module_dict.words {
-                let short_name = name
-                    .split_once('@')
-                    .map(|(_, short)| short)
-                    .unwrap_or(name.as_str());
-                if !imported.import_all_public && !imported.imported_words.contains(short_name) {
-                    continue;
-                }
-                let item = js_sys::Array::new();
-                item.push(&JsValue::from_str(name));
-                item.push(
-                    &def.description
-                        .clone()
-                        .map(JsValue::from)
-                        .unwrap_or(JsValue::NULL),
-                );
-                arr.push(&item);
-            }
-        }
-        arr.into()
+    pub fn collect_module_words_info(&self, _module_name: &str) -> JsValue {
+        js_sys::Array::new().into()
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
### Motivation

- Remove unreachable legacy "module" runtime artifacts that no longer appear in the specification and reduce runtime surface area that leaks legacy concepts into the kernel (module catalogs, import tables, and module epoch). 
- Move toward the Semantic Spine invariant by ensuring the runtime resolves only Core/User vocabulary and exposing an explicit anti-corruption boundary for frozen V1/WASM compatibility paths.

### Description

- Deleted the module runtime paths and metadata by removing `ModuleDictionary`/`ImportedModule`/`ImportTable` and the `module_vocabulary`/`import_table` resolution branches, and by dropping `module_epoch` from epoch and cache checks so cache invalidation is driven by dictionary epoch only. 
- Replaced the generic `module_state` storage with a clearer `runtime_scratch: HashMap<String, Box<dyn Any + Send>>` and migrated uses (for example the word-contract cache) to store and retrieve from `runtime_scratch`.
- Simplified name resolution to a Core + User two-layer model by removing module-lookup/`is_module_word_imported` logic and pruning module-related branches in `resolve_short_name`, `resolve_word_entry_readonly`, and related code paths. 
- Kept frozen WASM / HostProtocolV1 compatibility APIs as an anti-corruption boundary by returning empty module/import responses and making legacy import-state restore a no-op in the WASM bindings, while documenting the Phase 9 module-runtime deletion in the migration plan docs (`docs/dev/semantic-spine-migration-plan.md`).

### Testing

- Ran formatting and build checks with `cargo fmt --manifest-path rust/Cargo.toml -- --check` and `cargo check --manifest-path rust/Cargo.toml --all-targets`, both succeeded.
- Ran the Rust unit test suite with `cargo test --manifest-path rust/Cargo.toml --lib` which completed successfully (`810 passed, 1 ignored`).
- Ran JS/TS checks and tests `npm run check:semantic-firewall` and `npm test -- --run`, both succeeded (`231` Vitest tests passed).
- Note: `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` did not complete due to pre-existing clippy warnings in unrelated test files (`fraction_mcdc_tests.rs`, `tokenizer_mcdc_tests.rs`, and a few other legacy locations); clippy issues introduced by this change were addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b676171508326bacb2e1ddfff0ea2)