### PR TITLE
interpreter: a one-element vector is a CONCAT operand, not a count

### DIFF
--- a/docs/dev/semantic-spine-migration-plan.md
+++ b/docs/dev/semantic-spine-migration-plan.md
@@ -426,7 +426,52 @@ runtime の供給元にした。これで §4.2 が「JSON→Rust 生成に反�
 既に語彙から削除済みで、`executor_key: Some(Force)` を持つ `BuiltinSpec` は 1 件も無かった。
 生成 enum に Force が無いため arm ごと削除した。`force_flag` 自体は
 `execute_def` / `execute_del` から読まれているが、**書き手が居ないため常に false** である。
-フラグと関連分岐の削除は別変更（到達可能性は測定済み）。
+フラグと関連分岐の削除は別変更（到達可能性は測定済み）。→ **完了**（PR #1399）。
+フラグ、`CompiledCall::resets_force_flag`、到達不能になった
+「was redefined / was deleted」警告分岐、および存在しない `!` を案内していた
+拒否メッセージ 2 本と `DEL` の `failure_note` を削除した。
+
+### 10.5 Phase 8 引き継ぎの追跡
+
+§10.4 の作業中に見つけ、範囲外として手を付けなかったもの。
+
+| # | 事項 | 状態 |
+| --- | --- | --- |
+| 1 | `effects` の綴り重複（正典 `consoleWrite` / Rust `console-write`） | 未着手 |
+| 2 | 書き手のない `force_flag` | 完了（§10.4 追記） |
+| 3 | `[ 1 ] [ 2 ] CONCAT` が `Stack underflow` | 完了（下記） |
+| 4 | `SORT` / `UNIQUE` の `projection.when: emptyVector` が到達不能 | 未着手 |
+| 5 | `NIL?` が宣言した projection を行わない | 未着手 |
+
+**#1 の観測面**（着手時の前提）: `console-write` が wire に届くのは 2 経路。
+`ajisai contract --json` の `effects` 配列と、`wasm_interpreter_state.rs` の
+`get_builtin_word_registry()` 経由で GUI に渡る配列。
+
+**#3 の原因と解決**: 実体は singleton projection ではなく、**正典が宣言しない
+可変長 CONCAT** だった。`CONCAT` は先頭に省略可能な個数（`a b c 3 CONCAT`）を
+取り、それをスタック最上位から sniff する。sniff が数値 operand 共通の
+singleton projection を使っていたため、1 要素ベクタがその要素として読まれ、
+`[ 1 2 ] [ 3 ] CONCAT` は「上位 3 個を連結」と解釈されて underflow していた。
+1 文字 Text は 1 codepoint ベクタなので `'ab' 'c' CONCAT` も同様。正典は
+`2 -> 1` / `errorWhen: [nonVector]` しか宣言しないので、**呼び出しの arity が
+operand の要素数に依存してはならない**。個数は bare scalar のときだけ認識する。
+`rust/tests/string_laws.rs` の `finding_i2_*` は underflow を pin していたので、
+修正後の挙動を pin する法則へ反転させた。
+
+なお **可変長形そのものは依然として正典に無い**。`spec/words.json` の CONCAT は
+`stack {inputs: 2, outputs: 1}` のままで、`n CONCAT` は
+`rust/tests/structural_laws.rs` と `examples/nested-vector-brackets-test.ajisai`
+が使う未宣言の拡張である。宣言するか削るかは別問題として残る。
+
+**#4 の測定**: 空ベクタは構成不能。パーサが `[ ]` を拒否するだけでなく、空になる
+計算はすべて NIL を返す（`[ 1 2 3 ] { FALSE } FILTER` → `NIL`、
+`[ 1 2 3 ] [ 0 ] TAKE` → `NIL`、`[ 1 2 3 ] [ 0 3 ] SPLIT` → `NIL [ 1 2 3 ]`）。
+実装との乖離ではなく正典内部の空文であり、`when: "never"` が正しい宣言。
+
+**#5 の測定**: `5 NIL?` → `5/1 FALSE`、`5 NIL-REASON` → `5/1 NIL`。述語である
+`NIL?` は projection しないのが正しく、`NIL-REASON` は宣言どおり projection する。
+両者が同じ `projection` 宣言を共有しているのが誤りで、`NIL?` だけ
+`when: "never"` に直せばよい。
 
 ---
 

--- a/rust/src/interpreter/vector_ops/structure.rs
+++ b/rust/src/interpreter/vector_ops/structure.rs
@@ -9,6 +9,21 @@ use crate::types::fraction::Fraction;
 use crate::types::Value;
 use num_traits::ToPrimitive;
 
+/// Read the optional leading operand count of `CONCAT`.
+///
+/// `CONCAT` joins the top two values by default; a bare integer on top instead
+/// names how many values to join (`[ 1 2 ] [ 3 4 ] [ 5 6 ] 3 CONCAT`), negative
+/// for reversed order. The count is *sniffed* rather than declared, so the test
+/// that recognizes it decides which values `CONCAT` can accept as data.
+///
+/// A Vector is never a count. It used to be: the count was read with the same
+/// singleton projection every numeric operand uses, and that projection sees a
+/// one-element vector as its element, so `[ 1 2 ] [ 3 ] CONCAT` read `[ 3 ]` as
+/// "join the top 3" and failed with `Stack underflow` — as did `[ 1 ] [ 2 ]
+/// CONCAT` and, because a one-character Text is a one-codepoint vector,
+/// `'ab' 'c' CONCAT`. The specification declares `CONCAT` as `2 -> 1` over
+/// vectors with `nonVector` its only error, so a vector operand has to reach
+/// the join.
 fn parse_concat_count(
     interp: &mut Interpreter,
     default_count: i64,
@@ -16,6 +31,10 @@ fn parse_concat_count(
     let Some(top) = interp.stack.last() else {
         return Err(AjisaiError::StackUnderflow);
     };
+
+    if top.is_vector() {
+        return Ok((default_count, None));
+    }
 
     let Ok(count_bigint) = extract_bigint_from_value(top) else {
         return Ok((default_count, None));

--- a/rust/tests/string_laws.rs
+++ b/rust/tests/string_laws.rs
@@ -85,13 +85,14 @@ proptest! {
 
     /// **`CHARS` of a word has one element per codepoint, and `JOIN` of two
     /// char-vectors concatenates** (free monoid on codepoints):
-    /// `(u CHARS) (v CHARS) CONCAT JOIN = uv`. Both words are ≥ 2 chars so each
-    /// `CHARS` yields a multi-element vector (finding I2: `CONCAT` underflows on a
-    /// single-element top operand).
+    /// `(u CHARS) (v CHARS) CONCAT JOIN = uv`. The word lengths start at 1: a
+    /// one-character word makes `CHARS` yield a one-element vector, which
+    /// `CONCAT` used to mistake for an operand count (finding I2, now fixed —
+    /// see `finding_i2_concat_joins_a_singleton_top_operand`).
     #[test]
     fn join_concat_is_concatenation(
-        u in "[a-h]{2,6}",
-        v in "[a-h]{2,6}",
+        u in "[a-h]{1,6}",
+        v in "[a-h]{1,6}",
     ) {
         prop_assert_eq!(
             obs1(&format!("'{u}' CHARS '{v}' CHARS CONCAT JOIN")),
@@ -131,31 +132,29 @@ fn chr_anchor() {
     assert_eq!(obs1("65 CHR"), "'A'");
 }
 
-/// **Finding I2 (guarded oracle): `CONCAT` underflows on a single-element top
-/// operand.** A single-element vector on top of the stack is treated specially
-/// (spread), so `[ 1 ] [ 2 ] CONCAT` raises `StackUnderflow`, while a
-/// multi-element top operand concatenates normally (`[ 1 ] [ 2 3 ] CONCAT`).
-/// This is why the `JOIN`∘`CONCAT` law above requires ≥ 2-char words. Pinned so
-/// a future change to single-element handling is loud.
+/// **Finding I2 (resolved): a one-element vector on top of `CONCAT` is an
+/// operand, not an operand count.**
+///
+/// `CONCAT` accepts an optional leading count (`a b c 3 CONCAT`) that it sniffs
+/// off the top of the stack. The sniff used to read a one-element vector as its
+/// element, so `[ 1 ] [ 2 ] CONCAT` meant "join the top 2 after popping `[ 2 ]`"
+/// and raised `StackUnderflow`, while `[ 1 ] [ 2 3 ] CONCAT` joined normally.
+/// The specification declares `CONCAT` as `2 -> 1` over vectors with `nonVector`
+/// its only error, so the arity of a call may not depend on how many elements an
+/// operand happens to have. A count is now recognized only as a bare scalar.
 #[test]
-fn finding_i2_concat_underflows_on_singleton_top() {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .build()
-        .unwrap();
-    let ok = |s: &str| {
-        rt.block_on(async {
-            ajisai_core::interpreter::Interpreter::new()
-                .execute(s)
-                .await
-                .is_ok()
-        })
-    };
-    assert!(
-        !ok("[ 1 ] [ 2 ] CONCAT"),
-        "singleton top operand should underflow"
-    );
-    assert!(
-        ok("[ 1 ] [ 2 3 ] CONCAT"),
-        "multi-element top operand concatenates"
-    );
+fn finding_i2_concat_joins_a_singleton_top_operand() {
+    // The shapes that used to underflow.
+    assert_eq!(obs1("[ 1 ] [ 2 ] CONCAT"), "[ 1/1 2/1 ]");
+    assert_eq!(obs1("[ 1 2 ] [ 3 ] CONCAT"), "[ 1/1 2/1 3/1 ]");
+    assert_eq!(obs1("'ab' 'c' CONCAT JOIN"), "'abc'");
+
+    // The shape that always worked, unchanged.
+    assert_eq!(obs1("[ 1 ] [ 2 3 ] CONCAT"), "[ 1/1 2/1 3/1 ]");
+
+    // A bare scalar is still a count, in both directions, and the count still
+    // reaches past the default two operands.
+    assert_eq!(obs1("[ 1 2 ] [ 3 4 ] 2 CONCAT"), "[ 1/1 2/1 3/1 4/1 ]");
+    assert_eq!(obs1("[ 1 ] [ 2 ] [ 3 ] 3 CONCAT"), "[ 1/1 2/1 3/1 ]");
+    assert_eq!(obs1("[ 1 2 ] [ 3 4 ] -2 CONCAT"), "[ 3/1 4/1 1/1 2/1 ]");
 }

--- a/tests/conformance/index.html
+++ b/tests/conformance/index.html
@@ -398,6 +398,20 @@
   <div class="ajisai-expect-effects"></div>
 </section>
 
+<section class="ajisai-case" id="core-concat-singleton-operand" data-category="core">
+  <h3>CONCAT joins a one-element vector as an operand, not as a count</h3>
+  <pre class="ajisai-source">[ 1 2 ] [ 3 ] CONCAT</pre>
+  <pre class="ajisai-expect-result">[ 1/1 2/1 3/1 ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-concat-singleton-text-operand" data-category="core">
+  <h3>CONCAT joins a one-character Text, which is a one-codepoint vector</h3>
+  <pre class="ajisai-source">'ab' 'c' CONCAT</pre>
+  <pre class="ajisai-expect-result">[ 97/1 98/1 99/1 ]</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
 <section class="ajisai-case" id="core-round-tie-away-from-zero" data-category="core">
   <h3>ROUND breaks a tie away from zero</h3>
   <pre class="ajisai-source">-2.5 ROUND</pre>


### PR DESCRIPTION
## Summary

Handoff item 3: `[ 1 ] [ 2 ] CONCAT` raising `Stack underflow`.

The cause is not singleton projection on the operands — it is an **undeclared
variadic form of `CONCAT`**. `CONCAT` takes an optional leading operand count
(`a b c 3 CONCAT`, negative for reversed order) which it *sniffs* off the top of
the stack. `parse_concat_count` read that count with `extract_bigint_from_value`,
the same singleton projection every numeric operand uses, and that projection
sees a one-element vector as its element.

So `[ 1 2 ] [ 3 ] CONCAT` read `[ 3 ]` as "join the top 3", popped it, found one
value left, and failed. The failing set is exactly "top operand has one element":

| program | before | after |
| --- | --- | --- |
| `[ 1 2 ] [ 3 4 ] CONCAT` | `[ 1 2 3 4 ]` | unchanged |
| `[ 1 ] [ 2 3 ] CONCAT` | `[ 1 2 3 ]` | unchanged |
| `[ 1 2 ] [ 3 ] CONCAT` | `Stack underflow` | `[ 1 2 3 ]` |
| `[ 1 ] [ 2 ] CONCAT` | `Stack underflow` | `[ 1 2 ]` |
| `'ab' 'c' CONCAT` | `Stack underflow` | `[ 97 98 99 ]` |
| `[ [ 1 ] ] [ [ 2 ] ] CONCAT` | `Stack underflow` | `[ [ 1 ] [ 2 ] ]` |

The Text row is the same bug: a one-character Text is a one-codepoint vector.

`spec/words.json` declares `CONCAT` as `stack {inputs: 2, outputs: 1}` with
`nonVector` its only error condition, so the arity of a call may not depend on
how many elements an operand happens to have. **A count is now recognized only
as a bare scalar**; a Vector or Tensor on top is always data.

Every count-form program keeps working, because those counts are bare scalars —
verified against `rust/tests/structural_laws.rs` (the free-monoid laws are built
out of `2 CONCAT` / `3 CONCAT` / `-2 CONCAT`) and
`examples/nested-vector-brackets-test.ajisai`.

### The pinned finding

`rust/tests/string_laws.rs` pinned this underflow as "finding I2 (guarded
oracle)" and worked around it by generating only words of 2+ characters, so the
`JOIN`∘`CONCAT` law never reached a one-character operand. The pin is inverted
into a law that fixes the joined results, and the generator now starts at 1
character.

### Still open

The variadic form itself remains undeclared — `spec/words.json` says `2 -> 1`
and says nothing about `n CONCAT`. Whether to declare it or drop it is recorded
as an open question in `docs/dev/semantic-spine-migration-plan.md` §10.5, along
with the measurements behind handoff items 1, 4, and 5.

## Quality Classification

- Highest impacted level: QL-B (Core Word evaluation)

## Traceability

- Requirement(s): `LANG.VALUES.VECTOR`, `LANG.COLLECTIONS.LIFT` — the declared
  `CONCAT` contract in `spec/words.json` (`2 -> 1`, `errorWhen: [nonVector]`)
- Verification evidence:
  - `rust/tests/string_laws.rs` —
    `finding_i2_concat_joins_a_singleton_top_operand` (the inverted pin, fixing
    results rather than just success), `join_concat_is_concatenation` (now
    generated from 1 character up)
  - `tests/conformance/index.html` — `core-concat-singleton-operand`,
    `core-concat-singleton-text-operand`; suite grew 171 → 173 cases, all passing
  - `rust/tests/structural_laws.rs` — the count-form free-monoid laws, unchanged
    and passing

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — 813 + 82 tests, 0 failures
- [x] `npm run check`, if applicable — `specification:check`,
      `word:reference:check`, `check:semantic-firewall`, `check:reading-surfaces`,
      `check:file-size` all pass
- [ ] `cargo llvm-cov --branch --workspace`, if applicable
- [x] MC/DC-like checklist reviewed for modified boolean logic — one new guard
      (`top.is_vector()`), both branches covered: the true branch by the singleton
      and multi-element operand cases, the false branch by the `2` / `3` / `-2`
      count-form laws.
- [ ] Release checklist impact considered

## Notes

Observable-behavior delta: programs that previously raised `Stack underflow` now
produce a value. No program that previously produced a value changes.

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfBAnsPcN7DZLHNexAErpw)_