### PR TITLE
fix(gui): retire the symbols the host still shipped

### DIFF
--- a/src/gui/example-words.test.ts
+++ b/src/gui/example-words.test.ts
@@ -1,0 +1,79 @@
+// The seeded Example Words are the first thing a fresh session shows, and they
+// are the one place in the host that ships Ajisai source rather than reading it
+// from the interpreter. Nothing type-checks them: `restore_user_words` only
+// tokenizes a definition, so a body naming a word that no longer exists is
+// defined without complaint and fails only when the user runs it.
+//
+// That is how every SAY word and GREET came to fail with "Unknown word: ,,"
+// on first launch: `,,` was the symbol for KEEP, and it was retired when every
+// symbol became one character. FIZZBUZZ's fallback branch carried the same
+// token, so it errored on any input that was not a multiple of 3 or 5.
+//
+// These tests check the shape of every token the seed data ships, so retired
+// residue is caught here instead of on someone's first run.
+
+import { describe, expect, it } from 'vitest';
+import { EXAMPLE_USER_WORDS } from './example-words';
+
+// Symbols the lexer still accepts: one character each, plus the structural
+// delimiters. Kept as data so a token that is no longer one of these is a
+// visible diff rather than a silent runtime failure.
+const SYMBOL_ALIASES = ['+', '-', '*', '/', '%', '=', '<', '>', '?', '^'];
+const STRUCTURAL_TOKENS = ['[', ']', '{', '}', '|'];
+
+// Two-character symbols and the force/negation marks, all retired.
+const RETIRED_SYMBOLS = [',,', '<=', '>=', '<>', '&', '!', '..', '~'];
+
+const WORD_NAME = /^[A-Z][A-Z0-9-]*$/;
+// Integers, fractions and decimals; digits are required on both sides of a point.
+const NUMBER_LITERAL = /^-?\d+(?:\/\d+|\.\d+)?$/;
+
+// A string literal is opaque to this check: `'!'` is text, not the retired `!`.
+const stripStringLiterals = (definition: string): string =>
+    definition.replace(/'[^']*'/g, ' ');
+
+const tokenize = (definition: string): string[] =>
+    stripStringLiterals(definition).split(/\s+/).filter(Boolean);
+
+const exampleWordNames = new Set(EXAMPLE_USER_WORDS.map(word => word.name));
+
+describe('EXAMPLE_USER_WORDS', () => {
+    it('ships a definition for every word', () => {
+        for (const word of EXAMPLE_USER_WORDS) {
+            expect(word.definition, `${word.name} has no definition`).toBeTruthy();
+        }
+    });
+
+    it.each(EXAMPLE_USER_WORDS.map(w => [w.name, w.definition] as const))(
+        '%s uses no retired symbol',
+        (name, definition) => {
+            const tokens = tokenize(definition ?? '');
+            const retired = tokens.filter(token => RETIRED_SYMBOLS.includes(token));
+            expect(retired, `${name} still uses retired symbol(s)`).toEqual([]);
+        }
+    );
+
+    it.each(EXAMPLE_USER_WORDS.map(w => [w.name, w.definition] as const))(
+        '%s is built only from tokens the lexer still accepts',
+        (name, definition) => {
+            const unrecognized = tokenize(definition ?? '').filter(token =>
+                !SYMBOL_ALIASES.includes(token)
+                && !STRUCTURAL_TOKENS.includes(token)
+                && !NUMBER_LITERAL.test(token)
+                && !WORD_NAME.test(token)
+            );
+            expect(unrecognized, `${name} uses token(s) of no known shape`).toEqual([]);
+        }
+    );
+
+    it('only calls user words that are seeded alongside it', () => {
+        // A word-shaped token is either a Core word or another Example Word.
+        // Core names are not enumerated here, but a call to a *removed* example
+        // (say GREET losing SAY-BANG) is caught: the dependency must be seeded.
+        const greet = EXAMPLE_USER_WORDS.find(w => w.name === 'GREET');
+        expect(greet).toBeDefined();
+        for (const token of tokenize(greet!.definition ?? '')) {
+            expect(exampleWordNames.has(token), `GREET calls unseeded ${token}`).toBe(true);
+        }
+    });
+});

--- a/src/gui/example-words.ts
+++ b/src/gui/example-words.ts
@@ -1,23 +1,28 @@
 import type { UserWord } from '../wasm-interpreter-types';
 
 
-export const EXAMPLE_WORDS_VERSION = 11;
+export const EXAMPLE_WORDS_VERSION = 12;
 
+// `KEEP` is spelled out. It used to have the symbol `,,`, which every one of
+// these definitions was written against; once every symbol became one
+// character `,,` stopped being a name the dictionary holds, so the seeded
+// words defined fine (a body is only tokenized at DEF time) and then failed
+// with "Unknown word: ,," the moment they ran.
 export const EXAMPLE_USER_WORDS: UserWord[] = [
     // Hello-World family: teaches how words depend on other words.
     // GREET is built purely by chaining the three SAY words, so editing or
     // deleting any of them ripples up to GREET through the dependency graph.
     {
         name: 'SAY-HELLO',
-        definition: "'Hello' ,, PRINT",
+        definition: "'Hello' KEEP PRINT",
     },
     {
         name: 'SAY-WORLD',
-        definition: "'World' ,, PRINT",
+        definition: "'World' KEEP PRINT",
     },
     {
         name: 'SAY-BANG',
-        definition: "'!' ,, PRINT",
+        definition: "'!' KEEP PRINT",
     },
     {
         name: 'GREET',
@@ -29,6 +34,6 @@ export const EXAMPLE_USER_WORDS: UserWord[] = [
     {
         name: 'FIZZBUZZ',
         definition:
-            "{ [ 15 ] MOD [ 0 ] = } { 'FizzBuzz' PRINT } { [ 3 ] MOD [ 0 ] = } { 'Fizz' PRINT } { [ 5 ] MOD [ 0 ] = } { 'Buzz' PRINT } { TRUE } { ,, PRINT } COND",
+            "{ [ 15 ] MOD [ 0 ] = } { 'FizzBuzz' PRINT } { [ 3 ] MOD [ 0 ] = } { 'Fizz' PRINT } { [ 5 ] MOD [ 0 ] = } { 'Buzz' PRINT } { TRUE } { KEEP PRINT } COND",
     },
 ];

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -202,27 +202,23 @@ export const createVocabularyManager = (
             .map(createWordInfoFromTuple)
             .filter(word => word.dictionary === selectedDictionary);
 
-    const deleteWord = async (wordName: string, forceDelete: boolean): Promise<boolean> => {
-        const deleteCode = forceDelete
-            ? `! '${wordName}' DEL`
-            : `'${wordName}' DEL`;
-
+    // A referenced word is not deletable, and there is no way to override that:
+    // no Word in the vocabulary forces the delete, so the refusal is final and
+    // the only route is to delete the dependents first. This used to offer a
+    // force delete that re-ran the deletion as `! 'NAME' DEL`; `!` was one of
+    // the symbols retired when every symbol became one character, so accepting
+    // that prompt could only ever report "Unknown word: !". The interpreter
+    // already names the referencing words in its message, so surface it as-is.
+    const deleteWord = async (wordName: string): Promise<boolean> => {
         try {
-            const result = await window.ajisaiInterpreter.execute(deleteCode);
+            const result = await window.ajisaiInterpreter.execute(`'${wordName}' DEL`);
             if (result.status === 'ERROR') {
-                if (!forceDelete && result.message?.includes(DEPENDENCY_DELETE_ERROR)) {
-                    const confirmed = confirm(
-                        `Word '${wordName}' is referenced by other user words. Force delete with ! ?`
-                    );
-
-                    if (confirmed) {
-                        return deleteWord(wordName, true);
-                    }
-
-                    return false;
+                const message = result.message || 'Unknown error';
+                if (message.includes(DEPENDENCY_DELETE_ERROR)) {
+                    showInfo?.(message, true);
+                } else {
+                    alert(`Failed to delete word: ${message}`);
                 }
-
-                alert(`Failed to delete word: ${result.message}`);
                 return false;
             }
 
@@ -237,7 +233,7 @@ export const createVocabularyManager = (
     };
 
     const confirmAndDeleteWord = async (wordName: string): Promise<void> => {
-        await deleteWord(wordName, false);
+        await deleteWord(wordName);
     };
 
     const renderBuiltInWordsSorted = (


### PR DESCRIPTION
## Summary

Follow-up audit of the host after the dictionary collapsed to two tiers and every symbol became one character. Two definitions the host itself ships were written against words that no longer exist.

**The seeded Example Words were broken on every fresh session.** They used `,,`, the symbol `KEEP` used to carry, retired by `refactor(lexer)!: one boundary rule, and one character per symbol`. A definition is only *tokenized* when restored — never resolved — so all five words seeded without complaint and failed the moment they ran:

| Word | Before | After |
| --- | --- | --- |
| `GREET` (and the three `SAY-*`) | `ERROR: Unknown word: ,,` | prints `Hello World !` |
| `[ 1 ] FIZZBUZZ` | `ERROR: Unknown word: ,,` | prints `[ 1/1 ]` |
| `[ 3 ] FIZZBUZZ` | `Fizz` | `Fizz` |

`FIZZBUZZ` carried the same token in its `{ TRUE }` fallback branch, so it errored on any input that was not a multiple of 3 or 5 — the flagship teaching example failed on the most common input.

**The word context menu offered a force delete the language cannot do.** Right-clicking a word other words depend on prompted "Force delete with ! ?"; accepting re-ran the deletion as `` ! 'NAME' DEL ``. `!` went with the two-character symbols, so that could only ever report `Unknown word: !`. `execute_del.rs` states it directly: *"There is no force modifier: the vocabulary has no Word that overrides this, so the refusal is final and the caller's only route is to delete the dependents first."* The prompt is removed and the interpreter's message — which already names the referencing words — is surfaced instead.

Adds `src/gui/example-words.test.ts`. Nothing else type-checks the one place in the host that ships Ajisai source, so it asserts the shape of every token in the seed data: no retired symbol, and every token either a surviving one-character alias, a structural delimiter, a number literal, or a word name. String literals are stripped first, so `'!'` in `SAY-BANG` stays text.

## Quality Classification

- Highest impacted level: QL-B (host/GUI TypeScript and seed data; no language semantics, no Rust changes)

## Traceability

- Requirement(s): LANG.MODIFIERS.CONSUMPTION (`KEEP` is the Word; the `,,` symbol is retired); `DEL` dependency refusal is final (`rust/src/interpreter/execute_del.rs`)
- Verification evidence:
  - Reproduced against the shipped wasm before the change: `GREET` → `Unknown word: ,,`; `[ 1 ] FIZZBUZZ` → `Unknown word: ,,`; `! 'INC' DEL` → `Unknown word: !`.
  - Confirmed after: `GREET` → `Hello World !`, `FIZZBUZZ` correct for 1, 2, 3, 5, 15.
  - New `example-words.test.ts` (12 tests); reintroducing `,,` fails 2 of them.
  - Also verified during the audit that a definition's render → re-tokenize → re-define round trip is a fixed point (single-line, multi-line, vectors, fractions, nested blocks, `^`, `COND`), and that restoring words out of dependency order works — both are relied on by the worker sync and by persistence.
  - `npx vitest run` — 236 passed (14 files)
  - `npm run check` (`tsc --noEmit`) — clean
  - `npx eslint .` — clean

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable, no Rust changes
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable, no Rust changes
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — not applicable, no Rust changes
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable, no Rust changes
- [x] MC/DC-like checklist reviewed for modified boolean logic
- [x] Release checklist impact considered

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

`EXAMPLE_WORDS_VERSION` is bumped to 12 to reflect the content change. It is currently exported but unread anywhere in the tree.

One further piece of two-tier fallout was found and deliberately **not** changed here, because it is a UI decision rather than a defect: the `<select id="user-dictionary-select">` inside the User sheet is left over from the era of named user dictionaries. With one User tier it can only ever hold a single option, and it is labelled "Example Words" whenever the tier is empty and "User Words" otherwise. Its supporting machinery (`selectedDictionary` filtering, `setSelectedDictionary`, the persisted `activeUserDictionary` carried through both platform adapters, `REMOVED_USER_WORD_DICTIONARIES`, the `dictionary` label stamped onto imported words) is all vestigial but self-consistent — no functional break, so it is reported rather than removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ls7HTsgGRih4U47FHWRbzK)_