### PR TITLE
Stop the in-app Reference teaching the retired symbols

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -462,7 +462,7 @@
                     <h3>How to read the examples</h3>
                     <p>The <strong>Expected value</strong> column shows the final stack exactly as the language renders it, value by value. Two display conventions matter from the start:</p>
                     <p>Numbers display as exact fractions in <code>numerator/denominator</code> form — the integer three renders as <code>3/1</code>. Truth values display as <code>TRUE</code> and <code>FALSE</code>; the absence of a value displays as <code>NIL</code>.</p>
-                    <p>In the text of this reference, anything with a gray background is an Ajisai token. Every symbol token defined by Ajisai is a word in disguise — <code>+</code> is <code>ADD</code> and <code>,,</code> is <code>KEEP</code> — so the gray background is the signal that a mark belongs to the program, not to the prose.</p>
+                    <p>In the text of this reference, anything with a gray background is an Ajisai token. Every symbol token defined by Ajisai is a word in disguise — <code>+</code> is <code>ADD</code> and <code>^</code> is <code>VENT</code> — so the gray background is the signal that a mark belongs to the program, not to the prose.</p>
                 </section>
 
                 <section id="vectors" class="ref-page">
@@ -645,7 +645,7 @@
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
-                    <p class="ref-note">An irrational value itself renders as a nested continued fraction such as <code>( 1 ( 2 ( 2 ( 2 ...) ) ) )</code>, truncated at a display budget. The nested form is display output only — it is not source syntax, and <code>(</code> <code>)</code> are rejected in programs.</p>
+                    <p class="ref-note">An irrational value itself renders as a nested continued fraction such as <code>( 1 ( 2 ( 2 ( 2 ... ) ) ) )</code>, truncated at a display budget. The nested form is display output only — it is not source syntax, and <code>(</code> <code>)</code> are rejected in programs.</p>
                 </section>
 
                 <section id="stack" class="ref-page">
@@ -654,11 +654,11 @@
                     <div class="ref-table-wrap word-table">
                         <table class="ref-table">
                             <thead>
-                                <tr><th>Canonical</th><th>Sugar</th><th>Effect</th></tr>
+                                <tr><th>Canonical</th><th>Effect</th></tr>
                             </thead>
                             <tbody>
 
-                                <tr><td><code>KEEP</code></td><td><code>,,</code></td><td class="notes">Retain the operands and push the result as well.</td></tr>
+                                <tr><td><code>KEEP</code></td><td class="notes">Retain the operands and push the result as well.</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -691,7 +691,7 @@
                                 <tr>
                                     <td><code>3 4 KEEP ADD</code></td>
                                     <td><code>3/1 4/1 7/1</code></td>
-                                    <td class="notes"><code>KEEP</code> (<code>,,</code>) retains the operands; the result is pushed on top.</td>
+                                    <td class="notes"><code>KEEP</code> retains the operands; the result is pushed on top.</td>
                                 </tr>
                             </tbody>
                         </table>
@@ -789,11 +789,11 @@
                             </thead>
                             <tbody>
                                 <tr><td><code>EQ</code></td><td><code>=</code></td><td class="notes">Equal</td></tr>
-                                <tr><td><code>NEQ</code></td><td><code>&lt;&gt;</code></td><td class="notes">Not equal</td></tr>
+                                <tr><td><code>NEQ</code></td><td></td><td class="notes">Not equal</td></tr>
                                 <tr><td><code>LT</code></td><td><code>&lt;</code></td><td class="notes">Less than</td></tr>
-                                <tr><td><code>LTE</code></td><td><code>&lt;=</code></td><td class="notes">Less than or equal</td></tr>
+                                <tr><td><code>LTE</code></td><td></td><td class="notes">Less than or equal</td></tr>
                                 <tr><td><code>GT</code></td><td><code>&gt;</code></td><td class="notes">Greater than</td></tr>
-                                <tr><td><code>GTE</code></td><td><code>&gt;=</code></td><td class="notes">Greater than or equal</td></tr>
+                                <tr><td><code>GTE</code></td><td></td><td class="notes">Greater than or equal</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -859,7 +859,7 @@
 
                 <section id="logic" class="ref-page">
                     <h2>Logic</h2>
-                    <p><code>AND</code> (<code>&amp;</code>) and <code>OR</code> and <code>NOT</code> are the Boolean operations over the two truth values <code>TRUE</code> and <code>FALSE</code>. An absent operand passes through: <code>NIL</code> in, <code>NIL</code> out, so a bubble stays visible in the result even when the other operand would settle the answer.</p>
+                    <p><code>AND</code>, <code>OR</code> and <code>NOT</code> are the Boolean operations over the two truth values <code>TRUE</code> and <code>FALSE</code>. An absent operand passes through: <code>NIL</code> in, <code>NIL</code> out, so a bubble stays visible in the result even when the other operand would settle the answer.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
                         <table class="ref-table">
@@ -1645,7 +1645,7 @@ COND</code></td>
 
                 <section id="output" class="ref-page">
                     <h2>Output</h2>
-                    <p><code>PRINT</code> writes the top stack value to the output area. Like any word it consumes its operand by default; with <code>KEEP</code> (<code>,,</code>) the value also stays on the stack. The Playground always shows the final stack, so <code>PRINT</code> is for the output channel, not for seeing results.</p>
+                    <p><code>PRINT</code> writes the top stack value to the output area. Like any word it consumes its operand by default; with <code>KEEP</code> the value also stays on the stack. The Playground always shows the final stack, so <code>PRINT</code> is for the output channel, not for seeing results.</p>
                     <p>A string is shown on the stack wrapped in single quotes (<code>'TEST'</code>) so you can tell it apart from a numeric vector. Those quotes belong to the Stack display, not to the value: <code>PRINT</code> writes the raw text, so <code>'TEST'</code> prints as <code>TEST</code>. Quote characters that are part of the text are kept (a string whose content is <code>T'ES'T</code> prints as <code>T'ES'T</code>). Numbers and booleans print exactly as they appear on the stack.</p>
                     <div class="sample">
                         <div class="ref-table-wrap">
@@ -1655,9 +1655,9 @@ COND</code></td>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><code>42 ,, PRINT</code></td>
+                                    <td><code>42 KEEP PRINT</code></td>
                                     <td><code>42/1</code></td>
-                                    <td class="notes">The value goes to the output area and, thanks to <code>,,</code>, stays on the stack.</td>
+                                    <td class="notes">The value goes to the output area and, thanks to <code>KEEP</code>, stays on the stack.</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/scripts/check-reading-surfaces.mjs
+++ b/scripts/check-reading-surfaces.mjs
@@ -17,6 +17,10 @@ const manifest = JSON.parse(readFileSync('docs/word-manifest.json', 'utf8'));
 const known = new Set();
 for (const entry of manifest.entries) {
   known.add(entry.canonical);
+  // The manifest field is `surface` (singular). Reading a plural that no entry
+  // has meant the registered *symbols* were never in this set — harmless while
+  // only word-shaped tokens were checked, and wrong the moment they are not.
+  known.add(entry.surface);
   for (const surface of entry.surfaces ?? []) known.add(surface);
 }
 
@@ -39,6 +43,22 @@ const SURFACES = ['README.md', 'public/docs/index.html', 'SPECIFICATION.html'];
 // Anything else inside <code> is a literal, a fragment, or punctuation.
 const WORD_SHAPED = /^[A-Z][A-Z0-9@?!'-]*$/;
 
+// Punctuation-shaped: a token of nothing but punctuation is a *symbol* claim.
+// This half of the check did not exist, and the whole retired set — `,,`, `<=`,
+// `>=`, `<>` and `&` — sat in the in-app Reference presenting itself as usable
+// sugar while the gate reported success, because a symbol is not word-shaped.
+const SYMBOL_SHAPED = /^[^A-Za-z0-9\s]+$/;
+
+// Characters a document names in order to say the language does *not* allocate
+// them, plus prose placeholders inside shape sketches. Each is a deliberate
+// mention rather than a claim, so each is listed rather than inferred.
+const UNALLOCATED_MENTIONS = new Set([
+  // the decimal-literal clause names the point to say a lone `.` is a name
+  '.',
+  // `{ ... }` sketches a block's shape; the ellipsis stands for a body
+  '...',
+]);
+
 const errors = [];
 
 for (const path of SURFACES) {
@@ -58,9 +78,19 @@ for (const path of SURFACES) {
 
   for (const span of spans) {
     // A span may hold a whole program (`2 SQRT 2 LT`), so check every token.
-    for (const token of span.trim().split(/\s+/)) {
-      if (!WORD_SHAPED.test(token)) continue;
-      if (known.has(token) || EXAMPLE_NAMES.has(token)) continue;
+    for (const raw of span.trim().split(/\s+/)) {
+      // Markdown escapes a table-cell pipe as `\|`; the token is the pipe.
+      const token = raw.replace(/\\([|`*_])/g, '$1');
+      if (WORD_SHAPED.test(token)) {
+        if (known.has(token) || EXAMPLE_NAMES.has(token)) continue;
+        seen.set(token, (seen.get(token) ?? 0) + 1);
+        continue;
+      }
+      if (!SYMBOL_SHAPED.test(token)) continue;
+      // A token opening with a quote is a string literal, and its content is
+      // not vocabulary — `''` is the empty string, not a symbol.
+      if (token.startsWith("'")) continue;
+      if (known.has(token) || UNALLOCATED_MENTIONS.has(token)) continue;
       seen.set(token, (seen.get(token) ?? 0) + 1);
     }
   }
@@ -74,9 +104,10 @@ if (errors.length) {
   for (const error of errors) console.error(`[reading-surfaces] ${error}`);
   console.error('[reading-surfaces] LANG.AUTHORITY.PRESENT: a reading surface may name only Words the language has.');
   console.error('[reading-surfaces] If the name is a new worked example, add it to EXAMPLE_NAMES in this script.');
+  console.error('[reading-surfaces] If a symbol is named only to say the language does not allocate it, add it to UNALLOCATED_MENTIONS.');
   process.exitCode = 1;
 } else {
   console.log(
-    `[reading-surfaces] ${SURFACES.length} surfaces name only the ${manifest.entries.length} registered surfaces and ${EXAMPLE_NAMES.size} declared example names.`,
+    `[reading-surfaces] ${SURFACES.length} surfaces name only the ${manifest.entries.length} registered surfaces, ${EXAMPLE_NAMES.size} declared example names and ${UNALLOCATED_MENTIONS.size} declared unallocated mentions.`,
   );
 }


### PR DESCRIPTION
## Summary

The reading-surface gate reported success while `public/docs/index.html` — the documentation shipped inside the app — still presented every retired symbol as usable sugar:

| where | what it said |
|---|---|
| "a symbol is a word in disguise" | `,,` is `KEEP` |
| modifier table | a **Sugar** column holding `,,` |
| comparison table | LTE `<=`, GTE `>=`, NEQ `<>` |
| Boolean section | `AND` (`&`) |
| PRINT page | a runnable sample `42 ,, PRINT` |

Nine claims in total, every one of them now an Unknown Word.

## Why the gate missed all nine

Two defects, each hiding the other:

1. The gate only ever matched **word-shaped** tokens (`/^[A-Z][A-Z0-9@?!'-]*$/`). A symbol is not word-shaped, so a symbol claim was never checked at all.
2. Its registry set was built from `entry.surfaces` — a field no manifest entry has, since the singular is `surface`. Even had a symbol reached the comparison, none of the ten registered symbols would have been in the set to match against.

The plural typo was invisible *because* symbols were skipped, and the skip looked harmless *because* the set would not have matched anyway.

Both halves are fixed. A punctuation-only token is now a symbol claim and must be a registered surface; the registry set reads `surface`; a markdown-escaped `\|` unescapes to the pipe it denotes; and a token opening with a quote is a string literal, so `''` reads as the empty string rather than an unknown symbol.

Characters a document names in order to say the language does **not** allocate them are declared rather than inferred, in a new `UNALLOCATED_MENTIONS` set: `.`, which the decimal-literal clause names to explain that a lone point is a name, and `...`, the placeholder in a `{ ... }` shape sketch. That mirrors how the gate already handles worked-example names.

## Verified by poisoning

Appending `` `1 1 <=` ``, `` `2 3 ,,` `` and `` `TRUE FALSE &` `` to the README fails the gate with all three named:

```
[reading-surfaces] README.md names & (1x), which is not in the vocabulary registry
[reading-surfaces] README.md names ,, (1x), which is not in the vocabulary registry
[reading-surfaces] README.md names <= (1x), which is not in the vocabulary registry
```

Removing them restores it: `3 surfaces name only the 77 registered surfaces, 17 declared example names and 2 declared unallocated mentions.`

The continued-fraction display sample also gains a space before its closing paren (`( 2 ... )` rather than `( 2 ...)`) so the ellipsis is its own token — which reads better anyway in a form that is display output and explicitly not source.

## Quality Classification

- Highest impacted level: QL-D (shipped documentation content and a CI gate; no runtime code changes)

## Traceability

- Requirement(s): LANG.AUTHORITY.PRESENT — a reading surface may name only what the language has. This is the vocabulary half of the clause extended to its symbol half.
- Verification evidence:
  - `scripts/check-reading-surfaces.mjs` — symbol claims are checked against the manifest, with the poisoning result above as the negative case
  - `docs/word-manifest.json` — the ten registered symbols the gate now reads via `surface`

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — unchanged, no Rust code touched
- [x] `cargo test --all-targets --verbose` (in `rust/`) — 882 tests, 0 failures
- [x] `npm run check`, if applicable — plus `lint`, `vitest` (219), and every generated-surface, coverage, minimal-core, reading-surface, file-size, version-sync and semantic-firewall gate
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not run locally; the Quality Gate job runs it
- [x] MC/DC-like checklist reviewed for modified boolean logic — the new token classification has three outcomes (word-shaped, symbol-shaped, neither) and the symbol branch three exits (string literal, registered, declared mention); each is exercised by the surfaces plus the poisoning case
- [x] Release checklist impact considered — no version change; documentation now matches the merged symbol inventory

Also verified: `ajisai test examples` (10/10).

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJPnddmyMfndj2dfnZyCAB)_