### PR TITLE
feat(reflection): add REFLECT as an explicit reversible code/data boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ajisai is an AI-first, vector-oriented dataflow language for **auditable, exact 
 
 Its central promise is **value integrity first**: numbers stay exact, structure stays visible, partial failure stays diagnosable, and every built-in Word carries a machine-readable contract that a user word's declaration can be checked against ahead of execution (`ajisai check --contract`). That check is deliberately conservative — it verifies declarations within the syntactic fragment its inference can analyze, and reports anything it cannot prove as "cannot verify".
 
-**Ten concepts.** Ajisai is built from ten concepts and nothing else: exact rationals closed under `SQRT`; three outcomes (a value, a reasoned absence, an error); a stack and vectors; code blocks evaluated only on request; one modifier axis; a sealed-Core / User dictionary with content-addressed identity; a machine-readable contract per Word; a pre-execution check of user declarations against those contracts; one host protocol; and an executable conformance corpus. The vocabulary is **69 Words** in one flat dictionary.
+**Ten concepts.** Ajisai is built from ten concepts and nothing else: exact rationals closed under `SQRT`; three outcomes (a value, a reasoned absence, an error); a stack and vectors; code blocks evaluated only on request; one modifier axis; a sealed-Core / User dictionary with content-addressed identity; a machine-readable contract per Word; a pre-execution check of user declarations against those contracts; one host protocol; and an executable conformance corpus. The vocabulary is **70 Words** in one flat dictionary.
 
 **Numeric scope.** Numbers are *exact by default*: exact rationals and the multiquadratic field they generate under `SQRT` — square roots of non-negative rationals, closed under field arithmetic, in a normal form \(\sum_d c_d\sqrt d\). Arithmetic never rounds, coefficients are arbitrary-precision, and **comparison is total**: every comparison of two scalars decides in finite time. That field is the whole numeric domain, so π, e, and logarithms are not Ajisai values.
 
@@ -86,7 +86,7 @@ Spec links: [The consumption axis](https://masamoto1982.github.io/Ajisai/SPECIFI
 
 ### 5) Words and contracts: searchable channels for humans and AI
 
-The dictionary has two tiers: **Core** holds the 69 canonical Words and is sealed, and **User** holds definitions made by `DEF`. Every Core Word is reachable by its plain name, so a program starts with the full vocabulary already in scope.
+The dictionary has two tiers: **Core** holds the 70 canonical Words and is sealed, and **User** holds definitions made by `DEF`. Every Core Word is reachable by its plain name, so a program starts with the full vocabulary already in scope.
 
 Each Core Word's contract is a machine-readable record in [`spec/words.json`](spec/words.json): arity, consumption, NIL policy, projection reason, error conditions, purity, effects, and documentation. That record is the single place the Word is defined; prose is a projection of it.
 
@@ -197,7 +197,7 @@ Quality process documents live in [`docs/quality/`](docs/quality/), including th
 
 | Path | Purpose |
 | --- | --- |
-| [`spec/`](spec/) | Canonical sources: the semantic kernel, the 69-Word registry, the shared laws, presentation, and the host protocol |
+| [`spec/`](spec/) | Canonical sources: the semantic kernel, the 70-Word registry, the shared laws, presentation, and the host protocol |
 | [`SPECIFICATION.html`](SPECIFICATION.html) | Generated from `spec/` ([rendered here](https://masamoto1982.github.io/Ajisai/SPECIFICATION.html)) |
 | [`rust/src/`](rust/src/) | Rust interpreter core and value model |
 | [`src/`](src/) | TypeScript GUI/runtime shell |

--- a/SKILL.md
+++ b/SKILL.md
@@ -162,7 +162,7 @@ produce a value produces NIL (§4); a malformed one raises an error.
 
 ## 9. Word quick reference
 
-Generated from `docs/word-manifest.json` — the complete inventory: 69
+Generated from `docs/word-manifest.json` — the complete inventory: 70
 canonical Words in one flat Core dictionary. A word absent here does not
 exist. There is no module system and nothing to import.
 
@@ -237,6 +237,8 @@ exist. There is no module system and nothing to import.
 | `DEL` | dictionary | Delete a user word from the dictionary. — e.g. `{ [ 1 ] } 'W' DEF 'W' DEL` |
 | `LOOKUP` | dictionary | Display the documentation for a named word. — e.g. `'ADD' ?` |
 | `PRINT` | io | Write the top stack value to the output stream, consuming it. A string is written as its raw text, without the quotes the stack shows ('TEST' prints as TEST); nested strings keep their quotes. — e.g. `42 PRINT` |
+| `REFLECT` | reflection | Reflect a CodeBlock into canonical code data, or canonical code data into a CodeBlock. — e.g. `CodeBlock REFLECT
+code-data REFLECT` |
 | `+` | symbol alias | shorthand for `ADD` |
 | `-` | symbol alias | shorthand for `SUB` |
 | `*` | symbol alias | shorthand for `MUL` |

--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -261,7 +261,7 @@ Ajisai identity is the correspondence from normalized source to the ordered obse
 </p>
 
 <p>
-The vocabulary is 69 canonical Words and 16 symbolic aliases. Growth is not the goal: a proposed Word that is expressible as a user definition over the existing vocabulary does not belong in Core.
+The vocabulary is 70 canonical Words and 16 symbolic aliases. Growth is not the goal: a proposed Word that is expressible as a user definition over the existing vocabulary does not belong in Core.
 </p>
 
 <h3 id="lang-authority-freedom">LANG.AUTHORITY.FREEDOM — Implementation freedom</h3>
@@ -474,7 +474,7 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <h3 id="lang-dictionary-resolution">LANG.DICTIONARY.RESOLUTION — Deterministic lookup</h3>
 
-<p>The dictionary has two tiers. <strong>Core</strong> holds the 69 canonical Words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds definitions made by <code>DEF</code>. Resolution is a deterministic function of the normalized name and the current dictionary, and User never shadows Core.</p>
+<p>The dictionary has two tiers. <strong>Core</strong> holds the 70 canonical Words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds definitions made by <code>DEF</code>. Resolution is a deterministic function of the normalized name and the current dictionary, and User never shadows Core.</p>
 
 <p>Those two tiers are the whole dictionary: a name resolves in Core or in User, and a Core name is reachable by itself. <code>LOOKUP</code>, hover, the Reference, and execution must identify the same canonical entry.</p>
 
@@ -493,6 +493,12 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 <p>A Word may have exactly one other effect, and it stays inside the machine: <code>DEF</code> and <code>DEL</code> change the dictionary, under LANG.DICTIONARY.MUTATION. Output emission and dictionary mutation are therefore the two effects, and LANG.MACHINE.ORDER orders both of them against token evaluation.</p>
 
 <p>Every other Word changes nothing: given the same stack and dictionary it produces the same result. <code>LOOKUP</code> reads the dictionary, so it depends on one without changing it. A Word that evaluates a supplied code block has the effects of that block and no others, so it is pure exactly when the block is.</p>
+
+<h3 id="lang-source-reflection">LANG.SOURCE.REFLECTION — Explicit code/data reflection</h3>
+
+<p>CodeBlock and Vector remain disjoint domains: a Vector is data and is never directly executable. <code>REFLECT</code> is the sole reversible boundary between a CodeBlock token sequence and the versioned canonical Vector <code>[ 'AJISAI-CODE-1' token-record... ]</code>. Records preserve every token variant and its original Number lexeme, String content, and Symbol spelling; display text is not authoritative code.</p>
+
+<p>Reflection is pure, deterministic, non-evaluating, independent of dictionary state, and performs no name resolution or mutation. Strictly malformed code data is ERROR. On legal values it is an involution under token/structural equality. <code>EXEC</code> continues to accept only CodeBlock. <code>REFLECT</code> is neither a String parser nor a macro expander.</p>
 
 <h2 id="lang-contract">9. Contracts and Static Checking</h2>
 

--- a/docs/dev/code-data-reflection-design-2026-08.md
+++ b/docs/dev/code-data-reflection-design-2026-08.md
@@ -1,0 +1,7 @@
+# Code/data reflection design record (2026-08)
+
+This is a non-normative design-decision record; `spec/` remains the authority for semantics.
+
+`REFLECT` names a symmetric reflection rather than privileging either destination as `CODE` would. One involutive Word expresses one reversible capability, so two directional Words would unnecessarily enlarge Core. The explicit boundary justifies growing Core from 69 to 70: it adds metaprogramming without making ordinary Vector data executable.
+
+`EXEC` remains CodeBlock-only. The public `AJISAI-CODE-1` Vector is deliberately distinct from the private persistence wire format, preserving snapshot compatibility. This change introduces neither a String parser nor a macro system. It keeps Vector a data domain and adopts structural/token equality for the involution, preserving lexical spelling without relying on display rendering.

--- a/docs/formalization-coverage.json
+++ b/docs/formalization-coverage.json
@@ -13,7 +13,7 @@
       "flow"
     ],
     "entry_counts": {
-      "flow": 20,
+      "flow": 21,
       "identity": 27,
       "material": 138,
       "sugar": 28
@@ -3463,6 +3463,34 @@
       "algebraic_family": "syntax-sugar",
       "core_tier": "sugar",
       "desugars_to": "LOOKUP"
+    },
+    {
+      "id": "core.reflect",
+      "kind": "coreword",
+      "surface": "REFLECT",
+      "classification": "Core",
+      "spec_sections": [
+        "SPECIFICATION.html §7.8"
+      ],
+      "formalization_sections": [
+        "docs/dev/code-data-reflection-design-2026-08.md"
+      ],
+      "law_tests": [
+        "rust/src/types/code_data.rs"
+      ],
+      "conformance_cases": [
+        "reflection-code-to-data",
+        "reflection-data-exec"
+      ],
+      "status": "Formalized",
+      "notes": "Pure involution between CodeBlock token sequences and versioned canonical structured data.",
+      "semantic_role": "Primitive",
+      "primitive": true,
+      "derived_from": [
+        "algebra.state-transformer.composition"
+      ],
+      "algebraic_family": "state-transformer",
+      "core_tier": "flow"
     }
   ],
   "unclassified_allowlist": []

--- a/docs/primitive-test-map.json
+++ b/docs/primitive-test-map.json
@@ -6,8 +6,8 @@
   "summary": {
     "primitives": 23,
     "primitives_without_tests": 0,
-    "distinct_law_test_files": 13,
-    "distinct_conformance_cases": 35
+    "distinct_law_test_files": 15,
+    "distinct_conformance_cases": 37
   },
   "primitives": [
     {
@@ -233,7 +233,7 @@
       "kind": "domain",
       "status": "accepted",
       "derived_word_count": 12,
-      "law_test_count": 1,
+      "law_test_count": 2,
       "conformance_case_count": 0,
       "derived_words": [
         "core.chars",
@@ -250,6 +250,7 @@
         "core.trim"
       ],
       "law_tests": [
+        "rust/src/interpreter/io.rs",
         "rust/tests/string_laws.rs"
       ],
       "conformance_cases": []
@@ -521,20 +522,23 @@
       "algebraic_family": "state-transformer",
       "kind": "operation",
       "status": "accepted",
-      "derived_word_count": 8,
-      "law_test_count": 2,
-      "conformance_case_count": 4,
+      "derived_word_count": 10,
+      "law_test_count": 3,
+      "conformance_case_count": 6,
       "derived_words": [
         "core.cond",
+        "core.def",
         "core.del",
         "core.exec",
         "core.filter",
         "core.fold",
         "core.import.name-resolution",
         "core.map",
+        "core.reflect",
         "exploratory.child-runtime"
       ],
       "law_tests": [
+        "rust/src/types/code_data.rs",
         "rust/tests/higher_order_laws.rs",
         "rust/tests/naming_resolution_laws.rs"
       ],
@@ -542,7 +546,9 @@
         "core-fold",
         "core-fold-word-name",
         "core-map",
-        "core-user-definition-resolved"
+        "core-user-definition-resolved",
+        "reflection-code-to-data",
+        "reflection-data-exec"
       ]
     },
     {
@@ -569,17 +575,20 @@
       "algebraic_family": "dictionary",
       "kind": "domain",
       "status": "accepted",
-      "derived_word_count": 2,
+      "derived_word_count": 3,
       "law_test_count": 1,
-      "conformance_case_count": 0,
+      "conformance_case_count": 1,
       "derived_words": [
+        "core.def",
         "core.del",
         "core.structural.record"
       ],
       "law_tests": [
         "rust/tests/naming_resolution_laws.rs"
       ],
-      "conformance_cases": []
+      "conformance_cases": [
+        "core-user-definition-resolved"
+      ]
     },
     {
       "id": "algebra.observation.structured-diagnostic",

--- a/docs/word-manifest.json
+++ b/docs/word-manifest.json
@@ -11,10 +11,10 @@
   ],
   "semanticMetadataFrom": "docs/formalization-coverage.json",
   "counts": {
-    "corewords": 69,
+    "corewords": 70,
     "aliases": 16,
     "surface_forms": 8,
-    "total": 93
+    "total": 94
   },
   "entries": [
     {
@@ -1197,6 +1197,22 @@
       "effect_schema": "hosted-effect.capability-request-eff-observation",
       "implementation_schema": "hosted_effect_schema(capability.check -> request construction -> Eff append -> structured observation)",
       "classification": "HostedEffect"
+    },
+    {
+      "id": "core.reflect",
+      "kind": "coreword",
+      "surface": "REFLECT",
+      "category": "reflection",
+      "source": "spec/words.json",
+      "canonical": "REFLECT",
+      "coverage_entry_id": "core.reflect",
+      "semantic_role": "Primitive",
+      "algebraic_family": "state-transformer",
+      "core_tier": "flow",
+      "derived_from": [
+        "algebra.state-transformer.composition"
+      ],
+      "classification": "Core"
     },
     {
       "id": "alias.plus",

--- a/docs/word-reference.md
+++ b/docs/word-reference.md
@@ -3,7 +3,7 @@
 
 This reference is generated from [`spec/words.json`](../spec/words.json). Runtime catalogs are implementation-validation inputs, not documentation authorities.
 
-Canonical inventory: **69 Words**. Aliases and syntax surfaces are listed in [the generated manifest](word-manifest.json).
+Canonical inventory: **70 Words**. Aliases and syntax surfaces are listed in [the generated manifest](word-manifest.json).
 
 ## `TRUE`
 
@@ -908,3 +908,17 @@ Write the top stack value to the output stream, consuming it. A string is writte
 - **Capability / hosted effect:** `console` / `consoleWrite`
 - **Clauses:** `LANG.EFFECTS.OUTPUT`, `LANG.MACHINE.ORDER`
 - **Syntax:** `42 PRINT`
+
+## `REFLECT`
+
+Convert between a CodeBlock and its canonical structured data representation without evaluating the code.
+
+- **Family:** `reflection`
+- **Stack:** 1 input(s) → 1 output(s); `eat` consumption
+- **NIL policy:** `rejectNil`; projection: none
+- **Purity / determinism:** `pure` / `deterministic`
+- **Capability / hosted effect:** `none` / `none`
+- **Clauses:** `LANG.SOURCE.REFLECTION`
+- **Syntax:** `CodeBlock REFLECT
+code-data REFLECT`
+- **ERROR conditions:** `nonReflectableValue`, `malformedCodeData`

--- a/rust/src/builtins/generated_core_word_docs.rs
+++ b/rust/src/builtins/generated_core_word_docs.rs
@@ -632,4 +632,13 @@ pub(crate) const GENERATED_CORE_WORD_DOCS: &[GeneratedCoreWordDoc] = &[
         hover_summary: "PRINT — output value to display",
         hover_syntax: "42 PRINT",
     },
+    GeneratedCoreWordDoc {
+        name: "REFLECT",
+        category: "reflection",
+        summary: "Reflect a CodeBlock into canonical code data, or canonical code data into a CodeBlock.",
+        role: "Reflection primitive: cross the explicit boundary between executable code values and structured code data.",
+        stack_effect: "CodeBlock -> code-data\ncode-data -> CodeBlock",
+        hover_summary: "REFLECT — cross the code/data boundary",
+        hover_syntax: "CodeBlock REFLECT\ncode-data REFLECT",
+    },
 ];

--- a/rust/src/interpreter/control.rs
+++ b/rust/src/interpreter/control.rs
@@ -28,6 +28,8 @@ pub(crate) fn op_exec(interp: &mut Interpreter) -> Result<()> {
     };
 
     let tokens = tokens.clone();
+    crate::tokenizer::validate_code_tokens(&tokens).map_err(AjisaiError::from)?;
+    interp.check_source_numeric_literals(&tokens)?;
     interp.execute_section_core(&tokens, 0)?;
     Ok(())
 }

--- a/rust/src/interpreter/dictionary_resolution_tests.rs
+++ b/rust/src/interpreter/dictionary_resolution_tests.rs
@@ -1,7 +1,7 @@
 //! Resolution laws for `crate::interpreter::resolve_word`.
 //!
 //! LANG.DICTIONARY.RESOLUTION: "The dictionary has two tiers. **Core** holds
-//! the 69 canonical Words and is sealed: a Core name cannot be redefined or
+//! the 70 canonical Words and is sealed: a Core name cannot be redefined or
 //! deleted. **User** holds definitions made by `DEF`. Resolution is a
 //! deterministic function of the normalized name and the current dictionary,
 //! and User never shadows Core." And: "Those two tiers are the whole

--- a/rust/src/interpreter/execute_builtin.rs
+++ b/rust/src/interpreter/execute_builtin.rs
@@ -6,8 +6,8 @@ use super::compiled_plan::{execute_compiled_plan, is_plan_valid};
 
 use super::{
     algo_ops, arithmetic, cast, comparison, control, control_cond, execute_def, execute_del,
-    execute_lookup, higher_order, higher_order_fold, io, logic, math_ops, nil_diagnostics, sort,
-    tensor_cmds, vector_ops, ConsumptionMode, Interpreter,
+    execute_lookup, higher_order, higher_order_fold, io, logic, math_ops, nil_diagnostics,
+    reflection, sort, tensor_cmds, vector_ops, ConsumptionMode, Interpreter,
 };
 
 /// What a Word's declared `nilPolicy` requires of the operands on the stack,
@@ -309,6 +309,7 @@ impl Interpreter {
                 Ok(())
             }
             WordId::Exec => control::op_exec(self),
+            WordId::Reflect => reflection::op_reflect(self),
             WordId::Cond => control_cond::op_cond(self),
             WordId::Def => execute_def::op_def(self),
             WordId::Del => execute_del::op_del(self),

--- a/rust/src/interpreter/execute_def.rs
+++ b/rust/src/interpreter/execute_def.rs
@@ -5,39 +5,14 @@ use crate::types::{Capabilities, ExecutionLine, Stability, Tier, Token, ValueDat
 use std::collections::HashSet;
 use std::sync::Arc;
 
-/// Serialize a code-block token stream back into Ajisai source text.
-///
-/// `LineBreak` tokens become real newlines so that a multi-line `{ }` body is
-/// re-tokenized into one `ExecutionLine` per source line (see
-/// `parse_definition_body`). This is the only body shape DEF accepts.
-fn code_block_tokens_to_source(tokens: &[Token]) -> String {
-    tokens
-        .iter()
-        .map(|t| match t {
-            Token::Number(n) => n.to_string(),
-            Token::String(s) => format!("'{}'", s),
-            Token::Symbol(s) => s.to_string(),
-            Token::VectorStart => "[".to_string(),
-            Token::VectorEnd => "]".to_string(),
-            Token::BlockStart => "{".to_string(),
-            Token::BlockEnd => "}".to_string(),
-            Token::Pipeline => "~".to_string(),
-            Token::NilCoalesce => "^".to_string(),
-            Token::CondClauseSep => "|".to_string(),
-            Token::LineBreak => "\n".to_string(),
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
 /// DEF is strictly two positional arguments: `{ body } 'NAME' DEF`.
 ///
 /// The top of the stack is the name (a string), and directly below it is the
 /// body (a code block `{ }`). No value types are inspected to *guess* roles —
 /// position alone determines them — which is why a leftover string-like value
 /// on the stack can no longer shift argument interpretation. Definitions from
-/// data arrays are intentionally not accepted here; that path is reserved for
-/// the future `>CODE` conversion word.
+/// data arrays are intentionally not accepted here; canonical code data must
+/// first cross the explicit `REFLECT` boundary.
 pub fn op_def(interp: &mut Interpreter) -> Result<()> {
     if interp.stack.len() < 2 {
         return Err(AjisaiError::StackUnderflow);
@@ -48,8 +23,8 @@ pub fn op_def(interp: &mut Interpreter) -> Result<()> {
 
     let def_val = interp.stack.pop().ok_or(AjisaiError::StackUnderflow)?;
 
-    let definition_str = match &def_val.data {
-        ValueData::CodeBlock(tokens) => code_block_tokens_to_source(tokens),
+    let tokens = match &def_val.data {
+        ValueData::CodeBlock(tokens) => tokens.clone(),
         _ => {
             return Err(AjisaiError::from(
                 "DEF requires a code block { ... } as the definition body",
@@ -57,13 +32,12 @@ pub fn op_def(interp: &mut Interpreter) -> Result<()> {
         }
     };
 
-    let tokens = crate::tokenizer::tokenize(&definition_str)
-        .map_err(|e| AjisaiError::from(format!("Tokenization error in DEF: {}", e)))?;
-
     op_def_inner(interp, &name_str, &tokens)
 }
 
 pub(crate) fn op_def_inner(interp: &mut Interpreter, name: &str, tokens: &[Token]) -> Result<()> {
+    crate::tokenizer::validate_code_tokens(tokens).map_err(AjisaiError::from)?;
+    interp.check_source_numeric_literals(tokens)?;
     if let Some(message) =
         crate::interpreter::naming_convention_checker::check_reserved_word_name(name)
     {

--- a/rust/src/interpreter/execution_loop.rs
+++ b/rust/src/interpreter/execution_loop.rs
@@ -301,6 +301,10 @@ impl Interpreter {
         tokens: &[Token],
         start_index: usize,
     ) -> Result<usize> {
+        // Every execution route (EXEC and higher-order Words included) shares
+        // the source-entry numeric ceiling; dynamically reflected tokens may
+        // not bypass it.
+        self.check_source_numeric_literals(&tokens[start_index..])?;
         let mut i: usize = 0;
         let execute_tokens: &[Token] = &tokens[start_index..];
 
@@ -515,7 +519,7 @@ impl Interpreter {
     /// produced from source, before any of them is parsed into a value. Digit
     /// characters are counted directly (sign, radix point, and `/` excluded),
     /// so the bound tracks the magnitude of the BigInt that would be built.
-    fn check_source_numeric_literals(&self, tokens: &[Token]) -> Result<()> {
+    pub(crate) fn check_source_numeric_literals(&self, tokens: &[Token]) -> Result<()> {
         for token in tokens {
             if let Token::Number(literal) = token {
                 let digits = literal.chars().filter(|c| c.is_ascii_digit()).count();

--- a/rust/src/interpreter/interpreter_definition_tests.rs
+++ b/rust/src/interpreter/interpreter_definition_tests.rs
@@ -442,8 +442,7 @@ mod tests {
     #[tokio::test]
     async fn test_def_rejects_data_array_body() {
         // A data array `[ ... ]` is no longer accepted as a definition body;
-        // only a code block is. (Data-driven definition is reserved for a
-        // future `>CODE` conversion word.)
+        // only a code block is. Canonical code data must first be reflected.
         let mut interp = Interpreter::new();
         let result = interp.execute("[ '[ 2 ] *' ] 'DOUBLE' DEF").await;
         assert!(

--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -20,6 +20,7 @@ pub mod io;
 pub mod logic;
 pub mod math_ops;
 pub(crate) mod naming_convention_checker;
+mod reflection;
 mod resolve_cache;
 pub mod runtime_limits;
 mod session_lifecycle;

--- a/rust/src/interpreter/reflection.rs
+++ b/rust/src/interpreter/reflection.rs
@@ -1,0 +1,19 @@
+use crate::error::{AjisaiError, Result};
+use crate::interpreter::cast::cast_value_helpers::apply_unary_cast;
+use crate::interpreter::Interpreter;
+use crate::types::code_data::{code_data_to_tokens, tokens_to_code_data};
+use crate::types::{Value, ValueData};
+
+pub(crate) fn op_reflect(interp: &mut Interpreter) -> Result<()> {
+    apply_unary_cast(interp, reflect)
+}
+
+fn reflect(value: &Value) -> Result<Value> {
+    match &value.data {
+        ValueData::CodeBlock(tokens) => Ok(tokens_to_code_data(tokens)),
+        ValueData::Vector(_) => Ok(Value::from_code_block(code_data_to_tokens(value)?)),
+        _ => Err(AjisaiError::from(
+            "REFLECT requires a CodeBlock or canonical code-data Vector",
+        )),
+    }
+}

--- a/rust/src/interpreter/word_space.rs
+++ b/rust/src/interpreter/word_space.rs
@@ -89,7 +89,7 @@ fn builtin_space(id: WordId) -> (SpaceClass, bool) {
         Map | Filter | Fold | Any | All => (Unbounded, false),
         Exec | Cond => (Unbounded, false),
         // Structure access/observation: shares persistent structure, O(1) new.
-        Get | Length => (Const, false),
+        Get | Length | Reflect => (Const, false),
         NilCheck | NilReason => (Const, false),
         True | False | Nil => (Const, false),
         // Structure builders bounded by their operands' total size.

--- a/rust/src/kernel/generated/word_registry.rs
+++ b/rust/src/kernel/generated/word_registry.rs
@@ -78,6 +78,7 @@ pub enum WordId {
     Del,
     Lookup,
     Print,
+    Reflect,
 }
 
 /// Semantic family the Word selects its shared laws from.
@@ -109,6 +110,8 @@ pub enum Family {
     Dictionary,
     /// `output`
     Output,
+    /// `reflection`
+    Reflection,
 }
 
 impl Family {
@@ -126,6 +129,7 @@ impl Family {
             Family::StackModifier => "stackModifier",
             Family::Dictionary => "dictionary",
             Family::Output => "output",
+            Family::Reflection => "reflection",
         }
     }
 }
@@ -1363,5 +1367,20 @@ pub const GENERATED_WORDS: &[GeneratedWord] = &[
         purity: Purity::Effectful,
         determinism: Determinism::HostRelative,
         effects: &["consoleWrite"],
+    },
+    GeneratedWord {
+        id: WordId::Reflect,
+        name: "REFLECT",
+        aliases: &[],
+        family: Family::Reflection,
+        stack_inputs: Arity::Fixed(1),
+        stack_outputs: Arity::Fixed(1),
+        consumption: Consumption::Eat,
+        nil_policy: NilPolicy::RejectNil,
+        projection: None,
+        partiality: Partiality::Partial,
+        purity: Purity::Pure,
+        determinism: Determinism::Deterministic,
+        effects: &[],
     },
 ];

--- a/rust/src/tokenizer.rs
+++ b/rust/src/tokenizer.rs
@@ -169,6 +169,25 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, String> {
     Ok(tokens)
 }
 
+/// Validate the structural grammar of an already-tokenized code value.
+pub(crate) fn validate_code_tokens(tokens: &[Token]) -> Result<(), String> {
+    let mut delimiters = Vec::new();
+    for token in tokens {
+        match token {
+            Token::VectorStart => delimiters.push(Token::VectorStart),
+            Token::BlockStart => delimiters.push(Token::BlockStart),
+            Token::VectorEnd if delimiters.pop() == Some(Token::VectorStart) => {}
+            Token::BlockEnd if delimiters.pop() == Some(Token::BlockStart) => {}
+            Token::VectorEnd | Token::BlockEnd => return Err("mismatched code delimiter".into()),
+            _ => {}
+        }
+    }
+    if !delimiters.is_empty() {
+        return Err("unclosed code delimiter".into());
+    }
+    check_cond_clause_per_line_constraint(tokens)
+}
+
 fn is_special_char(c: char) -> bool {
     matches!(
         c,

--- a/rust/src/types/code_data.rs
+++ b/rust/src/types/code_data.rs
@@ -1,0 +1,146 @@
+use crate::error::{AjisaiError, Result};
+use crate::types::{Token, Value};
+
+pub(crate) const CODE_DATA_VERSION: &str = "AJISAI-CODE-1";
+
+pub(crate) fn tokens_to_code_data(tokens: &[Token]) -> Value {
+    let mut values = Vec::with_capacity(tokens.len() + 1);
+    values.push(Value::from_string(CODE_DATA_VERSION));
+    values.extend(tokens.iter().map(|token| {
+        let (tag, payload): (&str, Option<&str>) = match token {
+            Token::Number(value) => ("number", Some(value)),
+            Token::String(value) => ("string", Some(value)),
+            Token::Symbol(value) => ("symbol", Some(value)),
+            Token::VectorStart => ("vector-start", None),
+            Token::VectorEnd => ("vector-end", None),
+            Token::BlockStart => ("block-start", None),
+            Token::BlockEnd => ("block-end", None),
+            Token::Pipeline => ("pipeline", None),
+            Token::NilCoalesce => ("nil-coalesce", None),
+            Token::CondClauseSep => ("cond-clause-sep", None),
+            Token::LineBreak => ("line-break", None),
+        };
+        let mut record = vec![Value::from_string(tag)];
+        if let Some(payload) = payload {
+            record.push(Value::from_string(payload));
+        }
+        Value::from_vector(record)
+    }));
+    Value::from_vector(values)
+}
+
+fn malformed(message: impl Into<String>) -> AjisaiError {
+    AjisaiError::from(format!("malformed canonical code data: {}", message.into()))
+}
+
+pub(crate) fn code_data_to_tokens(value: &Value) -> Result<Vec<Token>> {
+    let values = value
+        .as_vector()
+        .ok_or_else(|| malformed("expected Vector"))?;
+    if values.first().and_then(Value::as_text) != Some(CODE_DATA_VERSION) {
+        return Err(malformed("missing AJISAI-CODE-1 header"));
+    }
+    let mut tokens = Vec::with_capacity(values.len().saturating_sub(1));
+    for value in &values[1..] {
+        let record = value
+            .as_vector()
+            .ok_or_else(|| malformed("record is not a Vector"))?;
+        let tag = record
+            .first()
+            .and_then(Value::as_text)
+            .ok_or_else(|| malformed("record tag is not a String"))?;
+        let token = match (tag, record.len()) {
+            ("number", 2) => {
+                let payload = record[1]
+                    .as_text()
+                    .ok_or_else(|| malformed("number payload is not a String"))?;
+                match crate::tokenizer::tokenize(payload).ok().as_deref() {
+                    Some([Token::Number(n)]) if n.as_ref() == payload => {
+                        Token::Number(payload.into())
+                    }
+                    _ => return Err(malformed("invalid number payload")),
+                }
+            }
+            ("string", 2) => Token::String(
+                record[1]
+                    .as_text()
+                    .ok_or_else(|| malformed("string payload is not a String"))?
+                    .into(),
+            ),
+            ("symbol", 2) => {
+                let payload = record[1]
+                    .as_text()
+                    .ok_or_else(|| malformed("symbol payload is not a String"))?;
+                match crate::tokenizer::tokenize(payload).ok().as_deref() {
+                    Some([Token::Symbol(s)]) if s.as_ref() == payload => {
+                        Token::Symbol(payload.into())
+                    }
+                    _ => return Err(malformed("invalid symbol payload")),
+                }
+            }
+            ("vector-start", 1) => Token::VectorStart,
+            ("vector-end", 1) => Token::VectorEnd,
+            ("block-start", 1) => Token::BlockStart,
+            ("block-end", 1) => Token::BlockEnd,
+            ("pipeline", 1) => Token::Pipeline,
+            ("nil-coalesce", 1) => Token::NilCoalesce,
+            ("cond-clause-sep", 1) => Token::CondClauseSep,
+            ("line-break", 1) => Token::LineBreak,
+            ("number" | "string" | "symbol", _) => {
+                return Err(malformed("payload record must contain exactly two fields"))
+            }
+            (
+                "vector-start" | "vector-end" | "block-start" | "block-end" | "pipeline"
+                | "nil-coalesce" | "cond-clause-sep" | "line-break",
+                _,
+            ) => {
+                return Err(malformed(
+                    "structural record must contain exactly one field",
+                ))
+            }
+            _ => return Err(malformed("unknown token tag")),
+        };
+        tokens.push(token);
+    }
+    crate::tokenizer::validate_code_tokens(&tokens).map_err(malformed)?;
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn all_token_variants_round_trip() {
+        let tokens = vec![
+            Token::Number(Arc::from("1/1")),
+            Token::String(Arc::from("🙂\n'")),
+            Token::Symbol(Arc::from("add")),
+            Token::VectorStart,
+            Token::VectorEnd,
+            Token::BlockStart,
+            Token::Number(Arc::from("2")),
+            Token::CondClauseSep,
+            Token::Number(Arc::from("3")),
+            Token::BlockEnd,
+            Token::Pipeline,
+            Token::NilCoalesce,
+            Token::LineBreak,
+        ];
+        assert_eq!(
+            code_data_to_tokens(&tokens_to_code_data(&tokens)).unwrap(),
+            tokens
+        );
+    }
+
+    #[test]
+    fn malformed_records_are_rejected() {
+        assert!(code_data_to_tokens(&Value::from_vector(vec![])).is_err());
+        assert!(code_data_to_tokens(&Value::from_vector(vec![
+            Value::from_string(CODE_DATA_VERSION),
+            Value::from_vector(vec![Value::from_string("unknown")])
+        ]))
+        .is_err());
+    }
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,4 +1,5 @@
 pub mod arena;
+pub(crate) mod code_data;
 pub mod display;
 pub mod exact;
 pub mod fraction;

--- a/scripts/check-semantic-kernel.mjs
+++ b/scripts/check-semantic-kernel.mjs
@@ -44,7 +44,7 @@ for (const family of familyIds) {
 // count is a budget rather than a fixed inventory: shrinking is free, growing is
 // a deliberate specification change.
 const aliases = words.entries.reduce((total, word) => total + word.aliases.length, 0);
-if (words.entries.length > 69) fail(`${words.entries.length} canonical Words (maximum 69)`);
+if (words.entries.length > 70) fail(`${words.entries.length} canonical Words (maximum 70)`);
 if (aliases > 16) fail(`${aliases} aliases (maximum 16)`);
 
 if (!process.exitCode) {

--- a/scripts/generate-skill-md.mjs
+++ b/scripts/generate-skill-md.mjs
@@ -389,7 +389,7 @@ ${renderForbiddenPatterns()}
 
 ## 9. Word quick reference
 
-Generated from \`docs/word-manifest.json\` — the complete inventory: 69
+Generated from \`docs/word-manifest.json\` — the complete inventory: 70
 canonical Words in one flat Core dictionary. A word absent here does not
 exist. There is no module system and nothing to import.
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -29,7 +29,7 @@ Run `npm run specification:generate` after an authoritative source change and
 `npm run specification:check` in quality gates.
 
 `npm run semantic-kernel:check` enforces the budgets that keep the language
-small: at most 400 lines of kernel, 12 semantic families, 69 canonical Words,
+small: at most 400 lines of kernel, 12 semantic families, 70 canonical Words,
 and 16 aliases, with every family and clause reference resolving. The budgets
 are ceilings — shrinking is always allowed, growing is a deliberate
 specification change.

--- a/spec/language-semantics.md
+++ b/spec/language-semantics.md
@@ -73,7 +73,7 @@ Ajisai identity is the correspondence from normalized source to the ordered obse
 </p>
 
 <p>
-The vocabulary is 69 canonical Words and 16 symbolic aliases. Growth is not the goal: a proposed Word that is expressible as a user definition over the existing vocabulary does not belong in Core.
+The vocabulary is 70 canonical Words and 16 symbolic aliases. Growth is not the goal: a proposed Word that is expressible as a user definition over the existing vocabulary does not belong in Core.
 </p>
 
 <h3 id="lang-authority-freedom">LANG.AUTHORITY.FREEDOM — Implementation freedom</h3>
@@ -286,7 +286,7 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <h3 id="lang-dictionary-resolution">LANG.DICTIONARY.RESOLUTION — Deterministic lookup</h3>
 
-<p>The dictionary has two tiers. <strong>Core</strong> holds the 69 canonical Words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds definitions made by <code>DEF</code>. Resolution is a deterministic function of the normalized name and the current dictionary, and User never shadows Core.</p>
+<p>The dictionary has two tiers. <strong>Core</strong> holds the 70 canonical Words and is sealed: a Core name cannot be redefined or deleted. <strong>User</strong> holds definitions made by <code>DEF</code>. Resolution is a deterministic function of the normalized name and the current dictionary, and User never shadows Core.</p>
 
 <p>Those two tiers are the whole dictionary: a name resolves in Core or in User, and a Core name is reachable by itself. <code>LOOKUP</code>, hover, the Reference, and execution must identify the same canonical entry.</p>
 
@@ -305,6 +305,12 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 <p>A Word may have exactly one other effect, and it stays inside the machine: <code>DEF</code> and <code>DEL</code> change the dictionary, under LANG.DICTIONARY.MUTATION. Output emission and dictionary mutation are therefore the two effects, and LANG.MACHINE.ORDER orders both of them against token evaluation.</p>
 
 <p>Every other Word changes nothing: given the same stack and dictionary it produces the same result. <code>LOOKUP</code> reads the dictionary, so it depends on one without changing it. A Word that evaluates a supplied code block has the effects of that block and no others, so it is pure exactly when the block is.</p>
+
+<h3 id="lang-source-reflection">LANG.SOURCE.REFLECTION — Explicit code/data reflection</h3>
+
+<p>CodeBlock and Vector remain disjoint domains: a Vector is data and is never directly executable. <code>REFLECT</code> is the sole reversible boundary between a CodeBlock token sequence and the versioned canonical Vector <code>[ 'AJISAI-CODE-1' token-record... ]</code>. Records preserve every token variant and its original Number lexeme, String content, and Symbol spelling; display text is not authoritative code.</p>
+
+<p>Reflection is pure, deterministic, non-evaluating, independent of dictionary state, and performs no name resolution or mutation. Strictly malformed code data is ERROR. On legal values it is an involution under token/structural equality. <code>EXEC</code> continues to accept only CodeBlock. <code>REFLECT</code> is neither a String parser nor a macro expander.</p>
 
 <h2 id="lang-contract">9. Contracts and Static Checking</h2>
 

--- a/spec/semantic-families.json
+++ b/spec/semantic-families.json
@@ -5,62 +5,104 @@
   "families": [
     {
       "id": "booleanLogic",
-      "clauses": ["LANG.VALUES.TRUTH"],
+      "clauses": [
+        "LANG.VALUES.TRUTH"
+      ],
       "truth": "twoValued",
       "nilPolicy": "contractSpecific"
     },
     {
       "id": "comparison",
-      "clauses": ["LANG.VALUES.TRUTH", "LANG.VALUES.EXACT"],
+      "clauses": [
+        "LANG.VALUES.TRUTH",
+        "LANG.VALUES.EXACT"
+      ],
       "decidability": "total",
       "nilPolicy": "passthrough"
     },
     {
       "id": "exactArithmetic",
-      "clauses": ["LANG.VALUES.EXACT", "LANG.COLLECTIONS.LIFT", "LANG.FAILURE.TRICHOTOMY"],
+      "clauses": [
+        "LANG.VALUES.EXACT",
+        "LANG.COLLECTIONS.LIFT",
+        "LANG.FAILURE.TRICHOTOMY"
+      ],
       "nilPolicy": "passthroughThenProject",
       "lifting": "elementwise"
     },
     {
       "id": "collection",
-      "clauses": ["LANG.VALUES.VECTOR", "LANG.COLLECTIONS.LIFT", "LANG.MACHINE.LIMITS"],
+      "clauses": [
+        "LANG.VALUES.VECTOR",
+        "LANG.COLLECTIONS.LIFT",
+        "LANG.MACHINE.LIMITS"
+      ],
       "nilPolicy": "contractSpecific",
       "budgetOutcome": "reasonedNil"
     },
     {
       "id": "higherOrder",
-      "clauses": ["LANG.COLLECTIONS.HIGHER"],
+      "clauses": [
+        "LANG.COLLECTIONS.HIGHER"
+      ],
       "effectOrder": "elementVisitOrder"
     },
     {
       "id": "text",
-      "clauses": ["LANG.VALUES.DISJOINT", "LANG.FAILURE.TRICHOTOMY"],
+      "clauses": [
+        "LANG.VALUES.DISJOINT",
+        "LANG.FAILURE.TRICHOTOMY"
+      ],
       "nilPolicy": "contractSpecific"
     },
     {
       "id": "control",
-      "clauses": ["LANG.MACHINE.TRANSFORMERS", "LANG.SOURCE.CODE"],
+      "clauses": [
+        "LANG.MACHINE.TRANSFORMERS",
+        "LANG.SOURCE.CODE"
+      ],
       "effectOrder": "evaluationOrder"
     },
     {
       "id": "absence",
-      "clauses": ["LANG.VALUES.NIL", "LANG.FAILURE.RECOVERY"],
+      "clauses": [
+        "LANG.VALUES.NIL",
+        "LANG.FAILURE.RECOVERY"
+      ],
       "nilPolicy": "inspectOrRecover"
     },
     {
       "id": "stackModifier",
-      "clauses": ["LANG.MODIFIERS.CONSUMPTION"],
-      "axes": ["consumption"]
+      "clauses": [
+        "LANG.MODIFIERS.CONSUMPTION"
+      ],
+      "axes": [
+        "consumption"
+      ]
     },
     {
       "id": "dictionary",
-      "clauses": ["LANG.DICTIONARY.RESOLUTION", "LANG.DICTIONARY.MUTATION"],
+      "clauses": [
+        "LANG.DICTIONARY.RESOLUTION",
+        "LANG.DICTIONARY.MUTATION"
+      ],
       "commit": "atomic"
     },
     {
       "id": "output",
-      "clauses": ["LANG.EFFECTS.OUTPUT", "LANG.MACHINE.ORDER"],
+      "clauses": [
+        "LANG.EFFECTS.OUTPUT",
+        "LANG.MACHINE.ORDER"
+      ],
       "effectOrder": "requestOrder"
+    },
+    {
+      "id": "reflection",
+      "clauses": [
+        "LANG.SOURCE.REFLECTION"
+      ],
+      "evaluation": "never",
+      "dictionaryAccess": "none"
     }
   ]
 }

--- a/spec/words.json
+++ b/spec/words.json
@@ -2798,6 +2798,45 @@
       ],
       "partiality": "partial",
       "category": "io"
+    },
+    {
+      "name": "REFLECT",
+      "aliases": [],
+      "family": "reflection",
+      "stack": {
+        "inputs": 1,
+        "outputs": 1
+      },
+      "consumption": "eat",
+      "nilPolicy": "rejectNil",
+      "projection": {
+        "when": "never",
+        "reason": null
+      },
+      "errorWhen": [
+        "nonReflectableValue",
+        "malformedCodeData"
+      ],
+      "purity": "pure",
+      "determinism": "deterministic",
+      "capability": "none",
+      "hostedEffect": "none",
+      "interpretationRole": "unassigned",
+      "clauses": [
+        "LANG.SOURCE.REFLECTION"
+      ],
+      "documentation": {
+        "summary": "Reflect a CodeBlock into canonical code data, or canonical code data into a CodeBlock.",
+        "hover": "REFLECT — cross the code/data boundary",
+        "lookup": "Convert between a CodeBlock and its canonical structured data representation without evaluating the code.",
+        "syntax": "CodeBlock REFLECT\ncode-data REFLECT",
+        "role": "Reflection primitive: cross the explicit boundary between executable code values and structured code data.",
+        "stackEffect": "CodeBlock -> code-data\ncode-data -> CodeBlock"
+      },
+      "executorKey": "Reflect",
+      "effects": [],
+      "partiality": "partial",
+      "category": "reflection"
     }
   ]
 }

--- a/spec/words.schema.json
+++ b/spec/words.schema.json
@@ -173,7 +173,8 @@
             "absence",
             "stackModifier",
             "dictionary",
-            "output"
+            "output",
+            "reflection"
           ]
         },
         "category": {

--- a/src/host-protocol-v1.contract.test.ts
+++ b/src/host-protocol-v1.contract.test.ts
@@ -92,16 +92,16 @@ describe('GUI Phase 0 freeze contract', () => {
         }
     });
 
-    test('the generated word inventory stays at 93 surfaces', () => {
+    test('the generated word inventory stays at 94 surfaces', () => {
         // The vocabulary is a ceiling, not a fixed inventory: shrinking is free,
         // growing is a deliberate specification change. Modules are gone, so
         // every Word is a flat Core Word.
         const manifest = readJson('docs/word-manifest.json');
         expect(manifest.counts).toEqual({
-            corewords: 69,
+            corewords: 70,
             aliases: 16,
             surface_forms: 8,
-            total: 93,
+            total: 94,
         });
     });
 });

--- a/tests/conformance/index.html
+++ b/tests/conformance/index.html
@@ -2040,5 +2040,23 @@
      and MUSIC@SIM set the playback mode silently; the mode is observed
      through the structure of the following MUSIC@PLAY audio effect. -->
 
+
+<!-- ===================== REFLECTION ===================== -->
+<section class="ajisai-case" id="reflection-code-to-data" data-category="core">
+<h3>REFLECT exposes canonical token data</h3><pre class="ajisai-source">{ 1 2 ADD } REFLECT</pre><pre class="ajisai-expect-result">[ 'AJISAI-CODE-1' [ 'number' '1' ] [ 'number' '2' ] [ 'symbol' 'ADD' ] ]</pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-data-exec" data-category="core">
+<h3>Canonical data crosses the boundary before EXEC</h3><pre class="ajisai-source">[ 'AJISAI-CODE-1' [ 'number' '1' ] [ 'number' '2' ] [ 'symbol' 'ADD' ] ] REFLECT EXEC</pre><pre class="ajisai-expect-result">3/1</pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-data-does-not-execute" data-category="core">
+<h3>REFLECT never evaluates represented code</h3><pre class="ajisai-source">[ 'AJISAI-CODE-1' [ 'number' '1' ] [ 'number' '2' ] [ 'symbol' 'ADD' ] ] REFLECT</pre><pre class="ajisai-expect-result">1 2 ADD</pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-empty-round-trip" data-category="core">
+<h3>Empty CodeBlock round trips</h3><pre class="ajisai-source">{ } REFLECT REFLECT</pre><pre class="ajisai-expect-result"></pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-dynamic-def" data-category="core">
+<h3>Canonical data can explicitly define a Word</h3><pre class="ajisai-source">[ 'AJISAI-CODE-1' [ 'number' '1' ] [ 'symbol' 'ADD' ] ] REFLECT 'INC-R' DEF 5 INC-R</pre><pre class="ajisai-expect-result">6/1</pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-symbol-string-distinct" data-category="core">
+<h3>Symbol and String token records remain distinct</h3><pre class="ajisai-source">{ ADD } REFLECT { 'ADD' } REFLECT EQ</pre><pre class="ajisai-expect-result">FALSE</pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-malformed-errors" data-category="core">
+<h3>Malformed code data is ERROR</h3><pre class="ajisai-source">[ 'AJISAI-CODE-1' [ 'number' '1' 'extra' ] ] REFLECT</pre><pre class="ajisai-expect-result"></pre><pre class="ajisai-expect-error">malformed canonical code data</pre><div class="ajisai-expect-effects"></div></section>
+<section class="ajisai-case" id="reflection-keep" data-category="core">
+<h3>KEEP preserves the reflected operand</h3><pre class="ajisai-source">{ 1 } KEEP REFLECT</pre><pre class="ajisai-expect-result">1 [ 'AJISAI-CODE-1' [ 'number' '1' ] ]</pre><div class="ajisai-expect-effects"></div></section>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Introduce a single canonical, reversible boundary between executable `CodeBlock` values and a strict, versioned structured data representation so code can be manipulated as data without enabling implicit execution. 
- Keep `EXEC` semantics unchanged (CodeBlock-only) and avoid adding evaluative or dictionary-dependent behavior to the reflection path. 
- Make authoritative token sequences the source of truth for `DEF` (remove CodeBlock → source → re-tokenize round-trip) and apply existing numeric-literal limits to dynamic code paths. 

### Description

- Add the `REFLECT` core Word and `reflection` semantic family, update spec and registries to increase Core Words from 69 → 70, and wire the new `WordId::Reflect` executor. 
- Implement a pure codec in `rust/src/types/code_data.rs` that encodes `Token` sequences to the canonical Vector form `['AJISAI-CODE-1' token-record...]` and decodes/validates it back to `Vec<Token>` with strict tag/arity/payload and structural validation. 
- Add `rust/src/interpreter/reflection.rs` implementing `op_reflect` using the shared unary-cast helper and integrate dispatch in `execute_builtin.rs`; add `validate_code_tokens` to `rust/src/tokenizer.rs` and call it where appropriate. 
- Replace `DEF`’s re-render-and-tokenize path: `DEF` now accepts `CodeBlock` tokens directly, validates tokens (`validate_code_tokens`), and enforces numeric-literal digit ceilings before registering definitions; also enforce the same numeric check at `EXEC` / execution entry to prevent dynamic bypass. 
- Update generated artifacts, documentation, conformance corpus and formalization metadata (`spec/*.json`, `SPECIFICATION.html`, `docs/*`, `tests/conformance/index.html`, `rust/src/kernel/generated/word_registry.rs`, generated docs) and add a non-normative design note `docs/dev/code-data-reflection-design-2026-08.md`. 

### Testing

- Ran Rust checks and tests: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets --verbose`, which completed successfully (Rust unit suites passed). 
- Ran JS/infra checks and generators: `npm run specification:generate` and the suite of registry/manifest/reference/doc generators, `npm run check`, `npm run lint`, and `npm test` (note: an initial baseline invocation used an unsupported `--runInBand` flag; the plain `npm test` was used and passed). 
- Ran semantic and quality gates: `npm run semantic-kernel:check`, `npm run word-schema:check`, `npm run word-registry:check`, `npm run word:manifest:check`, `npm run core-word-docs:check`, `npm run check:minimal-core`, `npm run check:formalization-coverage`, `npm run check:runtime-metadata`, `npm run check:semantic-firewall`, `npm run check:file-size`, `npm run check:reading-surfaces`, and `npm run check:skill` — all passed and reflect the updated counts. 
- Conformance coverage: regenerated manifest and ran `node scripts/check-conformance-coverage.mjs`; corpus increased to 240 cases and reports 70/70 Core Words covered (100%).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f215203688326b87faff9a542711f)