### PR TITLE
kernel: let the specification spell a Word's effects

### DIFF
--- a/docs/dev/semantic-spine-migration-plan.md
+++ b/docs/dev/semantic-spine-migration-plan.md
@@ -419,8 +419,8 @@ runtime の供給元にした。これで §4.2 が「JSON→Rust 生成に反�
 
 **残った重複**: `BuiltinSpec.effects`。`spec/words.json` は同じ effect を別綴りで持つ
 （`consoleWrite` / `console-write`）ため、統一は観測される wire 文字列の変更を伴う。
-別変更として残す。`category` / `partiality` / `safety_level` / `safe_preview` は
-正典が宣言しない runtime 固有の分類なので、重複ではない。
+別変更として残す。→ **完了**（§10.6）。`category` / `partiality` / `safety_level` /
+`safe_preview` は正典が宣言しない runtime 固有の分類なので、重複ではない。
 
 **副次的に到達不能になったもの**: `BuiltinExecutorKey::Force`。対応する Word（`FORC` / `!`）は
 既に語彙から削除済みで、`executor_key: Some(Force)` を持つ `BuiltinSpec` は 1 件も無かった。
@@ -437,7 +437,7 @@ runtime の供給元にした。これで §4.2 が「JSON→Rust 生成に反�
 
 | # | 事項 | 状態 |
 | --- | --- | --- |
-| 1 | `effects` の綴り重複（正典 `consoleWrite` / Rust `console-write`） | 未着手 |
+| 1 | `effects` の綴り重複（正典 `consoleWrite` / Rust `console-write`） | 完了（§10.6） |
 | 2 | 書き手のない `force_flag` | 完了（§10.4 追記） |
 | 3 | `[ 1 ] [ 2 ] CONCAT` が `Stack underflow` | 完了（下記） |
 | 4 | `SORT` / `UNIQUE` の `projection.when: emptyVector` が到達不能 | 完了（下記） |
@@ -497,6 +497,43 @@ operand の要素数に依存してはならない**。個数は bare scalar の
 **残った疑問**: `NIL-REASON` の `projection.reason: "notAvailable"` は観測できない。
 `5 NIL-REASON NIL-REASON` → `5/1 NIL NIL` であり、projection が生む NIL は理由を
 持たない素の NIL である。`reason` を落とすか、理由付き NIL を返すようにするかは別問題。
+
+### 10.6 Phase 8 実施記録（`effects` — §4.2 表の最後の重複）
+
+§10.5 #1。`effects` は §4.2 の「1事実・複数記述」表に残っていた最後の項目で、
+契約本体が生成レジストリへ移った後も Rust 側に手書きの第二の綴りが残っていた。
+これを削除し、`spec/words.json` の宣言をそのまま供給元にした。
+
+| 意味情報 | 削除した手書き | 新しい供給元 |
+| --- | --- | --- |
+| effects | `BuiltinSpec.effects`（kebab-case の再綴り） | 生成 `GeneratedWord.effects`（正典の綴りのまま） |
+
+`effects` は schema が enum を宣言せず自由文字列なので、`aliases` と同じく
+`&'static [&'static str]` として射影する。Rust 側の enum を作れば、schema が
+admit する語彙より狭い vocabulary をまた一つ増やすことになる（§10.4 で
+`NilPolicy` / `WordPurity` / `deterministic` が実際に誤らせた形）。
+
+**観測される変化**（§10.5 が予告した wire 文字列の変更）。2 経路とも綴りだけが変わる:
+
+- `ajisai contract --json` の `effects` 配列 — `console-write` → `consoleWrite`。
+- `get_builtin_word_registry()` 経由で GUI に渡る `CorewordMetadata.effects`。
+
+**手書き側にあって正典に無かったもの**:
+
+- `DEF` の `dictionary-register`。`dictionary-write` と同じ 1 文に写像されていたので、
+  読者向け prose は変わらない。正典の `DEF` は `dictionaryWrite` 1 件のみを宣言する。
+- LOOKUP prose の写像表にあった `code-execution` / `interpreter-mode-write` /
+  `runtime-control` の 3 arm。どの Word もこれらを宣言しておらず到達不能だった。
+  効果語彙が正典の宣言そのものになったので、写像表は宣言される 4 語だけになる。
+
+**追加した drift ガード**: `every_declared_effect_has_a_user_facing_sentence`。
+効果名が正典側の事実になったということは、`spec/words.json` に effect を足すだけで
+Rust を触らずに LOOKUP の "Side Effects" 節へ届くということでもある。文が無ければ
+生の protocol 名（`consoleWrite`）がそのまま読者に出るので、宣言された全 effect に
+文があることを test で要求する。写像 arm を 1 本外して実際に落ちることは確認済み。
+
+`check-word-schema-migration.mjs` の effect 照合（camelCase→kebab 変換して
+Rust ブロックに含まれるか）は、照合すべき第二の綴りが無くなったので削除した。
 
 ---
 

--- a/rust/src/builtins/builtin_word_definitions.rs
+++ b/rust/src/builtins/builtin_word_definitions.rs
@@ -13,10 +13,8 @@ use crate::coreword_registry::{ExecutionForm, Partiality, SafetyLevel};
 /// What remains is what the specification does not declare — the prose a reader
 /// sees, and three runtime-local classifications (`partiality`,
 /// `safety_level`, `safe_preview`) that describe how the *implementation*
-/// treats a Word rather than what the language says it means. `effects` is the
-/// last true duplicate: `spec/words.json` names the same effects in a different
-/// spelling, and reconciling those changes an observed wire string, so it is
-/// left for its own change.
+/// treats a Word rather than what the language says it means. Nothing here is
+/// a second copy of a canonical fact.
 #[derive(Clone, Copy, Debug)]
 pub struct BuiltinSpec {
     pub name: &'static str,
@@ -44,9 +42,6 @@ pub struct BuiltinSpec {
     /// A consistency test asserts this invariant.
     pub stability: &'static str,
 
-    /// Effect names for the LOOKUP prose and the Coreword registry. Non-empty
-    /// only for the Words whose declared purity is observational or effectful.
-    pub effects: &'static [&'static str],
     pub safe_preview: bool,
     pub partiality: Partiality,
     pub safety_level: SafetyLevel,
@@ -65,7 +60,6 @@ const SPEC_DEFAULT: BuiltinSpec = BuiltinSpec {
     role: "",
     stack_effect: "",
     stability: "stable",
-    effects: &[],
     safe_preview: true,
     partiality: Partiality::Total,
     safety_level: SafetyLevel::A,
@@ -791,7 +785,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ x ] -> [ ]",
         stability: "experimental",
-        effects: &["console-write"],
         safe_preview: false,
         partiality: Partiality::Partial,
         safety_level: SafetyLevel::D,
@@ -808,7 +801,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "{ body } [ name ] -> []",
         stability: "experimental",
-        effects: &["dictionary-write", "dictionary-register"],
         safe_preview: false,
         partiality: Partiality::Partial,
         safety_level: SafetyLevel::D,
@@ -825,7 +817,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ name ] -> []",
         stability: "experimental",
-        effects: &["dictionary-delete"],
         safe_preview: false,
         partiality: Partiality::Partial,
         safety_level: SafetyLevel::D,
@@ -842,7 +833,6 @@ const BUILTIN_SPECS: &[BuiltinSpec] = &[
 
         stack_effect: "[ name ] -> []",
         stability: "experimental",
-        effects: &["dictionary-read"],
         safe_preview: false,
         partiality: Partiality::Partial,
         safety_level: SafetyLevel::C,

--- a/rust/src/builtins/builtin_word_details.rs
+++ b/rust/src/builtins/builtin_word_details.rs
@@ -95,7 +95,7 @@ pub fn lookup_builtin_detail(name: &str) -> String {
 
     out.push('\n');
     out.push_str("Side Effects:\n");
-    push_indented(&mut out, &derive_side_effects_text(spec), "  ");
+    push_indented(&mut out, &derive_side_effects_text(&canonical), "  ");
 
     if let Some(doc) = doc {
         if !doc.related.is_empty() {
@@ -154,29 +154,37 @@ fn derive_failure_text(spec: &BuiltinSpec, canonical: &str) -> String {
     lines.join("\n")
 }
 
-/// Side Effects derived from the §7.14 `effects` list. The protocol names
-/// form a small closed set; each maps to one user-facing sentence.
-fn derive_side_effects_text(spec: &BuiltinSpec) -> String {
-    if spec.effects.is_empty() {
+/// Side Effects derived from the §7.14 `effects` list declared in
+/// `spec/words.json`. Each declared effect maps to one user-facing sentence;
+/// `effect_sentence` returns `None` for a name it does not know, which
+/// `builtin_word_details_tests.rs` turns into a failure rather than letting the
+/// raw protocol name reach a reader.
+fn derive_side_effects_text(canonical: &str) -> String {
+    let Some(word) = generated_word(canonical) else {
+        return "None.".to_string();
+    };
+    if word.effects.is_empty() {
         return "None.".to_string();
     }
     let mut sentences: Vec<&str> = Vec::new();
-    for effect in spec.effects {
-        let sentence = match *effect {
-            "console-write" => "Writes to the output area.",
-            "code-execution" => "Executes code supplied as data.",
-            "dictionary-write" | "dictionary-register" => "Modifies the dictionary.",
-            "dictionary-delete" => "Removes a word from the dictionary.",
-            "dictionary-read" => "Loads documentation into the editor.",
-            "interpreter-mode-write" => "Changes the interpreter mode for the next word.",
-            "runtime-control" => "Controls child runtime execution.",
-            other => other,
-        };
+    for effect in word.effects {
+        let sentence = effect_sentence(effect).unwrap_or(effect);
         if !sentences.contains(&sentence) {
             sentences.push(sentence);
         }
     }
     sentences.join("\n")
+}
+
+/// The user-facing sentence for a declared effect name.
+pub(super) fn effect_sentence(effect: &str) -> Option<&'static str> {
+    match effect {
+        "consoleWrite" => Some("Writes to the output area."),
+        "dictionaryWrite" => Some("Modifies the dictionary."),
+        "dictionaryDelete" => Some("Removes a word from the dictionary."),
+        "dictionaryRead" => Some("Loads documentation into the editor."),
+        _ => None,
+    }
 }
 
 pub fn render_four_section(

--- a/rust/src/builtins/builtin_word_details_tests.rs
+++ b/rust/src/builtins/builtin_word_details_tests.rs
@@ -7,10 +7,37 @@
 //! guarantee: a `hover_syntax` example must be a well-formed snippet (item 9),
 //! every word it names must be a real word (item 10), and every *concrete*
 //! example must actually run (item 10b).
+//!
+//! The declared-effect guard below is here for the same reason: it keeps the
+//! LOOKUP "Side Effects" prose total over what `spec/words.json` declares.
 
 use super::builtin_word_definitions::builtin_specs;
+use super::builtin_word_details::effect_sentence;
 use crate::interpreter::Interpreter;
+use crate::kernel::generated::GENERATED_WORDS;
 use crate::tokenizer::tokenize;
+
+/// The effect names are the specification's, not the runtime's, so a Word
+/// gaining an effect in `spec/words.json` reaches the LOOKUP prose without any
+/// Rust edit — and would print the raw protocol name if nobody wrote a sentence
+/// for it. Requiring a sentence for every declared effect makes that a test
+/// failure instead of a reader-visible `consoleWrite`.
+#[test]
+fn every_declared_effect_has_a_user_facing_sentence() {
+    let mut checked = 0;
+    for word in GENERATED_WORDS {
+        for effect in word.effects {
+            checked += 1;
+            assert!(
+                effect_sentence(effect).is_some(),
+                "{} declares effect `{}` with no user-facing sentence",
+                word.name,
+                effect
+            );
+        }
+    }
+    assert!(checked > 0, "no Word declares an effect; the guard is idle");
+}
 #[test]
 fn every_hover_syntax_is_a_well_formed_snippet() {
     // Ledger item 9. A `hover_syntax` is a runnable example, so requiring it to

--- a/rust/src/coreword_registry.rs
+++ b/rust/src/coreword_registry.rs
@@ -4,7 +4,7 @@
 //! is **not** written here. It is read from `kernel::generated`, projected from
 //! `spec/words.json`, and this module joins it with the runtime-local
 //! classifications that the specification does not declare (`category`,
-//! `partiality`, `safety_level`, `safe_preview`, `effects`).
+//! `partiality`, `safety_level`, `safe_preview`).
 //!
 //! Two of the vocabularies that used to be declared in this file were narrower
 //! than the canonical ones and mislabelled Words as a result: the hand-written
@@ -136,6 +136,7 @@ pub struct CorewordMetadata {
     pub category: String,
     /// Declared in `spec/words.json`.
     pub purity: Purity,
+    /// Declared in `spec/words.json`, in the specification's own spelling.
     pub effects: Vec<String>,
     /// Declared in `spec/words.json`. Was a `bool`, which could not express
     /// the specification's distinction between a Word that reads runtime state
@@ -273,7 +274,7 @@ fn core_word_metadata(word: &GeneratedWord) -> CorewordMetadata {
         name: word.name.to_string(),
         category: spec.category.to_lowercase(),
         purity: word.purity,
-        effects: spec.effects.iter().map(|e| e.to_string()).collect(),
+        effects: word.effects.iter().map(|e| e.to_string()).collect(),
         determinism: word.determinism,
         safe_preview: spec.safe_preview,
         partiality: spec.partiality,

--- a/rust/src/kernel/generated/mod.rs
+++ b/rust/src/kernel/generated/mod.rs
@@ -10,11 +10,8 @@
 //!
 //! What is still hand-written on `BuiltinSpec` is prose and runtime-local
 //! classification — documentation text, `category`, `partiality`,
-//! `safety_level`, `safe_preview`, `effects` — none of which the specification
-//! declares. `effects` is the one remaining duplicate: `spec/words.json` names
-//! the same effects in a different spelling (`consoleWrite` vs
-//! `console-write`), and reconciling that changes an observed wire string, so
-//! it is left for its own change.
+//! `safety_level`, `safe_preview` — none of which the specification declares.
+//! No canonical fact is written down twice.
 
 mod word_registry;
 

--- a/rust/src/kernel/generated/word_registry.rs
+++ b/rust/src/kernel/generated/word_registry.rs
@@ -294,6 +294,11 @@ pub struct GeneratedWord {
     pub projection: Option<&'static str>,
     pub purity: Purity,
     pub determinism: Determinism,
+    /// The effects the Word declares, in the specification's own spelling.
+    /// Empty for every `pure` Word; the vocabulary is open (the schema types
+    /// it as free strings), so this is projected as declared rather than
+    /// narrowed into a Rust enum.
+    pub effects: &'static [&'static str],
 }
 
 pub const GENERATED_WORDS: &[GeneratedWord] = &[
@@ -309,6 +314,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::False,
@@ -322,6 +328,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::And,
@@ -335,6 +342,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Or,
@@ -348,6 +356,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Not,
@@ -361,6 +370,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Eq,
@@ -374,6 +384,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Neq,
@@ -387,6 +398,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Lt,
@@ -400,6 +412,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Le,
@@ -413,6 +426,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Gt,
@@ -426,6 +440,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Gte,
@@ -439,6 +454,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Add,
@@ -452,6 +468,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Sub,
@@ -465,6 +482,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Mul,
@@ -478,6 +496,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Div,
@@ -491,6 +510,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("divisorEqualsZero"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Mod,
@@ -504,6 +524,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("integerProjectionUndecidable"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Floor,
@@ -517,6 +538,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("integerProjectionUndecidable"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Ceil,
@@ -530,6 +552,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("integerProjectionUndecidable"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Round,
@@ -543,6 +566,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("integerProjectionUndecidable"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Abs,
@@ -556,6 +580,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Neg,
@@ -569,6 +594,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Sign,
@@ -582,6 +608,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Min,
@@ -595,6 +622,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Max,
@@ -608,6 +636,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Sqrt,
@@ -621,6 +650,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("negativeScalar"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Get,
@@ -634,6 +664,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("indexOutOfBounds"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Insert,
@@ -647,6 +678,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Replace,
@@ -660,6 +692,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Remove,
@@ -673,6 +706,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Length,
@@ -686,6 +720,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Take,
@@ -699,6 +734,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Split,
@@ -712,6 +748,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Concat,
@@ -725,6 +762,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Reverse,
@@ -738,6 +776,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Reorder,
@@ -751,6 +790,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Collect,
@@ -764,6 +804,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Range,
@@ -777,6 +818,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("materializationBudgetExceeded"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Fill,
@@ -790,6 +832,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("materializationBudgetExceeded"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Sort,
@@ -803,6 +846,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Unique,
@@ -816,6 +860,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Contains,
@@ -829,6 +874,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::IndexOf,
@@ -842,6 +888,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("valueAbsent"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Map,
@@ -855,6 +902,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Filter,
@@ -868,6 +916,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Fold,
@@ -881,6 +930,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Any,
@@ -894,6 +944,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::All,
@@ -907,6 +958,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Chars,
@@ -920,6 +972,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Join,
@@ -933,6 +986,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Trim,
@@ -946,6 +1000,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Tokenize,
@@ -959,6 +1014,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Substitute,
@@ -972,6 +1028,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::StartsWith,
@@ -985,6 +1042,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::EndsWith,
@@ -998,6 +1056,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Num,
@@ -1011,6 +1070,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("parseFailure"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Str,
@@ -1024,6 +1084,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Chr,
@@ -1037,6 +1098,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("invalidCharacterCode"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Cond,
@@ -1050,6 +1112,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Exec,
@@ -1063,6 +1126,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Nil,
@@ -1076,6 +1140,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::NilCheck,
@@ -1089,6 +1154,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::NilReason,
@@ -1102,6 +1168,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: Some("valueIsNotOperationalNilOrFieldAbsent"),
         purity: Purity::Pure,
         determinism: Determinism::Deterministic,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::LazyNextUnitFallback,
@@ -1115,6 +1182,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Conditional,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::SetConsumptionConsume,
@@ -1128,6 +1196,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::SetConsumptionKeep,
@@ -1141,6 +1210,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Pure,
         determinism: Determinism::StateRelative,
+        effects: &[],
     },
     GeneratedWord {
         id: WordId::Def,
@@ -1154,6 +1224,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Effectful,
         determinism: Determinism::StateRelative,
+        effects: &["dictionaryWrite"],
     },
     GeneratedWord {
         id: WordId::Del,
@@ -1167,6 +1238,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Effectful,
         determinism: Determinism::StateRelative,
+        effects: &["dictionaryDelete"],
     },
     GeneratedWord {
         id: WordId::Lookup,
@@ -1180,6 +1252,7 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Observational,
         determinism: Determinism::StateRelative,
+        effects: &["dictionaryRead"],
     },
     GeneratedWord {
         id: WordId::Print,
@@ -1193,5 +1266,6 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         projection: None,
         purity: Purity::Effectful,
         determinism: Determinism::HostRelative,
+        effects: &["consoleWrite"],
     },
 ];

--- a/scripts/check-word-schema-migration.mjs
+++ b/scripts/check-word-schema-migration.mjs
@@ -53,10 +53,10 @@ for (const word of words.entries) {
   if (!normalizedBlock.includes(word.documentation.summary)) fail(`${word.name} summary drift`);
   if (!block.includes(`hover_summary: "${word.documentation.hover}"`)) fail(`${word.name} hover drift`);
   if (!block.includes(`hover_syntax: "${word.documentation.syntax}"`)) fail(`${word.name} syntax drift`);
-  for (const effect of word.effects) {
-    const rustEffect = effect.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
-    if (!block.includes(`"${rustEffect}"`)) fail(`${word.name} effect drift: ${effect}`);
-  }
+  // `effects` used to be written a second time on the Rust spec entry in a
+  // kebab-case respelling, and this reconciled the two copies. The runtime
+  // reads the declared list straight from the generated registry now, so there
+  // is no second spelling to reconcile — only prose is checked below.
   for (const alias of word.aliases) {
     const aliasPattern = `alias: "${alias}",`;
     const canonicalPattern = `canonical: Some("${word.name}"),`;

--- a/scripts/generate-word-registry.mjs
+++ b/scripts/generate-word-registry.mjs
@@ -114,8 +114,8 @@ const projection = (when) => (when === 'never' ? 'None' : `Some(${JSON.stringify
 // spec/words.json values are ASCII, so a JSON string literal is also a valid
 // Rust string literal.
 const rustStr = (value) => JSON.stringify(value);
-const rustAliases = (aliases) =>
-  aliases.length > 0 ? `&[${aliases.map(rustStr).join(', ')}]` : '&[]';
+const rustStrSlice = (values) =>
+  values.length > 0 ? `&[${values.map(rustStr).join(', ')}]` : '&[]';
 
 const variants = entries.map((word) => `    ${word.executorKey},`).join('\n');
 
@@ -124,7 +124,7 @@ const rows = entries
     (word) => `    GeneratedWord {
         id: WordId::${word.executorKey},
         name: ${rustStr(word.name)},
-        aliases: ${rustAliases(word.aliases)},
+        aliases: ${rustStrSlice(word.aliases)},
         family: ${enumRef('Family', word.family)},
         stack_inputs: ${arity(word.stack.inputs)},
         stack_outputs: ${arity(word.stack.outputs)},
@@ -133,6 +133,7 @@ const rows = entries
         projection: ${projection(word.projection.when)},
         purity: ${enumRef('Purity', word.purity)},
         determinism: ${enumRef('Determinism', word.determinism)},
+        effects: ${rustStrSlice(word.effects)},
     },`,
   )
   .join('\n');
@@ -195,6 +196,11 @@ pub struct GeneratedWord {
     pub projection: Option<&'static str>,
     pub purity: Purity,
     pub determinism: Determinism,
+    /// The effects the Word declares, in the specification's own spelling.
+    /// Empty for every \`pure\` Word; the vocabulary is open (the schema types
+    /// it as free strings), so this is projected as declared rather than
+    /// narrowed into a Rust enum.
+    pub effects: &'static [&'static str],
 }
 
 pub const GENERATED_WORDS: &[GeneratedWord] = &[


### PR DESCRIPTION
## Summary

Closes item **#1** of the Semantic Spine migration plan's §10.5 handoff table — the last entry left in the §4.2 "one semantic fact, several records" table.

The Word contract itself already came from `kernel/generated/word_registry.rs`, but `effects` did not: the names were hand-written on `BuiltinSpec` in a kebab-case respelling of what `spec/words.json` declares, and `check-word-schema-migration.mjs` reconciled the two copies by converting `consoleWrite` to `console-write` and grepping the Rust block for it.

This projects the declared list into the generated registry and reads it from there.

- `spec/words.schema.json` types `effects` as free strings rather than an enum, so it is projected as `&'static [&'static str]` like `aliases`. Adding a Rust enum here would reintroduce the failure mode §10.4 recorded: a vocabulary narrower than the canonical one, which is what mislabelled eleven Words when the hand-written `NilPolicy` carried five of the specification's seven values.
- The effect-drift check in `check-word-schema-migration.mjs` is removed — there is no second spelling left to reconcile.

**Observed wire strings change spelling** on both paths that carry them, as §10.5 predicted when it deferred this: `ajisai contract --json`'s `effects` array, and the `CorewordMetadata.effects` the GUI reads via `get_builtin_word_registry()`. `console-write` → `consoleWrite`, and likewise for the three dictionary effects.

Two things the hand-written copy carried are gone with it:

- `DEF`'s `dictionary-register`, which the specification does not declare and which mapped to the same reader-facing sentence as `dictionaryWrite`.
- Three arms of the LOOKUP prose table (`code-execution`, `interpreter-mode-write`, `runtime-control`) that no `BuiltinSpec` declared — unreachable, so deleted per §23's "delete once unreachable".

The prose a reader sees is unchanged for every Word (verified: PRINT "Writes to the output area.", DEF "Modifies the dictionary.", DEL, LOOKUP, and "None." for pure Words).

**New drift guard.** Because effect names are now canonical facts, a Word can gain an effect in `spec/words.json` and reach LOOKUP's "Side Effects" section with no Rust edit at all — printing the raw protocol name if nobody wrote a sentence for it. `every_declared_effect_has_a_user_facing_sentence` requires every declared effect to have one. Verified it actually catches regressions by removing the `consoleWrite` mapping arm and confirming the failure.

`docs/dev/semantic-spine-migration-plan.md` records the work as §10.6 and flips §10.5 #1 to 完了.

## Quality Classification

- Highest impacted level: QL-C (`LOOKUP` documentation surface and the Coreword registry wire form; no change to evaluation semantics)

## Traceability

- Requirement(s): AQ-REQ-007 (Coreword purity / `safe_preview` integrity — `coreword_registry.rs` supplies `effects` used by the AQ-VER-007 purity/effect coherence tests)
- Verification evidence:
  - `builtins::builtin_word_details_tests::every_declared_effect_has_a_user_facing_sentence` (new)
  - Existing AQ-VER-007 subset: pure Words declare no effects; effectful and observational Words must declare some — all still green against the generated source
  - `rust/tests/desugar_laws.rs`, `rust/tests/contract_modifier_laws.rs` (effect assertions unchanged and passing)
  - `npm run word-registry:check`, `word-schema:check`, `semantic-kernel:check`, `specification:check`, `word:manifest:check`, `word:reference:check`, `core-word-docs:check`, `check:skill`, `check:reading-surfaces`, `check:semantic-firewall`, `check:file-size`, `check:formalization-coverage` — all pass
  - `ajisai contract --json` on a `{ PRINT } 'SHOUT' DEF` program now reports `"effects": ["consoleWrite"]`

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated. (§10.6 added to the migration plan; §10.5 #1 marked complete)
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — 13 targets green
- [x] `npm run check` — plus `npm run lint` and `npm run test` (231 vitest tests) green
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not run
- [x] MC/DC-like checklist reviewed for modified boolean logic — `derive_side_effects_text` gained a `None`/empty split (no generated Word / empty `effects` / non-empty), and `effect_sentence` is a total match with an explicit `None` fallback; both arms of the new guard's assertion are exercised (pass on the four declared effects, failure confirmed by removing a mapping arm)
- [x] Release checklist impact considered — `effects` wire strings change spelling; noted above and in §10.6 as the cost §10.5 had already accounted for

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S888zxJHHpRsDiBcHXfYvH)_