### PR TITLE
refactor(dictionary): return the dictionary to the two tiers the clause names

### DIFF
--- a/docs/dev/language-coherence-review-2026-08.md
+++ b/docs/dev/language-coherence-review-2026-08.md
@@ -454,6 +454,52 @@ Boolean ではない）。§4.1 が `AND`/`OR`/`NOT` と `extract_predicate_bool
 述べるので、長さ 2 と 1 の対は ERROR であるべきである（監査 D12）。本項目は比較族と
 単項語に限定したため未修正。
 
+### 4.10 辞書を二層に戻した（LANG.DICTIONARY.RESOLUTION）
+
+§5 の第 5 項。
+
+節は「辞書は二層を持つ。**Core** は 69 の正準 Word を保持し封印されている……**User** は
+`DEF` による定義を保持する」「**この二層が辞書のすべてである**——名前は Core か User の
+どちらかで解決する」と述べる。実装はそれ以上を持っていた:
+
+- `user_dictionaries`: 名前付きユーザー辞書の map
+- `active_user_dictionary`: `DEF` の書き込み先
+- `owning_dictionary_context`: 実行中の Word 自身の辞書を優先する文脈
+- `DICT@WORD` / `USER@D@WORD` / `DICT@USER@D@WORD` の修飾パス
+- bare name の三段フォールバックと、content identity による曖昧性判定
+- 辞書間の依存グラフ（`dictionary_dependencies`）
+
+**これらは言語から到達不能だった。** `active_user_dictionary` を変更する Word が存在せず、
+既定の `"EXAMPLE"` に固定される。したがってすべての `DEF` は同じ辞書に書き、`user_words`
+はその平坦な写しとして既に維持されていた。層は**観測手段のない構造**であり、節は二層と
+言っている。
+
+観測:
+
+```
+{ 1 ADD } 'INC' DEF 5 INC             => 6/1
+{ 1 ADD } 'INC' DEF 5 EXAMPLE@INC     => ERROR（修飾パスは名前ではない）
+{ 1 } 'ADD' DEF                       => ERROR（Core は封印）
+'EXAMPLE@INC' DEL                     => ERROR（DEL も名前を取る）
+```
+
+削除に伴い、解決キャッシュの文脈修飾も消えた。節が「解決は正規化された名前と現在の辞書の
+決定的関数」と述べるとおり、二層では文脈が変わりようがないので、名前ごとに答えは一つで
+キャッシュ項も一つである。`check_ambiguity` は常に空を返す——一つの User 層では名前は
+保持されているかいないかのどちらかで、曖昧になりようがない。
+
+`collect_dictionary_dependencies` の WASM export は空配列を返す形で残した。辞書**間**の
+依存は層が複数あることの帰結であり、二層では依存する相手がない。Word 間の依存は無関係で、
+DEF/DEL の保護をこれまでどおり駆動する。
+
+`DEL` には、削除した owner 探索の中にあった二つの検査を戻した——Core 封印の前に surface
+alias を正準化すること（`'+' DEL` は `ADD` の削除）と、User 層が保持しない名前に
+`wordNotFound` を返すことである。
+
+Reference の「Dictionaries and Word Identity」節も書き直した。監査 D17 が「削除済みの
+module system をまだ教えている」と指摘していた箇所で、`DICT@WORD`・四段の解決ラダー・
+`Ambiguous word 'GREET': found in EXAMPLE@GREET, AUDIOLIB@GREET` の例を載せていた。
+
 ## 5. 残作業と順序
 
 提案書 §9 の実施順序は採らない。全 Word の再実装を第 9 段、100% conformance を第 10 段に
@@ -465,8 +511,7 @@ Boolean ではない）。§4.1 が `AND`/`OR`/`NOT` と `extract_predicate_bool
 2. ~~**空 Vector の解禁。**~~ — 実施済み（§4.7）。
 3. ~~**`Value::eq` から `hint` を外す。**~~ — 実施済み（§4.6。1 の直接の帰結）。
 4. ~~**比較族のリフティングを LANG.COLLECTIONS.LIFT に合わせる。**~~ — 実施済み（§4.8）。
-5. **辞書を二層に戻す。** `resolve_word.rs` の `@` 名前空間・active/owner 辞書・
-   三段フォールバックの削除。LANG.DICTIONARY.RESOLUTION は二層のみを規定する。
+5. ~~**辞書を二層に戻す。**~~ — 実施済み（§4.10）。
 6. ~~**LANG.EFFECTS.OUTPUT の作用数を LANG.MACHINE.ORDER に合わせる**~~ — 実施済み（§4.5）。
 7. **Host Protocol の一本化。** V2 を正式採用するか V3 を定義し、V1 を adapter へ隔離。
 

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1613,10 +1613,8 @@ COND</code></td>
 
                 <section id="dictionaries" class="ref-page">
                     <h2>Dictionaries and Word Identity</h2>
-                    <p>User words live in a <strong>dictionary</strong>. The words you define in the Playground go into the bundled <code>EXAMPLE</code> dictionary, and an imported word group forms its own dictionary named after the group. A dictionary is simply a map from names to definitions; the same name may exist in more than one dictionary at once.</p>
-
-                    <h3>Qualified names</h3>
-                    <p>A bare name like <code>ADD10</code> is resolved for you (see below), but you can always name a word unambiguously by qualifying it with its dictionary: <code>DICT@WORD</code>. The qualified form bypasses resolution and points straight at one dictionary's entry.</p>
+                    <p>The dictionary has <strong>two tiers</strong>, and those two are the whole of it. <strong>Core</strong> holds the 69 canonical words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds everything you define with <code>DEF</code>.</p>
+                    <p>A name resolves in Core or in User, and User never shadows Core. A word&#39;s name is therefore its whole address — there is no qualified form, no dictionary to select, and no way for a bare name to be ambiguous. Names are case-insensitive, so <code>add10</code> and <code>ADD10</code> are the same word.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -1625,39 +1623,31 @@ COND</code></td>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>{ [ 10 ] + } 'ADD10' DEF
-5 EXAMPLE@ADD10</code></td>
-                                    <td><code>[ 15/1 ]</code></td>
-                                    <td class="notes">A word you define lives in <code>EXAMPLE</code>, so <code>EXAMPLE@ADD10</code> names the same word as the bare <code>ADD10</code>.</td>
+                                    <td><code>{ 10 ADD } &#39;ADD10&#39; DEF
+5 ADD10</code></td>
+                                    <td><code>15</code></td>
+                                    <td class="notes">A defined word is reached by its name.</td>
+                                </tr>
+                                <tr>
+                                    <td><code>{ 1 } &#39;ADD&#39; DEF</code></td>
+                                    <td>error</td>
+                                    <td class="notes">Core is sealed, so a Core name cannot be taken.</td>
+                                </tr>
+                                <tr>
+                                    <td><code>{ 10 ADD } &#39;ADD10&#39; DEF
+{ 20 ADD } &#39;ADD10&#39; DEF
+5 ADD10</code></td>
+                                    <td><code>25</code></td>
+                                    <td class="notes">A redefinition rebinds the one User entry — unless another word depends on it, which <code>DEF</code> refuses.</td>
                                 </tr>
                             </tbody>
                         </table>
                         </div>
-                        <div class="sample-actions">
-                            <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
-                        </div>
                     </div>
 
-                    <h3>Words are identified by content</h3>
-                    <p>Ajisai is <strong>content-addressed</strong>: a user word's identity is computed from its content — its normalized body together with the identities of the words it calls — not from its name. Renaming a word, or defining an identical body in another dictionary, produces the very same identity, while changing the body produces a new one. A word's name is a label for an identity, not the word itself.</p>
-                    <p>Two consequences follow directly. Defining the same body twice does not store it twice — identical definitions share one identity and deduplicate. And because each word's dependencies are pinned to the <em>identities</em> they referenced at definition time, defining a new word or loading another dictionary later can never silently recapture an existing reference.</p>
-
-                    <h3>Resolving a bare name</h3>
-                    <p>A bare name is looked up in a fixed order, and the first match wins:</p>
-                    <ol class="ref-list">
-                        <li>Core words (the built-ins) — they are never shadowed by anything you define.</li>
-                        <li>Words from modules you have imported.</li>
-                        <li>The dictionary that the currently running word belongs to (so an imported group calls its own words).</li>
-                        <li>Any other user dictionary.</li>
-                    </ol>
-                    <p>The last step is where a name can match several dictionaries at once, and here the content-addressed model decides the outcome. If every match is the <em>same word</em> — the matches share one content identity — the bare name resolves to it, exactly as before. If the matches are <em>different words</em> — they carry distinct identities — the bare name is <strong>ambiguous</strong> and does not resolve; Ajisai reports the conflict and asks you to qualify it:</p>
-                    <p class="ref-note">For example, if a <code>GREET</code> with one body exists in <code>EXAMPLE</code> and a different <code>GREET</code> exists in an imported <code>AUDIOLIB</code>, calling the bare <code>GREET</code> raises <code>Ambiguous word 'GREET': found in EXAMPLE@GREET, AUDIOLIB@GREET. Use a qualified path to specify which one you mean.</code> Writing <code>EXAMPLE@GREET</code> or <code>AUDIOLIB@GREET</code> resolves it. Ambiguity is about a difference in <em>content</em>, not merely a shared name — two dictionaries holding the identical word are not in conflict.</p>
-
-                    <h3>Importing word groups</h3>
-                    <p>You can export a word group, edit the file, rename it, and import it again. Import is a <strong>merge by identity</strong>, never a destructive overwrite. Identical definitions deduplicate automatically, so re-importing an unchanged group is a no-op. If you edited a word and import it under a name that already exists, the name is re-pointed to the new identity while the previous identity stays in place — any words that referenced the old version remain pinned to it, so nothing breaks. The bundled <code>EXAMPLE</code> dictionary is treated exactly like any other in this respect; there is no special name to protect.</p>
-                    <p class="ref-note">Because identity is content-addressed, an imported group behaves identically in every environment, regardless of which other dictionaries happen to be loaded.</p>
+                    <h3>Word identity</h3>
+                    <p>Every word has a <strong>content identity</strong>: a digest over its normalized definition and the identities of the words it calls. Two definitions with the same identity are the same word, whatever they are named, and changing a definition changes the identity of everything that depends on it. That is what makes <code>DEF</code> and <code>DEL</code> refuse to disturb a word something else still references — the dependency is on the word, not on the spelling.</p>
                 </section>
-
 
 
                 <section id="output" class="ref-page">

--- a/rust/src/interpreter/control_cond_tests.rs
+++ b/rust/src/interpreter/control_cond_tests.rs
@@ -130,10 +130,10 @@ mod example_words_tests {
         setup_example_words(&mut interp).await;
 
         // The dependency graph must record that GREET relies on each SAY word.
-        for dep in ["EXAMPLE@SAY-HELLO", "EXAMPLE@SAY-WORLD", "EXAMPLE@SAY-BANG"] {
+        for dep in ["SAY-HELLO", "SAY-WORLD", "SAY-BANG"] {
             let dependents = interp.dependents.get(dep);
             assert!(
-                dependents.is_some_and(|d| d.contains("EXAMPLE@GREET")),
+                dependents.is_some_and(|d| d.contains("GREET")),
                 "{} should be referenced by EXAMPLE@GREET; got {:?}",
                 dep,
                 dependents

--- a/rust/src/interpreter/dependents_index_tests.rs
+++ b/rust/src/interpreter/dependents_index_tests.rs
@@ -28,12 +28,12 @@ mod tests {
         interp.execute("{ A } 'B' DEF").await.unwrap();
 
         assert_eq!(
-            interp.collect_dependents("EXAMPLE@A"),
-            set(&["EXAMPLE@B"]),
+            interp.collect_dependents("A"),
+            set(&["B"]),
             "B references A, so A's dependents must be {{B}}"
         );
         assert!(
-            interp.collect_dependents("EXAMPLE@B").is_empty(),
+            interp.collect_dependents("B").is_empty(),
             "nothing references B, so B has no dependents"
         );
     }
@@ -48,22 +48,22 @@ mod tests {
         interp.execute("{ B } 'C' DEF").await.unwrap();
 
         assert_eq!(
-            interp.collect_dependents("EXAMPLE@A"),
-            set(&["EXAMPLE@B"]),
+            interp.collect_dependents("A"),
+            set(&["B"]),
             "direct dependents of A is just B"
         );
         assert_eq!(
-            interp.collect_transitive_dependents("EXAMPLE@A"),
-            set(&["EXAMPLE@B", "EXAMPLE@C"]),
+            interp.collect_transitive_dependents("A"),
+            set(&["B", "C"]),
             "transitive dependents of A reach C through B"
         );
         assert_eq!(
-            interp.collect_transitive_dependents("EXAMPLE@B"),
-            set(&["EXAMPLE@C"]),
+            interp.collect_transitive_dependents("B"),
+            set(&["C"]),
             "transitive dependents of B is just C"
         );
         assert!(
-            interp.collect_transitive_dependents("EXAMPLE@C").is_empty(),
+            interp.collect_transitive_dependents("C").is_empty(),
             "C is a leaf in the dependency chain"
         );
     }
@@ -77,8 +77,8 @@ mod tests {
         interp.execute("{ A } 'C' DEF").await.unwrap();
 
         assert_eq!(
-            interp.collect_dependents("EXAMPLE@A"),
-            set(&["EXAMPLE@B", "EXAMPLE@C"]),
+            interp.collect_dependents("A"),
+            set(&["B", "C"]),
             "both B and C reference A"
         );
     }
@@ -92,13 +92,13 @@ mod tests {
         let mut interp = Interpreter::new();
         interp.execute("{ [ 1 ] } 'A' DEF").await.unwrap();
         interp.execute("{ A } 'B' DEF").await.unwrap();
-        assert_eq!(interp.collect_dependents("EXAMPLE@A"), set(&["EXAMPLE@B"]));
+        assert_eq!(interp.collect_dependents("A"), set(&["B"]));
 
         // B no longer references A. B has no dependents, so no force is needed.
         interp.execute("{ [ 2 ] } 'B' DEF").await.unwrap();
 
         assert!(
-            interp.collect_dependents("EXAMPLE@A").is_empty(),
+            interp.collect_dependents("A").is_empty(),
             "after redefining B without A, A must have no dependents"
         );
     }
@@ -109,13 +109,13 @@ mod tests {
         let mut interp = Interpreter::new();
         interp.execute("{ [ 1 ] } 'A' DEF").await.unwrap();
         interp.execute("{ A } 'B' DEF").await.unwrap();
-        assert_eq!(interp.collect_dependents("EXAMPLE@A"), set(&["EXAMPLE@B"]));
+        assert_eq!(interp.collect_dependents("A"), set(&["B"]));
 
         // B is a leaf (nothing depends on it), so a plain DEL is allowed.
         interp.execute("'B' DEL").await.unwrap();
 
         assert!(
-            interp.collect_dependents("EXAMPLE@A").is_empty(),
+            interp.collect_dependents("A").is_empty(),
             "after deleting B, A must have no dependents"
         );
     }
@@ -128,13 +128,11 @@ mod tests {
         interp.execute("{ [ 1 ] } 'A' DEF").await.unwrap();
 
         assert!(
-            interp.collect_dependents("EXAMPLE@NOPE").is_empty(),
+            interp.collect_dependents("NOPE").is_empty(),
             "a name nothing references has no dependents"
         );
         assert!(
-            interp
-                .collect_transitive_dependents("EXAMPLE@NOPE")
-                .is_empty(),
+            interp.collect_transitive_dependents("NOPE").is_empty(),
             "an unreferenced name has no transitive dependents"
         );
     }

--- a/rust/src/interpreter/dictionary_operation_tests.rs
+++ b/rust/src/interpreter/dictionary_operation_tests.rs
@@ -47,51 +47,34 @@ mod tests {
         }
     }
 
-    /// Section 8.6: a word group imported into its own dictionary must be
-    /// self-referential. When the same names already exist in another dictionary
-    /// (e.g. the bundled Example Words), references inside the imported group
-    /// must bind to the group's own words for both dependency tracking and
-    /// execution — not to the earlier-loaded dictionary.
+    /// A redefinition rebinds the one User entry, and dependents follow it.
+    ///
+    /// This used to test that a word resolved its references through its *own*
+    /// dictionary, so two dictionaries could each hold a `SAY`/`GREET` pair
+    /// without their edges crossing. There is one User tier, so the second
+    /// definition of a name replaces the first and the dependency edge moves
+    /// with it.
     #[tokio::test]
-    async fn test_imported_dictionary_is_self_referential() {
+    async fn test_redefinition_rebinds_the_single_user_entry() {
         let mut interp = Interpreter::new();
 
-        // EXAMPLE dictionary: SAY pushes [ 1 ], GREET calls SAY.
         interp.execute("{ [ 1 ] } 'SAY' DEF").await.unwrap();
         interp.execute("{ SAY } 'GREET' DEF").await.unwrap();
-
-        // TEST dictionary duplicates the names; here SAY pushes [ 2 ].
-        interp.active_user_dictionary = "TEST".to_string();
-        interp.execute("{ [ 2 ] } 'SAY' DEF").await.unwrap();
-        interp.execute("{ SAY } 'GREET' DEF").await.unwrap();
-
         interp.rebuild_dependencies().unwrap();
 
-        // Dependency graph: TEST@GREET depends on TEST@SAY (not EXAMPLE@SAY),
-        // so TEST@SAY is shown as referenced rather than unreferenced.
-        let test_say_deps = interp.dependents.get("TEST@SAY");
         assert!(
-            test_say_deps.is_some_and(|d| d.contains("TEST@GREET")),
-            "TEST@SAY should be referenced by TEST@GREET; got {:?}",
-            test_say_deps
-        );
-        assert!(
-            !test_say_deps.is_some_and(|d| d.contains("EXAMPLE@GREET")),
-            "EXAMPLE@GREET must not depend on TEST@SAY"
-        );
-        let example_say_deps = interp.dependents.get("EXAMPLE@SAY");
-        assert!(
-            example_say_deps.is_some_and(|d| d.contains("EXAMPLE@GREET")),
-            "EXAMPLE@SAY should be referenced by EXAMPLE@GREET; got {:?}",
-            example_say_deps
+            interp
+                .dependents
+                .get("SAY")
+                .is_some_and(|d| d.contains("GREET")),
+            "GREET depends on SAY"
         );
 
-        // Execution: TEST@GREET runs TEST@SAY ([ 2 ]), not EXAMPLE@SAY ([ 1 ]).
-        interp.stack.clear();
-        interp.execute("TEST@GREET").await.unwrap();
-        let top = interp.stack.last().expect("result present");
-        let only = top.child(0).expect("vector has one child");
-        assert_eq!(only.as_scalar().unwrap().to_i64().unwrap(), 2);
+        interp.execute("GREET").await.unwrap();
+        assert_eq!(
+            format!("{}", interp.get_stack().last().expect("a result")),
+            "[ 1/1 ]"
+        );
     }
 
     /// Section 8.6: identical content yields one identity regardless of name or
@@ -99,16 +82,14 @@ mod tests {
     #[tokio::test]
     async fn test_identical_content_shares_identity() {
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "A".to_string();
         interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
-        interp.active_user_dictionary = "B".to_string();
         interp.execute("{ [ 1 ] } 'LEED' DEF").await.unwrap();
         interp.execute("{ [ 2 ] } 'OTHER' DEF").await.unwrap();
         interp.rebuild_dependencies().unwrap();
 
-        let a_leaf = interp.word_identity("A@LEAF").cloned();
-        let b_leed = interp.word_identity("B@LEED").cloned();
-        let b_other = interp.word_identity("B@OTHER").cloned();
+        let a_leaf = interp.word_identity("LEAF").cloned();
+        let b_leed = interp.word_identity("LEED").cloned();
+        let b_other = interp.word_identity("OTHER").cloned();
         assert!(a_leaf.is_some(), "identity should be computed");
         assert_eq!(a_leaf, b_leed, "identical bodies must share an identity");
         assert_ne!(a_leaf, b_other, "different bodies must differ");
@@ -120,16 +101,14 @@ mod tests {
     #[tokio::test]
     async fn test_identity_is_name_independent() {
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "A".to_string();
         interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
         interp.execute("{ LEAF } 'USE' DEF").await.unwrap();
-        interp.active_user_dictionary = "B".to_string();
         interp.execute("{ [ 1 ] } 'LEED' DEF").await.unwrap();
         interp.execute("{ LEED } 'USE' DEF").await.unwrap();
         interp.rebuild_dependencies().unwrap();
 
-        let a_use = interp.word_identity("A@USE").cloned();
-        let b_use = interp.word_identity("B@USE").cloned();
+        let a_use = interp.word_identity("USE").cloned();
+        let b_use = interp.word_identity("USE").cloned();
         assert!(a_use.is_some());
         assert_eq!(
             a_use, b_use,
@@ -143,18 +122,17 @@ mod tests {
     async fn test_recursive_identity_is_stable() {
         async fn rec_id() -> Option<String> {
             let mut interp = Interpreter::new();
-            interp.active_user_dictionary = "R".to_string();
             interp.execute("{ REC } 'REC' DEF").await.unwrap();
             interp.rebuild_dependencies().unwrap();
             // The self-reference must be recorded, then hashed as a cycle.
             assert!(
                 interp
                     .dependents
-                    .get("R@REC")
-                    .is_some_and(|d| d.contains("R@REC")),
+                    .get("REC")
+                    .is_some_and(|d| d.contains("REC")),
                 "recursive self-reference should be tracked"
             );
-            interp.word_identity("R@REC").cloned()
+            interp.word_identity("REC").cloned()
         }
 
         let first = rec_id().await;
@@ -169,17 +147,16 @@ mod tests {
     #[tokio::test]
     async fn test_unresolved_reference_identity_is_not_recaptured() {
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "A".to_string();
         interp.execute("{ MISSING } 'CALLER' DEF").await.unwrap();
         let before = interp
-            .word_identity("A@CALLER")
+            .word_identity("CALLER")
             .cloned()
             .expect("identity should be computed for caller");
 
         interp.execute("{ [ 1 ] } 'MISSING' DEF").await.unwrap();
 
         let after = interp
-            .word_identity("A@CALLER")
+            .word_identity("CALLER")
             .cloned()
             .expect("identity should remain computed for caller");
         assert_eq!(
@@ -189,27 +166,24 @@ mod tests {
         assert!(
             !interp
                 .dependents
-                .get("A@MISSING")
-                .is_some_and(|deps| deps.contains("A@CALLER")),
+                .get("MISSING")
+                .is_some_and(|deps| deps.contains("CALLER")),
             "the existing caller must not become dependent on the later word"
         );
     }
 
-    /// Section 8.6 content store: textually identical bodies defined under
-    /// different names/dictionaries share a single stored body in memory rather
-    /// than being duplicated.
+    /// Content store: textually identical bodies defined under different names
+    /// share a single stored body in memory rather than being duplicated.
     #[tokio::test]
     async fn test_identical_bodies_share_one_stored_body() {
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "A".to_string();
         interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
-        interp.active_user_dictionary = "B".to_string();
         interp.execute("{ [ 1 ] } 'TWIN' DEF").await.unwrap();
         interp.execute("{ [ 2 ] } 'OTHER' DEF").await.unwrap();
 
-        let a_leaf = interp.user_dictionaries["A"].words["LEAF"].lines.clone();
-        let b_twin = interp.user_dictionaries["B"].words["TWIN"].lines.clone();
-        let b_other = interp.user_dictionaries["B"].words["OTHER"].lines.clone();
+        let a_leaf = interp.user_words["LEAF"].lines.clone();
+        let b_twin = interp.user_words["TWIN"].lines.clone();
+        let b_other = interp.user_words["OTHER"].lines.clone();
 
         assert!(
             std::sync::Arc::ptr_eq(&a_leaf, &b_twin),
@@ -227,19 +201,18 @@ mod tests {
     #[tokio::test]
     async fn test_deferred_identity_recompute() {
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "A".to_string();
 
         interp.defer_identity_recompute = true;
         interp.execute("{ [ 1 ] } 'LEAF' DEF").await.unwrap();
         assert!(
-            interp.word_identity("A@LEAF").is_none(),
+            interp.word_identity("LEAF").is_none(),
             "identity recompute should be deferred"
         );
 
         interp.defer_identity_recompute = false;
         interp.rebuild_dependencies().unwrap();
         assert!(
-            interp.word_identity("A@LEAF").is_some(),
+            interp.word_identity("LEAF").is_some(),
             "identity should be computed once after the batch"
         );
     }
@@ -249,12 +222,10 @@ mod tests {
     #[tokio::test]
     async fn test_body_store_gc() {
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "A".to_string();
         interp.execute("{ [ 1 ] } 'X' DEF").await.unwrap();
         assert_eq!(interp.body_store.len(), 1);
 
         // Identical body in another dictionary shares one store entry.
-        interp.active_user_dictionary = "B".to_string();
         interp.execute("{ [ 1 ] } 'Y' DEF").await.unwrap();
         assert_eq!(
             interp.body_store.len(),
@@ -263,12 +234,10 @@ mod tests {
         );
 
         // Redefining A@X keeps [1] (still used by B@Y) and adds [9].
-        interp.active_user_dictionary = "A".to_string();
         interp.execute("{ [ 9 ] } 'X' DEF").await.unwrap();
         assert_eq!(interp.body_store.len(), 2, "shared [1] kept, [9] added");
 
         // Redefining B@Y away orphans [1]; it is reclaimed, leaving [9] and [8].
-        interp.active_user_dictionary = "B".to_string();
         interp.execute("{ [ 8 ] } 'Y' DEF").await.unwrap();
         assert_eq!(interp.body_store.len(), 2, "orphaned [1] reclaimed");
     }
@@ -405,47 +374,31 @@ mod tests {
         assert!(!interp.user_words.contains_key("C4"));
     }
 
+    /// A qualified path is not a name.
+    ///
+    /// `DEL` used to accept `DICT@WORD` and delete through the named
+    /// dictionary. LANG.DICTIONARY.RESOLUTION gives two tiers, so a Word's name
+    /// is its whole address and a path addresses nothing.
     #[tokio::test]
-    async fn test_del_sample_user_words_with_fqn() {
+    async fn test_del_rejects_a_qualified_path() {
         let mut interp = Interpreter::new();
 
-        let example_words = vec![
-            ("C4", "264", "純正律 C4"),
-            ("D4", "C4 9 * 8 /", "純正律 D4"),
-            ("E4", "C4 5 * 4 /", "純正律 E4"),
-        ];
+        let example_words = vec![("D4", "264", "test word")];
         restore_example_words(&mut interp, &example_words);
-
         assert!(interp.user_words.contains_key("D4"));
 
         let result = interp.execute("'EXAMPLE@D4' DEL").await;
+        assert!(result.is_err(), "a qualified path names nothing");
         assert!(
-            result.is_ok(),
-            "Should delete D4 via FQN: {:?}",
-            result.err()
-        );
-        assert!(!interp.user_words.contains_key("D4"));
-
-        let result = interp.execute("'EXAMPLE@NONEXISTENT' DEL").await;
-        assert!(result.is_err(), "Should error for non-existent FQN word");
-
-        let result = interp.execute("'EXAMPLE@C4' DEL").await;
-        assert!(
-            result.is_err(),
-            "Should not delete C4 via FQN (has dependents)"
+            interp.user_words.contains_key("D4"),
+            "the word is untouched"
         );
 
         interp
-            .execute("'EXAMPLE@E4' DEL")
+            .execute("'D4' DEL")
             .await
-            .expect("Should delete the remaining dependent E4");
-        let result = interp.execute("'EXAMPLE@C4' DEL").await;
-        assert!(
-            result.is_ok(),
-            "Should delete C4 via FQN once nothing depends on it: {:?}",
-            result.err()
-        );
-        assert!(!interp.user_words.contains_key("C4"));
+            .expect("its name deletes it");
+        assert!(!interp.user_words.contains_key("D4"));
     }
 
     #[tokio::test]

--- a/rust/src/interpreter/dictionary_resolution_tests.rs
+++ b/rust/src/interpreter/dictionary_resolution_tests.rs
@@ -1,238 +1,130 @@
-//! Test suite for `crate::interpreter::resolve_word`.
+//! Resolution laws for `crate::interpreter::resolve_word`.
+//!
+//! LANG.DICTIONARY.RESOLUTION: "The dictionary has two tiers. **Core** holds
+//! the 69 canonical Words and is sealed: a Core name cannot be redefined or
+//! deleted. **User** holds definitions made by `DEF`. Resolution is a
+//! deterministic function of the normalized name and the current dictionary,
+//! and User never shadows Core." And: "Those two tiers are the whole
+//! dictionary: a name resolves in Core or in User."
+//!
+//! This file used to test a different dictionary. It had named user
+//! dictionaries addressed by `DICT@WORD`, `USER@DICT@WORD` and
+//! `DICT@USER@DICT@WORD`; a bare name fell through three stages, and a name
+//! held by several dictionaries was collapsed by content identity or reported
+//! ambiguous. None of it was reachable from the language — no Word changes the
+//! active dictionary, so every `DEF` wrote to the same one — and the clause
+//! says there are two tiers. The laws below are what is left once there are.
 
 #[cfg(test)]
 mod tests {
     use crate::interpreter::Interpreter;
 
-    fn restore_example_words(interp: &mut Interpreter, example_words: &[(&str, &str, &str)]) {
-        use crate::tokenizer;
-
-        for (name, definition, _description) in example_words {
-            let tokens = tokenizer::tokenize(definition)
-                .unwrap_or_else(|e| panic!("Failed to tokenize {}: {}", name, e));
-
-            crate::interpreter::execute_def::op_def_inner(interp, name, &tokens)
-                .unwrap_or_else(|e| panic!("Failed to define {}: {}", name, e));
-        }
-
-        interp
-            .rebuild_dependencies()
-            .expect("Failed to rebuild dependencies");
+    fn define(interp: &mut Interpreter, name: &str, definition: &str) {
+        let tokens = crate::tokenizer::tokenize(definition)
+            .unwrap_or_else(|e| panic!("failed to tokenize {name}: {e}"));
+        crate::interpreter::execute_def::op_def_inner(interp, name, &tokens)
+            .unwrap_or_else(|e| panic!("failed to define {name}: {e}"));
     }
 
     #[tokio::test]
-    async fn test_path_short_name_no_collision() {
-        let mut interp = Interpreter::new();
-        let example_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
-        restore_example_words(&mut interp, &example_words);
-        let _ = interp.collect_output();
-
-        let result = interp.execute("SAY-HELLO-WORLD").await;
-        assert!(
-            result.is_ok(),
-            "Short name should resolve: {:?}",
-            result.err()
-        );
-        assert_eq!(interp.stack.len(), 1);
+    async fn a_core_name_resolves_to_core() {
+        let interp = Interpreter::new();
+        let (name, def) = interp
+            .resolve_word_entry_readonly("ADD")
+            .expect("ADD is a Core Word");
+        assert_eq!(name, "ADD");
+        assert!(def.is_builtin);
     }
 
     #[tokio::test]
-    async fn test_path_dict_at_word() {
+    async fn a_user_name_resolves_to_user_by_its_bare_name() {
         let mut interp = Interpreter::new();
-        let example_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
-        restore_example_words(&mut interp, &example_words);
-        let _ = interp.collect_output();
+        define(&mut interp, "INC", "1 ADD");
 
-        let result = interp.execute("EXAMPLE@SAY-HELLO-WORLD").await;
-        assert!(
-            result.is_ok(),
-            "EXAMPLE@SAY-HELLO-WORLD should resolve: {:?}",
-            result.err()
-        );
-        assert_eq!(interp.stack.len(), 1);
+        let (name, def) = interp
+            .resolve_word_entry_readonly("INC")
+            .expect("INC was defined");
+        assert_eq!(name, "INC", "a name is the whole address");
+        assert!(!def.is_builtin);
     }
 
     #[tokio::test]
-    async fn test_path_user_dict_word() {
+    async fn resolution_is_case_insensitive() {
         let mut interp = Interpreter::new();
-        let example_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
-        restore_example_words(&mut interp, &example_words);
-        let _ = interp.collect_output();
-
-        let result = interp.execute("USER@EXAMPLE@SAY-HELLO-WORLD").await;
-        assert!(
-            result.is_ok(),
-            "USER@EXAMPLE@SAY-HELLO-WORLD should resolve: {:?}",
-            result.err()
-        );
-        assert_eq!(interp.stack.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_path_fully_qualified_user() {
-        let mut interp = Interpreter::new();
-        let example_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
-        restore_example_words(&mut interp, &example_words);
-        let _ = interp.collect_output();
-
-        let result = interp.execute("DICT@USER@EXAMPLE@SAY-HELLO-WORLD").await;
-        assert!(
-            result.is_ok(),
-            "DICT@USER@EXAMPLE@SAY-HELLO-WORLD should resolve: {:?}",
-            result.err()
-        );
-        assert_eq!(interp.stack.len(), 1);
-    }
-    #[tokio::test]
-    async fn test_path_core_at_word() {
-        let mut interp = Interpreter::new();
-        interp.execute("[ 10 20 30 ]").await.unwrap();
-
-        let result = interp.execute("[ 1 ] CORE@GET").await;
-        assert!(
-            result.is_ok(),
-            "CORE@GET should resolve: {:?}",
-            result.err()
-        );
-    }
-
-    #[tokio::test]
-    async fn test_path_dict_core_word() {
-        let mut interp = Interpreter::new();
-        interp.execute("[ 10 20 30 ]").await.unwrap();
-
-        let result = interp.execute("[ 1 ] DICT@CORE@GET").await;
-        assert!(
-            result.is_ok(),
-            "DICT@CORE@GET should resolve: {:?}",
-            result.err()
-        );
-    }
-    #[tokio::test]
-    async fn test_path_case_insensitive_user() {
-        let mut interp = Interpreter::new();
-        let example_words = vec![("SAY-HELLO-WORLD", "[ 42 ]", "test word")];
-        restore_example_words(&mut interp, &example_words);
-        let _ = interp.collect_output();
-
-        let result = interp.execute("example@say-hello-world").await;
-        assert!(
-            result.is_ok(),
-            "example@say-hello-world should resolve: {:?}",
-            result.err()
-        );
-        assert_eq!(interp.stack.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_user_word_short_name_wins_without_music_sample_collision() {
-        let mut interp = Interpreter::new();
-        interp.execute("{ [ 999 ] } 'SEQ' DEF").await.unwrap();
-        let _ = interp.collect_output();
-
-        interp.execute("").await.unwrap();
-        let _ = interp.collect_output();
-
-        let result = interp.execute("SEQ").await;
-        assert!(
-            result.is_ok(),
-            "SEQ should resolve to the user word when MUSIC has no SEQ sample: {:?}",
-            result.err()
-        );
-        if let Some(val) = interp.stack.last() {
-            let scalar_owned = val
-                .as_scalar()
-                .cloned()
-                .or_else(|| val.child(0).and_then(|c| c.as_scalar().cloned()));
-            let scalar = scalar_owned.expect("SEQ should resolve to a numeric user word");
-            assert_eq!(scalar.to_i64().unwrap(), 999);
+        define(&mut interp, "INC", "1 ADD");
+        for spelling in ["INC", "inc", "Inc"] {
+            assert_eq!(
+                interp
+                    .resolve_word_entry_readonly(spelling)
+                    .map(|(n, _)| n)
+                    .as_deref(),
+                Some("INC"),
+                "{spelling} must normalize to INC"
+            );
         }
     }
-    /// Section 8.6 (content-first resolution): a bare name that matches several
-    /// user dictionaries with *identical content* is the same word, so it
-    /// resolves without an ambiguity error.
+
     #[tokio::test]
-    async fn test_cross_dictionary_same_content_resolves() {
+    async fn user_never_shadows_core() {
+        // The seal is enforced at definition time, so the shadowing case is
+        // unconstructible rather than merely losing the lookup.
         let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "XXX".to_string();
-        interp.execute("{ [ 42 ] } 'TEST' DEF").await.unwrap();
-        interp.active_user_dictionary = "YYY".to_string();
-        interp.execute("{ [ 42 ] } 'TEST' DEF").await.unwrap();
-        interp.rebuild_dependencies().unwrap();
-        let _ = interp.collect_output();
+        let tokens = crate::tokenizer::tokenize("1 ADD").expect("tokenize");
+        let result = crate::interpreter::execute_def::op_def_inner(&mut interp, "ADD", &tokens);
+        assert!(result.is_err(), "Core is sealed against redefinition");
 
-        interp.stack.clear();
-        let result = interp.execute("TEST").await;
-        assert!(
-            result.is_ok(),
-            "identical content across dictionaries must resolve without ambiguity: {:?}",
-            result.err()
-        );
-    }
-
-    /// Section 8.6 (content-first resolution): a bare name that matches several
-    /// user dictionaries with *divergent content* is a true ambiguity. It must
-    /// raise an error naming both qualified paths instead of silently picking
-    /// the oldest registration. The qualified paths still resolve.
-    #[tokio::test]
-    async fn test_cross_dictionary_divergent_content_is_ambiguous() {
-        let mut interp = Interpreter::new();
-        interp.active_user_dictionary = "XXX".to_string();
-        interp.execute("{ [ 1 ] } 'TEST' DEF").await.unwrap();
-        interp.active_user_dictionary = "YYY".to_string();
-        interp.execute("{ [ 2 ] } 'TEST' DEF").await.unwrap();
-        interp.rebuild_dependencies().unwrap();
-        let _ = interp.collect_output();
-
-        interp.stack.clear();
-        let result = interp.execute("TEST").await;
-        assert!(
-            result.is_err(),
-            "divergent content across dictionaries must be ambiguous"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("Ambiguous"),
-            "error should report ambiguity, got: {}",
-            msg
-        );
-        assert!(
-            msg.contains("XXX@TEST") && msg.contains("YYY@TEST"),
-            "error should list both qualified paths, got: {}",
-            msg
-        );
-
-        // Qualified paths disambiguate and resolve.
-        interp.stack.clear();
-        assert!(
-            interp.execute("XXX@TEST").await.is_ok(),
-            "qualified XXX@TEST should resolve"
-        );
-        interp.stack.clear();
-        assert!(
-            interp.execute("YYY@TEST").await.is_ok(),
-            "qualified YYY@TEST should resolve"
-        );
+        let (_, def) = interp.resolve_word_entry_readonly("ADD").expect("ADD");
+        assert!(def.is_builtin, "ADD still resolves to Core");
     }
 
     #[tokio::test]
-    async fn test_builtin_not_ambiguous() {
+    async fn a_qualified_path_is_not_a_name() {
+        // `DICT@WORD` addressed a tier that no longer exists. It is now just a
+        // name that nothing holds.
         let mut interp = Interpreter::new();
+        define(&mut interp, "INC", "1 ADD");
 
-        let result = interp.execute("[ 10 20 30 ] [ 0 ] GET").await;
-        assert!(
-            result.is_ok(),
-            "Built-in GET should always work: {:?}",
-            result.err()
-        );
+        for path in [
+            "EXAMPLE@INC",
+            "USER@EXAMPLE@INC",
+            "CORE@ADD",
+            "DICT@CORE@ADD",
+        ] {
+            assert!(
+                interp.resolve_word_entry_readonly(path).is_none(),
+                "{path} must not resolve"
+            );
+        }
     }
+
     #[tokio::test]
-    async fn test_unknown_qualified_name_does_not_resolve() {
+    async fn a_bare_name_is_never_ambiguous() {
+        // Ambiguity was a consequence of several dictionaries holding a name.
+        // With one User tier a name is held or it is not.
         let mut interp = Interpreter::new();
-        let result = interp.execute("JSON@PARSE").await;
-        assert!(
-            result.is_err(),
-            "A qualified name with no matching user dictionary word must not resolve"
+        define(&mut interp, "INC", "1 ADD");
+        assert!(interp.check_ambiguity("INC").is_empty());
+        assert!(interp.check_ambiguity("ADD").is_empty());
+        assert!(interp.check_ambiguity("NOPE").is_empty());
+    }
+
+    #[tokio::test]
+    async fn an_unknown_name_does_not_resolve() {
+        let interp = Interpreter::new();
+        assert!(interp.resolve_word_entry_readonly("NO-SUCH-WORD").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_redefinition_replaces_the_user_entry() {
+        let mut interp = Interpreter::new();
+        define(&mut interp, "INC", "1 ADD");
+        define(&mut interp, "INC", "2 ADD");
+
+        interp.execute("5 INC").await.expect("INC runs");
+        assert_eq!(
+            format!("{}", interp.get_stack().last().expect("a result")),
+            "7/1",
+            "the second definition is the one that resolves"
         );
     }
 }

--- a/rust/src/interpreter/dictionary_tier_tests.rs
+++ b/rust/src/interpreter/dictionary_tier_tests.rs
@@ -33,11 +33,7 @@ mod tests {
     async fn user_defined_word_is_contrib_tier() {
         let mut interp = Interpreter::new();
         interp.execute("{ 1 } 'X' DEF").await.unwrap();
-        let def = interp
-            .user_dictionaries
-            .get("EXAMPLE")
-            .and_then(|d| d.words.get("X"))
-            .unwrap();
+        let def = interp.user_words.get("X").unwrap();
         assert_eq!(def.tier, Tier::Contrib);
         assert_eq!(def.stability, Stability::Stable);
     }

--- a/rust/src/interpreter/execute_builtin.rs
+++ b/rust/src/interpreter/execute_builtin.rs
@@ -88,15 +88,6 @@ impl Interpreter {
         }
         self.call_depth += 1;
 
-        // Section 8.6: resolve this word's bare references through its own
-        // dictionary first, both while compiling its execution plan and while
-        // running its body. Saved and restored so nested calls into other
-        // dictionaries see their own dictionary's context.
-        let owning_dict = self
-            .split_qualified_name(&resolved_name)
-            .map(|(dict, _)| dict);
-        let prev_owning = std::mem::replace(&mut self.owning_dictionary_context, owning_dict);
-
         let plan_set = self.get_execution_plan_set(&resolved_name, &def);
 
         self.call_stack.push(resolved_name.clone());
@@ -150,7 +141,6 @@ impl Interpreter {
         self.tail_self_word = prev_tail_self;
 
         self.call_stack.pop();
-        self.owning_dictionary_context = prev_owning;
         self.call_depth -= 1;
         result
     }
@@ -423,16 +413,11 @@ impl Interpreter {
         resolved_name: &str,
         plan_set: std::sync::Arc<super::execution_plan_set::ExecutionPlanSet>,
     ) {
-        if let Some((ns, word)) = resolved_name.split_once('@') {
-            if let Some(dict) = self.user_dictionaries.get_mut(ns) {
-                if let Some(old_def) = dict.words.get(word).cloned() {
-                    let mut updated = (*old_def).clone();
-                    updated.execution_plans = Some(plan_set.clone());
-                    dict.words
-                        .insert(word.to_string(), std::sync::Arc::new(updated));
-                    self.sync_user_words_cache();
-                }
-            }
+        if let Some(old_def) = self.user_words.get(resolved_name).cloned() {
+            let mut updated = (*old_def).clone();
+            updated.execution_plans = Some(plan_set.clone());
+            self.user_words
+                .insert(resolved_name.to_string(), std::sync::Arc::new(updated));
         }
     }
 

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -85,15 +85,10 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         interp.output_buffer.push_str(&format!("{}\n", warning));
     }
 
-    let dict_name = interp.active_user_dictionary.clone();
-    let fq_name = format!("{}@{}", dict_name, upper_name);
-
-    if let Some(existing) = interp
-        .user_dictionaries
-        .get(&dict_name)
-        .and_then(|dict| dict.words.get(&upper_name))
-    {
-        let dependents = interp.collect_dependents(&fq_name);
+    // One User tier (LANG.DICTIONARY.RESOLUTION), so a Word's name is its
+    // whole address: no active dictionary to pick, no `DICT@WORD` to build.
+    if let Some(existing) = interp.user_words.get(&upper_name) {
+        let dependents = interp.collect_dependents(&upper_name);
 
         // A referenced word is not redefinable. There is no force modifier: the
         // vocabulary has no Word that overrides this, so the refusal is final
@@ -102,13 +97,13 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
             let dep_list = dependents.iter().cloned().collect::<Vec<_>>().join(", ");
             return Err(AjisaiError::from(format!(
                 "Cannot redefine '{}': referenced by {}. Delete those words first.",
-                fq_name, dep_list
+                upper_name, dep_list
             )));
         }
 
         for dep_name in &existing.dependencies {
             if let Some(dependents) = interp.dependents.get_mut(dep_name) {
-                dependents.remove(&fq_name);
+                dependents.remove(&upper_name);
             }
         }
     }
@@ -130,9 +125,6 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
     };
 
     // Section 8.6: resolve this word's references through its own dictionary
-    // first, so the dependency it records is its own dictionary's word rather
-    // than a same-named word in another (e.g. earlier-loaded) dictionary.
-    let prev_owning = interp.owning_dictionary_context.replace(dict_name.clone());
     let mut new_dependencies = HashSet::new();
     for line in lines.iter() {
         for token in line.body_tokens.iter() {
@@ -146,14 +138,13 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
             }
         }
     }
-    interp.owning_dictionary_context = prev_owning;
 
     for dep_name in &new_dependencies {
         interp
             .dependents
             .entry(dep_name.clone())
             .or_default()
-            .insert(fq_name.clone());
+            .insert(upper_name.clone());
     }
 
     let new_def = WordDefinition {
@@ -165,31 +156,19 @@ pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token
         description: None,
         dependencies: new_dependencies,
         original_source: None,
-        namespace: Some(dict_name.clone()),
+        namespace: None,
         registration_order: interp.next_registration_order(),
         execution_plans: None,
     };
 
-    let dict_order = interp
-        .user_dictionaries
-        .get(&dict_name)
-        .map(|dict| dict.order)
-        .unwrap_or_else(|| new_def.registration_order);
     interp
-        .user_dictionaries
-        .entry(dict_name.clone())
-        .or_insert_with(|| crate::interpreter::UserDictionary {
-            order: dict_order,
-            words: std::collections::HashMap::new(),
-        })
-        .words
+        .user_words
         .insert(upper_name.clone(), Arc::new(new_def));
-    interp.sync_user_words_cache();
     interp.recompute_word_identities();
     interp.gc_body_store();
     interp
         .output_buffer
-        .push_str(&format!("Defined word: {}@{}\n", dict_name, name));
+        .push_str(&format!("Defined word: {}\n", name));
 
     interp.bump_dictionary_epoch();
     Ok(())

--- a/rust/src/interpreter/execute_del.rs
+++ b/rust/src/interpreter/execute_del.rs
@@ -7,13 +7,12 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
 
     let name = extract_word_name_from_value(&val)?;
 
-    let upper_name = name.to_uppercase();
+    // Canonicalize first, so a surface alias reaches the same entry the
+    // Core seal protects (`'+' DEL` is a delete of `ADD`).
+    let upper_name =
+        crate::core_word_aliases::canonicalize_core_word_name(&name.to_uppercase()).into_owned();
 
-    let (target_dict, word_name) = if let Some((ns, w)) = interp.split_qualified_name(&upper_name) {
-        (Some(ns), w)
-    } else {
-        (None, upper_name.clone())
-    };
+    let word_name = upper_name.clone();
 
     if interp.core_vocabulary.contains_key(&word_name) {
         return Err(AjisaiError::BuiltinProtection {
@@ -22,21 +21,20 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         });
     }
 
-    if target_dict.is_none() && interp.user_dictionaries.contains_key(&word_name) {
-        interp.user_dictionaries.remove(&word_name);
-        interp.sync_user_words_cache();
-        interp.rebuild_dependencies()?;
-        interp
-            .output_buffer
-            .push_str(&format!("Deleted dictionary: {}\n", word_name));
-        interp.bump_dictionary_epoch();
-        return Ok(());
+    // A name that no User Word holds is `wordNotFound`. DEL used to reach this
+    // through a dictionary-owner search that also accepted `DICT@WORD`; with
+    // two tiers the name is the whole address, so the question is simply
+    // whether the User tier holds it.
+    if !interp.user_words.contains_key(&word_name) {
+        return Err(AjisaiError::from(format!(
+            "Word '{}' is not defined",
+            word_name
+        )));
     }
 
-    let owner_name = find_word_owner(interp, target_dict.as_deref(), &word_name)?;
-
-    let fq_name = format!("{}@{}", owner_name, word_name);
-    let dependents = interp.collect_dependents(&fq_name);
+    // DEL used to also delete a whole named dictionary when the name matched
+    // one. There are no named dictionaries to delete now.
+    let dependents = interp.collect_dependents(&word_name);
 
     // A referenced word is not deletable. There is no force modifier: the
     // vocabulary has no Word that overrides this, so the refusal is final and
@@ -49,58 +47,26 @@ pub fn op_del(interp: &mut Interpreter) -> Result<()> {
         )));
     }
 
-    let removed_def = interp
-        .user_dictionaries
-        .get_mut(&owner_name)
-        .and_then(|dict| dict.words.remove(&word_name));
+    let removed_def = interp.user_words.remove(&word_name);
 
     if let Some(removed_def) = removed_def {
-        interp.sync_user_words_cache();
         for dep_name in &removed_def.dependencies {
             if let Some(deps) = interp.dependents.get_mut(dep_name) {
-                deps.remove(&fq_name);
+                deps.remove(&upper_name);
             }
         }
-        interp.dependents.remove(&fq_name);
+        interp.dependents.remove(&upper_name);
         for deps in interp.dependents.values_mut() {
-            deps.remove(&fq_name);
+            deps.remove(&upper_name);
         }
     }
 
     interp
         .output_buffer
-        .push_str(&format!("Deleted word: {}\n", fq_name));
+        .push_str(&format!("Deleted word: {}\n", word_name));
 
     interp.recompute_word_identities();
     interp.gc_body_store();
     interp.bump_dictionary_epoch();
     Ok(())
-}
-
-fn find_word_owner(
-    interp: &Interpreter,
-    target_dict: Option<&str>,
-    word_name: &str,
-) -> Result<String> {
-    if let Some(dict_name) = target_dict {
-        if let Some(dict) = interp.user_dictionaries.get(dict_name) {
-            if dict.words.contains_key(word_name) {
-                return Ok(dict_name.to_string());
-            }
-        }
-        Err(AjisaiError::from(format!(
-            "Word '{}@{}' is not defined",
-            dict_name, word_name
-        )))
-    } else {
-        for (dict_name, dict) in &interp.user_dictionaries {
-            if dict.words.contains_key(word_name) {
-                return Ok(dict_name.clone());
-            }
-        }
-        Err(AjisaiError::from(format!(
-            "Word '{}' is not defined",
-            word_name
-        )))
-    }
 }

--- a/rust/src/interpreter/interpreter_core.rs
+++ b/rust/src/interpreter/interpreter_core.rs
@@ -59,18 +59,6 @@ pub enum ConsumptionMode {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct UserDictionary {
-    pub order: u64,
-    pub words: HashMap<String, Arc<WordDefinition>>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct DictionaryDependencyInfo {
-    pub depends_on: HashSet<String>,
-    pub depended_by: HashSet<String>,
-}
-
-#[derive(Debug, Clone)]
 pub struct ResolveCacheEntry {
     pub resolved_name: String,
     pub dictionary_epoch: u64,
@@ -141,7 +129,6 @@ pub struct Interpreter {
     pub(crate) stack: Stack,
     pub(crate) core_vocabulary: HashMap<String, Arc<WordDefinition>>,
     pub(crate) user_words: HashMap<String, Arc<WordDefinition>>,
-    pub(crate) user_dictionaries: HashMap<String, UserDictionary>,
     pub(crate) dependents: HashMap<String, HashSet<String>>,
     pub(crate) output_buffer: String,
     /// Structured, ordered host effects produced during execution. This is the
@@ -181,9 +168,7 @@ pub struct Interpreter {
     /// than running for minutes. Reset per top-level `execute`.
     pub(crate) numeric_work_used: u64,
 
-    pub(crate) dictionary_dependencies: HashMap<String, DictionaryDependencyInfo>,
     pub(crate) next_registration_order: u64,
-    pub(crate) active_user_dictionary: String,
 
     pub(crate) global_epoch: u64,
     pub(crate) dictionary_epoch: u64,
@@ -203,7 +188,6 @@ pub struct Interpreter {
     /// dictionary's words first (Section 8.6), so an imported word group is
     /// self-referential regardless of which other dictionaries are loaded.
     /// `None` at top level, where resolution falls back to the global order.
-    pub(crate) owning_dictionary_context: Option<String>,
 
     /// Content identity of each user word, keyed by fully-qualified name
     /// (Section 8.6). Derived state: recomputed whenever the user-word graph
@@ -296,7 +280,6 @@ impl Interpreter {
             stack: Stack::new(),
             core_vocabulary: HashMap::new(),
             user_words: HashMap::new(),
-            user_dictionaries: HashMap::new(),
             dependents: HashMap::new(),
             output_buffer: String::new(),
             host_effects: Vec::new(),
@@ -313,9 +296,7 @@ impl Interpreter {
             max_execution_steps: DEFAULT_MAX_EXECUTION_STEPS,
             runtime_limits: super::runtime_limits::RuntimeLimits::default(),
             numeric_work_used: 0,
-            dictionary_dependencies: HashMap::new(),
             next_registration_order: 1,
-            active_user_dictionary: "EXAMPLE".to_string(),
             global_epoch: 0,
             dictionary_epoch: 0,
             execution_epoch: 0,
@@ -326,7 +307,6 @@ impl Interpreter {
 
             // Elastic Engine
             resolve_cache: HashMap::new(),
-            owning_dictionary_context: None,
             word_identities: HashMap::new(),
             body_store: HashMap::new(),
             defer_identity_recompute: false,

--- a/rust/src/interpreter/resolve_cache.rs
+++ b/rust/src/interpreter/resolve_cache.rs
@@ -5,16 +5,16 @@ impl Interpreter {
         crate::core_word_aliases::canonicalize_core_word_name(name).into_owned()
     }
 
-    /// Cache key qualified by the active owning-dictionary context (Section 8.6).
-    /// A bare name can resolve to different targets depending on which
-    /// dictionary's word is currently executing, so the cache must not share an
-    /// entry across contexts.
+    /// The cache key is the name.
+    ///
+    /// It used to be qualified by the executing word's owning dictionary,
+    /// because a bare name could resolve to different targets depending on
+    /// which dictionary's word was running. LANG.DICTIONARY.RESOLUTION makes
+    /// resolution "a deterministic function of the normalized name and the
+    /// current dictionary" — with two tiers there is no context to vary, so a
+    /// name has one answer and one cache entry.
     fn contextual_resolve_cache_key(&self, name: &str) -> String {
-        let base = Self::make_resolve_cache_key(name);
-        match &self.owning_dictionary_context {
-            Some(ctx) => format!("{}\u{1}{}", ctx, base),
-            None => base,
-        }
+        Self::make_resolve_cache_key(name)
     }
 
     pub(crate) fn lookup_resolve_cache(&mut self, name: &str) -> Option<String> {

--- a/rust/src/interpreter/resolve_word.rs
+++ b/rust/src/interpreter/resolve_word.rs
@@ -1,170 +1,45 @@
 use crate::types::WordDefinition;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use super::Interpreter;
 
-/// Outcome of resolving a bare name against the user dictionaries (the final
-/// fallback stage of `resolve_short_name`). Section 8.6 makes user words
-/// content-addressed, so a bare name that matches several dictionaries is only
-/// ambiguous when those matches carry *distinct* content identities.
-pub(crate) enum UserBareOutcome {
-    /// No user dictionary holds the name.
-    None,
-    /// Every match collapses to a single content identity — the same word.
-    /// Carries the display fq-name (lowest `registration_order`) and its body.
-    Unique(String, Arc<WordDefinition>),
-    /// Two or more distinct content identities share the name — a true
-    /// ambiguity. Carries every matching fq-name for the diagnostic.
-    Ambiguous(Vec<String>),
-}
-
 impl Interpreter {
-    pub(crate) fn split_path(name: &str) -> (Vec<String>, String) {
-        let parts: Vec<String> = name.split('@').map(|s| s.to_uppercase()).collect();
-        if parts.len() == 1 {
-            (vec![], parts[0].clone())
-        } else {
-            let word = parts.last().unwrap().clone();
-            let layers = parts[..parts.len() - 1].to_vec();
-            (layers, word)
-        }
-    }
-
-    pub(crate) fn split_qualified_name(&self, name: &str) -> Option<(String, String)> {
-        let (layers, word) = Self::split_path(name);
-        if layers.len() == 1 {
-            Some((layers[0].clone(), word))
-        } else if layers.is_empty() {
-            None
-        } else {
-            Some((layers.last().unwrap().clone(), word))
-        }
-    }
-
-    // Consumed only by the wasm bindings (feature = "wasm"); present but unused
-    // in a default build, so the dead-code lint is allowed there only.
-    #[cfg_attr(not(feature = "wasm"), allow(dead_code))]
-    pub(crate) fn user_dictionary_names(&self) -> Vec<String> {
-        let mut names: Vec<_> = self.user_dictionaries.keys().cloned().collect();
-        names.sort();
-        names
-    }
-
-    #[cfg_attr(not(feature = "wasm"), allow(dead_code))]
-    pub(crate) fn user_dictionary_words(
-        &self,
-        dictionary_name: &str,
-    ) -> Vec<(String, Arc<WordDefinition>)> {
-        self.user_dictionaries
-            .get(&dictionary_name.to_uppercase())
-            .map(|dict| {
-                dict.words
-                    .iter()
-                    .map(|(name, def)| (name.clone(), def.clone()))
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
-    pub(crate) fn sync_user_words_cache(&mut self) {
-        self.user_words = self
-            .user_dictionaries
-            .get("EXAMPLE")
-            .map(|dict| dict.words.clone())
-            .unwrap_or_default();
-    }
-
+    /// Resolve a name against the dictionary LANG.DICTIONARY.RESOLUTION
+    /// describes: "The dictionary has two tiers. **Core** holds the 69
+    /// canonical Words and is sealed ... **User** holds definitions made by
+    /// `DEF`. Resolution is a deterministic function of the normalized name and
+    /// the current dictionary, and User never shadows Core." And: "Those two
+    /// tiers are the whole dictionary."
+    ///
+    /// It used to be more than two. A `user_dictionaries` map held named user
+    /// dictionaries; an `active_user_dictionary` decided which one `DEF` wrote
+    /// to; an `owning_dictionary_context` gave a word's own dictionary priority;
+    /// and a bare name fell through three stages, collapsing cross-dictionary
+    /// matches by content identity and reporting an `Ambiguous` outcome when
+    /// they disagreed. `DICT@WORD`, `USER@D@WORD` and `DICT@USER@D@WORD` paths
+    /// addressed those tiers.
+    ///
+    /// None of it was reachable from the language: no Word changes the active
+    /// dictionary, so every `DEF` wrote to the same one ("EXAMPLE"), and
+    /// `user_words` was already maintained as a flat mirror of it. The tiers
+    /// were structure without a way to observe them, and the clause says there
+    /// are two.
     pub(crate) fn resolve_short_name(&self, name: &str) -> Option<(String, Arc<WordDefinition>)> {
         let upper = name.to_uppercase();
 
+        // Core first: User never shadows Core.
         if let Some(def) = self.core_vocabulary.get(&upper) {
             return Some((upper, def.clone()));
         }
 
-        // Section 8.6: a bare name resolves through the owning dictionary's
-        // words before any other user dictionary, so an imported word group is
-        // self-referential regardless of which other dictionaries are loaded.
-        if let Some(owning) = &self.owning_dictionary_context {
-            if let Some(dict) = self.user_dictionaries.get(owning) {
-                if let Some(def) = dict.words.get(&upper) {
-                    return Some((format!("{}@{}", owning, upper), def.clone()));
-                }
-            }
-        }
-
-        // Final fallback: other user dictionaries. Section 8.6 — group matches
-        // by content identity so that a name shared across dictionaries resolves
-        // when (and only when) the matches are the same word.
-        match self.resolve_user_bare(&upper) {
-            UserBareOutcome::Unique(name, def) => Some((name, def)),
-            // A true ambiguity resolves to None here; the caller's error path
-            // (`check_ambiguity`) turns that into the "qualified path" diagnostic.
-            UserBareOutcome::Ambiguous(_) => None,
-            UserBareOutcome::None => None,
-        }
+        self.user_words.get(&upper).map(|def| (upper, def.clone()))
     }
 
-    /// Resolve a bare (already uppercased) name against the user dictionaries by
-    /// content identity. Shared by `resolve_short_name`'s final fallback and
-    /// `check_ambiguity` so the two never drift apart.
-    pub(crate) fn resolve_user_bare(&self, upper: &str) -> UserBareOutcome {
-        let mut matches: Vec<(String, Arc<WordDefinition>, u64)> = Vec::new();
-        for (dict_name, dict) in &self.user_dictionaries {
-            if let Some(def) = dict.words.get(upper) {
-                matches.push((
-                    format!("{}@{}", dict_name, upper),
-                    def.clone(),
-                    def.registration_order,
-                ));
-            }
-        }
-
-        if matches.is_empty() {
-            return UserBareOutcome::None;
-        }
-
-        // Stable display order: the earliest registration represents the group.
-        matches.sort_by_key(|(_, _, order)| *order);
-
-        // Collapse the matches by their content identity (Section 8.6).
-        let mut distinct: HashSet<String> = HashSet::new();
-        let mut any_missing_identity = false;
-        for (fq, _, _) in &matches {
-            match self.word_identity(fq) {
-                Some(id) => {
-                    distinct.insert(id.clone());
-                }
-                // Conservative fallback: a match without a computed identity
-                // (e.g. before a quiescent recompute) is not treated as
-                // divergent — we fall back to the historical earliest-registered
-                // representative rather than raise a spurious ambiguity. At
-                // quiescent points identities are fresh, so this is not hit in
-                // practice.
-                None => any_missing_identity = true,
-            }
-        }
-
-        if any_missing_identity || distinct.len() <= 1 {
-            let (name, def, _) = matches.into_iter().next().unwrap();
-            return UserBareOutcome::Unique(name, def);
-        }
-
-        UserBareOutcome::Ambiguous(matches.into_iter().map(|(fq, _, _)| fq).collect())
-    }
-
-    pub(crate) fn check_ambiguity(&self, name: &str) -> Vec<String> {
-        let upper = name.to_uppercase();
-
-        // Core words win the bare-name ladder and are never ambiguous.
-        if self.core_vocabulary.contains_key(&upper) {
-            return vec![];
-        }
-
-        match self.resolve_user_bare(&upper) {
-            UserBareOutcome::Ambiguous(paths) => paths,
-            UserBareOutcome::Unique(..) | UserBareOutcome::None => vec![],
-        }
+    /// A bare name is never ambiguous: there is one User tier, so a name is in
+    /// it or it is not. Retained as the single place the answer is stated.
+    pub(crate) fn check_ambiguity(&self, _name: &str) -> Vec<String> {
+        vec![]
     }
 
     pub(crate) fn resolve_word_entry_readonly(
@@ -172,60 +47,7 @@ impl Interpreter {
         name: &str,
     ) -> Option<(String, Arc<WordDefinition>)> {
         let canonical_name = crate::core_word_aliases::canonicalize_core_word_name(name);
-        let name = canonical_name.as_ref();
-        let (layers, word) = Self::split_path(name);
-
-        match layers.len() {
-            0 => self.resolve_short_name(name),
-            1 => {
-                let ns = &layers[0];
-                if ns == "CORE" {
-                    return self
-                        .core_vocabulary
-                        .get(&word)
-                        .cloned()
-                        .map(|def| (word.clone(), def));
-                }
-                if let Some(user_dict) = self.user_dictionaries.get(ns.as_str()) {
-                    if let Some(def) = user_dict.words.get(&word) {
-                        return Some((format!("{}@{}", ns, word), def.clone()));
-                    }
-                }
-                None
-            }
-            2 => {
-                let first = &layers[0];
-                let second = &layers[1];
-                if first == "USER" {
-                    if let Some(user_dict) = self.user_dictionaries.get(second.as_str()) {
-                        if let Some(def) = user_dict.words.get(&word) {
-                            return Some((format!("{}@{}", second, word), def.clone()));
-                        }
-                    }
-                } else if first == "DICT" && second == "CORE" {
-                    return self
-                        .core_vocabulary
-                        .get(&word)
-                        .cloned()
-                        .map(|def| (word.clone(), def));
-                }
-                None
-            }
-            3 => {
-                let first = &layers[0];
-                let second = &layers[1];
-                let third = &layers[2];
-                if first == "DICT" && second == "USER" {
-                    if let Some(user_dict) = self.user_dictionaries.get(third.as_str()) {
-                        if let Some(def) = user_dict.words.get(&word) {
-                            return Some((format!("{}@{}", third, word), def.clone()));
-                        }
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
+        self.resolve_short_name(canonical_name.as_ref())
     }
 
     pub(crate) fn resolve_word_entry(
@@ -235,18 +57,11 @@ impl Interpreter {
         let canonical_name = crate::core_word_aliases::canonicalize_core_word_name(name);
         let name = canonical_name.as_ref();
         if let Some(cached_name) = self.lookup_resolve_cache(name) {
-            let (layers, word) = Self::split_path(&cached_name);
-            if layers.is_empty() {
-                if let Some(def) = self.core_vocabulary.get(&word).cloned() {
-                    return Some((word, def));
-                }
-            } else if layers.len() == 1 {
-                let ns = &layers[0];
-                if let Some(dict) = self.user_dictionaries.get(ns.as_str()) {
-                    if let Some(def) = dict.words.get(&word).cloned() {
-                        return Some((format!("{}@{}", ns, word), def));
-                    }
-                }
+            if let Some(def) = self.core_vocabulary.get(&cached_name).cloned() {
+                return Some((cached_name, def));
+            }
+            if let Some(def) = self.user_words.get(&cached_name).cloned() {
+                return Some((cached_name, def));
             }
         }
 
@@ -275,24 +90,14 @@ impl Interpreter {
         self.bump_dictionary_epoch();
 
         self.dependents.clear();
-        self.dictionary_dependencies.clear();
 
-        let mut all_words: Vec<(String, Arc<WordDefinition>)> = Vec::new();
-
-        for (dict_name, dict) in &self.user_dictionaries {
-            for (name, def) in &dict.words {
-                all_words.push((format!("{}@{}", dict_name, name), Arc::clone(def)));
-            }
-        }
-
-        let mut dictionary_edges: HashMap<String, HashSet<String>> = HashMap::new();
+        let all_words: Vec<(String, Arc<WordDefinition>)> = self
+            .user_words
+            .iter()
+            .map(|(name, def)| (name.clone(), Arc::clone(def)))
+            .collect();
 
         for (word_name, word_def) in &all_words {
-            // Section 8.6: scan each word's references through its own dictionary
-            // first, so dependents are recorded against the word's own
-            // dictionary rather than a same-named word elsewhere.
-            self.owning_dictionary_context =
-                self.split_qualified_name(word_name).map(|(dict, _)| dict);
             let mut dependencies = HashSet::new();
             for line in word_def.lines.iter() {
                 for token in line.body_tokens.iter() {
@@ -301,7 +106,9 @@ impl Interpreter {
                         if let Some((resolved_name, resolved_def)) =
                             self.resolve_word_entry(&upper_s)
                         {
-                            if !resolved_def.is_builtin || resolved_name.contains('@') {
+                            // Only User Words are dependencies: Core is sealed,
+                            // so nothing can invalidate a reference to it.
+                            if !resolved_def.is_builtin {
                                 dependencies.insert(resolved_name.clone());
                                 self.dependents
                                     .entry(resolved_name)
@@ -312,46 +119,11 @@ impl Interpreter {
                     }
                 }
             }
-            if let Some((dict_name, short_name)) = self.split_qualified_name(word_name) {
-                if let Some(dict) = self.user_dictionaries.get_mut(&dict_name) {
-                    if let Some(def) = dict.words.get_mut(&short_name) {
-                        Arc::make_mut(def).dependencies = dependencies.clone();
-                    }
-                }
-                let edge_set = dictionary_edges.entry(dict_name.clone()).or_default();
-                for dep in &dependencies {
-                    if let Some((dep_dict, _)) = self.split_qualified_name(dep) {
-                        if dep_dict != dict_name {
-                            edge_set.insert(dep_dict);
-                        }
-                    }
-                }
+            if let Some(def) = self.user_words.get_mut(word_name) {
+                Arc::make_mut(def).dependencies = dependencies;
             }
         }
 
-        self.owning_dictionary_context = None;
-
-        for dict in self.user_dictionaries.keys() {
-            self.dictionary_dependencies
-                .entry(dict.clone())
-                .or_default();
-        }
-        for (from, tos) in dictionary_edges {
-            for to in tos {
-                self.dictionary_dependencies
-                    .entry(from.clone())
-                    .or_default()
-                    .depends_on
-                    .insert(to.clone());
-                self.dictionary_dependencies
-                    .entry(to)
-                    .or_default()
-                    .depended_by
-                    .insert(from.clone());
-            }
-        }
-
-        self.sync_user_words_cache();
         self.recompute_word_identities();
         self.gc_body_store();
         Ok(())
@@ -389,11 +161,9 @@ impl Interpreter {
     /// path.
     fn collect_dependents_by_scan(&self, word_name: &str) -> HashSet<String> {
         let mut result = HashSet::new();
-        for (dict_name, dict) in &self.user_dictionaries {
-            for (name, def) in &dict.words {
-                if def.dependencies.contains(word_name) {
-                    result.insert(format!("{}@{}", dict_name, name));
-                }
+        for (name, def) in &self.user_words {
+            if def.dependencies.contains(word_name) {
+                result.insert(name.clone());
             }
         }
         result

--- a/rust/src/interpreter/session_lifecycle.rs
+++ b/rust/src/interpreter/session_lifecycle.rs
@@ -26,7 +26,6 @@ impl Interpreter {
         self.stack.clear();
         self.core_vocabulary.clear();
         self.user_words.clear();
-        self.user_dictionaries.clear();
         self.dependents.clear();
         self.output_buffer.clear();
         self.host_effects.clear();
@@ -42,13 +41,10 @@ impl Interpreter {
         self.tail_jump_pending = false;
         // `cond_dispatch_enabled` is a configuration flag, not run state, so it
         // is intentionally not reset here.
-        self.owning_dictionary_context = None;
         self.word_identities.clear();
         self.body_store.clear();
         self.defer_identity_recompute = false;
-        self.dictionary_dependencies.clear();
         self.next_registration_order = 1;
-        self.active_user_dictionary = "EXAMPLE".to_string();
         // Top-level roles live on the stack now and were cleared with it above
         // (`self.stack.clear()`); the registry keeps only value-id-keyed flow
         // state, which session reset leaves untouched, as before.

--- a/rust/src/interpreter/word_identity.rs
+++ b/rust/src/interpreter/word_identity.rs
@@ -298,33 +298,26 @@ impl Interpreter {
             return;
         }
 
-        // 1. Snapshot all user words: (fully-qualified name, dictionary, def).
-        let mut words: Vec<(String, String, Arc<WordDefinition>)> = Vec::new();
-        for (dict_name, dict) in &self.user_dictionaries {
-            for (name, def) in &dict.words {
-                words.push((
-                    format!("{}@{}", dict_name, name),
-                    dict_name.clone(),
-                    def.clone(),
-                ));
-            }
-        }
-        let user_set: HashSet<String> = words.iter().map(|(fq, _, _)| fq.clone()).collect();
+        // 1. Snapshot all user words. One User tier, so a name is the whole
+        //    address and there is no dictionary to carry alongside it.
+        let words: Vec<(String, Arc<WordDefinition>)> = self
+            .user_words
+            .iter()
+            .map(|(name, def)| (name.clone(), def.clone()))
+            .collect();
+        let user_set: HashSet<String> = words.iter().map(|(name, _)| name.clone()).collect();
         let reg_order: HashMap<String, u64> = words
             .iter()
-            .map(|(fq, _, def)| (fq.clone(), def.registration_order))
+            .map(|(name, def)| (name.clone(), def.registration_order))
             .collect();
 
         // 2. Canonical shape of each body; references to other user words are
-        //    captured as Atom::Ref and resolved through the owning dictionary.
-        let prev_ctx = self.owning_dictionary_context.take();
+        //    captured as Atom::Ref.
         let mut shapes: HashMap<String, Vec<Atom>> = HashMap::new();
-        for (fq, dict, def) in &words {
-            self.owning_dictionary_context = Some(dict.clone());
+        for (name, def) in &words {
             let atoms = self.build_word_shape(def, &user_set);
-            shapes.insert(fq.clone(), atoms);
+            shapes.insert(name.clone(), atoms);
         }
-        self.owning_dictionary_context = prev_ctx;
 
         // 3. Dependency graph restricted to user words.
         let mut adj: HashMap<String, Vec<String>> = HashMap::new();

--- a/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
+++ b/rust/src/wasm_interpreter_bindings/wasm_interpreter_state.rs
@@ -69,22 +69,23 @@ impl AjisaiInterpreter {
     pub fn collect_user_words_info(&self) -> JsValue {
         let js_array = js_sys::Array::new();
 
-        for dict_name in self.interpreter.user_dictionary_names() {
-            for (name, _def) in self.interpreter.user_dictionary_words(&dict_name) {
-                let fq_name = format!("{}@{}", dict_name, name);
-                let is_protected = self
-                    .interpreter
-                    .dependents
-                    .get(&fq_name)
-                    .is_some_and(|deps| !deps.is_empty());
+        let mut names: Vec<&String> = self.interpreter.user_words.keys().collect();
+        names.sort();
+        for name in names {
+            let is_protected = self
+                .interpreter
+                .dependents
+                .get(name)
+                .is_some_and(|deps| !deps.is_empty());
 
-                let item = js_sys::Array::new();
-                item.push(&dict_name.clone().into());
-                item.push(&name.clone().into());
-                item.push(&is_protected.into());
+            let item = js_sys::Array::new();
+            // The dictionary slot stays in the shape for the host, which reads
+            // a fixed triple; there is one User tier, so it is constant.
+            item.push(&"USER".into());
+            item.push(&name.clone().into());
+            item.push(&is_protected.into());
 
-                js_array.push(&item);
-            }
+            js_array.push(&item);
         }
 
         js_array.into()
@@ -96,15 +97,14 @@ impl AjisaiInterpreter {
     #[wasm_bindgen]
     pub fn collect_word_identities(&self) -> JsValue {
         let js_array = js_sys::Array::new();
-        for dict_name in self.interpreter.user_dictionary_names() {
-            for (name, _def) in self.interpreter.user_dictionary_words(&dict_name) {
-                let fq_name = format!("{}@{}", dict_name, name);
-                if let Some(id) = self.interpreter.word_identity(&fq_name) {
-                    let item = js_sys::Array::new();
-                    item.push(&fq_name.clone().into());
-                    item.push(&id.clone().into());
-                    js_array.push(&item);
-                }
+        let mut names: Vec<&String> = self.interpreter.user_words.keys().collect();
+        names.sort();
+        for name in names {
+            if let Some(id) = self.interpreter.word_identity(name) {
+                let item = js_sys::Array::new();
+                item.push(&name.clone().into());
+                item.push(&id.clone().into());
+                js_array.push(&item);
             }
         }
         js_array.into()
@@ -115,21 +115,16 @@ impl AjisaiInterpreter {
     }
 
     pub(crate) fn collect_user_words_for_state(&self) -> JsValue {
-        let words_info: Vec<UserWordData> = self
-            .interpreter
-            .user_dictionary_names()
+        let mut names: Vec<String> = self.interpreter.user_words.keys().cloned().collect();
+        names.sort();
+        let words_info: Vec<UserWordData> = names
             .into_iter()
-            .flat_map(|dict_name| {
-                self.interpreter
-                    .user_dictionary_words(&dict_name)
-                    .into_iter()
-                    .map(move |(name, _def)| UserWordData {
-                        dictionary: Some(dict_name.clone()),
-                        name: name.clone(),
-                        definition: self
-                            .interpreter
-                            .lookup_word_definition_tokens(&format!("{}@{}", dict_name, name)),
-                    })
+            .map(|name| UserWordData {
+                // Kept in the serialized shape for older snapshots to decode
+                // against; there is one User tier, so it no longer selects.
+                dictionary: None,
+                definition: self.interpreter.lookup_word_definition_tokens(&name),
+                name,
             })
             .collect();
         to_value(&words_info).unwrap_or(JsValue::NULL)
@@ -217,26 +212,14 @@ impl AjisaiInterpreter {
     }
 
     #[wasm_bindgen]
+    /// Always empty. Dependencies between *named dictionaries* were a
+    /// consequence of there being more than one user tier; LANG.DICTIONARY.
+    /// RESOLUTION gives two tiers, so there is nothing for a dictionary to
+    /// depend on. Word-level dependencies are unaffected and still drive
+    /// DEF/DEL protection. The export is kept so the generated binding surface
+    /// does not change under callers.
     pub fn collect_dictionary_dependencies(&self) -> JsValue {
-        let arr = js_sys::Array::new();
-        for (dict_name, dep) in &self.interpreter.dictionary_dependencies {
-            let item = js_sys::Array::new();
-            item.push(&JsValue::from_str(dict_name));
-
-            let depends_on = js_sys::Array::new();
-            for name in &dep.depends_on {
-                depends_on.push(&JsValue::from_str(name));
-            }
-            item.push(&depends_on.into());
-
-            let depended_by = js_sys::Array::new();
-            for name in &dep.depended_by {
-                depended_by.push(&JsValue::from_str(name));
-            }
-            item.push(&depended_by.into());
-            arr.push(&item);
-        }
-        arr.into()
+        js_sys::Array::new().into()
     }
 
     #[wasm_bindgen]
@@ -254,19 +237,8 @@ impl AjisaiInterpreter {
     #[wasm_bindgen]
     pub fn remove_word(&mut self, name: &str) {
         let upper_name = name.to_uppercase();
-        if let Some((dict_name, short_name)) = self.interpreter.split_qualified_name(&upper_name) {
-            if let Some(dict) = self.interpreter.user_dictionaries.get_mut(&dict_name) {
-                dict.words.remove(&short_name);
-            }
+        if self.interpreter.user_words.remove(&upper_name).is_some() {
             let _ = self.interpreter.rebuild_dependencies();
-            return;
-        }
-
-        for dict in self.interpreter.user_dictionaries.values_mut() {
-            if dict.words.remove(&upper_name).is_some() {
-                let _ = self.interpreter.rebuild_dependencies();
-                return;
-            }
         }
     }
 
@@ -466,11 +438,9 @@ impl AjisaiInterpreter {
 
     fn define_restored_words(&mut self, words: Vec<UserWordData>) -> Result<(), String> {
         for word in words {
-            self.interpreter.active_user_dictionary = word
-                .dictionary
-                .clone()
-                .unwrap_or_else(|| "EXAMPLE".to_string())
-                .to_uppercase();
+            // A restored word's saved `dictionary` label is legacy state: the
+            // dictionary has two tiers and User is one of them, so every
+            // restored definition lands in the same place.
             let definition = match &word.definition {
                 Some(def) if !def.is_empty() => def.clone(),
                 _ => continue,

--- a/tests/conformance/index.html
+++ b/tests/conformance/index.html
@@ -1681,6 +1681,48 @@
      a Tier 0/1 operand still decides regardless of budget. MATH@ENCLOSE
      observes a rational enclosure under an explicit water budget. -->
 
+<!-- ===================== CORE: the two-tier dictionary ===================== -->
+<!-- LANG.DICTIONARY.RESOLUTION: "The dictionary has two tiers ... Those two
+     tiers are the whole dictionary: a name resolves in Core or in User."
+
+     The implementation had more: named user dictionaries addressed by
+     `DICT@WORD`, `USER@DICT@WORD` and `DICT@USER@DICT@WORD`, an active
+     dictionary that `DEF` wrote to, an owning-dictionary context that gave a
+     word's own dictionary priority, and a three-stage bare-name fallback that
+     could report a name ambiguous. None of it was reachable from the language,
+     because no Word changes the active dictionary. -->
+
+<section class="ajisai-case" id="core-dict-name-is-the-whole-address" data-category="core">
+  <h3>A Word's name is its whole address</h3>
+  <pre class="ajisai-source">{ 1 ADD } 'INC' DEF 5 INC</pre>
+  <pre class="ajisai-expect-result">6/1</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-dict-qualified-path-is-not-a-name" data-category="core">
+  <h3>A qualified path addresses no tier</h3>
+  <pre class="ajisai-source">{ 1 ADD } 'INC' DEF 5 EXAMPLE@INC</pre>
+  <pre class="ajisai-expect-result"></pre>
+  <pre class="ajisai-expect-error">Unknown word: EXAMPLE@INC</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-dict-user-never-shadows-core" data-category="core">
+  <h3>User never shadows Core: the seal refuses the definition outright</h3>
+  <pre class="ajisai-source">{ 1 } 'ADD' DEF</pre>
+  <pre class="ajisai-expect-result"></pre>
+  <pre class="ajisai-expect-error">ADD</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
+<section class="ajisai-case" id="core-dict-del-rejects-qualified-path" data-category="core">
+  <h3>DEL takes a name, not a path</h3>
+  <pre class="ajisai-source">{ 1 ADD } 'INC' DEF 'EXAMPLE@INC' DEL</pre>
+  <pre class="ajisai-expect-result"></pre>
+  <pre class="ajisai-expect-error">is not defined</pre>
+  <div class="ajisai-expect-effects"></div>
+</section>
+
 <!-- ===================== CORE: element lifting ===================== -->
 <!-- LANG.COLLECTIONS.LIFT: "An arithmetic or comparison Word applies
      element-wise when given vectors. Two vectors combine element-wise when


### PR DESCRIPTION
## Summary

Item 5 of the convergence plan in `docs/dev/language-coherence-review-2026-08.md` §5.

> **Stacked on #1417** (comparison lifting), which is itself stacked on #1416. Base is `claude/ajisai-comparison-lift`; it retargets as those merge.

LANG.DICTIONARY.RESOLUTION:

> The dictionary has two tiers. **Core** holds the 69 canonical Words and is sealed … **User** holds definitions made by `DEF`. … Those two tiers are the whole dictionary: a name resolves in Core or in User.

The implementation had more than two:

- `user_dictionaries` — a map of *named* user dictionaries
- `active_user_dictionary` — which one `DEF` wrote to
- `owning_dictionary_context` — an executing word's own dictionary, given priority
- `DICT@WORD`, `USER@D@WORD`, `DICT@USER@D@WORD` — paths addressing them
- a three-stage bare-name fallback that collapsed cross-dictionary matches by content identity and reported an **ambiguity** when they disagreed
- `dictionary_dependencies` — a dependency graph *between dictionaries*

**None of it was reachable from the language.** No Word changes the active dictionary, so every `DEF` wrote to the same one (`"EXAMPLE"`), and `user_words` was already maintained as a flat mirror of it. The tiers were structure with no way to observe them — and the clause says there are two.

```
{ 1 ADD } 'INC' DEF 5 INC          =>  6/1
{ 1 ADD } 'INC' DEF 5 EXAMPLE@INC  =>  ERROR   (a path names nothing)
{ 1 } 'ADD' DEF                    =>  ERROR   (Core is sealed)
'EXAMPLE@INC' DEL                  =>  ERROR   (DEL takes a name too)
```

## What follows from having two

- **The resolve cache loses its context qualifier.** The clause calls resolution "a deterministic function of the normalized name and the current dictionary"; with two tiers there is nothing to vary, so a name has one answer and one cache entry.
- **`check_ambiguity` always answers empty.** Ambiguity was a consequence of several dictionaries holding a name. One User tier holds a name or does not.
- **`collect_dictionary_dependencies` returns an empty array**, kept as an export so the generated binding surface is unchanged. Dependencies *between dictionaries* were a consequence of there being several. Word-level dependencies are untouched and still drive `DEF`/`DEL` protection.

## DEL

Two checks lived inside the removed owner search and are restored explicitly: it canonicalizes a surface alias before the Core seal (`'+' DEL` is a delete of `ADD`), and it reports `wordNotFound` for a name the User tier does not hold. Both are covered by tests that caught their absence.

## Reference

The "Dictionaries and Word Identity" section is rewritten. It was teaching `DICT@WORD`, a four-step resolution ladder, and an `Ambiguous word 'GREET': found in EXAMPLE@GREET, AUDIOLIB@GREET` example — the surface the audit's **D17** flagged as still describing a deleted module system. The section now states the two tiers, that a name is a word's whole address, and keeps the content-identity paragraph, which is what actually explains why `DEF`/`DEL` refuse to disturb a referenced word.

`dictionary_resolution_tests.rs` is rewritten in the same spirit: every test in it addressed a tier that no longer exists, so it becomes a set of two-tier laws (Core resolves, User resolves by bare name, case-insensitivity, User never shadows Core, a path is not a name, no bare name is ambiguous, redefinition rebinds).

## Conformance

Corpus 228 → 232 cases; Core coverage stays 69/69 (100.0%).

## Quality Classification

- Highest impacted level: **QL-A** (name resolution)

## Traceability

- Requirement(s): LANG.DICTIONARY.RESOLUTION (two tiers; deterministic lookup; User never shadows Core), LANG.DICTIONARY.MUTATION (content identity, which is unchanged). Prior finding: audit D17 (the Reference teaching a deleted module system).
- Verification evidence: 232 conformance cases; 13 Rust test targets; `dictionary_resolution_tests.rs` restated as two-tier laws. Recorded in `docs/dev/language-coherence-review-2026-08.md` §4.10.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`)
- [x] `npm run check`, plus `npm run lint` and `npm test`
- [ ] `cargo llvm-cov --branch --workspace` — not run; coverage instrumentation not available in this environment
- [x] MC/DC-like checklist reviewed for modified boolean logic — resolution went from a multi-branch ladder to two sequential lookups; both arms plus the miss are covered by tests and conformance cases.
- [x] Release checklist impact considered — a saved word's `dictionary` label is now ignored on restore, since there is one User tier for it to land in.

Also verified: `cargo clippy --features wasm --target wasm32-unknown-unknown -- -D warnings`, the 14 repo gates, and every file in `examples/` still runs.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

Remaining in §5: item 7 (settle on one Host Protocol). Continuing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NewX3abHjfCCSeTnTis2kN)_