### PR TITLE
chore: sync Tauri lockfile version to 0.2.0-beta.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ajisai-tauri"
-version = "0.1.0"
+version = "0.2.0-beta.1"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
### Motivation
- Ensure the Tauri lockfile package version is consistent with the npm package for the beta release (`0.2.0-beta.1`).

### Description
- Update `src-tauri/Cargo.lock` to set the `ajisai-tauri` package `version` from `0.1.0` to `0.2.0-beta.1` to keep manifests synchronized.

### Testing
- Ran `npm test` (Vitest: 14 files / 236 tests passed), `npm run check`, `npm run specification:check`, `npm run word:manifest:check`, `npm run word:reference:check`, `npm run check:formalization-coverage`, `npm run check:minimal-core`, `npm run check:version-sync`, `npm run check:runtime-metadata`, `npm run check:file-size`, `npm run lint`, and `npm run build:web` which all succeeded (the web build emitted non-fatal warnings), while `cd src-tauri && cargo test` failed in this environment due to a missing system `glib-2.0` / `pkg-config` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72908371488326a9a1e6ec3ec2ffba)