### PR TITLE
Introduce beta-freeze vocabulary classification, schema updates, and validation scripts

### DIFF
--- a/docs/dev/beta-freeze-2026-08.md
+++ b/docs/dev/beta-freeze-2026-08.md
@@ -1,0 +1,117 @@
+# Ajisai β版改修指示書 — 57 canonical / 35 Semantic Kernel
+
+Status: **Non-canonical / 方針記録・改修指示書**。正典は `spec/` 配下と、そこから生成される `SPECIFICATION.html` である。実装作業は GitHub Issue #1429 で追跡する。
+
+## 1. β版の境界
+
+- REFLECT を含む `ebb66a5f9d14a6c8d6610488724e476e652abc35` をα版の基準点とする。
+- 全完了条件を初めて満たす commit からβ版を開始し、最初の版番号を `0.2.0-beta.1` とする。
+- 公開Coreは単一の平坦なdictionaryにある57 canonical Wordsであり、35語のSemantic Kernelと22語のStandard Wordsに設計分類する。namespace、module、import、prelude、別dictionaryは導入しない。
+- 35語は数学的・世界的な最小集合ではなくAjisaiの意味論的な幹である。57語がβ版の実用的なcanonical surfaceである。
+
+## 2. 固定する語集合
+
+### Semantic Kernel（35）
+
+- Truth / comparison: `TRUE FALSE AND NOT EQ LT GT`
+- Exact arithmetic: `ADD MUL DIV FLOOR NEG SQRT`
+- Vector / iteration: `GET LENGTH CONCAT COLLECT RANGE FOLD`
+- Text boundaries: `CHARS JOIN NUM STR`
+- Control / absence / modifier / dictionary / effect / reflection: `COND EXEC NIL NIL? NIL-REASON VENT KEEP DEF DEL LOOKUP PRINT REFLECT`
+
+### Standard Words（22）
+
+- Truth / comparison: `OR NEQ LTE GTE`
+- Exact arithmetic: `SUB MOD ROUND ABS MIN MAX`
+- Vector / higher-order: `TAKE REVERSE FILL SORT INDEX-OF MAP FILTER ANY ALL`
+- Text algorithms: `TRIM TOKENIZE SUBSTITUTE`
+
+Standard Wordsは互換層や任意bundleではない。Kernelと同水準のmachine-readable contract、Specification、Reference、hover、LOOKUP、形式化、law test、conformance、runtime/compiled一致、REFLECT表現を持つ。
+
+### 削除するWords（13）
+
+`CEIL SIGN INSERT REPLACE REMOVE SPLIT REORDER UNIQUE CONTAINS STARTS-WITH? ENDS-WITH? CHR EAT`
+
+互換prelude、deprecated canonical name、自動変換器、復元bundleは提供しない。registryから隠すだけではなく、dispatch、executor、compiled path、alias、documentation、tests、migrationを削除する。
+
+## 3. 分類metadata
+
+残存する全entryは `spec/words.json` に `vocabularyTier: "kernel" | "standard"` を持つ。Standard entryは次のいずれかの `standardKind` を持つ。
+
+- `shorthand`: 直接的な短縮表現
+- `namedPattern`: 頻出定型処理の安定した名前と契約
+- `algorithm`: 境界条件や複雑度を含む標準アルゴリズム
+- `operational`: 短絡、隔離、復元、資源制限などnative実装の観測契約
+
+`docs/formalization-coverage.json` の `core_tier`（`identity` / `flow` / `material`）は別軸であり、名称・意味を変更しない。
+
+Kernelとの関係は、次の16語を `derivable`、次の6語を `operational` とする。
+
+- derivable: `OR NEQ LTE GTE SUB MOD ROUND ABS MIN MAX TAKE REVERSE INDEX-OF TRIM TOKENIZE SUBSTITUTE`
+- operational: `MAP FILTER ANY ALL FILL SORT`
+
+operational Wordは、Kernelの表現能力とは別に、効果回数、短絡点、ERROR復元、計算量または資源制限に関するnative保持理由を明記する。
+
+## 4. `check-minimal-core` gate
+
+集約gateは次を検査する。
+
+1. canonical inventoryが57語であり、Kernel 35語、Standard 22語の名前集合が本書と一致する。
+2. 削除13語がinventoryに存在しない。
+3. 57語すべてにformalization entryと存在するlaw-test fileがある。
+4. Kernel witnessがPrimitive、Derived、HostedEffectのいずれかとして有効である。
+5. Standardが`derivable`または`operational`を宣言し、必要なwitnessと保持理由を持つ。
+6. 孤立Core Wordがなく、`core_tier`と`vocabularyTier`を混同していない。
+
+Phase 1中のみ、削除予定13語を明示した70語inventoryを移行状態として許す。成功時は少なくとも以下を出力する。
+
+```text
+[minimal-core] 35/35 Semantic Kernel Words have executable witnesses.
+[minimal-core] 22/22 Standard Words have complete contracts and law witnesses.
+```
+
+## 5. Manifestと公開面
+
+Word Manifestは`canonicalWords: 57`、`semanticKernelWords: 35`、`standardWords: 22`を機械可読に公開し、各Wordにも`vocabularyTier`を出力する。aliasやsurface formをcanonical countに加算しない。
+
+README、Specification、Reference、Manifest、Rust docs、hover、LOOKUP、SKILL.md、conformance metadataは **57 canonical Words / 35-Word Semantic Kernel** に統一する。Referenceでは57語すべてを通常のCore Wordとして扱いながら、Kernel/Standardを識別可能にする。
+
+## 6. 互換層の終了
+
+- HostProtocolV2を唯一のcurrent protocolとし、V1 schema、golden、contract test、`kernel::legacy_v1`、GUI adapterを削除する。
+- module/import廃止後のno-op API、空field、UI、execution-mode/hedged-trace互換とworker hedging branchを削除する。
+- stack snapshot、user-word export、persistenceは現行のlossless/versioned形式だけを受理し、α形式reader、downgrade、fallback、migration、dictionary recoveryを残さない。
+- 削除Word専用aliasとlegacy canonicalization pathを削除する。記号糖の新設・再編は別scopeとする。
+
+## 7. 実装順序
+
+1. **契約と分類**: metadata schema、57語の分類、35/22構造gateを追加する。13語が残る間は移行中であることを明示する。
+2. **13語削除**: 正典、生成registry、runtime、compiled path、tests、docs、fixturesを収束させ、inventory gateを57語へ切り替える。
+3. **Standard契約**: 16 derivable witnessと6 operational contractを完成させる。
+4. **互換層削除**: V1 protocol、旧snapshot/import/export、module/import残骸、hedged互換を削除する。
+5. **公開面とversion**: 全生成物を再生成し、公開表記と全versionを`0.2.0-beta.1`へ同期し、β境界commitを記録する。
+
+巨大な一括PRを避け、各Phaseをレビュー可能なPRに分けてよい。ただし中間状態をreleaseしない。
+
+## 8. 必須law test
+
+- derivable 16語にはKernelのみを使う実行可能なAjisai programまたは同値性testを置く。
+- `MAP` / `FILTER`はindex順、isolated stack、effect順、truth/NIL policy、ERROR復元を検査する。
+- `ANY` / `ALL`は短絡点と未訪問effectの非実行を検査する。
+- `FILL`はshape overflowとmaterialization ceilingをallocation前に検査し、`spaceExhausted` NILを返す。
+- `SORT`はdeterministic order、比較ERROR時の原子性、元operand復元を検査する。
+- source、REFLECT decode、compiled planを含む全入口で削除13語がUnknown Wordまたは不正tokenになることを検査する。
+
+## 9. 完了条件
+
+- inventory、分類、名前集合が57/35/22で一致する。
+- 削除13語の正典、生成物、runtime、docs、tests、migrationが残らない。
+- Standard 22語が完全な契約、形式化、law test、conformanceを持つ。
+- Manifest/Reference/runtime/compiled/hover/LOOKUP/REFLECTが同じ57語を認識する。
+- V1 protocol、旧persistence/import/export、module/import残骸、hedged互換がproduction codeにない。
+- Rust fmt、clippy、library/integration tests、WASM、TypeScript、lint、Vitest、semantic firewall、生成同期、形式化、minimal-core、reading surface、version同期の全gateが通る。
+- package、crate、Tauri、配布metadataが`0.2.0-beta.1`で一致し、α基準点とβ境界commitがREADME/Specificationに記録される。
+
+## 10. Non-goals
+
+35語だけの公開、Kernel/Standardのnamespace分離、Standardの任意bundle化、α形式の自動変換、旧protocol readerの維持、記号糖再設計、35語の数学的最小性の主張は行わない。

--- a/docs/formalization-coverage.json
+++ b/docs/formalization-coverage.json
@@ -904,7 +904,8 @@
       ],
       "algebraic_family": "boolean-truth",
       "core_tier": "identity",
-      "implementation_schema": "logic_kleene.join_k3 via compute_k3_binary_value/fold_k3_values"
+      "implementation_schema": "logic_kleene.join_k3 via compute_k3_binary_value/fold_k3_values",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.not",
@@ -1021,7 +1022,8 @@
       ],
       "algebraic_family": "exact-arithmetic",
       "core_tier": "material",
-      "implementation_schema": "exact_arithmetic_schema(Sub) via apply_exact_arithmetic_schema"
+      "implementation_schema": "exact_arithmetic_schema(Sub) via apply_exact_arithmetic_schema",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.mul",
@@ -1111,7 +1113,8 @@
         "algebra.bubble.passthrough"
       ],
       "algebraic_family": "exact-arithmetic",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.floor",
@@ -1192,7 +1195,8 @@
         "algebra.bubble.passthrough"
       ],
       "algebraic_family": "exact-arithmetic",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.comparison",
@@ -1287,7 +1291,8 @@
       ],
       "algebraic_family": "observation",
       "core_tier": "identity",
-      "implementation_schema": "budgeted_order_projection(NEQ) via pairwise_eq/scalar_pair_eq"
+      "implementation_schema": "budgeted_order_projection(NEQ) via pairwise_eq/scalar_pair_eq",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.lt",
@@ -1347,7 +1352,8 @@
       ],
       "algebraic_family": "observation",
       "core_tier": "identity",
-      "implementation_schema": "ordering_schema(Le) via apply_ordering_schema"
+      "implementation_schema": "ordering_schema(Le) via apply_ordering_schema",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.gt",
@@ -1407,7 +1413,8 @@
       ],
       "algebraic_family": "observation",
       "core_tier": "identity",
-      "implementation_schema": "ordering_schema(Ge) via apply_ordering_schema"
+      "implementation_schema": "ordering_schema(Ge) via apply_ordering_schema",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.exact-real.sqrt",
@@ -1600,7 +1607,9 @@
       ],
       "algebraic_family": "structure-lift",
       "core_tier": "material",
-      "implementation_schema": "traversal_scheme(map) -> block_application -> structure_lift"
+      "implementation_schema": "traversal_scheme(map) -> block_application -> structure_lift",
+      "standard_relation": "operational",
+      "native_retention_reason": "Fixes index-order visitation, isolated callback stacks, effect order, and atomic ERROR restoration."
     },
     {
       "id": "core.filter",
@@ -1628,7 +1637,9 @@
       ],
       "algebraic_family": "structure-lift",
       "core_tier": "material",
-      "implementation_schema": "traversal_scheme(filter) -> predicate_application -> sequence_projection"
+      "implementation_schema": "traversal_scheme(filter) -> predicate_application -> sequence_projection",
+      "standard_relation": "operational",
+      "native_retention_reason": "Fixes predicate truth/NIL policy, index-order visitation, isolated callbacks, and atomic ERROR restoration."
     },
     {
       "id": "core.fold",
@@ -1685,7 +1696,9 @@
       ],
       "algebraic_family": "boolean-truth",
       "core_tier": "identity",
-      "implementation_schema": "predicate_fold(exists) via traversal_scheme + K3 projection"
+      "implementation_schema": "predicate_fold(exists) via traversal_scheme + K3 projection",
+      "standard_relation": "operational",
+      "native_retention_reason": "Fixes left-to-right short-circuiting so effects for unvisited elements do not run."
     },
     {
       "id": "core.all",
@@ -1712,7 +1725,9 @@
       ],
       "algebraic_family": "boolean-truth",
       "core_tier": "identity",
-      "implementation_schema": "predicate_fold(forall) via traversal_scheme + K3 projection"
+      "implementation_schema": "predicate_fold(forall) via traversal_scheme + K3 projection",
+      "standard_relation": "operational",
+      "native_retention_reason": "Fixes left-to-right short-circuiting so effects for unvisited elements do not run."
     },
     {
       "id": "hosted.clock.deterministic",
@@ -2011,7 +2026,8 @@
         "algebra.structure-lift.indexed-sequence"
       ],
       "algebraic_family": "structure-lift",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.split",
@@ -2093,7 +2109,8 @@
         "algebra.structure-lift.indexed-sequence"
       ],
       "algebraic_family": "structure-lift",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.range",
@@ -2200,7 +2217,9 @@
         "algebra.structure-lift.reshape-group"
       ],
       "algebraic_family": "structure-lift",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "operational",
+      "native_retention_reason": "Checks shape overflow and the materialization ceiling before allocation."
     },
     {
       "id": "core.structural.record",
@@ -2326,7 +2345,8 @@
         "algebra.exact-scalar.codepoint-sequence"
       ],
       "algebraic_family": "exact-scalar",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.tokenize",
@@ -2352,7 +2372,8 @@
         "algebra.exact-scalar.codepoint-sequence"
       ],
       "algebraic_family": "exact-scalar",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.substitute",
@@ -2378,7 +2399,8 @@
         "algebra.exact-scalar.codepoint-sequence"
       ],
       "algebraic_family": "exact-scalar",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "core.starts-with",
@@ -2719,7 +2741,9 @@
         "algebra.k3.domain"
       ],
       "algebraic_family": "structure-lift",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "operational",
+      "native_retention_reason": "Fixes deterministic ordering and restores the original operand atomically on comparison ERROR."
     },
     {
       "id": "module.algo.unique",
@@ -2800,7 +2824,8 @@
         "algebra.bubble.domain"
       ],
       "algebraic_family": "structure-lift",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "module.math.abs",
@@ -2829,7 +2854,8 @@
         "algebra.exact-real.gosper"
       ],
       "algebraic_family": "exact-arithmetic",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "module.math.neg",
@@ -2915,7 +2941,8 @@
         "algebra.k3.domain"
       ],
       "algebraic_family": "exact-arithmetic",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "module.math.max",
@@ -2944,7 +2971,8 @@
         "algebra.k3.domain"
       ],
       "algebraic_family": "exact-arithmetic",
-      "core_tier": "material"
+      "core_tier": "material",
+      "standard_relation": "derivable"
     },
     {
       "id": "surface.hash",

--- a/scripts/check-minimal-core.mjs
+++ b/scripts/check-minimal-core.mjs
@@ -1,17 +1,53 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync } from 'node:fs';
 
-const words = JSON.parse(readFileSync('spec/words.json', 'utf8')).entries;
+const KERNEL = new Set(`TRUE FALSE AND NOT EQ LT GT
+ADD MUL DIV FLOOR NEG SQRT
+GET LENGTH CONCAT COLLECT RANGE FOLD
+CHARS JOIN NUM STR
+COND EXEC NIL NIL? NIL-REASON VENT KEEP DEF DEL LOOKUP PRINT REFLECT`.split(/\s+/));
+const STANDARD = new Set(`OR NEQ LTE GTE SUB MOD ROUND ABS MIN MAX
+TAKE REVERSE FILL SORT INDEX-OF MAP FILTER ANY ALL
+TRIM TOKENIZE SUBSTITUTE`.split(/\s+/));
+const REMOVED = new Set(`CEIL SIGN INSERT REPLACE REMOVE SPLIT REORDER UNIQUE CONTAINS
+STARTS-WITH? ENDS-WITH? CHR EAT`.split(/\s+/));
+const STANDARD_RELATIONS = new Set(['derivable', 'operational']);
+const STANDARD_KINDS = new Set(['shorthand', 'namedPattern', 'algorithm', 'operational']);
+
+const contracts = JSON.parse(readFileSync('spec/words.json', 'utf8'));
+const words = contracts.entries;
 const coverage = JSON.parse(readFileSync('docs/formalization-coverage.json', 'utf8'));
 const wordNames = new Set(words.map((word) => word.name));
 const entries = coverage.entries.filter((entry) => wordNames.has(entry.surface));
 const primitives = new Set(coverage.algebra_primitives.map((entry) => entry.id));
 const bySurface = new Map();
 const errors = [];
+const setDifference = (left, right) => [...left].filter((item) => !right.has(item));
 
+if (words.length !== wordNames.size) errors.push('canonical inventory contains duplicate names');
 for (const entry of entries) {
   if (bySurface.has(entry.surface)) errors.push(`duplicate Core Word witness: ${entry.surface}`);
   bySurface.set(entry.surface, entry);
+}
+
+const kernelWords = new Set(words.filter((word) => word.vocabularyTier === 'kernel').map((word) => word.name));
+const standardWords = new Set(words.filter((word) => word.vocabularyTier === 'standard').map((word) => word.name));
+for (const name of setDifference(KERNEL, kernelWords)) errors.push(`${name}: missing Semantic Kernel classification`);
+for (const name of setDifference(kernelWords, KERNEL)) errors.push(`${name}: unexpected Semantic Kernel classification`);
+for (const name of setDifference(STANDARD, standardWords)) errors.push(`${name}: missing Standard classification`);
+for (const name of setDifference(standardWords, STANDARD)) errors.push(`${name}: unexpected Standard classification`);
+if (kernelWords.size !== 35) errors.push(`Semantic Kernel has ${kernelWords.size} Words; expected 35`);
+if (standardWords.size !== 22) errors.push(`Standard vocabulary has ${standardWords.size} Words; expected 22`);
+
+const isPhaseOne = contracts.migration?.betaFreezePhase === 1;
+if (isPhaseOne) {
+  if (words.length !== 70) errors.push(`phase 1 transitional inventory has ${words.length} Words; expected 70`);
+  const pendingRemoval = new Set(words.filter((word) => !word.vocabularyTier).map((word) => word.name));
+  for (const name of setDifference(REMOVED, pendingRemoval)) errors.push(`${name}: missing from phase 1 removal set`);
+  for (const name of setDifference(pendingRemoval, REMOVED)) errors.push(`${name}: unclassified Word is not in the removal set`);
+} else {
+  if (words.length !== 57) errors.push(`canonical inventory has ${words.length} Words; expected 57`);
+  for (const name of REMOVED) if (wordNames.has(name)) errors.push(`${name}: removed Word remains canonical`);
 }
 
 for (const word of words) {
@@ -25,14 +61,10 @@ for (const word of words) {
   for (const testPath of witness.law_tests ?? []) {
     if (!existsSync(testPath)) errors.push(`${word.name}: missing law test file ${testPath}`);
   }
-  if (!['identity', 'flow', 'material'].includes(witness.core_tier)) {
-    errors.push(`${word.name}: invalid Core tier ${witness.core_tier}`);
-  }
+  if (!['identity', 'flow', 'material'].includes(witness.core_tier)) errors.push(`${word.name}: invalid core_tier ${witness.core_tier}`);
+  if (witness.core_tier === word.vocabularyTier) errors.push(`${word.name}: core_tier is confused with vocabularyTier`);
   if (witness.semantic_role === 'Primitive') {
     if (!witness.primitive) errors.push(`${word.name}: Primitive role is not marked primitive`);
-    if (!['identity', 'flow'].includes(witness.core_tier)) {
-      errors.push(`${word.name}: primitive lies outside Minimal Core`);
-    }
   } else if (witness.semantic_role === 'Derived') {
     if (witness.primitive) errors.push(`${word.name}: Derived role is marked primitive`);
     if (!witness.derived_from?.length) errors.push(`${word.name}: derived Word has no algebra basis`);
@@ -42,19 +74,24 @@ for (const word of words) {
   for (const dependency of witness.derived_from ?? []) {
     if (!primitives.has(dependency)) errors.push(`${word.name}: unknown algebra primitive ${dependency}`);
   }
+  if (word.vocabularyTier === 'standard') {
+    if (!STANDARD_KINDS.has(word.standardKind)) errors.push(`${word.name}: invalid or missing standardKind`);
+    if (!STANDARD_RELATIONS.has(witness.standard_relation)) errors.push(`${word.name}: invalid or missing Standard relation`);
+    if (witness.standard_relation === 'operational' && !witness.native_retention_reason) {
+      errors.push(`${word.name}: operational Standard has no native retention reason`);
+    }
+  }
 }
 
-for (const surface of bySurface.keys()) {
-  if (!words.some((word) => word.name === surface)) errors.push(`${surface}: witness has no canonical Word`);
+for (const entry of coverage.entries.filter((entry) => entry.kind === 'coreword')) {
+  if (!wordNames.has(entry.surface)) errors.push(`${entry.surface}: witness has no canonical Word`);
 }
-
-if (bySurface.size !== words.length) {
-  errors.push(`witness inventory has ${bySurface.size} entries; expected ${words.length}`);
-}
+if (bySurface.size !== words.length) errors.push(`witness inventory has ${bySurface.size} entries; expected ${words.length}`);
 
 if (errors.length) {
   errors.forEach((error) => console.error(`[minimal-core] ${error}`));
   process.exit(1);
 }
-console.log(`[minimal-core] ${words.length}/${words.length} Core Words have a formalized, executable primitive/derivation witness.`);
-console.log('[minimal-core] coverage completeness is not a global proof that the current Word basis is irreducible.');
+console.log('[minimal-core] 35/35 Semantic Kernel Words have executable witnesses.');
+console.log('[minimal-core] 22/22 Standard Words have complete contracts and law witnesses.');
+if (isPhaseOne) console.log('[minimal-core] phase 1: 13 alpha Words remain explicitly pending removal.');

--- a/scripts/check-word-schema-migration.mjs
+++ b/scripts/check-word-schema-migration.mjs
@@ -17,12 +17,17 @@ const manifestNames = new Set(manifest.entries.map((entry) => entry.canonical));
 const names = new Set();
 
 if (words.migration.completeInventory !== true) fail('the canonical Word inventory must be marked complete');
+if (words.migration.betaFreezePhase !== 1) fail('the beta vocabulary migration must be in phase 1');
 
 for (const word of words.entries) {
   if (names.has(word.name)) fail(`duplicate Word: ${word.name}`);
   names.add(word.name);
   for (const field of required) if (!(field in word)) fail(`${word.name} lacks required field ${field}`);
   if (!familyIds.has(word.family)) fail(`${word.name} references unknown family ${word.family}`);
+  if (word.vocabularyTier === 'standard' && !['shorthand', 'namedPattern', 'algorithm', 'operational'].includes(word.standardKind)) {
+    fail(`${word.name} lacks a valid standardKind`);
+  }
+  if (word.vocabularyTier === 'kernel' && 'standardKind' in word) fail(`${word.name} is Kernel but declares standardKind`);
   if (!manifestNames.has(word.name)) fail(`${word.name} is absent from the frozen manifest`);
   for (const clause of word.clauses) if (!language.includes(`${clause} —`)) fail(`${word.name} references missing clause ${clause}`);
 

--- a/spec/words.json
+++ b/spec/words.json
@@ -2,7 +2,8 @@
   "schemaVersion": 1,
   "migration": {
     "phase": 6,
-    "completeInventory": true
+    "completeInventory": true,
+    "betaFreezePhase": 1
   },
   "entries": [
     {
@@ -39,7 +40,8 @@
       "executorKey": "True",
       "effects": [],
       "partiality": "total",
-      "category": "constant"
+      "category": "constant",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "FALSE",
@@ -75,7 +77,8 @@
       "executorKey": "False",
       "effects": [],
       "partiality": "total",
-      "category": "constant"
+      "category": "constant",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "AND",
@@ -115,7 +118,8 @@
       "executorKey": "And",
       "effects": [],
       "partiality": "total",
-      "category": "logic"
+      "category": "logic",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "OR",
@@ -153,7 +157,9 @@
       "executorKey": "Or",
       "effects": [],
       "partiality": "total",
-      "category": "logic"
+      "category": "logic",
+      "vocabularyTier": "standard",
+      "standardKind": "shorthand"
     },
     {
       "name": "NOT",
@@ -191,7 +197,8 @@
       "executorKey": "Not",
       "effects": [],
       "partiality": "total",
-      "category": "logic"
+      "category": "logic",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "EQ",
@@ -233,7 +240,8 @@
       "executorKey": "Eq",
       "effects": [],
       "partiality": "projecting",
-      "category": "comparison"
+      "category": "comparison",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "NEQ",
@@ -275,7 +283,9 @@
       "executorKey": "Neq",
       "effects": [],
       "partiality": "projecting",
-      "category": "comparison"
+      "category": "comparison",
+      "vocabularyTier": "standard",
+      "standardKind": "shorthand"
     },
     {
       "name": "LT",
@@ -318,7 +328,8 @@
       "executorKey": "Lt",
       "effects": [],
       "partiality": "projecting",
-      "category": "comparison"
+      "category": "comparison",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "LTE",
@@ -361,7 +372,9 @@
       "executorKey": "Le",
       "effects": [],
       "partiality": "projecting",
-      "category": "comparison"
+      "category": "comparison",
+      "vocabularyTier": "standard",
+      "standardKind": "shorthand"
     },
     {
       "name": "GT",
@@ -404,7 +417,8 @@
       "executorKey": "Gt",
       "effects": [],
       "partiality": "projecting",
-      "category": "comparison"
+      "category": "comparison",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "GTE",
@@ -447,7 +461,9 @@
       "executorKey": "Gte",
       "effects": [],
       "partiality": "projecting",
-      "category": "comparison"
+      "category": "comparison",
+      "vocabularyTier": "standard",
+      "standardKind": "shorthand"
     },
     {
       "name": "ADD",
@@ -490,7 +506,8 @@
       "executorKey": "Add",
       "effects": [],
       "partiality": "total",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "SUB",
@@ -533,7 +550,9 @@
       "executorKey": "Sub",
       "effects": [],
       "partiality": "total",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "standard",
+      "standardKind": "shorthand"
     },
     {
       "name": "MUL",
@@ -576,7 +595,8 @@
       "executorKey": "Mul",
       "effects": [],
       "partiality": "total",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "DIV",
@@ -619,7 +639,8 @@
       "executorKey": "Div",
       "effects": [],
       "partiality": "projecting",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "MOD",
@@ -663,7 +684,9 @@
       "executorKey": "Mod",
       "effects": [],
       "partiality": "projecting",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "FLOOR",
@@ -704,7 +727,8 @@
       "executorKey": "Floor",
       "effects": [],
       "partiality": "projecting",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "CEIL",
@@ -786,7 +810,9 @@
       "executorKey": "Round",
       "effects": [],
       "partiality": "projecting",
-      "category": "arithmetic"
+      "category": "arithmetic",
+      "vocabularyTier": "standard",
+      "standardKind": "algorithm"
     },
     {
       "name": "ABS",
@@ -827,7 +853,9 @@
       "executorKey": "Abs",
       "effects": [],
       "partiality": "total",
-      "category": "math"
+      "category": "math",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "NEG",
@@ -868,7 +896,8 @@
       "executorKey": "Neg",
       "effects": [],
       "partiality": "total",
-      "category": "math"
+      "category": "math",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "SIGN",
@@ -950,7 +979,9 @@
       "executorKey": "Min",
       "effects": [],
       "partiality": "total",
-      "category": "math"
+      "category": "math",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "MAX",
@@ -991,7 +1022,9 @@
       "executorKey": "Max",
       "effects": [],
       "partiality": "total",
-      "category": "math"
+      "category": "math",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "SQRT",
@@ -1033,7 +1066,8 @@
       "executorKey": "Sqrt",
       "effects": [],
       "partiality": "projecting",
-      "category": "math"
+      "category": "math",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "GET",
@@ -1074,7 +1108,8 @@
       "executorKey": "Get",
       "effects": [],
       "partiality": "projecting",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "INSERT",
@@ -1239,7 +1274,8 @@
       "executorKey": "Length",
       "effects": [],
       "partiality": "partial",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "TAKE",
@@ -1280,7 +1316,9 @@
       "executorKey": "Take",
       "effects": [],
       "partiality": "partial",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "SPLIT",
@@ -1361,7 +1399,8 @@
       "executorKey": "Concat",
       "effects": [],
       "partiality": "partial",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "REVERSE",
@@ -1401,7 +1440,9 @@
       "executorKey": "Reverse",
       "effects": [],
       "partiality": "partial",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "REORDER",
@@ -1483,7 +1524,8 @@
       "executorKey": "Collect",
       "effects": [],
       "partiality": "partial",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "RANGE",
@@ -1523,7 +1565,8 @@
       "executorKey": "Range",
       "effects": [],
       "partiality": "projecting",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "FILL",
@@ -1563,7 +1606,9 @@
       "executorKey": "Fill",
       "effects": [],
       "partiality": "projecting",
-      "category": "tensor"
+      "category": "tensor",
+      "vocabularyTier": "standard",
+      "standardKind": "operational"
     },
     {
       "name": "SORT",
@@ -1604,7 +1649,9 @@
       "executorKey": "Sort",
       "effects": [],
       "partiality": "total",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "standard",
+      "standardKind": "operational"
     },
     {
       "name": "UNIQUE",
@@ -1727,7 +1774,9 @@
       "executorKey": "IndexOf",
       "effects": [],
       "partiality": "projecting",
-      "category": "vector"
+      "category": "vector",
+      "vocabularyTier": "standard",
+      "standardKind": "namedPattern"
     },
     {
       "name": "MAP",
@@ -1767,7 +1816,9 @@
       "executorKey": "Map",
       "effects": [],
       "partiality": "partial",
-      "category": "higher-order"
+      "category": "higher-order",
+      "vocabularyTier": "standard",
+      "standardKind": "operational"
     },
     {
       "name": "FILTER",
@@ -1807,7 +1858,9 @@
       "executorKey": "Filter",
       "effects": [],
       "partiality": "partial",
-      "category": "higher-order"
+      "category": "higher-order",
+      "vocabularyTier": "standard",
+      "standardKind": "operational"
     },
     {
       "name": "FOLD",
@@ -1847,7 +1900,8 @@
       "executorKey": "Fold",
       "effects": [],
       "partiality": "partial",
-      "category": "higher-order"
+      "category": "higher-order",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "ANY",
@@ -1887,7 +1941,9 @@
       "executorKey": "Any",
       "effects": [],
       "partiality": "partial",
-      "category": "higher-order"
+      "category": "higher-order",
+      "vocabularyTier": "standard",
+      "standardKind": "operational"
     },
     {
       "name": "ALL",
@@ -1927,7 +1983,9 @@
       "executorKey": "All",
       "effects": [],
       "partiality": "partial",
-      "category": "higher-order"
+      "category": "higher-order",
+      "vocabularyTier": "standard",
+      "standardKind": "operational"
     },
     {
       "name": "CHARS",
@@ -1966,7 +2024,8 @@
       "executorKey": "Chars",
       "effects": [],
       "partiality": "partial",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "JOIN",
@@ -2006,7 +2065,8 @@
       "executorKey": "Join",
       "effects": [],
       "partiality": "partial",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "TRIM",
@@ -2045,7 +2105,9 @@
       "executorKey": "Trim",
       "effects": [],
       "partiality": "partial",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "standard",
+      "standardKind": "algorithm"
     },
     {
       "name": "TOKENIZE",
@@ -2085,7 +2147,9 @@
       "executorKey": "Tokenize",
       "effects": [],
       "partiality": "partial",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "standard",
+      "standardKind": "algorithm"
     },
     {
       "name": "SUBSTITUTE",
@@ -2124,7 +2188,9 @@
       "executorKey": "Substitute",
       "effects": [],
       "partiality": "partial",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "standard",
+      "standardKind": "algorithm"
     },
     {
       "name": "STARTS-WITH?",
@@ -2243,7 +2309,8 @@
       "executorKey": "Num",
       "effects": [],
       "partiality": "projecting",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "STR",
@@ -2280,7 +2347,8 @@
       "executorKey": "Str",
       "effects": [],
       "partiality": "partial",
-      "category": "cast"
+      "category": "cast",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "CHR",
@@ -2360,7 +2428,8 @@
       "executorKey": "Cond",
       "effects": [],
       "partiality": "partial",
-      "category": "control"
+      "category": "control",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "EXEC",
@@ -2400,7 +2469,8 @@
       "executorKey": "Exec",
       "effects": [],
       "partiality": "partial",
-      "category": "control"
+      "category": "control",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "NIL",
@@ -2437,7 +2507,8 @@
       "executorKey": "Nil",
       "effects": [],
       "partiality": "total",
-      "category": "constant"
+      "category": "constant",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "NIL?",
@@ -2474,7 +2545,8 @@
       "executorKey": "NilCheck",
       "effects": [],
       "partiality": "total",
-      "category": "absence"
+      "category": "absence",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "NIL-REASON",
@@ -2511,7 +2583,8 @@
       "executorKey": "NilReason",
       "effects": [],
       "partiality": "total",
-      "category": "absence"
+      "category": "absence",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "VENT",
@@ -2552,7 +2625,8 @@
       "executorKey": "LazyNextUnitFallback",
       "effects": [],
       "partiality": "total",
-      "category": "control-directive"
+      "category": "control-directive",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "EAT",
@@ -2628,7 +2702,8 @@
       "executorKey": "SetConsumptionKeep",
       "effects": [],
       "partiality": "total",
-      "category": "modifier"
+      "category": "modifier",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "DEF",
@@ -2671,7 +2746,8 @@
         "dictionaryWrite"
       ],
       "partiality": "partial",
-      "category": "dictionary"
+      "category": "dictionary",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "DEL",
@@ -2714,7 +2790,8 @@
         "dictionaryDelete"
       ],
       "partiality": "partial",
-      "category": "dictionary"
+      "category": "dictionary",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "LOOKUP",
@@ -2758,7 +2835,8 @@
         "dictionaryRead"
       ],
       "partiality": "partial",
-      "category": "dictionary"
+      "category": "dictionary",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "PRINT",
@@ -2797,7 +2875,8 @@
         "consoleWrite"
       ],
       "partiality": "partial",
-      "category": "io"
+      "category": "io",
+      "vocabularyTier": "kernel"
     },
     {
       "name": "REFLECT",
@@ -2836,7 +2915,8 @@
       "executorKey": "Reflect",
       "effects": [],
       "partiality": "partial",
-      "category": "reflection"
+      "category": "reflection",
+      "vocabularyTier": "kernel"
     }
   ]
 }

--- a/spec/words.schema.json
+++ b/spec/words.schema.json
@@ -25,6 +25,11 @@
         },
         "completeInventory": {
           "type": "boolean"
+        },
+        "betaFreezePhase": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
         }
       },
       "additionalProperties": false
@@ -291,9 +296,61 @@
         "executorKey": {
           "type": "string",
           "pattern": "^(?:[A-Z][A-Za-z0-9]*|[a-z][a-z0-9_]*::[a-z][a-z0-9_]*)$"
+        },
+        "vocabularyTier": {
+          "enum": [
+            "kernel",
+            "standard"
+          ]
+        },
+        "standardKind": {
+          "enum": [
+            "shorthand",
+            "namedPattern",
+            "algorithm",
+            "operational"
+          ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "vocabularyTier": {
+                "const": "standard"
+              }
+            },
+            "required": [
+              "vocabularyTier"
+            ]
+          },
+          "then": {
+            "required": [
+              "standardKind"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "vocabularyTier": {
+                "const": "kernel"
+              }
+            },
+            "required": [
+              "vocabularyTier"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "standardKind"
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Establish a formal β-phase freeze for the Ajisai canonical vocabulary by classifying the 57 canonical Words into a 35-word Semantic Kernel and 22-word Standard set and record the policy and rollout plan.
- Enforce machine-checkable contracts and manifest consistency so the repository can validate the frozen inventory and Standard/Kernel metadata during migration phases.

### Description

- Add `docs/dev/beta-freeze-2026-08.md` describing the β boundary, vocabulary composition (57 canonical / 35 Semantic Kernel / 22 Standard), removal of 13 Words, migration phases, gates, and law-test requirements.
- Extend `spec/words.json` entries and `migration` metadata with `vocabularyTier` for each Word, add `standardKind` for Standard Words, and set `migration.betaFreezePhase`: 1.
- Update `spec/words.schema.json` to validate `vocabularyTier` and `standardKind` with conditional requirements (Standard Words must include `standardKind`, Kernel must not declare it), and allow `migration.betaFreezePhase` in migration metadata.
- Update `docs/formalization-coverage.json` entries to carry `standard_relation` and for operational Standards include `native_retention_reason` where applicable.
- Revise validation tooling: `scripts/check-minimal-core.mjs` now enforces the canonical Kernel/Standard/Removed sets, checks `vocabularyTier`/`standardKind`/`standard_relation`/`native_retention_reason`, supports phase-1 transitional inventory expectations, and prints the expected phase success messages; `scripts/check-word-schema-migration.mjs` now requires `migration.betaFreezePhase` to be set and validates per-word `vocabularyTier` / `standardKind` constraints and runtime dispatch presence.

### Testing

- Ran the updated JSON schema validation against `spec/words.schema.json` and `spec/words.json` (via the schema and `ajv`-style check) and it succeeded.
- Executed the repository validation scripts `node scripts/check-word-schema-migration.mjs` and `node scripts/check-minimal-core.mjs` against the modified `spec/words.json` and `docs/formalization-coverage.json`, both returned success (no errors and printed the expected minimal-core messages).
- No other unit or integration test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a705f92fb7483269ea9bcee5c608fc2)