### PR TITLE
kernel: remove the module metadata and word-listing model

### DIFF
--- a/docs/dev/semantic-spine-migration-plan.md
+++ b/docs/dev/semantic-spine-migration-plan.md
@@ -352,6 +352,41 @@ Word として分類し、unknown-word 診断も import ではなく User dictio
 V1 が固定する module 関連 wasm method の**署名**は保持するが、restore method の空ループは
 引数を無視する明示的 no-op に縮約した。
 
+### 10.3 Phase 9 実施記録（module メタデータと listing 模型の削除）
+
+10.2 で module runtime を削除した後も、**静的メタデータ側**に module 座標系が残っていた。
+到達可能性を実測し、構築者が 0 になったものを削除した。
+
+| 削除対象 | 到達可能性の実測 |
+| --- | --- |
+| `CanonicalHome`（`Core` / `Module(String)`） | 構築点は `core_word_metadata_from_spec` の 1 箇所のみで、常に `Core`。`Module(_)` は構築 0 |
+| `CorewordMetadata.listed_in_core` | 常に `true` の定数フィールド |
+| `CorewordMetadata.listed_in_modules` | 供給元は `CORE_BOUNDARY_LISTINGS` の `IO` / `MATH` のみ。両 module とも既に存在しない |
+| `CORE_BOUNDARY_LISTINGS` / `MODULE_CORE_LISTINGS` / `apply_*_listings` | `MODULE_CORE_LISTINGS` は空の `module_entries` に対してのみ適用され、効果 0 |
+| `build_builtin_word_registry` の `module_entries` | `Vec::new()` のまま `extend` される空ベクタと、その上の空ループ |
+| listing 問い合わせ関数群（`get_module_listed_words` / `get_category_listed_words` / `get_core_listed_words` / `get_boundary_words` / `get_canonical_core_words` / `get_canonical_module_words` / `is_listing_only_for_module`） | 参照は自テストのみ。`get_module_listed_words` / `get_category_listed_words` / `get_boundary_words` は参照 0 |
+| `get_coreword_metadata` の `MODULE@WORD` 分岐 | `canonical_module()` が常に `None` のため常に `None` を返す。builtin 名に `@` は現れないので、平坦な名前一致に縮約しても挙動は不変 |
+| `WordShape`（`builtin_word_types.rs`） | 唯一の消費者と説明されていた `ModuleWord` が存在せず、`#[allow(dead_code)]` で黙らされていた |
+| `execute_def.rs` の `collision_modules` | `Vec::new()` 固定のため、module 衝突警告のブロック全体が到達不能 |
+| `builtin_word_details.rs` の `dictionary-{,un}import{,-only}` effect arm | どの `BuiltinSpec` もこれらの effect を宣言しない |
+| `module_word_call()`（`tests/test_support/generators.rs`） | 参照 0。`MATH` / `JSON` / `ALGO` という存在しない module を前提にしていた |
+| `core_word_is_not_shadowed_by_import`（`naming_resolution_laws.rs`） | import 削除後、同一文字列同士を比較する恒真テストになっていた |
+
+`listed_in_categories`（`CAST` / `TEXT` / `TENSOR` / `RUNTIME`）も併せて削除した。参照は
+自テストのみで、語の分類は正典側 `spec/words.json` の `family`（11 分類）が担っている。
+§4.2 の「1事実・複数記述」を残さない方針に従い、Rust 側の並行分類は保持しない。
+
+あわせて、10.2 の `ErrorLocus.module` 削除時に追随漏れとなり4つの law test binary を
+コンパイル不能にしていた `tests/test_support/observe.rs` の `DiagnosisObservation.module`
+を削除した（write のみで read 0）。
+
+凍結済み V1 wasm method（`collect_available_modules` / `collect_module_catalog_words_info` /
+`collect_import_state` / `restore_import_state`）は §10.2 の方針どおり署名を保持する。
+実挙動に合わせて doc comment のみ「常に空」を記述するよう更新した。
+
+これで module は runtime に続き**静的メタデータからも到達不能**になり、
+built-in Word は単一の平坦な名前空間になった。
+
 ---
 
 ## 11. 最重要 invariant（CI 最優先ルール）

--- a/rust/src/builtins/builtin_word_details.rs
+++ b/rust/src/builtins/builtin_word_details.rs
@@ -156,10 +156,6 @@ fn derive_side_effects_text(spec: &BuiltinSpec) -> String {
             "dictionary-write" | "dictionary-register" => "Modifies the dictionary.",
             "dictionary-delete" => "Removes a word from the dictionary.",
             "dictionary-read" => "Loads documentation into the editor.",
-            "dictionary-import"
-            | "dictionary-import-only"
-            | "dictionary-unimport"
-            | "dictionary-unimport-only" => "Changes which module words are active.",
             "interpreter-mode-write" => "Changes the interpreter mode for the next word.",
             "runtime-control" => "Controls child runtime execution.",
             other => other,

--- a/rust/src/builtins/builtin_word_types.rs
+++ b/rust/src/builtins/builtin_word_types.rs
@@ -68,18 +68,3 @@ pub enum BuiltinExecutorKey {
     NilCheck,
     NilReason,
 }
-
-// WordShape classifies how a word treats its data argument. Used by
-// module words (see ModuleWord::word_shape) to feed future
-// vector-pipeline planning. `Fold` and `Other` are not produced by
-// any current module spec but are reserved for completeness of the
-// classification and to keep planning code able to pattern-match all
-// variants without `_ =>` catch-alls.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
-pub enum WordShape {
-    Map,
-    Form,
-    Fold,
-    Other,
-}

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -448,17 +448,15 @@ fn normalize_word(symbol: &str) -> String {
 }
 
 /// Best-effort static resolution: a word resolves when it is a builtin, a
-/// canonical alias, a word the file itself defines via DEF, a word imported
-/// from a module the file IMPORTs, or a qualified `DICT@WORD` reference into
-/// a user dictionary (runtime state, accepted statically). Returns unknown
+/// canonical alias, or a word the file itself defines via DEF. Returns unknown
 /// words in first-appearance order, deduplicated.
 fn resolve_words(interp: &Interpreter, tokens: &[Token]) -> Vec<String> {
     use std::collections::HashSet;
 
     let mut locally_known: HashSet<String> = HashSet::new();
-    // Pre-pass: `'NAME' DEF` definitions and `'MODULE' IMPORT[-ONLY]`
-    // imports anywhere in the file (definitions may be referenced before
-    // they appear, e.g. mutual recursion between user words).
+    // Pre-pass: `'NAME' DEF` definitions anywhere in the file (definitions may
+    // be referenced before they appear, e.g. mutual recursion between user
+    // words).
     for (i, token) in tokens.iter().enumerate() {
         let Token::String(text) = token else {
             continue;

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -114,19 +114,6 @@ pub enum WordProfile {
     PlatformSpecific,
 }
 
-/// Canonical implementation home for a built-in word.
-///
-/// Every built-in word has exactly one canonical home. `Core` means the word
-/// is implemented as a Canonical Core word in `builtins/`, while `Module(m)`
-/// means the canonical implementation lives in module `m` and is invoked as
-/// `m@WORD` after `IMPORT 'm'`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-#[serde(tag = "kind", content = "module", rename_all = "lowercase")]
-pub enum CanonicalHome {
-    Core,
-    Module(String),
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CorewordMetadata {
@@ -145,153 +132,13 @@ pub struct CorewordMetadata {
     /// Portability profile used by conformance tooling to keep the Core
     /// profile free of host-boundary words.
     pub profile: WordProfile,
-    /// Capability required when `profile == Hosted`; absent for Core words.
-    /// Where the canonical implementation lives (Core or a specific module).
-    pub canonical_home: CanonicalHome,
-    /// Whether the word appears in the Core word listing view.
-    pub listed_in_core: bool,
-    /// Module names whose dictionary view includes this word. A word may be
-    /// listed in modules other than its canonical home (boundary words).
-    /// Listing is presentation-only — it does not affect IMPORT or execution.
-    pub listed_in_modules: Vec<String>,
-    /// Documentation-only category labels (e.g. CAST, TEXT, TENSOR, RUNTIME)
-    /// used by GUI/docs to group words. These are not real modules and cannot
-    /// be `IMPORT`ed.
-    pub listed_in_categories: Vec<String>,
-}
-
-impl CorewordMetadata {
-    pub fn is_canonical_core(&self) -> bool {
-        matches!(self.canonical_home, CanonicalHome::Core)
-    }
-
-    pub fn is_canonical_module(&self) -> bool {
-        matches!(self.canonical_home, CanonicalHome::Module(_))
-    }
-
-    pub fn canonical_module(&self) -> Option<&str> {
-        match &self.canonical_home {
-            CanonicalHome::Module(m) => Some(m.as_str()),
-            CanonicalHome::Core => None,
-        }
-    }
-
-    pub fn is_core_listed(&self) -> bool {
-        self.listed_in_core
-    }
-
-    pub fn is_module_listed(&self) -> bool {
-        !self.listed_in_modules.is_empty()
-    }
-
-    pub fn is_category_listed(&self) -> bool {
-        !self.listed_in_categories.is_empty()
-    }
-
-    /// A boundary word appears in both the Core listing view and at least one
-    /// module-or-category listing view.
-    pub fn is_boundary_word(&self) -> bool {
-        self.listed_in_core && (self.is_module_listed() || self.is_category_listed())
-    }
-}
-
-/// Boundary listing table. For Canonical Core words that should also appear
-/// in a module listing view (real modules) and/or a documentation category
-/// view (presentation-only labels). Listing is presentation-only — it does
-/// **not** add the word to that module's IMPORT-able set, and it does not
-/// create new module entities.
-///
-/// Entries: `(WORD, &[real_module_listings], &[category_listings])`.
-const CORE_BOUNDARY_LISTINGS: &[(&str, &[&str], &[&str])] = &[
-    ("PRINT", &["IO"], &[]),
-    ("STR", &[], &["CAST"]),
-    ("NUM", &[], &["CAST"]),
-    ("BOOL", &[], &["CAST"]),
-    ("CHR", &[], &["TEXT"]),
-    ("CHARS", &[], &["TEXT"]),
-    ("JOIN", &[], &["TEXT"]),
-    ("TRIM", &[], &["TEXT"]),
-    ("TRIM-LEFT", &[], &["TEXT"]),
-    ("TRIM-RIGHT", &[], &["TEXT"]),
-    ("TOKENIZE", &[], &["TEXT"]),
-    ("SUBSTITUTE", &[], &["TEXT"]),
-    ("STARTS-WITH?", &[], &["TEXT"]),
-    ("ENDS-WITH?", &[], &["TEXT"]),
-    ("MOD", &["MATH"], &[]),
-    ("FLOOR", &["MATH"], &[]),
-    ("CEIL", &["MATH"], &[]),
-    ("ROUND", &["MATH"], &[]),
-    ("QUANTIZE", &["MATH"], &[]),
-    ("QUANTIZE-HALF-AWAY", &["MATH"], &[]),
-    ("QUANTIZE-FLOOR", &["MATH"], &[]),
-    ("QUANTIZE-CEIL", &["MATH"], &[]),
-    ("QUANTIZE-TRUNC", &["MATH"], &[]),
-    ("SHAPE", &[], &["TENSOR"]),
-    ("RANK", &[], &["TENSOR"]),
-    ("RESHAPE", &[], &["TENSOR"]),
-    ("TRANSPOSE", &[], &["TENSOR"]),
-    ("FILL", &[], &["TENSOR"]),
-    ("SPAWN", &[], &["RUNTIME"]),
-    ("AWAIT", &[], &["RUNTIME"]),
-    ("STATUS", &[], &["RUNTIME"]),
-    ("KILL", &[], &["RUNTIME"]),
-    ("MONITOR", &[], &["RUNTIME"]),
-    ("SUPERVISE", &[], &["RUNTIME"]),
-];
-
-/// Canonical Module words that should additionally appear in the Core listing
-/// view (e.g. `SORT` is canonically `ALGO@SORT`, but is also surfaced in the
-/// Core dictionary because it's central to vector reasoning).
-///
-/// Listing is presentation-only — calling bare `SORT` still requires
-/// `'ALGO' IMPORT` per current execution semantics. This table only affects
-/// `listed_in_core`, never name resolution.
-const MODULE_CORE_LISTINGS: &[&str] = &["SORT"];
-
-fn apply_core_boundary_listings(meta: &mut CorewordMetadata) {
-    if !meta.is_canonical_core() {
-        return;
-    }
-    for (name, modules, categories) in CORE_BOUNDARY_LISTINGS {
-        if *name == meta.name {
-            for m in *modules {
-                if !meta.listed_in_modules.iter().any(|x| x == m) {
-                    meta.listed_in_modules.push((*m).to_string());
-                }
-            }
-            for c in *categories {
-                if !meta.listed_in_categories.iter().any(|x| x == c) {
-                    meta.listed_in_categories.push((*c).to_string());
-                }
-            }
-            return;
-        }
-    }
-}
-
-fn apply_module_to_core_listings(meta: &mut CorewordMetadata) {
-    if !meta.is_canonical_module() {
-        return;
-    }
-    if MODULE_CORE_LISTINGS.iter().any(|n| *n == meta.name) {
-        meta.listed_in_core = true;
-    }
 }
 
 fn build_builtin_word_registry() -> Vec<CorewordMetadata> {
-    let mut registry: Vec<CorewordMetadata> = builtin_specs()
+    builtin_specs()
         .iter()
         .map(core_word_metadata_from_spec)
-        .collect();
-    for meta in registry.iter_mut() {
-        apply_core_boundary_listings(meta);
-    }
-    let mut module_entries = Vec::new();
-    for meta in module_entries.iter_mut() {
-        apply_module_to_core_listings(meta);
-    }
-    registry.extend(module_entries);
-    registry
+        .collect()
 }
 
 /// The complete built-in word registry. Built once on first access and
@@ -301,39 +148,20 @@ pub fn get_builtin_word_registry() -> &'static [CorewordMetadata] {
     REGISTRY.get_or_init(build_builtin_word_registry)
 }
 
-/// Metadata lookup with namespace-aware disambiguation.
+/// Metadata lookup by bare word name.
 ///
-/// - `MODULE@WORD` form returns the canonical module entry (or `None` if the
-///   module does not own that word).
-/// - Bare `WORD` form prefers a Canonical Core entry when one exists; only
-///   when no core entry matches does it fall back to a canonical module
-///   entry. This mirrors the runtime resolution order in
-///   `interpreter/resolve-word.rs`, so callers reasoning about the visible
-///   binding for a bare token see the same word the interpreter would run.
+/// Built-in words form a single flat namespace, so lookup is an exact match on
+/// the upper-cased name. A qualified `DICTIONARY@WORD` token never names a
+/// built-in — it addresses a User dictionary word — and so resolves to `None`.
 pub fn get_coreword_metadata(name: &str) -> Option<CorewordMetadata> {
     let upper = name.to_uppercase();
-    let registry = get_builtin_word_registry();
-
-    if let Some((module, word)) = upper.split_once('@') {
-        return registry
-            .iter()
-            .find(|m| {
-                m.name == word && m.canonical_module().map(|cm| cm == module).unwrap_or(false)
-            })
-            .cloned();
-    }
-
-    if let Some(core) = registry
+    get_builtin_word_registry()
         .iter()
-        .find(|m| m.name == upper && m.is_canonical_core())
-    {
-        return Some(core.clone());
-    }
-    registry.iter().find(|m| m.name == upper).cloned()
+        .find(|m| m.name == upper)
+        .cloned()
 }
 
-/// Alias of `get_coreword_metadata`. Use this in new code; the registry
-/// covers all built-in words regardless of canonical home.
+/// Alias of `get_coreword_metadata`. Use this in new code.
 pub fn get_builtin_word_metadata(name: &str) -> Option<CorewordMetadata> {
     get_coreword_metadata(name)
 }
@@ -371,150 +199,25 @@ pub fn get_hosted_profile_words() -> Vec<CorewordMetadata> {
     get_words_by_profile(WordProfile::Hosted)
 }
 
-/// Words whose Core listing view includes them (canonical core + core-listed
-/// boundary words).
-pub fn get_core_listed_words() -> Vec<CorewordMetadata> {
-    get_builtin_word_registry()
-        .iter()
-        .filter(|word| word.listed_in_core)
-        .cloned()
-        .collect()
-}
-
-/// Words whose listing includes the given module name. Includes canonical
-/// module words for that module plus core boundary words listed there.
-pub fn get_module_listed_words(module_name: &str) -> Vec<CorewordMetadata> {
-    let needle = module_name.to_uppercase();
-    get_builtin_word_registry()
-        .iter()
-        .filter(|word| {
-            word.canonical_module()
-                .map(|m| m == needle)
-                .unwrap_or(false)
-                || word.listed_in_modules.contains(&needle)
-        })
-        .cloned()
-        .collect()
-}
-
-/// Words tagged with the given documentation category (e.g. CAST, TEXT,
-/// TENSOR, RUNTIME). Categories are presentation-only — they are not real
-/// modules and do not participate in IMPORT.
-pub fn get_category_listed_words(category: &str) -> Vec<CorewordMetadata> {
-    let needle = category.to_uppercase();
-    get_builtin_word_registry()
-        .iter()
-        .filter(|word| word.listed_in_categories.contains(&needle))
-        .cloned()
-        .collect()
-}
-
-pub fn get_canonical_core_words() -> Vec<CorewordMetadata> {
-    get_builtin_word_registry()
-        .iter()
-        .filter(|word| word.is_canonical_core())
-        .cloned()
-        .collect()
-}
-
-/// Canonical Module words. When `module_name` is `Some(m)`, restricts to that
-/// module's canonical words.
-pub fn get_canonical_module_words(module_name: Option<&str>) -> Vec<CorewordMetadata> {
-    let needle = module_name.map(|m| m.to_uppercase());
-    get_builtin_word_registry()
-        .iter()
-        .filter(|word| match (&needle, word.canonical_module()) {
-            (Some(n), Some(m)) => n == m,
-            (None, Some(_)) => true,
-            _ => false,
-        })
-        .cloned()
-        .collect()
-}
-
-pub fn get_boundary_words() -> Vec<CorewordMetadata> {
-    get_builtin_word_registry()
-        .iter()
-        .filter(|word| word.is_boundary_word())
-        .cloned()
-        .collect()
-}
-
-/// Returns true if `word_name` is core-listed only (canonical core, no
-/// canonical module home). Used by IMPORT-ONLY to silently skip selectors
-/// that are core-listed in a module view but not actually owned by that
-/// module.
-pub fn is_listing_only_for_module(word_name: &str, module_name: &str) -> bool {
-    let upper = word_name.to_uppercase();
-    let module_upper = module_name.to_uppercase();
-    let Some(meta) = get_coreword_metadata(&upper) else {
-        return false;
-    };
-    if meta
-        .canonical_module()
-        .map(|m| m == module_upper)
-        .unwrap_or(false)
-    {
-        return false;
-    }
-    meta.listed_in_modules.contains(&module_upper)
-        || meta.listed_in_categories.contains(&module_upper)
-}
-
 pub fn is_safe_preview_word(name: &str) -> bool {
     get_coreword_metadata(name)
         .map(|word| word.safe_preview)
         .unwrap_or(false)
 }
 
-/// Validates that no two registry entries share both `name` AND
-/// `canonical_home`. Two entries with the same bare name but different homes
-/// (e.g. core `GET` vs `JSON@GET`) are legitimate — they live in distinct
-/// runtime namespaces and are disambiguated by `get_coreword_metadata`.
-/// Used internally by tests to guard against accidental true duplicates.
+/// Validates that no two registry entries share a `name`. Built-in words form
+/// a single flat namespace, so a repeated name is always a genuine duplicate.
+/// Used internally by tests.
 #[cfg(test)]
-fn collect_duplicate_entries(registry: &[CorewordMetadata]) -> Vec<(String, CanonicalHome)> {
-    let mut seen: HashSet<(String, CanonicalHome)> = HashSet::new();
-    let mut dupes: Vec<(String, CanonicalHome)> = Vec::new();
+fn collect_duplicate_entries(registry: &[CorewordMetadata]) -> Vec<String> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut dupes: Vec<String> = Vec::new();
     for word in registry {
-        let key = (word.name.clone(), word.canonical_home.clone());
-        if !seen.insert(key.clone()) {
-            dupes.push(key);
+        if !seen.insert(word.name.as_str()) {
+            dupes.push(word.name.clone());
         }
     }
     dupes
-}
-
-/// Returns bare names that appear under more than one canonical home. These
-/// are not bugs but require namespace-aware lookup.
-#[cfg(test)]
-fn collect_namespace_overlapping_names(registry: &[CorewordMetadata]) -> Vec<String> {
-    use std::collections::BTreeMap;
-    let mut by_name: BTreeMap<&str, Vec<&CanonicalHome>> = BTreeMap::new();
-    for word in registry {
-        by_name
-            .entry(&word.name)
-            .or_default()
-            .push(&word.canonical_home);
-    }
-    by_name
-        .into_iter()
-        .filter(|(_, homes)| homes.len() > 1)
-        .map(|(name, _)| name.to_string())
-        .collect()
-}
-
-#[cfg(test)]
-impl std::hash::Hash for CanonicalHome {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            CanonicalHome::Core => 0u8.hash(state),
-            CanonicalHome::Module(m) => {
-                1u8.hash(state);
-                m.hash(state);
-            }
-        }
-    }
 }
 
 fn builtin_profile(name: &str) -> WordProfile {
@@ -540,10 +243,6 @@ fn core_word_metadata_from_spec(spec: &crate::builtins::BuiltinSpec) -> Coreword
         safety_level: spec.safety_level,
         mass: spec.mass,
         profile,
-        canonical_home: CanonicalHome::Core,
-        listed_in_core: true,
-        listed_in_modules: Vec::new(),
-        listed_in_categories: Vec::new(),
     }
 }
 
@@ -558,11 +257,9 @@ mod tests {
     //! the full coreword-registry coverage subset.
 
     use super::{
-        collect_duplicate_entries, collect_namespace_overlapping_names, get_builtin_word_metadata,
-        get_builtin_word_registry, get_canonical_core_words, get_canonical_module_words,
-        get_core_listed_words, get_coreword_metadata, get_hosted_profile_words,
-        is_listing_only_for_module, is_safe_preview_word, CanonicalHome, NilPolicy, Partiality,
-        SafetyLevel, WordProfile, WordPurity,
+        collect_duplicate_entries, get_builtin_word_registry, get_coreword_metadata,
+        get_hosted_profile_words, is_safe_preview_word, NilPolicy, Partiality, SafetyLevel,
+        WordProfile, WordPurity,
     };
 
     #[test]
@@ -940,124 +637,15 @@ mod tests {
         }
     }
 
-    // ---------------------------------------------------------------------
-    // AQ-VER-LISTING — Canonical home / listing tests for the redesigned
-    // built-in word vocabulary.
-    // ---------------------------------------------------------------------
-
     #[test]
-    fn aq_ver_listing_a_no_two_entries_share_name_and_home() {
+    fn aq_ver_listing_a_no_two_entries_share_a_name() {
         let registry = get_builtin_word_registry();
         let dupes = collect_duplicate_entries(registry);
         assert!(
             dupes.is_empty(),
-            "(name, canonical_home) pair must be unique (duplicates: {:?})",
+            "built-in word names must be unique (duplicates: {:?})",
             dupes
         );
-    }
-
-    /// Bare names like `GET` legitimately appear under multiple canonical
-    /// homes (core list `GET` and `JSON@GET`). The registry intentionally
-    /// keeps both entries — they live in distinct runtime namespaces — but
-    /// `get_coreword_metadata("GET")` must always disambiguate to the
-    /// canonical core entry, matching the runtime resolution order.
-    #[test]
-    fn aq_ver_listing_b_namespace_overlap_disambiguates_to_core() {
-        let registry = get_builtin_word_registry();
-        let overlapping = collect_namespace_overlapping_names(registry);
-        for name in overlapping {
-            let resolved = get_coreword_metadata(&name)
-                .unwrap_or_else(|| panic!("{} must resolve via bare lookup", name));
-            assert!(
-                resolved.is_canonical_core(),
-                "{} bare lookup must prefer the core canonical entry, got {:?}",
-                name,
-                resolved.canonical_home
-            );
-            // The qualified form must reach the module entry instead.
-            if let Some(module_entry) = registry
-                .iter()
-                .find(|m| m.name == name && matches!(m.canonical_home, CanonicalHome::Module(_)))
-            {
-                let module_name = module_entry
-                    .canonical_module()
-                    .expect("module entry must have canonical_module");
-                let qualified = format!("{}@{}", module_name, name);
-                let qualified_resolved = get_coreword_metadata(&qualified)
-                    .unwrap_or_else(|| panic!("{} must resolve via qualified lookup", qualified));
-                assert_eq!(
-                    qualified_resolved.canonical_home,
-                    CanonicalHome::Module(module_name.to_string()),
-                    "{} qualified lookup must reach the module entry",
-                    qualified
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn aq_ver_listing_c_every_word_has_at_least_one_listing() {
-        let registry = get_builtin_word_registry();
-        for word in registry {
-            let listed = word.listed_in_core
-                || !word.listed_in_modules.is_empty()
-                || !word.listed_in_categories.is_empty();
-            assert!(
-                listed,
-                "{} must be listed in at least one dictionary view",
-                word.name
-            );
-        }
-    }
-
-    #[test]
-    fn aq_ver_listing_d_canonical_module_implies_module_listing() {
-        for word in get_canonical_module_words(None) {
-            let canonical = word
-                .canonical_module()
-                .expect("canonical module word must report canonical_module")
-                .to_string();
-            assert!(
-                word.listed_in_modules.contains(&canonical),
-                "{} canonical module {} must appear in listed_in_modules ({:?})",
-                word.name,
-                canonical,
-                word.listed_in_modules
-            );
-        }
-    }
-
-    #[test]
-    fn aq_ver_listing_f_print_is_canonical_core_listed_in_io() {
-        let print = get_builtin_word_metadata("PRINT").expect("PRINT must be in registry");
-        assert_eq!(print.canonical_home, CanonicalHome::Core);
-        assert!(print.is_canonical_core());
-        assert!(print.listed_in_core);
-        assert!(print.listed_in_modules.iter().any(|m| m == "IO"));
-        assert!(print.is_boundary_word());
-    }
-
-    #[test]
-    fn aq_ver_listing_k_core_view_includes_core_listed_only() {
-        for word in get_core_listed_words() {
-            assert!(
-                word.listed_in_core,
-                "{} returned by get_core_listed_words must have listed_in_core=true",
-                word.name
-            );
-        }
-    }
-
-    #[test]
-    fn aq_ver_listing_m_listing_only_predicate_distinguishes_canonical_from_boundary() {
-        // PRINT is a Core word listed in IO → listing-only relative to IO.
-        assert!(is_listing_only_for_module("PRINT", "IO"));
-        // SORT is canonical to ALGO → NOT listing-only for ALGO.
-        assert!(!is_listing_only_for_module("SORT", "ALGO"));
-        // CSPRNG is canonical to CRYPTO → NOT listing-only for CRYPTO.
-        assert!(!is_listing_only_for_module("CSPRNG", "CRYPTO"));
-        // Unknown word → false.
-        assert!(!is_listing_only_for_module("__NOSUCH__", "IO"));
     }
 
     #[test]
@@ -1081,17 +669,6 @@ mod tests {
             assert_ne!(
                 word.name, "PRINT",
                 "PRINT is the effectful Word and must not be Core-profile"
-            );
-        }
-    }
-
-    #[test]
-    fn aq_ver_listing_n_canonical_core_helper_excludes_module_words() {
-        for word in get_canonical_core_words() {
-            assert!(
-                word.is_canonical_core(),
-                "{} returned by get_canonical_core_words must be canonical core",
-                word.name
             );
         }
     }

--- a/rust/src/interpreter/dictionary_resolution_tests.rs
+++ b/rust/src/interpreter/dictionary_resolution_tests.rs
@@ -227,12 +227,12 @@ mod tests {
         );
     }
     #[tokio::test]
-    async fn test_fully_qualified_requires_import() {
+    async fn test_unknown_qualified_name_does_not_resolve() {
         let mut interp = Interpreter::new();
         let result = interp.execute("JSON@PARSE").await;
         assert!(
             result.is_err(),
-            "Unimported module words should not resolve"
+            "A qualified name with no matching user dictionary word must not resolve"
         );
     }
 }

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -87,8 +87,6 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         interp.output_buffer.push_str(&format!("{}\n", warning));
     }
 
-    let collision_modules: Vec<String> = Vec::new();
-
     let dict_name = interp.active_user_dictionary.clone();
     let fq_name = format!("{}@{}", dict_name, upper_name);
 
@@ -201,23 +199,6 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         .output_buffer
         .push_str(&format!("Defined word: {}@{}\n", dict_name, name));
 
-    if !collision_modules.is_empty() {
-        let module_paths: Vec<String> = collision_modules
-            .iter()
-            .map(|m| format!("{}@{}", m, upper_name))
-            .collect();
-        let user_path = format!("{}@{}", dict_name, upper_name);
-        let all_paths: Vec<String> = module_paths
-            .iter()
-            .chain(std::iter::once(&user_path))
-            .cloned()
-            .collect();
-        interp.output_buffer.push_str(&format!(
-            "Warning: '{}' now exists in both {}. Use a qualified path when calling this word.\n",
-            upper_name,
-            all_paths.join(" and ")
-        ));
-    }
     interp.bump_dictionary_epoch();
     interp.force_flag = false;
     Ok(())

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -36,7 +36,7 @@ pub(crate) fn end_of_source_unit(tokens: &[Token], start: usize) -> usize {
     i
 }
 
-/// After a core/module word runs, retag the top-of-stack plane role from a small
+/// After a core word runs, retag the top-of-stack plane role from a small
 /// name-keyed table (SPEC §12). The interpreted loop applies this after every
 /// symbol; the compiled plan mirrors it after each call op so the two routes
 /// leave identical `(value, role)` observations. A no-op for words not in the

--- a/rust/src/interpreter/nil_conformance_tests.rs
+++ b/rust/src/interpreter/nil_conformance_tests.rs
@@ -13,7 +13,7 @@
 //!
 //! Trace: docs/quality/TRACEABILITY_MATRIX.md (NIL/Bubble conformance).
 
-use crate::coreword_registry::{get_builtin_word_registry, CanonicalHome, NilPolicy};
+use crate::coreword_registry::{get_builtin_word_registry, NilPolicy};
 use crate::error::NilReason;
 use crate::interpreter::Interpreter;
 use crate::types::Value;
@@ -89,8 +89,7 @@ fn core_passthrough_completeness() {
     // Every Core passthrough word in a covered category must be classified,
     // and every classified word must still be a Core passthrough word.
     for meta in get_builtin_word_registry() {
-        let covered = meta.canonical_home == CanonicalHome::Core
-            && meta.nil_policy == NilPolicy::Passthrough
+        let covered = meta.nil_policy == NilPolicy::Passthrough
             && COVERED_CATEGORIES.contains(&meta.category.as_str());
         if covered {
             assert!(
@@ -113,11 +112,6 @@ fn core_passthrough_completeness() {
             NilPolicy::Passthrough,
             "`{name}` is classified as passthrough but registry says {:?}",
             meta.nil_policy
-        );
-        assert_eq!(
-            meta.canonical_home,
-            CanonicalHome::Core,
-            "`{name}` is classified as a Core passthrough word but is not Core"
         );
     }
 }

--- a/rust/src/interpreter/word_contract.rs
+++ b/rust/src/interpreter/word_contract.rs
@@ -2,7 +2,7 @@
 //!
 //! Phase 1 deliberately does not add surface syntax. A user word's contract is
 //! inferred from its body and resolved dependency contracts without executing
-//! Ajisai code. Built-in and module contracts are projected from the existing
+//! Ajisai code. Built-in contracts are projected from the existing
 //! §7.14 registry; user-word contracts are widened monotonically as dependencies
 //! are joined. When recursion or a dynamic structure prevents a complete proof,
 //! the result is conservative rather than Ajisai's logical `UNKNOWN` value.

--- a/rust/src/interpreter/word_identity.rs
+++ b/rust/src/interpreter/word_identity.rs
@@ -250,7 +250,7 @@ impl Interpreter {
                                     // later same-named word as a fresh capture.
                                     Atom::Ref(resolved)
                                 } else if rdef.is_builtin {
-                                    // Core / module word: stable global vocabulary,
+                                    // Core word: stable global vocabulary,
                                     // encoded by its canonical resolved name.
                                     let mut b = vec![b'G'];
                                     b.extend_from_slice(resolved.as_bytes());

--- a/rust/src/interpreter/word_space.rs
+++ b/rust/src/interpreter/word_space.rs
@@ -104,7 +104,7 @@ fn builtin_space(key: BuiltinExecutorKey) -> (SpaceClass, bool) {
         StartsWith | EndsWith => (Linear, false),
         // Repetition can multiply sizes (pattern × replacement, k × separator).
         Substitute | Join => (Superlinear, false),
-        // Dictionary/module registration copies bounded structure.
+        // Dictionary registration copies bounded structure.
         Def => (Linear, false),
         Del | Lookup => (Const, false),
         Print => (Linear, false),
@@ -132,8 +132,8 @@ fn space_arity_override(key: BuiltinExecutorKey) -> Option<(u16, u16)> {
 
 /// Space classification for a resolved built-in word, by canonical name.
 /// A spec without an executor key is a modifier/directive marker that
-/// materializes nothing (`Const`); a name with no builtin spec (module words)
-/// is conservatively unclassified.
+/// materializes nothing (`Const`); a name with no builtin spec is
+/// conservatively unclassified.
 pub(crate) fn builtin_space_for(name: &str) -> (SpaceClass, bool) {
     match crate::builtins::lookup_builtin_spec(name) {
         Some(spec) => match spec.executor_key {

--- a/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
@@ -180,9 +180,8 @@ impl AjisaiInterpreter {
         js_sys::Array::new().into()
     }
 
-    /// All importable module names, in specification order. Drives the GUI's
-    /// module selector, which pre-lists every module (active or not) so an
-    /// inactive module can be surfaced greyed-out and toggled with IMPORT.
+    /// Frozen V1 surface. Modules are gone from the language, so the catalog
+    /// of importable module names is always empty.
     #[wasm_bindgen]
     pub fn collect_available_modules(&self) -> JsValue {
         let arr = js_sys::Array::new();
@@ -190,20 +189,17 @@ impl AjisaiInterpreter {
         arr.into()
     }
 
-    /// Full word catalog for a module, regardless of import state.
-    /// Tuple shape: `(shortName, description, imported: bool)`.
-    /// `imported` reflects the live import table so the GUI can render active
-    /// words normally and inactive words greyed-out within the same sheet.
+    /// Frozen V1 surface. Tuple shape: `(shortName, description, imported:
+    /// bool)`. No module owns any word, so every catalog is empty.
     #[wasm_bindgen]
     pub fn collect_module_catalog_words_info(&self, _module_name: &str) -> JsValue {
         // Modules are gone from the language; every catalog is empty.
         js_sys::Array::new().into()
     }
 
-    /// Detailed import state for persistence. Tuple shape:
-    /// `(module, importAllPublic: bool, words: string[], samples: string[])`.
-    /// Captures partial imports (IMPORT-ONLY / UNIMPORT-ONLY results) that
-    /// `collect_imported_modules` (module names only) cannot represent.
+    /// Frozen V1 surface. Tuple shape: `(module, importAllPublic: bool,
+    /// words: string[], samples: string[])`. There is no import state to
+    /// report, so the result is always empty.
     #[wasm_bindgen]
     pub fn collect_import_state(&self) -> JsValue {
         js_sys::Array::new().into()

--- a/rust/tests/minimal_core_derivation.rs
+++ b/rust/tests/minimal_core_derivation.rs
@@ -15,7 +15,7 @@
 //!   - `COND` `IDLE` — flow tier (state-transformer composition/identity, §7.7)
 //!   - `NIL` and numeric literals — identity / sugar
 //!
-//! No `material`-tier word (no arithmetic, no vector word, no module word)
+//! No `material`-tier word (no arithmetic, no vector word)
 //! appears in the definition, so a green run witnesses that `SIGN`'s
 //! observable contract is reconstructible from the Minimal Core alone.
 //!
@@ -136,8 +136,8 @@ fn minimal_core_sign_decided_spot_checks() {
 /// finding this witness first surfaced: the built-in used to reject these
 /// operands with `SIGN: expected a number` while the derivation handled them,
 /// and once `SIGN` was fixed the two became fully equivalent here too.
-/// Each operand needs the math module in scope to be *constructed*; `SIGN2`
-/// itself still uses only Minimal Core words.
+/// Each operand is *constructed* with `SQRT`; `SIGN2` itself still uses only
+/// Minimal Core words.
 #[test]
 fn minimal_core_sign_matches_builtin_on_lazy_irrationals() {
     for (x, want) in [

--- a/rust/tests/naming_resolution_laws.rs
+++ b/rust/tests/naming_resolution_laws.rs
@@ -1,27 +1,17 @@
-//! Property-based name-resolution / dictionary / module laws (Phase 6).
+//! Property-based name-resolution / dictionary laws (Phase 6).
 //!
 //! Encodes the algebraic content of
 //! `docs/dev/ajisai-mathematical-formalization.md` §9-quinquies F (Phase 6):
 //! the dictionary `Dict = Name ⇀ Blk`, the deterministic resolver
-//! `resolve : Name × Vis ⇀ Blk + Unknown` with order **Core → imported module →
-//! user**, `DEF`/`DEL` as state transducers with a dependency guard (`FORC`,
-//! SPEC §8.2), and `IMPORT`/`IMPORT-ONLY`/`UNIMPORT`/`UNIMPORT-ONLY` as
-//! monotone visibility operators (SPEC §9.2).
+//! `resolve : Name × Vis ⇀ Blk + Unknown` with order **Core → user**, and
+//! `DEF`/`DEL` as state transducers with a dependency guard (SPEC §8.2).
 //!
 //! Every law was checked against the reference implementation with a throwaway
 //! probe (`_probe_naming.rs`, deleted) before being written (roadmap §1.2-(T)
-//! discipline). The two surprises the probe surfaced are recorded as
-//! §9-quinquies F.5 findings and pinned here as guarded oracles:
-//!   * **F1** — runtime `MODULE@WORD` resolution is *import-gated*: the static
-//!     contract registry always reaches the module entry, but the runtime only
-//!     resolves it after `IMPORT` (`4 SQRT` is `Unknown` un-imported).
-//!   * **F2** — an imported module word *shadows a same-named user word* (the
-//!     resolver checks imported modules before user dictionaries).
+//! discipline).
 //!
 //! Observation stays firewall-clean: laws compare whole-stack renders / the
-//! Ok-vs-Err resolution outcome, never a Rust enum or `Debug` string. The few
-//! registry-level invariants read the public contract metadata (SPEC §7.14
-//! listing fields), mirroring `contract_modifier_laws.rs`.
+//! Ok-vs-Err resolution outcome, never a Rust enum or `Debug` string.
 
 mod test_support;
 
@@ -62,18 +52,6 @@ fn outcome(src: &str) -> Result<Vec<String>, ()> {
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(48))]
-    /// **Core precedence — import never shadows a Canonical Core word.** Bare
-    /// `GET` is core (`canonical_home = Core`), so it resolves to the core
-    /// vector index whether or not `JSON` (which also lists a `GET`) is
-    /// imported. The observation is invariant under the import.
-    #[test]
-    fn core_word_is_not_shadowed_by_import(xs in prop::collection::vec(small(), 1..4), i in 0usize..3) {
-        let body = xs.iter().map(i64::to_string).collect::<Vec<_>>().join(" ");
-        let plain = obs(&format!("[ {body} ] {i} GET"));
-        let after_import = obs(&format!("[ {body} ] {i} GET"));
-        prop_assert_eq!(plain, after_import);
-    }
-
     /// **User never shadows Core** (LANG.DICTIONARY.RESOLUTION). Core is
     /// sealed: defining a user word over a Core name is rejected outright, so
     /// a Core name always means the Core Word.

--- a/rust/tests/test_support/generators.rs
+++ b/rust/tests/test_support/generators.rs
@@ -86,29 +86,6 @@ pub fn block_src() -> impl Strategy<Value = String> {
 
 // ───────────────────────── Phase 6: names & dictionary ──────────────────────
 
-/// A canonical **module word call**: `(module, bare-program, qualified-program)`.
-/// Both programs assume the module is already imported and, when run after
-/// `'module' IMPORT`, leave the *same* stack — the boundary-word law
-/// `bare ≡ MODULE@WORD` (roadmap Phase 6). Every entry is a `Total` module word
-/// over the chosen operands (probe-confirmed: no NIL / error).
-pub fn module_word_call() -> impl Strategy<Value = (&'static str, String, String)> {
-    prop::sample::select(vec![
-        ("MATH", "4 SQRT", "4 SQRT"),
-        ("MATH", "9 SQRT", "9 SQRT"),
-        ("MATH", "-5 ABS", "-5 ABS"),
-        ("MATH", "7 NEG", "7 NEG"),
-        ("MATH", "-3 SIGN", "-3 SIGN"),
-        ("MATH", "2 10 POW", "2 10 MATH@POW"),
-        ("MATH", "3 7 MIN", "3 7 MIN"),
-        ("MATH", "3 7 MAX", "3 7 MAX"),
-        ("JSON", "'[1]' PARSE", "'[1]' JSON@PARSE"),
-        ("JSON", "'[1,2]' PARSE", "'[1,2]' JSON@PARSE"),
-        ("ALGO", "[ 3 1 2 ] SORT", "[ 3 1 2 ] SORT"),
-        ("ALGO", "[ 5 ] SORT", "[ 5 ] SORT"),
-    ])
-    .prop_map(|(m, b, q)| (m, b.to_string(), q.to_string()))
-}
-
 /// A short user-word name in the runtime's action-object style (already
 /// uppercase, so word-name normalization §3.8 is a no-op on it). Kept distinct
 /// from every built-in so `DEF` never hits the "cannot redefine built-in" path.

--- a/rust/tests/test_support/observe.rs
+++ b/rust/tests/test_support/observe.rs
@@ -50,7 +50,6 @@ pub struct DiagnosisObservation {
     pub when: &'static str,
     pub where_kind: &'static str,
     pub word: Option<String>,
-    pub module: Option<String>,
     pub why: &'static str,
     pub agreed_prefix: Option<usize>,
 }
@@ -108,7 +107,6 @@ pub fn observe_axes(v: &Value) -> AxisObservation {
                 when: diagnosis.when.as_protocol_str(),
                 where_kind: diagnosis.where_.kind.as_protocol_str(),
                 word: diagnosis.where_.word.clone(),
-                module: diagnosis.where_.module.clone(),
                 why: diagnosis.why.as_protocol_str(),
                 agreed_prefix: diagnosis.agreed_prefix,
             }),


### PR DESCRIPTION
## Summary

Continues Phase 9 of `docs/dev/semantic-spine-migration-plan.md`. The previous pass (§10.2) removed the module runtime from resolution and execution, but the module coordinate system was still standing in the **static metadata**. This removes what that made unreachable, and records the pass as §10.3.

Reachability was measured first; only things with no remaining constructor were deleted.

**Module metadata (`coreword_registry.rs`)**
- `CanonicalHome` — one construction site, always `Core`, so `Module(_)` was unreachable and `is_canonical_core` / `is_canonical_module` / `canonical_module` were constant.
- `listed_in_core` was permanently `true`; `listed_in_modules` was fed only by `IO` / `MATH` entries naming modules that no longer exist.
- `build_builtin_word_registry` extended the registry with an always-empty `module_entries`, making `MODULE_CORE_LISTINGS` and its apply pass no-ops.
- Listing queries (`get_module_listed_words`, `get_category_listed_words`, `get_boundary_words`, `get_core_listed_words`, `get_canonical_core_words`, `get_canonical_module_words`, `is_listing_only_for_module`) were referenced only by their own tests; three had no references at all.
- `get_coreword_metadata`'s `MODULE@WORD` branch always returned `None`. A built-in name never contains `@`, so reducing lookup to a flat name match preserves behavior.

`listed_in_categories` goes too. It is also test-only, and word grouping is carried by `family` in `spec/words.json` (11 families), so keeping a parallel Rust classification would leave one fact with two representations (plan §4.2).

**Other unreachable module residue**
- `WordShape` (`builtin_word_types.rs`) — silenced with `#[allow(dead_code)]`; the `ModuleWord` documented as its consumer does not exist.
- `execute_def.rs` `collision_modules` — a fixed empty vector, so the module-collision warning block was unreachable.
- `builtin_word_details.rs` `dictionary-{,un}import{,-only}` effect arms — no `BuiltinSpec` declares these effects.
- `module_word_call()` (test generator) — no references; assumed `MATH` / `JSON` / `ALGO`.
- `core_word_is_not_shadowed_by_import` — had degraded into comparing a string with itself once imports were removed.

**Build fix.** Removing `ErrorLocus.module` in commit `5e47dbb` left a reader in `tests/test_support/observe.rs`, which broke four law-test binaries on `main`. That field was written and never read, so it is removed rather than restored.

Frozen V1 wasm methods (`collect_available_modules`, `collect_module_catalog_words_info`, `collect_import_state`, `restore_import_state`) keep their signatures as the anti-corruption boundary per §10.2; only their doc comments change, to state that results are always empty.

Net: −572 / +87. Built-in words are now a single flat namespace.

## Quality Classification

- Highest impacted level: QL-C — removal of unreachable code and static metadata. No change to language semantics, evaluation, or the frozen V1 wire format.

## Traceability

- Requirement(s): AQ-REQ-007 (built-in word purity / `safe_preview` self-consistency) — the AQ-VER-007 suite is unchanged and still green. The eight vacuous `aq_ver_listing_*` tests are replaced by one `aq_ver_listing_a_no_two_entries_share_a_name`, which now guards name uniqueness over the flat namespace. No `docs/` or `spec/` file referenced the removed test IDs.
- Verification evidence:
  - `cargo fmt --check` — clean
  - `cargo clippy --all-targets -- -D warnings` — clean
  - `cargo test --all-targets` — all 12 suites green (804 lib tests + law suites)
  - `npm run check` (tsc) — clean; `npm run lint` — clean; `npm run test` — 231 vitest tests across 13 files
  - `src/host-protocol-v1.contract.test.ts` green against the unmodified `spec/freeze/host-protocol-v1.golden.json`, confirming the frozen V1 surface is untouched
  - CI gates green: `check:semantic-firewall`, `check:file-size`, `check:reading-surfaces`, `specification:check`, `semantic-kernel:check`, `word-schema:check`, `word:manifest:check`, `word-registry:check`, `word:reference:check`, `core-word-docs:check`, `check:skill`, `check:formalization-coverage`

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`)
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not run; this change only deletes code and adds no branches
- [x] MC/DC-like checklist reviewed for modified boolean logic — the one surviving predicate change is `get_coreword_metadata`, reduced from a three-way namespace disambiguation to a single flat name match. The removed branches were provably unreachable (`canonical_module()` was constant `None`), so no reachable condition combination is lost.
- [x] Release checklist impact considered — `CorewordMetadata` is serialized to the host via `collect_builtin_word_registry`, so `canonicalHome` / `listedIn*` disappear from that payload. No TS/JS source reads those fields (only the generated wasm glue exposes the method), and the payload is not part of the frozen V1 golden.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

One thing worth a reviewer's eye: dropping `listed_in_categories` (`CAST` / `TEXT` / `TENSOR` / `RUNTIME`) is the one judgement call rather than a pure reachability result. It is unreferenced outside its own tests, but if those labels are wanted for a future GUI grouping surface, say so and I will restore that field alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSCj5HiYh7MRUiBefTkYzm)_