### PR TITLE
ci: enforce BuiltinSpec as a projection, not a source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,15 @@ jobs:
       - name: Check Minimal Core closure
         run: npm run check:minimal-core
 
+      - name: Runtime Core Word metadata is projected, not authored
+        # BuiltinSpec is a joined view over generated docs and generated
+        # contracts, never a second place to write language facts down. A
+        # hand-authored table alongside it is what let two branches disagree
+        # about Core Word metadata and produce a tree that would not compile.
+        # This asserts the projection structurally, so a parallel table fails
+        # here whatever it is named — see scripts/check-runtime-metadata-source.mjs.
+        run: npm run check:runtime-metadata
+
       - name: TypeScript check
         run: npm run check
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "core-word-docs:check": "node scripts/generate-core-word-docs.mjs --check",
     "check:formalization-coverage": "node scripts/check-formalization-coverage.mjs",
     "check:minimal-core": "node scripts/check-minimal-core.mjs",
+    "check:runtime-metadata": "node scripts/check-runtime-metadata-source.mjs",
     "generate:skill": "node scripts/generate-skill-md.mjs",
     "check:skill": "node scripts/generate-skill-md.mjs --check",
     "primitive:test-map": "node scripts/generate-primitive-test-map.mjs",

--- a/rust/src/builtins/builtin_word_definitions.rs
+++ b/rust/src/builtins/builtin_word_definitions.rs
@@ -104,6 +104,12 @@ mod tests {
         }
     }
 
+    /// Every prose field of a spec must be the generated value, verbatim.
+    ///
+    /// `check:runtime-metadata` proves the same thing syntactically — that each
+    /// field is written as `doc.<field>` — but only this asserts it of the
+    /// values actually observed at runtime, so a projection that compiled while
+    /// transforming or substituting prose would still be caught here.
     #[test]
     fn generated_core_docs_preserve_the_legacy_observation() {
         let generated = super::super::generated_core_word_docs::GENERATED_CORE_WORD_DOCS;
@@ -111,8 +117,45 @@ mod tests {
 
         for (doc, spec) in generated.iter().zip(super::builtin_specs()) {
             assert_eq!(doc.name, spec.name);
+            assert_eq!(doc.category, spec.category, "{} category", doc.name);
+            assert_eq!(doc.summary, spec.summary, "{} summary", doc.name);
+            assert_eq!(doc.role, spec.role, "{} role", doc.name);
+            assert_eq!(
+                doc.stack_effect, spec.stack_effect,
+                "{} stack_effect",
+                doc.name
+            );
             assert_eq!(doc.hover_summary, spec.hover_summary);
             assert_eq!(doc.hover_syntax, spec.hover_syntax);
+        }
+    }
+
+    /// The contract-projected fields must equal the canonical contract's own
+    /// projection for the same Word, so `BuiltinSpec` cannot drift from
+    /// `spec/words.json` even if someone rewires the assembly.
+    #[test]
+    fn contract_projected_fields_match_the_canonical_contract() {
+        for spec in super::builtin_specs() {
+            let word = crate::kernel::generated::generated_word(spec.name)
+                .expect("every spec name must be a canonical Word");
+            assert_eq!(
+                spec.stability,
+                crate::coreword_registry::stability_from_contract(word),
+                "{} stability",
+                spec.name
+            );
+            assert_eq!(
+                spec.partiality,
+                crate::coreword_registry::partiality_from_contract(word),
+                "{} partiality",
+                spec.name
+            );
+            assert_eq!(
+                spec.execution_form,
+                crate::coreword_registry::execution_form_from_contract(word),
+                "{} execution_form",
+                spec.name
+            );
         }
     }
 

--- a/scripts/check-runtime-metadata-source.mjs
+++ b/scripts/check-runtime-metadata-source.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// Enforces the invariant that `BuiltinSpec` is a *projection*, never a source.
+//
+// The failure this exists to prevent is not a particular retired type name; it
+// is the shape of the bug. A hand-authored Core Word metadata table
+// (historically `RuntimeSpec` + `SPEC_DEFAULT`) reappears alongside the
+// projection, and the two disagree — or, as happened once, one side is deleted
+// while the other keeps importing it and the tree stops compiling. Grepping for
+// the old names would only catch a repeat under the same spelling, and would
+// pass the moment someone calls the parallel table something else.
+//
+// So the check is a positive whitelist over the construction of `BuiltinSpec`
+// rather than a blocklist over names: every field must be traceable, at the
+// syntax level, to one of the two canonical sources.
+//
+//   prose      -> `doc.<field>`, a field of the generated `GeneratedCoreWordDoc`
+//   contract   -> `<path>::<name>_from_contract(word)`, defined in
+//                 rust/src/coreword_registry/contract.rs
+//
+// Anything else — a string literal, a `const`, a lookup into a second table, a
+// `..Default::default()` spread — fails, whatever it is named. Together with
+// `core-word-docs:check` (generated docs match spec/words.json) this closes the
+// path from the canonical source to the runtime view.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const DEFINITIONS = 'rust/src/builtins/builtin_word_definitions.rs';
+const GENERATED_DOCS = 'rust/src/builtins/generated_core_word_docs.rs';
+const CONTRACT = 'rust/src/coreword_registry/contract.rs';
+
+const errors = [];
+const read = (path) => readFileSync(resolve(repoRoot, path), 'utf8');
+
+// Rust source is scanned with a brace matcher rather than a regex: field
+// initializers contain nested calls and generics, so a non-greedy match would
+// stop at the first `}` inside the body.
+function matchBrace(source, openIndex) {
+  let depth = 0;
+  let inString = false;
+  for (let i = openIndex; i < source.length; i += 1) {
+    const char = source[i];
+    if (inString) {
+      if (char === '\\') i += 1;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+// Split `a: x, b: f(y, z)` on top-level commas only, so an argument list does
+// not read as a field boundary.
+function splitTopLevel(body) {
+  const parts = [];
+  let depth = 0;
+  let inString = false;
+  let current = '';
+  for (let i = 0; i < body.length; i += 1) {
+    const char = body[i];
+    if (inString) {
+      current += char;
+      if (char === '\\') current += body[(i += 1)];
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if ('([{<'.includes(char)) depth += 1;
+    else if (')]}>'.includes(char)) depth -= 1;
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts.map((part) => part.trim()).filter(Boolean);
+}
+
+// Strip line comments and attributes so `#[allow(dead_code)]` between fields
+// does not read as a field.
+function structFields(source, declaration, label) {
+  const at = source.indexOf(declaration);
+  if (at === -1) {
+    errors.push(`${label}: could not find \`${declaration}\``);
+    return [];
+  }
+  const open = source.indexOf('{', at);
+  const close = matchBrace(source, open);
+  const body = source
+    .slice(open + 1, close)
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/#\[[^\]]*\]/g, '');
+  return splitTopLevel(body)
+    .map((field) => field.match(/^(?:pub(?:\([^)]*\))?\s+)?([a-z_][a-z0-9_]*)\s*:/)?.[1])
+    .filter(Boolean);
+}
+
+const definitions = read(DEFINITIONS);
+const generatedDocs = read(GENERATED_DOCS);
+const contract = read(CONTRACT);
+
+// The generated docs file must actually be generator output. If it were
+// hand-editable, "sourced from `doc.x`" would guarantee nothing.
+if (!generatedDocs.startsWith('// @generated')) {
+  errors.push(`${GENERATED_DOCS}: missing \`// @generated\` banner; it must be generator output`);
+}
+
+const specFields = structFields(definitions, 'pub struct BuiltinSpec', DEFINITIONS);
+const docFields = new Set(structFields(generatedDocs, 'struct GeneratedCoreWordDoc', GENERATED_DOCS));
+const contractFns = new Set(
+  [...contract.matchAll(/\bfn\s+([a-z_][a-z0-9_]*_from_contract)\s*\(/g)].map((match) => match[1]),
+);
+
+if (specFields.length === 0) errors.push(`${DEFINITIONS}: BuiltinSpec declares no fields`);
+if (docFields.size === 0) errors.push(`${GENERATED_DOCS}: GeneratedCoreWordDoc declares no fields`);
+if (contractFns.size === 0) errors.push(`${CONTRACT}: no \`*_from_contract\` projections found`);
+
+// `builtin_specs()` must iterate the generated docs. Iterating anything else
+// would mean the inventory has a second source, even if every field checked out.
+const assembler = definitions.slice(definitions.indexOf('fn builtin_specs('));
+if (!/GENERATED_CORE_WORD_DOCS\s*\n?\s*\.iter\(\)/.test(assembler)) {
+  errors.push(`${DEFINITIONS}: builtin_specs() must iterate GENERATED_CORE_WORD_DOCS`);
+}
+
+// Every construction of BuiltinSpec, anywhere in the crate. More than one means
+// a second assembly path exists; a 69-entry authored table would show up here as
+// 69 sites.
+const sites = [];
+const pattern = /(?<!struct\s)\bBuiltinSpec\s*\{/g;
+for (const match of definitions.matchAll(pattern)) {
+  const open = definitions.indexOf('{', match.index);
+  const close = matchBrace(definitions, open);
+  sites.push({ index: match.index, body: definitions.slice(open + 1, close) });
+}
+
+if (sites.length !== 1) {
+  errors.push(
+    `${DEFINITIONS}: expected exactly 1 BuiltinSpec construction site, found ${sites.length}. ` +
+      'A second site means Core Word metadata is assembled in more than one place.',
+  );
+}
+
+for (const site of sites) {
+  const line = definitions.slice(0, site.index).split('\n').length;
+  const seen = new Set();
+  for (const entry of splitTopLevel(site.body.replace(/\/\/[^\n]*/g, ''))) {
+    if (entry.startsWith('..')) {
+      errors.push(
+        `${DEFINITIONS}:${line}: struct-update syntax \`${entry}\` is not allowed; ` +
+          'every field must name its canonical source explicitly.',
+      );
+      continue;
+    }
+    const field = entry.match(/^([a-z_][a-z0-9_]*)\s*:/)?.[1];
+    if (!field) {
+      errors.push(`${DEFINITIONS}:${line}: could not parse field initializer \`${entry}\``);
+      continue;
+    }
+    seen.add(field);
+    const value = entry.slice(entry.indexOf(':') + 1).trim();
+
+    const fromDocs = value.match(/^doc\.([a-z_][a-z0-9_]*)$/);
+    if (fromDocs) {
+      if (!docFields.has(fromDocs[1])) {
+        errors.push(
+          `${DEFINITIONS}:${line}: ${field} reads \`doc.${fromDocs[1]}\`, ` +
+            `which is not a field of GeneratedCoreWordDoc in ${GENERATED_DOCS}`,
+        );
+      }
+      continue;
+    }
+
+    const fromContract = value.match(
+      /^(?:[A-Za-z_][A-Za-z0-9_]*::)*([a-z_][a-z0-9_]*_from_contract)\(\s*word\s*\)$/,
+    );
+    if (fromContract) {
+      if (!contractFns.has(fromContract[1])) {
+        errors.push(
+          `${DEFINITIONS}:${line}: ${field} calls \`${fromContract[1]}\`, ` +
+            `which is not defined in ${CONTRACT}`,
+        );
+      }
+      continue;
+    }
+
+    errors.push(
+      `${DEFINITIONS}:${line}: ${field} is set from \`${value}\`, which is neither ` +
+        'generated documentation (`doc.<field>`) nor a canonical contract projection ' +
+        '(`<name>_from_contract(word)`). BuiltinSpec is a projection of spec/words.json, ' +
+        'not a place to author Core Word metadata.',
+    );
+  }
+
+  // A field that is declared but never initialized here cannot have come from a
+  // canonical source, so the whitelist above would not have seen it.
+  for (const field of specFields) {
+    if (!seen.has(field)) errors.push(`${DEFINITIONS}:${line}: BuiltinSpec.${field} is never assigned`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('[runtime-metadata] BuiltinSpec must be projected from canonical sources only:');
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  `[runtime-metadata] BuiltinSpec projects ${specFields.length} fields from generated docs ` +
+    `and ${contractFns.size} canonical contract projections; no authored metadata table.`,
+);


### PR DESCRIPTION
## Summary

Follow-up to #1411. That PR fixed the broken tree; this one makes the broken tree unrepresentable.

The `E0432` failure was a symptom. The cause was that Core Word metadata had **two homes** — an authored Rust table and a projection over generated docs/contracts. Two branches changed different homes, git merged them with no textual conflict, and the result did not compile.

A grep for `RuntimeSpec`/`SPEC_DEFAULT` would only catch a repeat under the same spelling, and would pass the moment a parallel table were named something else. This asserts the invariant instead.

### `scripts/check-runtime-metadata-source.mjs`

A **positive whitelist** over the construction of `BuiltinSpec`. Every field must be written as either:

- `doc.<field>` — a declared field of the generated `GeneratedCoreWordDoc`, or
- `<name>_from_contract(word)` — a projection defined in `rust/src/coreword_registry/contract.rs`

It additionally requires exactly one construction site, rejects struct-update syntax (`..SPEC_DEFAULT`), requires the assembler to iterate `GENERATED_CORE_WORD_DOCS`, requires that generated file to carry its `@generated` banner, and cross-checks that every referenced doc field and contract projection actually exists. A string literal, a `const`, or a read from a second table fails **whatever it is named**.

### Rust tests

Two tests assert the same invariant of the values seen at runtime, which a syntactic check cannot: prose fields must equal the generated values verbatim (extended from 3 fields to all 7), and the contract-projected fields must equal the canonical contract's own projection.

## Why this is a guarantee and not another smoke alarm

The check was validated by injecting each failure mode and confirming rejection — it is not vacuous:

| injected defect | result |
|---|---|
| parallel authored table under a **different** name (`runtime.category`) | rejected |
| hand-authored string literal in a field | rejected |
| struct-update spread (`..SPEC_DEFAULT` shape) | rejected |
| second `BuiltinSpec` construction site | rejected |
| `doc.<field>` that does not exist in `GeneratedCoreWordDoc` | rejected |
| `*_from_contract` not defined in `contract.rs` | rejected |
| iterating a source other than `GENERATED_CORE_WORD_DOCS` | rejected |
| generated docs file losing its `@generated` banner | rejected |
| `BuiltinSpec` field declared but never assigned | rejected |

Run against the **pre-incident tree** (`1d6524d1`) — which compiled cleanly and passed clippy — the check rejects it with 10 errors. It would have blocked the authored table at #1406/#1407, before the collision could be constructed.

### Division of labour for this bug class

| how a parallel table is reintroduced | what rejects it |
|---|---|
| wired into the projection | **this check** |
| present but unused (dead code) | `clippy -D warnings` (verified: fails on `dead_code`) |
| references retired symbols | `cargo check` (this is what went red originally) |

The three together are complete. Notably, this check does **not** reject the exact broken merge ref `4c65a69f` — there the assembler was already clean and the stale modules were orphaned, which is `cargo check`'s job and which it did. That boundary is deliberate, not a gap.

## Quality Classification

- Highest impacted level: QL-B (CI enforcement; no runtime behaviour change)

## Traceability

- Requirement(s): `spec/words.json` is the single canonical source — `spec/words.json` -> generated contracts/docs -> `BuiltinSpec`. `BuiltinSpec` is a joined view for GUI/LOOKUP and owns no language facts.
- Verification evidence: 9 injected-defect rejections plus the historical-tree rejection above; full gate below.

| check | result |
|---|---|
| `npm run check:runtime-metadata` | pass (10 fields, 5 projections) |
| `cargo fmt --check` | pass |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test --all-targets` | 903 passed, 0 failed |
| `cargo check --features wasm --target wasm32-unknown-unknown` | pass |
| `rust/wasm-tests` build (`wasm32-unknown-unknown`) | pass |
| all 17 Quality Gate node steps | pass |

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`)
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not run locally; requires the nightly toolchain the Quality Gate installs.
- [x] MC/DC-like checklist reviewed for modified boolean logic — no runtime boolean logic changed; the new code is a build-time checker and two assertions.
- [x] Release checklist impact considered

## Notes

Not addressed here, because it is a repository setting rather than code: **"Require branches to be up to date before merging"** in branch protection. That is what makes a merge-ref CI result authoritative at merge time, and it is the remaining structural gap for the general "clean merge, broken tree" class. Worth enabling if you want the guarantee to extend beyond this one invariant.

---
_Generated by [Claude Code](https://claude.ai/code/session_012h63F94JkTJxeDynDiQ4C7)_