### PR TITLE
fix(gui): address user words by bare name, not DICT@NAME

### DIFF
--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -74,10 +74,9 @@ const collectAutocompleteWords = (): string[] => {
         .filter((w): w is string => w !== undefined && !HIDDEN_AUTOCOMPLETE_ALIASES.has(w));
 
     const userWordsInfo = INTERPRETER_CLIENT.collectUserWordsInfo();
-    const userWords: string[] = userWordsInfo.flatMap(word => [
-        word[1],
-        `${word[0]}@${word[1]}`
-    ]);
+    // Bare names only: a `DICT@NAME` completion no longer resolves to anything,
+    // so suggesting one only offered code that fails to run.
+    const userWords: string[] = userWordsInfo.map(word => word[1]);
 
     const allWords: Set<string> = new Set([...coreWords, ...userWords]);
     autocompleteWordsCache = Array.from(allWords).sort((a: string, b: string) => a.localeCompare(b));

--- a/src/gui/interpreter-execution-utils.test.ts
+++ b/src/gui/interpreter-execution-utils.test.ts
@@ -1,0 +1,159 @@
+// Regression for the auto-transition fault: running a pure stack program such
+// as the Reference's `3 4 KEEP ADD` pulled the right column to the Dictionary
+// instead of the Stack.
+//
+// The cause was name addressing, not the layout rule. The dictionary has two
+// tiers and User is one of them (LANG.DICTIONARY.RESOLUTION), so a word is
+// addressed by its bare name and the interpreter no longer resolves a
+// `DICT@NAME` composite. The host still composed one, so every definition read
+// back as null; `restore_user_words` skips a definition-less word, so the
+// worker ran without the user's words and reported none back, and the
+// post-execution sync wiped them from the main interpreter. Every run then
+// looked like a dictionary change.
+//
+// The fake below reproduces exactly those three contracts of the wasm boundary
+// (bare-name lookup, definition-less words skipped on restore, session reset
+// clears the User tier), so the round trip is exercised without the wasm.
+
+import { describe, expect, it } from 'vitest';
+import type { AjisaiInterpreter, ExecuteResult, UserWord, Value } from '../wasm-interpreter-types';
+import { collectUserWords, createExecutionSnapshot, syncInterpreterState } from './interpreter-execution-utils';
+import { detectExecutionSurfaceChanges } from './execution-surface-changes';
+
+const num = (n: number): Value =>
+    ({ type: 'number', value: { numerator: String(n), denominator: '1' } } as unknown as Value);
+
+interface FakeInterpreter extends AjisaiInterpreter {
+    readonly words: Map<string, string>;
+    setStack(stack: Value[]): void;
+}
+
+const createFakeInterpreter = (): FakeInterpreter => {
+    const words = new Map<string, string>();
+    let stack: Value[] = [];
+
+    const fake: Partial<FakeInterpreter> = {
+        words,
+        setStack: (next: Value[]) => { stack = next; },
+        collect_stack: () => stack,
+        // Tuple shape: [dictionary, name, isProtected]. There is one User tier,
+        // so the dictionary slot is a constant label, not an address.
+        collect_user_words_info: () =>
+            [...words.keys()].sort().map(name => ['USER', name, false] as [string, string, boolean]),
+        // Resolves a bare name only: `USER@FOO` is not a name the dictionary has.
+        lookup_word_definition: (name: string) => words.get(name.toUpperCase()) ?? null,
+        snapshot_stack: () => JSON.stringify(stack),
+        restore_stack_snapshot: (snapshot: string) => { stack = JSON.parse(snapshot) as Value[]; },
+        restore_user_words: (restored: UserWord[]) => {
+            for (const word of restored) {
+                // A word with no definition cannot be defined, so it is skipped.
+                if (!word.definition) continue;
+                words.set(word.name.toUpperCase(), word.definition);
+            }
+        },
+        reset_session: () => {
+            words.clear();
+            stack = [];
+            return { status: 'OK' } as ExecuteResult;
+        },
+        set_max_execution_steps: () => { /* budget is not modelled here */ },
+        update_serial_inbox: () => { /* no serial in this model */ },
+        mark_serial_disconnected: () => { /* no serial in this model */ },
+    };
+
+    return fake as FakeInterpreter;
+};
+
+// One `executeCode` round: snapshot the main interpreter, run in a second
+// interpreter (the worker), sync the result back, and report what changed.
+const runOneExecution = (
+    main: FakeInterpreter,
+    worker: FakeInterpreter,
+    execute: (worker: FakeInterpreter) => ExecuteResult
+) => {
+    const before = { stack: main.collect_stack(), userWords: collectUserWords(main) };
+    const snapshot = createExecutionSnapshot(main);
+
+    worker.reset_session();
+    worker.restore_stack_snapshot(snapshot.stackSnapshot!);
+    worker.restore_user_words(snapshot.userWords);
+
+    const result = execute(worker);
+    result.stackSnapshot = worker.snapshot_stack();
+    result.userWords = collectUserWords(worker);
+
+    syncInterpreterState(main, result);
+
+    const after = { stack: main.collect_stack(), userWords: collectUserWords(main) };
+    return detectExecutionSurfaceChanges(before, after, result);
+};
+
+describe('collectUserWords', () => {
+    it('reads a definition by bare name, not by a DICT@NAME composite', () => {
+        const interpreter = createFakeInterpreter();
+        interpreter.words.set('ADD10', '10 ADD');
+
+        expect(collectUserWords(interpreter)).toEqual([
+            { dictionary: 'USER', name: 'ADD10', definition: '10 ADD' }
+        ]);
+    });
+});
+
+describe('execution round trip with user words present', () => {
+    it('keeps the user words and reports a stack-only change for `3 4 KEEP ADD`', () => {
+        const main = createFakeInterpreter();
+        const worker = createFakeInterpreter();
+        main.words.set('ADD10', '10 ADD');
+
+        const changes = runOneExecution(main, worker, (w) => {
+            w.setStack([num(3), num(4), num(7)]);
+            return { status: 'OK', output: '' } as ExecuteResult;
+        });
+
+        expect(changes.stackChanged).toBe(true);
+        expect(changes.dictionaryChanged).toBe(false);
+        expect(changes.dictionarySheetId).toBeUndefined();
+        // The words survived the worker round trip rather than being wiped.
+        expect(collectUserWords(main)).toEqual([
+            { dictionary: 'USER', name: 'ADD10', definition: '10 ADD' }
+        ]);
+    });
+
+    it('carries the user words into the worker so a user word stays callable', () => {
+        const main = createFakeInterpreter();
+        const worker = createFakeInterpreter();
+        main.words.set('ADD10', '10 ADD');
+
+        runOneExecution(main, worker, (w) => {
+            expect(w.lookup_word_definition('ADD10')).toBe('10 ADD');
+            return { status: 'OK' } as ExecuteResult;
+        });
+    });
+
+    it('still reports a dictionary change when a word is actually defined', () => {
+        const main = createFakeInterpreter();
+        const worker = createFakeInterpreter();
+
+        const changes = runOneExecution(main, worker, (w) => {
+            w.words.set('ADD10', '10 ADD');
+            return { status: 'OK', output: 'Defined word: ADD10\n' } as ExecuteResult;
+        });
+
+        expect(changes.dictionaryChanged).toBe(true);
+        expect(changes.dictionarySheetId).toBe('user');
+    });
+
+    it('still reports a dictionary change when a word is deleted', () => {
+        const main = createFakeInterpreter();
+        const worker = createFakeInterpreter();
+        main.words.set('ADD10', '10 ADD');
+
+        const changes = runOneExecution(main, worker, (w) => {
+            w.words.delete('ADD10');
+            return { status: 'OK', output: 'Deleted word: ADD10\n' } as ExecuteResult;
+        });
+
+        expect(changes.dictionaryChanged).toBe(true);
+        expect(changes.dictionarySheetId).toBe('user');
+    });
+});

--- a/src/gui/interpreter-execution-utils.ts
+++ b/src/gui/interpreter-execution-utils.ts
@@ -15,12 +15,20 @@ const collectSerialInbox = (): SerialInboxEntry[] | undefined => {
     return entries.length > 0 ? entries : undefined;
 };
 
+// A word is addressed by its bare name. The dictionary has two tiers and User
+// is one of them (LANG.DICTIONARY.RESOLUTION), so there is nothing for a
+// `DICT@NAME` prefix to select and the interpreter no longer resolves one:
+// looking a word up as `USER@FOO` returns null. That null then travelled the
+// whole execution path — `restore_user_words` skips a definition-less word, so
+// the worker ran without the user's words and reported none back, and the
+// post-run sync wiped them from the main interpreter. Every run then looked
+// like a dictionary change and dragged the right column to the Words sheet.
 export const collectUserWords = (interpreter: AjisaiInterpreter): UserWord[] => {
     const userWordsInfo = interpreter.collect_user_words_info();
     return userWordsInfo.map(wordData => ({
         dictionary: wordData[0],
         name: wordData[1],
-        definition: interpreter.lookup_word_definition(`${wordData[0]}@${wordData[1]}`)
+        definition: interpreter.lookup_word_definition(wordData[1])
     }));
 };
 

--- a/src/gui/interpreter-state-persistence.ts
+++ b/src/gui/interpreter-state-persistence.ts
@@ -49,13 +49,17 @@ declare global {
     }
 }
 
+// Words are addressed by bare name (LANG.DICTIONARY.RESOLUTION: two tiers, and
+// User is one of them). A `DICT@NAME` prefix resolves to nothing, so composing
+// one here persisted every definition as null and lost the user's words on the
+// next load.
 const toUserWord = (
     wordData: [string, string, boolean],
     getDefinition: (name: string) => string | null
 ): UserWord => ({
     dictionary: wordData[0],
     name: wordData[1],
-    definition: getDefinition(`${wordData[0]}@${wordData[1]}`)
+    definition: getDefinition(wordData[1])
 });
 
 const readActiveSelections = (): {
@@ -107,10 +111,12 @@ interface ExportDocument {
     readonly words: ExportWord[];
 }
 
+// Keyed by bare name, matching `collect_word_identities`, which reports the
+// User-tier key itself rather than a `DICT@NAME` composite.
 const collectWordIdentityMap = (interpreter: AjisaiInterpreter): Map<string, string> => {
     const map = new Map<string, string>();
     for (const [fqName, id] of interpreter.collect_word_identities()) {
-        map.set(fqName.toUpperCase(), id);
+        map.set(buildWordKey(fqName), id);
     }
     return map;
 };
@@ -119,11 +125,11 @@ const createExportData = (interpreter: AjisaiInterpreter, dictionaryName: string
     const identities = collectWordIdentityMap(interpreter);
     const words: ExportWord[] = interpreter.collect_user_words_info()
         .filter(([dictionary]) => dictionary === dictionaryName)
-        .map(([dictionary, name]) => {
-            const id = identities.get(buildWordKey(dictionary, name));
+        .map(([, name]) => {
+            const id = identities.get(buildWordKey(name));
             return {
                 name,
-                definition: interpreter.lookup_word_definition(`${dictionary}@${name}`),
+                definition: interpreter.lookup_word_definition(name),
                 ...(id ? { id } : {})
             };
         });
@@ -138,7 +144,8 @@ export interface ParsedImport {
 }
 
 const buildExportFilename = (name: string): string => `${name}.json`;
-const buildWordKey = (dictionary: string, name: string): string => `${dictionary}@${name}`.toUpperCase();
+// The whole key of a User-tier word: its normalized name.
+const buildWordKey = (name: string): string => name.toUpperCase();
 const filenameToDictionaryName = (filename: string): string => filename.replace(/\.json$/i, '').toUpperCase();
 
 // Validate a single raw word entry from an (untrusted) import file. Returns a
@@ -319,13 +326,12 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
                     await window.ajisaiInterpreter.restore_user_words(wordsToRestore);
 
                     const savedWordKeys = new Set(
-                        wordsToRestore.map((w: UserWord) => buildWordKey(w.dictionary || 'EXAMPLE', w.name))
+                        wordsToRestore.map((w: UserWord) => buildWordKey(w.name))
                     );
                     const currentWords = window.ajisaiInterpreter.collect_user_words_info();
-                    for (const [dictionary, name] of currentWords) {
-                        const currentWordKey = buildWordKey(dictionary, name);
-                        if (!savedWordKeys.has(currentWordKey)) {
-                            window.ajisaiInterpreter.remove_word(`${dictionary}@${name}`);
+                    for (const [, name] of currentWords) {
+                        if (!savedWordKeys.has(buildWordKey(name))) {
+                            window.ajisaiInterpreter.remove_word(name);
                         }
                     }
 
@@ -402,7 +408,7 @@ export const createPersistence = (callbacks: PersistenceCallbacks = {}): Persist
                 let deduplicated = 0;
                 const idMismatches: string[] = [];
                 for (const word of importedWords) {
-                    const fqName = buildWordKey(dictionary, word.name);
+                    const fqName = buildWordKey(word.name);
                     if (before.has(fqName) && before.get(fqName) === after.get(fqName)) {
                         deduplicated++;
                     } else {

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -298,10 +298,14 @@ export const createVocabularyManager = (
             const button = createWordButtonElement(
                 wordInfo.name,
                 className,
-                () => onWordClick(wordInfo.dictionary === 'EXAMPLE' ? wordInfo.name : `${wordInfo.dictionary}@${wordInfo.name}`),
+                // A word is addressed by its bare name: the dictionary has two
+                // tiers and User is one of them, so a `DICT@NAME` prefix
+                // selects nothing and no longer resolves — inserting it wrote
+                // uncallable code into the editor, and looking a word up under
+                // it showed no definition.
+                () => onWordClick(wordInfo.name),
                 () => {
-                    const lookupName = `${wordInfo.dictionary}@${wordInfo.name}`;
-                    const definition = window.ajisaiInterpreter?.lookup_word_definition(lookupName) ?? '';
+                    const definition = window.ajisaiInterpreter?.lookup_word_definition(wordInfo.name) ?? '';
                     renderWordInfo(
                         elements.userWordInfo,
                         definition || DEFAULT_WORD_INFO_MESSAGE,
@@ -309,7 +313,7 @@ export const createVocabularyManager = (
                     );
                 },
                 () => { resetWordInfoDisplay(elements.userWordInfo); },
-                (event) => renderDeleteContextMenu(event, `${wordInfo.dictionary}@${wordInfo.name}`)
+                (event) => renderDeleteContextMenu(event, wordInfo.name)
             );
 
             fragment.appendChild(button);


### PR DESCRIPTION
## Summary

Running a pure stack program such as the Reference's `3 4 KEEP ADD` (Stack and Modifiers) moved the right column to the **Dictionary** instead of the **Stack**. Only `DEF` and `DEL` should take it to the Words sheet.

The layout rule was correct; the change detection feeding it was not. The dictionary has two tiers and User is one of them, so a word is addressed by its **bare name** and a `DICT@NAME` composite no longer resolves. The host still composed one, so `lookup_word_definition('USER@FOO')` returned `null` for every user word, and that null travelled the whole execution path:

1. `collectUserWords` produced words with `definition: null`.
2. `restore_user_words` skips a definition-less word, so the execution snapshot carried **no** user words into the worker — a user word was not even callable during a run.
3. The worker reported an empty `userWords` back.
4. `syncInterpreterState` → `applyInterpreterSnapshot` resets the session (which clears the User tier) and restored nothing, wiping the words from the main interpreter.
5. Pre- and post-execution therefore always disagreed, so `detectExecutionSurfaceChanges` reported `dictionaryChanged: true` on **every** run.

This change addresses words by bare name everywhere on the host:

- `interpreter-execution-utils.ts` — execution snapshots and the before/after comparison (the reported fault).
- `interpreter-state-persistence.ts` — persisted definitions, export/import content-identity keys, and the stale-word sweep on load (`remove_word`). Saved definitions were `null`, so user words were lost across reloads.
- `vocabulary-state-controller.ts` — word-button insert, definition preview, and the delete context menu (`'USER@FOO' DEL` did not resolve).
- `gui-application.ts` — drops the `DICT@NAME` autocomplete entries, which only offered code that fails to run.

No layout or presentation-profile logic changed.

## Quality Classification

- Highest impacted level: QL-B (host/GUI TypeScript; no language semantics, no Rust changes)

## Traceability

- Requirement(s): SPEC §12.3 Observation surfaces / Portability Profiles "Presentation Profile"; LANG.DICTIONARY.RESOLUTION (two tiers, bare-name resolution)
- Verification evidence:
  - New `src/gui/interpreter-execution-utils.test.ts` (5 tests) exercises a full snapshot → worker → sync round trip against a fake that reproduces the three real wasm contracts (bare-name lookup, definition-less words skipped on restore, session reset clears the User tier). 4 of the 5 fail on the pre-fix code.
  - Verified against the shipped wasm: with a user word defined, `3 4 KEEP ADD` now reports a stack-only change and leaves the word intact and callable, while `DEF` and `DEL` still report a dictionary change.
  - `npx vitest run` — 224 passed (13 files)
  - `npm run check` (`tsc --noEmit`) — clean
  - `npx eslint .` — clean

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable, no Rust changes
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable, no Rust changes
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — not applicable, no Rust changes
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable, no Rust changes
- [x] MC/DC-like checklist reviewed for modified boolean logic
- [x] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

Beyond the reported auto-transition fault, the same addressing bug silently broke user-word persistence (definitions saved as `null`), calling a user word inside a run, deleting a word from the context menu, and export/import content-identity dedup. All are fixed by the same change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ls7HTsgGRih4U47FHWRbzK)_