### PR TITLE
fix(gui): bound the Stack drawing, list all 57 Core Words, recall submitted source

### DIFF
--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -292,6 +292,10 @@ This numeric grammar is the single definition of what text denotes a number. A c
 </p>
 
 <p>
+Whitespace separates tokens and is otherwise insignificant, with one exception, which is stated here so that it is not discovered by hitting it: a line break delimits <code>COND</code> clauses. A code block containing a top-level <code>|</code> is a guard clause, and at most one such block may begin on any one line. Two clauses written on the same line are a source error, so the vertical layout of a <code>COND</code> is part of its spelling rather than a convention.
+</p>
+
+<p>
 Malformed delimiters, malformed literals, invalid names, and invalid definition forms are source errors. They do not denote NIL.
 </p>
 
@@ -469,7 +473,9 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <h3 id="lang-collections-lift">LANG.COLLECTIONS.LIFT — Element lifting</h3>
 
-<p>An arithmetic or comparison Word applies element-wise when given vectors. Two vectors combine element-wise when their lengths are equal; a scalar combines with every element of a vector. Any other pairing is ERROR.</p>
+<p>An arithmetic or comparison Word applies element-wise when given vectors. A scalar combines with every element of a vector, however that vector is nested, including a ragged one.</p>
+
+<p>Two vectors combine by pairing their axes. A vector whose nesting is rectangular has a shape: the lengths of its axes, outermost first. The two shapes are aligned at their innermost axis, and an axis the shorter shape does not reach counts as length 1. Paired axes combine when their lengths are equal, and when one of them is 1 that operand's single lane is reused across the other's length; the result carries the longer length on that axis. This makes a one-element vector combine with a vector of any length, and <code>[ 1 2 3 ] [ 10 ] *</code> is <code>[ 10/1 20/1 30/1 ]</code>. Any other pairing is ERROR, and so is any pairing of two vectors where either one is ragged.</p>
 
 <p>Each lane preserves the exactness, truth, NIL, and ERROR distinctions of the scalar law. Vectorization cannot turn an ERROR lane into NIL.</p>
 

--- a/docs/dev/gui-current-design-memory.md
+++ b/docs/dev/gui-current-design-memory.md
@@ -17,8 +17,9 @@ This note captures the current Ajisai web-playground GUI behavior for reference.
 - Main code entry is a textarea.
 - Run via button or `Shift+Enter`.
 - Step execution via `Ctrl+Enter`.
-- Abort via `Escape`.
+- Abort via `Escape`. The window-level Escape listener captures and stops propagation, so it asks the editor first (`Editor.dismissSuggestions`): an open suggestion panel takes the key and closes, and Abort gets Escape only when there is no panel to close. Without that hand-off the panel could not be dismissed with Escape at all.
 - Full reset via `Ctrl+Alt+Enter` (with confirmation dialog).
+- **Recall of submitted source** via `Ctrl+Up` / `Ctrl+Down` (`src/gui/editor-history.ts`). A successful Run clears the editor and Reset clears it too, while the Stack persists across runs; without recall the natural edit-and-rerun loop meant retyping the whole program. History is session-lived, holds source text only, survives Reset, and stores neither values nor dictionary entries. The plain arrows are left to caret movement and to the suggestion panel's own list navigation.
 - Output panel supports copy-to-clipboard.
 - Clicking output panel (desktop) toggles focus back to input mode.
 
@@ -32,6 +33,8 @@ This note captures the current Ajisai web-playground GUI behavior for reference.
 
 ## Data/state behavior
 - Stack display and dictionary update after execution.
+- **The Stack area's drawing is bounded** (`src/gui/stack-render-budget.ts`): at most 100 elements are drawn from any one collection and at most 2000 across a whole render, with the undrawn tail replaced in place by a `… N more` marker (styled as muted italic commentary so it cannot be read as part of the value). The interpreter's materialization ceiling bounds what a generative Word may build, not what the host may draw: `[ 1 500000 ] RANGE` is a legal program well inside that ceiling, and drawing one DOM node per element locked the tab for ~27s with no way to abort, clear the editor, or read the result. The bound is presentation, in the same class as the step limit — the value on the stack is whole and every Word still sees all of it.
+- Relatedly, `detectExecutionSurfaceChanges` compares the pre/post stack **structurally with an early exit** rather than by `JSON.stringify` of both: two full serializations of a possibly-huge stack ran on every single run to answer a question a first difference settles.
 - Stack area has visual highlight modes triggered by code content, scanned as whole whitespace-delimited modifier tokens so the combined forms (`.,,`, `..,,`) and the `;`/`;;` sugar are recognized, and decimals like `.5`/`5.` never false-trigger. Both modifier axes ride on one **background-fill** channel on the operand nodes (a fill rather than a text-color change, so it never competes with the bracket depth-colors that show Vector nesting; the tint is kept very pale so the value's own ink stays legible) — the filled set is the target, the fill color is the consumption fate (a non-operand can never be consumed, so no extra marker is needed):
   - Target axis (which items are filled): `..` (or `;;`) fills every stack item (STAK), otherwise the default `.` (TOP) fills only the top item — "which values are the operands".
   - Consumption axis (the fill color): the default `,` (EAT) is a very pale warm red (operands are removed), `,,` (or `;;`) a very pale teal-green (KEEP — operands are retained) — "what becomes of them". The two tints are separated in lightness as well as hue (`--color-consume-eat` / `--color-consume-keep` in `tokens.css`) so they read apart under color-vision deficiency. The fill uses even padding on all four sides so the value gets equal vertical and horizontal breathing room. The two axes are independent, mirroring SPEC §6.3.

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -462,6 +462,8 @@
                     <h3>How to read the examples</h3>
                     <p>The <strong>Expected value</strong> column shows the final stack exactly as the language renders it, value by value. Two display conventions matter from the start:</p>
                     <p>Numbers display as exact fractions in <code>numerator/denominator</code> form — the integer three renders as <code>3/1</code>. Truth values display as <code>TRUE</code> and <code>FALSE</code>; the absence of a value displays as <code>NIL</code>.</p>
+                    <p class="ref-note">That is the Stack area's standard rendering, and it is what this reference's Expected value column shows. The Stack area also carries a <strong>LaTeX</strong> checkbox — off by default — that redraws the same values as typeset mathematics: a fraction becomes a stacked fraction, a numeric vector becomes a matrix, and a denominator of one reads as a plain integer, so <code>3/1</code> is drawn as <em>3</em>. That is a second reading of one value, not a second value: the number is the same exact rational either way, nothing is rounded or reduced, and unchecking the box brings the canonical form back. A value with no faithful mathematical reading — a string, <code>NIL</code>, a ragged vector — stays in the standard rendering even with the box checked.</p>
+                    <p class="ref-note">A collection can hold far more elements than are worth drawing, so the Stack area draws a leading part of a large one and ends it with a marker such as <em>… 199900 more</em>. The marker is a statement about the drawing, never about the value: the collection on the stack is complete, every word still sees all of it, and <code>LENGTH</code> reports the real length.</p>
                     <p>In the text of this reference, anything with a gray background is an Ajisai token. Every symbol token defined by Ajisai is a word in disguise — <code>+</code> is <code>ADD</code> and <code>^</code> is <code>VENT</code> — so the gray background is the signal that a mark belongs to the program, not to the prose.</p>
                 </section>
 
@@ -482,6 +484,8 @@
                             </tbody>
                         </table>
                     </div>
+                    <h3>Where a line break matters</h3>
+                    <p>Whitespace is whitespace: a newline separates tokens exactly as a space does, and a program may be laid out over as many lines as you like. There is <strong>one</strong> exception, and it is worth knowing before you meet it. A <code>COND</code> guard clause — a block containing a top-level <code>|</code> — must start its own line, and at most one such clause may begin on any line. Writing a whole <code>COND</code> on one line is a source error, not a style choice, and the message says so: <em>COND: | clauses must be written one clause per line</em>. See <a href="#cond">Conditionals</a>. Nothing else in the language reads line breaks.</p>
                     <h3>Number literals</h3>
                     <p>A decimal literal carries at least one digit on <strong>both</strong> sides of the point: <code>0.5</code> and <code>5.0</code> are numbers, while <code>.5</code> and <code>5.</code> are not. The point is therefore never the first or last character of a number, which is what lets a lone <code>.</code> be an ordinary name rather than a truncated literal.</p>
                     <p class="ref-note">A string closes on the quote that sits at a token boundary, which is how a string carries an apostrophe with no escape character: <code>'It's fine'</code> is one string. A quote followed immediately by a name character stays inside the text, so <code>'abc'CHARS</code> is an unclosed string rather than two tokens.</p>
@@ -727,6 +731,7 @@
                 <section id="arithmetic" class="ref-page">
                     <h2>Arithmetic</h2>
                     <p>The arithmetic words act element-wise between vectors, and a one-element vector broadcasts across a longer one. Each word has a canonical English name; the symbol is sugar:</p>
+                    <p class="ref-note">Broadcasting is a rule about axes, not only about one-element vectors. Two vectors are paired axis by axis starting from the innermost, an axis the shorter one does not reach counts as length 1, and an axis of length 1 is reused across the other side's length — so <code>[ 1 2 3 ] [ 10 ] *</code> is <code>[ 10/1 20/1 30/1 ]</code> and <code>[ [ 1 2 ] [ 3 4 ] ] [ 10 20 ] *</code> is <code>[ [ 10/1 40/1 ] [ 30/1 80/1 ] ]</code>. Anything else is an error: <code>[ 1 2 3 ] [ 10 20 ] *</code> cannot pair 3 with 2. A scalar needs no axes and combines with every element however the vector is nested, ragged ones included; two <em>vectors</em> can only broadcast when both are rectangular.</p>
                     <div class="ref-table-wrap word-table">
                         <table class="ref-table">
                             <thead>
@@ -1541,6 +1546,7 @@ COND</code></td>
                         </div>
                     </div>
                     <p class="ref-note">Each guard answers <code>TRUE</code> or <code>FALSE</code>, so a clause either fires or does not. If no clause matches and no else clause is present, <code>COND</code> raises an error.</p>
+                    <p class="ref-note">One clause per line is a rule, not a layout preference — it is the only place in the language where a line break is significant (see <a href="#tokens">Tokens and Spelling</a>). Collapsing the clause form onto one line fails before anything runs, with <em>COND: | clauses must be written one clause per line</em>. The pair form above has no <code>|</code> in it and so carries no such rule: it fits on one line.</p>
                 </section>
 
                 <section id="strings" class="ref-page">
@@ -1746,6 +1752,10 @@ COND</code></td>
                             <a class="btn js-open-playground" href="../index.html">Open in Playground</a>
                         </div>
                     </div>
+                    <h3>What DEF checks, and what it does not</h3>
+                    <p><code>DEF</code> stores the body; it does not resolve the names inside it. A definition whose body calls a word that does not exist is accepted and reported as defined, and the failure surfaces the first time the word is <strong>called</strong>: <code>{ TOTALL 1 } 'FOO' DEF</code> succeeds, and only running <code>FOO</code> reports <em>Unknown word: TOTALL</em>.</p>
+                    <p>This is a design choice rather than a missing check. Names resolve at call time, which is exactly what lets one word call another that is defined after it — so a pair of words may call each other, and a definition never has to be ordered around its dependencies.</p>
+                    <p class="ref-note">The cost is that a mistyped name in a body sits quietly until something calls it. The headless CLI is where that is caught ahead of time: <code>ajisai check</code> resolves every name in a file without executing anything and reports the unknown ones, and <code>ajisai check --contract</code> additionally verifies declared word contracts. The Playground has no equivalent — in the app, calling the word is the check.</p>
                     <h3>Managing words</h3>
                     <p><code>DEL</code> deletes a user word by quoted name. Dependencies are tracked: a word that other words depend on cannot be deleted at all, so a dangling reference is impossible — delete the dependents first.</p>
                     <p class="ref-note">Word names are case-insensitive (<code>add10</code> and <code>ADD10</code> are the same word) and conventionally follow an action-object style such as <code>APPLY-GAIN</code>. How a name is matched to a definition is the subject of <a href="#dictionaries">Dictionaries and Word Identity</a>.</p>

--- a/scripts/check-reading-surfaces.mjs
+++ b/scripts/check-reading-surfaces.mjs
@@ -38,6 +38,9 @@ const EXAMPLE_NAMES = new Set([
   // a placeholder name, introduced by the Vector clause to show that `[ FOO ]`
   // holds the text FOO whether or not FOO is a defined Word
   'FOO',
+  // a deliberate typo, introduced by the Defining Words clause to show that a
+  // body's names resolve when the word is called rather than when it is defined
+  'TOTALL',
 ]);
 
 const SURFACES = ['README.md', 'public/docs/index.html', 'SPECIFICATION.html'];

--- a/spec/language-semantics.md
+++ b/spec/language-semantics.md
@@ -104,6 +104,10 @@ This numeric grammar is the single definition of what text denotes a number. A c
 </p>
 
 <p>
+Whitespace separates tokens and is otherwise insignificant, with one exception, which is stated here so that it is not discovered by hitting it: a line break delimits <code>COND</code> clauses. A code block containing a top-level <code>|</code> is a guard clause, and at most one such block may begin on any one line. Two clauses written on the same line are a source error, so the vertical layout of a <code>COND</code> is part of its spelling rather than a convention.
+</p>
+
+<p>
 Malformed delimiters, malformed literals, invalid names, and invalid definition forms are source errors. They do not denote NIL.
 </p>
 
@@ -281,7 +285,9 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <h3 id="lang-collections-lift">LANG.COLLECTIONS.LIFT — Element lifting</h3>
 
-<p>An arithmetic or comparison Word applies element-wise when given vectors. Two vectors combine element-wise when their lengths are equal; a scalar combines with every element of a vector. Any other pairing is ERROR.</p>
+<p>An arithmetic or comparison Word applies element-wise when given vectors. A scalar combines with every element of a vector, however that vector is nested, including a ragged one.</p>
+
+<p>Two vectors combine by pairing their axes. A vector whose nesting is rectangular has a shape: the lengths of its axes, outermost first. The two shapes are aligned at their innermost axis, and an axis the shorter shape does not reach counts as length 1. Paired axes combine when their lengths are equal, and when one of them is 1 that operand's single lane is reused across the other's length; the result carries the longer length on that axis. This makes a one-element vector combine with a vector of any length, and <code>[ 1 2 3 ] [ 10 ] *</code> is <code>[ 10/1 20/1 30/1 ]</code>. Any other pairing is ERROR, and so is any pairing of two vectors where either one is ragged.</p>
 
 <p>Each lane preserves the exactness, truth, NIL, and ERROR distinctions of the scalar law. Vectorization cannot turn an ERROR lane into NIL.</p>
 

--- a/src/gui/code-input-editor.ts
+++ b/src/gui/code-input-editor.ts
@@ -15,6 +15,12 @@ export interface Editor {
     readonly removeLastWord: () => void;
     readonly format: () => void;
     readonly focus: () => void;
+    /**
+     * Close the suggestion panel if it is open. Returns whether there was
+     * anything to close, so a shared Escape handler can spend the key on the
+     * panel and leave Abort alone.
+     */
+    readonly dismissSuggestions: () => boolean;
     readonly registerContentChangeCallback: (callback: (content: string) => void) => void;
 }
 
@@ -446,6 +452,17 @@ export const createEditor = (
         onContentChangeCallback = callback;
     };
 
+    // Escape is bound window-wide to Abort, on a capturing listener that stops
+    // propagation, so the panel's own Escape branch never ran and the panel
+    // could not be dismissed with the key every other editor dismisses it with.
+    // The window handler now asks here first and only aborts when there was no
+    // panel to close.
+    const dismissSuggestions = (): boolean => {
+        if (suggestionPanel.style.display === 'none') return false;
+        hideSuggestions();
+        return true;
+    };
+
     return {
         extractValue,
         updateValue,
@@ -455,6 +472,7 @@ export const createEditor = (
         removeLastWord,
         format,
         focus,
+        dismissSuggestions,
         registerContentChangeCallback
     };
 };

--- a/src/gui/core-word-name.test.ts
+++ b/src/gui/core-word-name.test.ts
@@ -1,0 +1,56 @@
+// The Core dictionary sheet must be able to show every canonical Word.
+//
+// The sheet filters the interpreter's Core payload through
+// `isCanonicalCoreWordName`, so that predicate is the last gate between a Word
+// existing and a reader being able to find it. The authority for what a
+// canonical name looks like is spec/words.json, so this test reads that file
+// rather than restating a list: a name shape the vocabulary adopts later is
+// covered the moment it lands.
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { isCanonicalCoreWordName } from './core-word-name';
+
+interface WordEntry {
+    readonly name: string;
+    readonly aliases?: readonly string[];
+}
+
+const registry = JSON.parse(readFileSync('spec/words.json', 'utf8')) as { entries: WordEntry[] };
+
+describe('isCanonicalCoreWordName', () => {
+    test('the registry is the 57 canonical Words the Specification claims', () => {
+        expect(registry.entries).toHaveLength(57);
+    });
+
+    test.each(registry.entries.map(word => word.name))('accepts the canonical name %s', name => {
+        expect(isCanonicalCoreWordName(name)).toBe(true);
+    });
+
+    test('every canonical Word survives the sheet filter', () => {
+        const listed = registry.entries.map(word => word.name).filter(isCanonicalCoreWordName);
+        expect(listed).toHaveLength(registry.entries.length);
+    });
+
+    // The regression this predicate was fixed for: `NIL?` is a canonical Word
+    // and was the one the Core sheet dropped, leaving 56 of 57 visible.
+    test('accepts a name ending in the absence-question mark', () => {
+        expect(isCanonicalCoreWordName('NIL?')).toBe(true);
+    });
+
+    test('rejects the symbolic aliases, which are surface forms rather than Words', () => {
+        const symbolic = registry.entries
+            .flatMap(word => word.aliases ?? [])
+            .filter(alias => !/^[A-Za-z]/.test(alias));
+        expect(symbolic.length).toBeGreaterThan(0);
+        for (const alias of symbolic) {
+            expect(isCanonicalCoreWordName(alias)).toBe(false);
+        }
+    });
+
+    test('rejects lower-case and empty spellings', () => {
+        expect(isCanonicalCoreWordName('nil?')).toBe(false);
+        expect(isCanonicalCoreWordName('')).toBe(false);
+        expect(isCanonicalCoreWordName('1ADD')).toBe(false);
+    });
+});

--- a/src/gui/core-word-name.ts
+++ b/src/gui/core-word-name.ts
@@ -1,0 +1,19 @@
+// Canonical Core Word spelling, as the Dictionary sheet must recognize it.
+//
+// The Core sheet lists what the interpreter reports as Core vocabulary and
+// drops anything that is not a canonical name (a symbolic alias is a surface
+// form of a Word, not a second Word, and must not be listed twice). That
+// filter is only as honest as its idea of "canonical": a predicate narrower
+// than the real name grammar silently deletes a real Word from the sheet, and
+// the sheet is exactly where a reader — a human or an agent — goes to find out
+// what the language has. `NIL?` disappeared that way, leaving 56 of the 57
+// canonical Words visible while `NIL?` kept working when typed.
+//
+// The grammar below is the canonical-name pattern from spec/words.schema.json,
+// which is the schema every entry in spec/words.json is validated against. It
+// is duplicated here rather than derived because the GUI cannot read the spec
+// at runtime; `core-word-name.test.ts` closes that gap by asserting the
+// predicate against spec/words.json itself, so a future name shape that the
+// schema admits cannot go missing from the sheet unnoticed.
+export const isCanonicalCoreWordName = (name: string): boolean =>
+    /^(?:[A-Z][A-Z0-9@?-]*(?:@[A-Z][A-Z0-9@?-]*)?|>[A-Z][A-Z0-9@?-]*)$/.test(name);

--- a/src/gui/editor-history.test.ts
+++ b/src/gui/editor-history.test.ts
@@ -1,0 +1,95 @@
+// Recall of submitted programs. A successful Run empties the editor and Reset
+// empties it too, so the only way back to what you just wrote is this history.
+
+import { describe, expect, test } from 'vitest';
+import { MAX_HISTORY_ENTRIES, createEditorHistory } from './editor-history';
+
+describe('createEditorHistory', () => {
+    test('walks back through submitted programs, oldest last', () => {
+        const history = createEditorHistory();
+        history.record('1 2 +');
+        history.record('3 4 *');
+
+        expect(history.recallOlder('')).toBe('3 4 *');
+        expect(history.recallOlder('')).toBe('1 2 +');
+    });
+
+    test('stops at the oldest entry instead of wrapping', () => {
+        const history = createEditorHistory();
+        history.record('1 2 +');
+
+        expect(history.recallOlder('')).toBe('1 2 +');
+        expect(history.recallOlder('')).toBeNull();
+    });
+
+    test('stepping forward returns the draft that was being typed', () => {
+        const history = createEditorHistory();
+        history.record('1 2 +');
+
+        expect(history.recallOlder('3 4')).toBe('1 2 +');
+        expect(history.recallNewer()).toBe('3 4');
+    });
+
+    test('there is nothing newer than the draft', () => {
+        const history = createEditorHistory();
+        history.record('1 2 +');
+
+        expect(history.recallNewer()).toBeNull();
+    });
+
+    test('recording rewinds the cursor, so the next recall is the newest entry', () => {
+        const history = createEditorHistory();
+        history.record('1 2 +');
+        history.recallOlder('');
+        history.record('3 4 *');
+
+        expect(history.recallOlder('')).toBe('3 4 *');
+    });
+
+    test('an empty or blank submission is not recorded', () => {
+        const history = createEditorHistory();
+        history.record('   ');
+        history.record('');
+
+        expect(history.entries()).toEqual([]);
+        expect(history.recallOlder('')).toBeNull();
+    });
+
+    test('re-running the same program does not bury the history in duplicates', () => {
+        const history = createEditorHistory();
+        history.record('1 2 +');
+        history.record('1 2 +');
+        history.record('1 2 +');
+
+        expect(history.entries()).toEqual(['1 2 +']);
+    });
+
+    test('entries are stored trimmed, as submitted rather than as laid out', () => {
+        const history = createEditorHistory();
+        history.record('  1 2 +\n');
+
+        expect(history.entries()).toEqual(['1 2 +']);
+    });
+
+    test('the oldest entries drop once the limit is reached', () => {
+        const history = createEditorHistory(3);
+        for (const source of ['A', 'B', 'C', 'D']) history.record(source);
+
+        expect(history.entries()).toEqual(['B', 'C', 'D']);
+    });
+
+    test('the default limit is the documented one', () => {
+        const history = createEditorHistory();
+        for (let i = 0; i <= MAX_HISTORY_ENTRIES; i++) history.record(`${i} 1 +`);
+
+        expect(history.entries()).toHaveLength(MAX_HISTORY_ENTRIES);
+        expect(history.entries()[0]).toBe('1 1 +');
+    });
+
+    test('an empty history recalls nothing in either direction', () => {
+        const history = createEditorHistory();
+
+        expect(history.recallOlder('draft')).toBeNull();
+        expect(history.recallNewer()).toBeNull();
+    });
+});

--- a/src/gui/editor-history.ts
+++ b/src/gui/editor-history.ts
@@ -1,0 +1,77 @@
+// Recall of previously run source.
+//
+// A successful Run empties the editor, and Reset empties it too. The Stack, by
+// contrast, persists across runs. That combination is what makes the Playground
+// awkward to learn in: the natural loop — run something, change one token, run
+// it again — required retyping the whole program every time, and a Reset after
+// a run that did not happen took the text with it.
+//
+// So every submitted program is remembered for the session and can be walked
+// back into the editor. This is editor convenience in the same class as the
+// suggestion panel: it stores source text only, never a value, never a
+// dictionary entry, and it cannot change what a program observes.
+
+/** Programs kept for recall. Past this the oldest are dropped. */
+export const MAX_HISTORY_ENTRIES = 100;
+
+export interface EditorHistory {
+    /** Remember a submitted program and rewind the cursor to the newest end. */
+    readonly record: (source: string) => void;
+    /**
+     * Step one entry towards older, returning the source to show, or `null`
+     * when there is nothing older (leave the editor as it is).
+     *
+     * `draft` is the editor's current text; it is stashed on the first step
+     * back so stepping forward again returns what the user was typing.
+     */
+    readonly recallOlder: (draft: string) => string | null;
+    /**
+     * Step one entry towards newer. Returns the source to show — the stashed
+     * draft (possibly empty) once past the newest entry — or `null` when the
+     * cursor is already at the newest end.
+     */
+    readonly recallNewer: () => string | null;
+    /** Entries currently held, oldest first. Recall state is not included. */
+    readonly entries: () => readonly string[];
+}
+
+export const createEditorHistory = (limit: number = MAX_HISTORY_ENTRIES): EditorHistory => {
+    const entries: string[] = [];
+    // Index into `entries` of the entry currently recalled; `entries.length`
+    // means "not recalling — the editor holds the draft".
+    let cursor = 0;
+    let stashedDraft = '';
+
+    const record = (source: string): void => {
+        const trimmed = source.trim();
+        // An empty submission is not a program, and re-running the identical
+        // program should not push a second copy: recall is for finding what you
+        // wrote, and a run of duplicates buries it.
+        if (trimmed !== '' && entries[entries.length - 1] !== trimmed) {
+            entries.push(trimmed);
+            if (entries.length > limit) entries.shift();
+        }
+        cursor = entries.length;
+        stashedDraft = '';
+    };
+
+    const recallOlder = (draft: string): string | null => {
+        if (cursor === 0) return null;
+        if (cursor === entries.length) stashedDraft = draft;
+        cursor -= 1;
+        return entries[cursor]!;
+    };
+
+    const recallNewer = (): string | null => {
+        if (cursor >= entries.length) return null;
+        cursor += 1;
+        return cursor === entries.length ? stashedDraft : entries[cursor]!;
+    };
+
+    return {
+        record,
+        recallOlder,
+        recallNewer,
+        entries: () => entries
+    };
+};

--- a/src/gui/execution-surface-changes.test.ts
+++ b/src/gui/execution-surface-changes.test.ts
@@ -78,4 +78,56 @@ describe('detectExecutionSurfaceChanges', () => {
         );
         expect(changes.outputChanged).toBe(true);
     });
+
+    // The stack comparison walks the values structurally instead of stringifying
+    // the whole stack twice per run (a stack can legally hold hundreds of
+    // thousands of elements). These pin the equality it has to reproduce.
+    it('reports no stack change when equal values are distinct objects', () => {
+        const changes = detectExecutionSurfaceChanges(
+            view({ stack: [num(5)] }),
+            view({ stack: [num(5)] }),
+            okResult()
+        );
+        expect(changes.stackChanged).toBe(false);
+    });
+
+    it('sees a change deep inside a nested vector', () => {
+        const vector = (...elements: Value[]): Value =>
+            ({ type: 'vector', value: elements } as unknown as Value);
+        const changes = detectExecutionSurfaceChanges(
+            view({ stack: [vector(vector(num(1), num(2)))] }),
+            view({ stack: [vector(vector(num(1), num(3)))] }),
+            okResult()
+        );
+        expect(changes.stackChanged).toBe(true);
+    });
+
+    it('sees a change of length alone', () => {
+        const changes = detectExecutionSurfaceChanges(
+            view({ stack: [num(1), num(2)] }),
+            view({ stack: [num(1)] }),
+            okResult()
+        );
+        expect(changes.stackChanged).toBe(true);
+    });
+
+    it('sees a value that gained a property', () => {
+        const plain = { type: 'number', value: { numerator: '1', denominator: '1' } } as unknown as Value;
+        const tagged = {
+            type: 'number',
+            value: { numerator: '1', denominator: '1' },
+            semantics: { approximate: true }
+        } as unknown as Value;
+        const changes = detectExecutionSurfaceChanges(
+            view({ stack: [plain] }),
+            view({ stack: [tagged] }),
+            okResult()
+        );
+        expect(changes.stackChanged).toBe(true);
+    });
+
+    it('reports no stack change for two empty stacks', () => {
+        const changes = detectExecutionSurfaceChanges(view(), view(), okResult());
+        expect(changes.stackChanged).toBe(false);
+    });
 });

--- a/src/gui/execution-surface-changes.ts
+++ b/src/gui/execution-surface-changes.ts
@@ -3,6 +3,43 @@ import type { ExecutionSurfaceChanges } from './gui-layout-state';
 
 const stableStringify = (value: unknown): string => JSON.stringify(value ?? null);
 
+// Whether the stack changed, decided without building a string of it.
+//
+// This used to compare `JSON.stringify(before.stack)` with the same of
+// `after.stack`. That is two full serializations of the stack on every single
+// run, and a stack is not small by construction: `[ 1 200000 ] RANGE` is a
+// legal program whose one value holds two hundred thousand elements, and
+// stringifying it twice cost the better part of a second of frozen main thread
+// for an answer that a length mismatch settles immediately. A structural walk
+// with an early exit answers the same question, allocates nothing, and stops at
+// the first difference — which for a run that produced anything is usually the
+// first slot it looks at.
+const checkValuesEqual = (left: unknown, right: unknown): boolean => {
+    if (left === right) return true;
+    // JSON.stringify wrote both null and undefined into the same text for a
+    // top-level value, so treat the pair as equal here too rather than reporting
+    // a change the previous comparison never saw.
+    if (left === null || left === undefined) return right === null || right === undefined;
+    if (right === null || right === undefined) return false;
+    if (typeof left !== 'object' || typeof right !== 'object') return false;
+
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right)) return false;
+        if (left.length !== right.length) return false;
+        return left.every((element, index) => checkValuesEqual(element, right[index]));
+    }
+
+    const leftKeys = Object.keys(left as object);
+    const rightKeys = Object.keys(right as object);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every(key =>
+        Object.prototype.hasOwnProperty.call(right, key)
+        && checkValuesEqual(
+            (left as Record<string, unknown>)[key],
+            (right as Record<string, unknown>)[key]
+        ));
+};
+
 // Order-insensitive identity of the user dictionary. The pre-execution
 // snapshot and the post-execution read-back can enumerate words in different
 // orders (a synced interpreter rebuilds its dictionaries from scratch), so the
@@ -41,7 +78,7 @@ export const detectExecutionSurfaceChanges = (
 
     return {
         outputChanged: hasError || Boolean((result.output ?? '').trim()),
-        stackChanged: stableStringify(before.stack) !== stableStringify(after.stack),
+        stackChanged: !checkValuesEqual(before.stack, after.stack),
         dictionaryChanged: userWordsChanged,
         // Defining your own word lands on the 'user' sheet.
         dictionarySheetId: userWordsChanged ? 'user' : undefined

--- a/src/gui/gui-event-bindings.ts
+++ b/src/gui/gui-event-bindings.ts
@@ -9,6 +9,7 @@ import type { VocabularyManager } from './vocabulary-state-controller';
 import type { GUIElements } from './gui-dom-cache';
 import type { LayoutState } from './gui-layout-state';
 import type { LayoutController } from './layout/layout-controller';
+import { createEditorHistory } from './editor-history';
 
 export type GuiEventBindingContext = {
     readonly elements: GUIElements;
@@ -102,6 +103,9 @@ function bindLayoutEvents(context: GuiEventBindingContext): void {
 
 function bindInteractionEvents(context: GuiEventBindingContext): void {
     const { elements, vocabulary, editor, mobile, layoutState, switchArea, display, persistence, executionController } = context;
+    // Session-lived recall of submitted programs, so a run (which clears the
+    // editor) and a Reset are both recoverable. See editor-history.ts.
+    const history = createEditorHistory();
     const applySearchFilter = (filter: string): void => {
         elements.dictionarySearch.value = filter;
         elements.mobileDictionarySearch.value = filter;
@@ -126,9 +130,27 @@ function bindInteractionEvents(context: GuiEventBindingContext): void {
 
     // Reformat the editor before running it, so the source that defines words
     // (and therefore the stored definition) is tidied at execution time.
+    //
+    // The submitted source is recorded before execution, not after: a run that
+    // succeeds clears the editor and a Reset clears it too, so recording later
+    // would be recording exactly the cases the user can no longer recover.
     const runEditorCode = (): void => {
         editor.format();
-        executionController.executeCode(editor.extractValue());
+        const source = editor.extractValue();
+        history.record(source);
+        executionController.executeCode(source);
+    };
+
+    // Ctrl+Up / Ctrl+Down walk the session's submitted programs back into the
+    // editor. The plain arrows are left alone — they are how you move the caret
+    // through a multi-line program, and the suggestion panel already uses them
+    // to move through its list.
+    const recallHistory = (direction: 'older' | 'newer'): void => {
+        const recalled = direction === 'older'
+            ? history.recallOlder(elements.codeInput.value)
+            : history.recallNewer();
+        if (recalled === null) return;
+        editor.updateValue(recalled);
     };
 
     elements.outputArea.addEventListener('dblclick', (e: MouseEvent) => {
@@ -183,6 +205,10 @@ function bindInteractionEvents(context: GuiEventBindingContext): void {
         if (e.key === 'Enter' && e.ctrlKey && !e.altKey && !e.shiftKey) {
             e.preventDefault();
             executionController.executeStep();
+        }
+        if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && e.ctrlKey && !e.altKey && !e.shiftKey) {
+            e.preventDefault();
+            recallHistory(e.key === 'ArrowUp' ? 'older' : 'newer');
         }
         // Shift+Alt+F reformats the editor contents (matches the format button).
         if (e.code === 'KeyF' && e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey) {
@@ -249,6 +275,17 @@ function bindInteractionEvents(context: GuiEventBindingContext): void {
 
     window.addEventListener('keydown', (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
+            // This listener captures and stops propagation, so the editor's own
+            // Escape branch never sees the key: an open suggestion panel could
+            // not be dismissed the way every other editor dismisses one, and the
+            // panel stayed over the code while the user pressed Escape at it.
+            // Dismissing takes priority; Abort still gets Escape whenever there
+            // is no panel to close.
+            if (editor.dismissSuggestions()) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                return;
+            }
             WORKER_MANAGER.abortAll();
             executionController.abortExecution();
             e.preventDefault();

--- a/src/gui/gui-layout-state.ts
+++ b/src/gui/gui-layout-state.ts
@@ -38,6 +38,7 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
     'Step → Ctrl+Enter',
     'Format → Shift+Alt+F',
     'Suggestions → Ctrl+Space',
+    'Recall → Ctrl+Up / Ctrl+Down',
     'Reset → Ctrl+Alt+Enter',
     'Abort → Escape'
 ].join('\n');

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -4,6 +4,12 @@ import type { Value, ExecuteResult, RuntimeMetricsSnapshot } from '../wasm-inter
 import { AUDIO_ENGINE } from '../audio/audio-engine';
 import { getPlatform } from '../platform';
 import { valueToLatex } from './value-latex';
+import {
+    createRenderBudget,
+    formatElision,
+    planCollectionRender,
+    type RenderBudget
+} from './stack-render-budget';
 
 export interface DisplayElements {
     outputDisplay: HTMLElement;
@@ -232,18 +238,34 @@ const renderMathValueNode = (item: Value): HTMLElement | null => {
     return node;
 };
 
-const renderStackValueNode = (item: Value, depth: number): HTMLElement => {
+// The undrawn tail of a collection, stated as a count rather than drawn. See
+// stack-render-budget.ts for why the Stack area is bounded at all.
+const createElisionSpan = (elided: number): HTMLSpanElement => {
+    const span = document.createElement('span');
+    span.className = 'stack-elision';
+    span.textContent = formatElision(elided);
+    span.title = `${elided} more element(s) are on the stack but not drawn; LENGTH reports the full length.`;
+    return span;
+};
+
+const renderStackValueNode = (item: Value, depth: number, budget: RenderBudget): HTMLElement => {
     const node = document.createElement('span');
     node.className = 'stack-node';
 
     if (item.type === 'vector' && Array.isArray(item.value)) {
+        const children = item.value as Value[];
+        const { shown, elided } = planCollectionRender(children.length, budget);
         node.classList.add('stack-node-vector');
         node.dataset.depth = String(depth);
         node.appendChild(createBracketSpan('[', depth));
-        item.value.forEach((child, index) => {
+        for (let index = 0; index < shown; index++) {
             if (index > 0) node.append(' ');
-            node.appendChild(renderStackValueNode(child, depth + 1));
-        });
+            node.appendChild(renderStackValueNode(children[index]!, depth + 1, budget));
+        }
+        if (elided > 0) {
+            if (shown > 0) node.append(' ');
+            node.appendChild(createElisionSpan(elided));
+        }
         node.appendChild(createBracketSpan(']', depth));
         return node;
     }
@@ -268,11 +290,16 @@ const renderStackValueNode = (item: Value, depth: number): HTMLElement => {
                 if ((tensor.displayHint ?? '').toLowerCase() === 'text') {
                     tensorNode.append(deserializeBytesToString(tensorData));
                 } else {
+                    const { shown, elided } = planCollectionRender(tensorData.length, budget);
                     tensorNode.appendChild(createBracketSpan('[', tensorDepth));
-                    tensorData.forEach((frac, index) => {
+                    for (let index = 0; index < shown; index++) {
                         if (index > 0) tensorNode.append(' ');
-                        tensorNode.append(formatFraction(frac));
-                    });
+                        tensorNode.append(formatFraction(tensorData[index]));
+                    }
+                    if (elided > 0) {
+                        if (shown > 0) tensorNode.append(' ');
+                        tensorNode.appendChild(createElisionSpan(elided));
+                    }
                     tensorNode.appendChild(createBracketSpan(']', tensorDepth));
                 }
                 return tensorNode;
@@ -282,10 +309,15 @@ const renderStackValueNode = (item: Value, depth: number): HTMLElement => {
             const outerSize = tensorShape[0] ?? 0;
             const innerShape = tensorShape.slice(1);
             const innerSize = innerShape.reduce((a, b) => a * b, 1);
-            for (let i = 0; i < outerSize; i++) {
+            const { shown, elided } = planCollectionRender(outerSize, budget);
+            for (let i = 0; i < shown; i++) {
                 if (i > 0) tensorNode.append(' ');
                 const innerData = tensorData.slice(i * innerSize, (i + 1) * innerSize);
                 tensorNode.appendChild(renderTensorNode(innerShape, innerData, tensorDepth + 1));
+            }
+            if (elided > 0) {
+                if (shown > 0) tensorNode.append(' ');
+                tensorNode.appendChild(createElisionSpan(elided));
             }
             tensorNode.appendChild(createBracketSpan(']', tensorDepth));
             return tensorNode;
@@ -725,12 +757,16 @@ export const createDisplay = (elements: DisplayElements): Display => {
         const container = document.createElement('div');
         container.className = 'area-content-flow stack-content-flow';
 
+        // One budget for the whole render: the Stack area draws a bounded
+        // amount however the values on it are shaped.
+        const budget = createRenderBudget();
+
         lastStack.forEach((item, index) => {
             const elem = document.createElement('span');
             elem.className = 'stack-item';
             try {
                 const mathNode = mathViewEnabled ? renderMathValueNode(item) : null;
-                elem.appendChild(mathNode ?? renderStackValueNode(item, 1));
+                elem.appendChild(mathNode ?? renderStackValueNode(item, 1, budget));
             } catch {
                 console.error(`Error formatting item ${index}`);
                 elem.textContent = 'ERROR';

--- a/src/gui/stack-render-budget.test.ts
+++ b/src/gui/stack-render-budget.test.ts
@@ -1,0 +1,73 @@
+// The Stack area's drawing bound. A legal program can put a half-million
+// element Vector on the stack; drawing it unbounded froze the browser tab for
+// tens of seconds, so the render is capped and the undrawn tail is counted.
+
+import { describe, expect, test } from 'vitest';
+import {
+    MAX_RENDERED_ELEMENTS_PER_COLLECTION,
+    MAX_RENDERED_ELEMENTS_PER_STACK,
+    createRenderBudget,
+    formatElision,
+    planCollectionRender
+} from './stack-render-budget';
+
+describe('planCollectionRender', () => {
+    test('a small collection is drawn whole and elides nothing', () => {
+        const budget = createRenderBudget();
+        expect(planCollectionRender(3, budget)).toEqual({ shown: 3, elided: 0 });
+        expect(budget.remaining).toBe(MAX_RENDERED_ELEMENTS_PER_STACK - 3);
+    });
+
+    test('an empty collection costs nothing', () => {
+        const budget = createRenderBudget();
+        expect(planCollectionRender(0, budget)).toEqual({ shown: 0, elided: 0 });
+        expect(budget.remaining).toBe(MAX_RENDERED_ELEMENTS_PER_STACK);
+    });
+
+    test('a collection past the per-collection cap is cut there and the rest counted', () => {
+        const budget = createRenderBudget();
+        const plan = planCollectionRender(500_000, budget);
+        expect(plan.shown).toBe(MAX_RENDERED_ELEMENTS_PER_COLLECTION);
+        expect(plan.elided).toBe(500_000 - MAX_RENDERED_ELEMENTS_PER_COLLECTION);
+    });
+
+    test('many collections cannot together exceed the per-render budget', () => {
+        const budget = createRenderBudget();
+        let drawn = 0;
+        for (let i = 0; i < 10_000; i++) {
+            drawn += planCollectionRender(MAX_RENDERED_ELEMENTS_PER_COLLECTION, budget).shown;
+        }
+        expect(drawn).toBe(MAX_RENDERED_ELEMENTS_PER_STACK);
+        expect(budget.remaining).toBe(0);
+    });
+
+    test('an exhausted budget draws nothing and elides everything', () => {
+        const budget = createRenderBudget(0);
+        expect(planCollectionRender(7, budget)).toEqual({ shown: 0, elided: 7 });
+    });
+
+    test('shown plus elided always accounts for the whole collection', () => {
+        for (const length of [1, 99, 100, 101, 2_500, 1_000_000]) {
+            const budget = createRenderBudget();
+            const plan = planCollectionRender(length, budget);
+            expect(plan.shown + plan.elided).toBe(length);
+        }
+    });
+
+    test('a nonsense length is treated as empty rather than drawn', () => {
+        const budget = createRenderBudget();
+        expect(planCollectionRender(Number.NaN, budget)).toEqual({ shown: 0, elided: 0 });
+        expect(planCollectionRender(-5, budget)).toEqual({ shown: 0, elided: 0 });
+        expect(budget.remaining).toBe(MAX_RENDERED_ELEMENTS_PER_STACK);
+    });
+});
+
+describe('formatElision', () => {
+    test('states the exact undrawn count', () => {
+        expect(formatElision(499_900)).toBe('… 499900 more');
+    });
+
+    test('is not Ajisai-shaped, so it cannot be misread as part of the value', () => {
+        expect(formatElision(3)).not.toMatch(/^[[\]A-Z0-9'/-]+$/);
+    });
+});

--- a/src/gui/stack-render-budget.ts
+++ b/src/gui/stack-render-budget.ts
@@ -1,0 +1,61 @@
+// How much of a stack value the Stack area draws.
+//
+// The interpreter's materialization ceiling bounds what a generative Word may
+// build, not what the host can draw. `[ 1 500000 ] RANGE` sits well inside that
+// ceiling and is an ordinary, correct program — and rendering it drew one DOM
+// node per element, locking the browser tab for tens of seconds with no way to
+// abort, clear the editor, or read the result. A safety mechanism that stops
+// the interpreter and then hands the host an unbounded drawing job has only
+// moved where the program hangs.
+//
+// So the Stack area draws a bounded prefix of any collection and says, in
+// place, how many elements it left out. This is presentation, in the same class
+// as the execution step limit: a host control, not a language constraint. The
+// value on the stack is whole and unmodified, every Word still sees all of it,
+// and `LENGTH` remains the way to ask how long it really is.
+
+/** Elements drawn from any one collection before the rest is summarized. */
+export const MAX_RENDERED_ELEMENTS_PER_COLLECTION = 100;
+
+/**
+ * Elements drawn across the whole Stack area in one render. A per-collection
+ * cap alone still admits a stack of ten thousand short vectors, so the budget
+ * is global to the render and every collection draws from it.
+ */
+export const MAX_RENDERED_ELEMENTS_PER_STACK = 2_000;
+
+export interface RenderBudget {
+    remaining: number;
+}
+
+export const createRenderBudget = (
+    total: number = MAX_RENDERED_ELEMENTS_PER_STACK
+): RenderBudget => ({ remaining: Math.max(0, total) });
+
+export interface CollectionRenderPlan {
+    /** Leading elements to draw. */
+    readonly shown: number;
+    /** Elements summarized instead of drawn; 0 means the collection is complete. */
+    readonly elided: number;
+}
+
+/**
+ * Decide how much of a `length`-element collection to draw, and charge the
+ * drawn part to the shared budget. A nested collection costs one element in its
+ * parent and then draws its own children from the same budget, so the total
+ * node count of one render stays bounded whatever the nesting looks like.
+ */
+export const planCollectionRender = (length: number, budget: RenderBudget): CollectionRenderPlan => {
+    const safeLength = Number.isFinite(length) && length > 0 ? Math.floor(length) : 0;
+    const shown = Math.min(safeLength, MAX_RENDERED_ELEMENTS_PER_COLLECTION, budget.remaining);
+    budget.remaining -= shown;
+    return { shown, elided: safeLength - shown };
+};
+
+/**
+ * The marker that stands in for the undrawn tail. It is deliberately not
+ * Ajisai-shaped — a reader must never mistake it for part of the value — and it
+ * states the exact count, so the display never implies the collection ends
+ * where the drawing does.
+ */
+export const formatElision = (elided: number): string => `… ${elided} more`;

--- a/src/gui/vocabulary-state-controller.ts
+++ b/src/gui/vocabulary-state-controller.ts
@@ -11,6 +11,7 @@ import {
     renderWordInfo,
     resetWordInfoDisplay,
 } from './dictionary-element-builders';
+import { isCanonicalCoreWordName } from './core-word-name';
 
 export interface WordInfo {
     readonly dictionary: string;
@@ -69,7 +70,8 @@ const clearElement = (element: HTMLElement): void => {
     element.innerHTML = '';
 };
 
-const isCanonicalCoreWordName = (name: string): boolean => /^[A-Z][A-Z0-9-]*$/.test(name);
+// See core-word-name.ts: the predicate lives beside its spec-driven test so a
+// canonical Word can never be filtered out of the Core sheet again.
 
 const DEPENDENCY_DELETE_ERROR = 'Cannot delete';
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -755,6 +755,18 @@
 }
 
 
+/* The Stack area draws a bounded prefix of a large collection (see
+   src/gui/stack-render-budget.ts). The marker that stands for the undrawn tail
+   is styled as commentary — muted, italic, never bold — so it cannot be read as
+   part of the value even when it sits inside the brackets. */
+.stack-elision {
+    font-style: italic;
+    font-weight: normal;
+    opacity: 0.65;
+    white-space: nowrap;
+}
+
+
 .stack-node-vector {
     background-color: transparent;
     color: var(--color-stack);


### PR DESCRIPTION
## Summary

An external review drove the Playground against the README, Specification and Reference and reported eight defects. Each was checked against the sources and the running app (Chromium + the `ajisai` CLI) before anything was changed. Five were real; three were misdiagnosed but sat next to something real. All eight are addressed.

| # | Reported | Verdict | Change |
|---|---|---|---|
| 1 | LaTeX view is on by default and reduces `1/1` to `1`, breaking the fraction promise | **Partly wrong.** The LaTeX checkbox is off by default (verified). Reading a unit denominator as an integer is deliberate, presentation-only design. The real gap is that the Reference never mentioned the view at all. | Reference documents the view, its default, and what it changes |
| 2 | `[ 1 100000000000 ] RANGE LENGTH` freezes the tab; the ceiling is not O(1) | **Repro wrong, complaint right.** That request is refused in O(1) and returns NIL in ~30 ms. But `[ 1 500000 ] RANGE` — legal and well inside the ceiling — drew one DOM node per element and locked the tab for ~27 s | Stack drawing is bounded |
| 3 | Input is cleared on every run, no history | **Confirmed** | `Ctrl+Up` / `Ctrl+Down` recall |
| 4 | The suggestion popup swallows Shift+Enter with no feedback | **Wrong** — Shift+Enter runs and the error surfaces on Output. But Escape could not dismiss the popup at all | Escape dismisses the popup first |
| 5 | The Core Words sheet lists 56, `NIL?` missing | **Confirmed** | Predicate corrected, driven from `spec/words.json` |
| 6 | The Specification omits the vector broadcast rule the Reference promises | **Confirmed**, and the real rule is broader than either document said | Specification and Reference both state it |
| 7 | `COND`'s one-clause-per-line rule is not in the tokenization rules | **Confirmed** | Stated where tokenization is described |
| 8 | `DEF` does not check that a body's words exist | **Confirmed**, and deliberate | Documented, with the reason and the CLI that does check |

### Stack drawing is bounded (issue 2)

The interpreter's materialization ceiling bounds what a generative Word may *build*, not what the host may *draw*. `[ 1 500000 ] RANGE` passes the ceiling and then handed the browser an unbounded drawing job: 500 005 DOM nodes, ~27 s of frozen main thread, no way to abort, clear the editor, or read the result. A safety mechanism that stops the interpreter and then hangs the host has only moved where the program hangs.

The Stack area now draws at most 100 elements from any one collection and 2 000 across a whole render, replacing the tail in place with a `… N more` marker styled as muted italic commentary. This is presentation, in the same class as the step limit: the value on the stack is whole, every Word still sees all of it, and `LENGTH` reports the real length.

Measured in Chromium, `[ 1 200000 ] RANGE`:

| | before | after |
|---|---|---|
| stack DOM nodes | 200 005 | 106 |
| wall clock | ~27 s (at 500 000) / 11 s (at 200 000) | 7–9 s |

The residual seconds are **not** the drawing — they are the per-run state-sync pipeline (`collect_stack` runs three times per execution on the main thread, plus two structured-clone crossings to the worker and the IndexedDB write). `[ 1 300000 ] RANGE LENGTH`, which leaves a scalar on the stack, completes end to end in 61 ms, so the interpreter is not the cost. Collapsing those repeated stack reads into one is a worthwhile follow-up but is a refactor of the state-sync path across three modules, so it is deliberately **not** in this PR. What is fixed here is the part that was unbounded.

One related cleanup did land, because it was contained: `detectExecutionSurfaceChanges` compared the pre/post stack by `JSON.stringify`-ing both in full on every run, purely to decide which panel to show. It now walks the values structurally with an early exit.

### Core Words sheet lists 57 again (issue 5)

The sheet filtered the interpreter's Core payload through `/^[A-Z][A-Z0-9-]*$/`, which does not admit `?`. `NIL?` is a canonical Word that works when typed and was deleted from the one surface a reader — human or agent — consults to find out what the language has, leaving 56 of 57 visible. The predicate is now the canonical spelling from `spec/words.schema.json`, and `core-word-name.test.ts` drives it from `spec/words.json` itself, so a name shape adopted later cannot go missing unnoticed.

### Recall of submitted source (issue 3)

A successful Run clears the editor and Reset clears it too, while the Stack persists across runs. That combination made the ordinary loop — run, change one token, run again — a full retype, and made a Reset after a run that did not happen take the text with it. `Ctrl+Up` / `Ctrl+Down` now walk the session's submitted programs back into the editor. History is session-lived, stores source text only, and survives Reset. The plain arrows are left to caret movement and the suggestion panel's list.

### Escape dismisses the suggestion panel (issue 4)

Shift+Enter is not swallowed by the popup — it runs, and a failed run surfaces on Output with the layout switching to show it. What was actually broken: the window-level Escape listener captures and calls `stopImmediatePropagation`, so the editor's own Escape branch never ran and the panel could not be dismissed with Escape at all. The window handler now asks the editor first; Abort still gets Escape whenever there is no panel to close.

### Documentation (issues 1, 6, 7, 8)

`LANG.COLLECTIONS.LIFT` stated only equal-length and scalar pairing. The implementation performs axis broadcasting — shapes aligned at the innermost axis, a missing axis counting as 1, a length-1 axis reused across the other side's length — which is what makes the one-element broadcast the Reference already promised work at all, and which also covers `[ [ 1 2 ] [ 3 4 ] ] [ 10 20 ] *`. Both documents now state the rule, including that two vectors broadcast only when both are rectangular while a scalar reaches into a ragged one.

The one-clause-per-line `COND` rule is the single place in the language where a line break is significant, and it was described only under Conditionals. It is now also stated where tokenization is, with the exact error text, and Conditionals says it is a rule rather than a layout preference.

The Reference additionally gains: the LaTeX view (what it is, that it is off by default, that a unit denominator reads as an integer, and that unchecking restores the canonical form); the `… N more` marker and what it does not mean; and `DEF`'s call-time name resolution — with the reason it works that way (words may be defined in any order, so a pair may call each other) and the pointer to `ajisai check`, which does resolve names ahead of execution.

## Quality Classification

- Highest impacted level: **QL-C** — presentation, editor input handling, and reading surfaces. No language semantics, no Word contract, no Rust source is touched; the Specification edit records the broadcast rule the implementation already had and the tokenization rule it already enforced.

## Traceability

- Clauses touched: `LANG.COLLECTIONS.LIFT` (broadcast rule stated), `LANG.SOURCE.TEXT` (line significance stated), `GUI presentation profile` (Stack drawing bound, Escape hand-off, recall shortcut)
- Verification evidence:
  - New unit tests: `src/gui/stack-render-budget.test.ts` (9), `src/gui/editor-history.test.ts` (11), `src/gui/core-word-name.test.ts` (62, generated from `spec/words.json`); `src/gui/execution-surface-changes.test.ts` extended by 5 for the structural comparison
  - Full suite: 323 tests / 17 files passing
  - CI gate run locally: `check`, `lint`, `test`, `check:semantic-firewall`, `check:file-size`, `check:reading-surfaces`, `specification:check`, `semantic-kernel:check`, `word-schema:check`, `word:reference:check`, `core-word-docs:check`, `word-registry:check`, `word:manifest:check`, `check:formalization-coverage`, `check:minimal-core`, `check:version-sync`, `check:runtime-metadata`, `check:skill` — all pass
  - Behavioral verification in Chromium against `npm run dev`, before and after, for every one of the eight reported items; the `ajisai` CLI used to separate interpreter behavior from host behavior

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — no Rust changed
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — no Rust changed
- [x] `npm run check`
- [ ] `cargo llvm-cov --branch --workspace` — no Rust changed
- [x] MC/DC-like checklist reviewed for modified boolean logic (the render-budget plan, the history cursor at both ends, and the Escape hand-off each have both outcomes covered)
- [x] Release checklist impact considered — the `… N more` marker is a new user-visible Stack rendering and `Ctrl+Up`/`Ctrl+Down` is a new shortcut; both are recorded in `docs/dev/gui-current-design-memory.md` and the Reference

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

Known and deliberately out of scope: the per-run state-sync cost on very large stacks, described under issue 2 above.

---
_Generated by [Claude Code](https://claude.ai/code/session_015MtFgwxVgFvd8UVWMgDvpU)_