### PR TITLE
Say what to do when the specification line budget is full

### DIFF
--- a/scripts/check-semantic-kernel.mjs
+++ b/scripts/check-semantic-kernel.mjs
@@ -11,8 +11,31 @@ const fail = (message) => {
 
 // The kernel is a ceiling, not a floor: a shorter specification is always an
 // improvement, a longer one is the regression this gate exists to catch.
+//
+// The budget is normally slack, and then one day it is not. Adding
+// LANG.SOURCE.FRAME took the file to the ceiling exactly, so the next clause
+// added here fails this check on arrival. That is the gate working: the answer
+// is to shorten or merge an existing clause, which is the question "does the
+// specification need this, or does it already say it elsewhere?" asked at the
+// only moment anyone will actually ask it.
+//
+// Two answers that look like fixes are not. Raising the number right after
+// hitting it retires the brake; and reflowing prose to put more words on fewer
+// lines keeps the count down while the specification grows, which is the thing
+// being measured. Raising it deliberately, when the language genuinely has more
+// to say, is a different act and a fine one — it just wants to be a decision
+// rather than a reflex.
+//
+// `headroom` below is reported on every green run, so how close the file is
+// sitting is visible without reading this comment.
+const LINE_BUDGET = 400;
 const lines = language.split('\n').length;
-if (lines > 400) fail(`language-semantics.md has ${lines} lines (maximum 400)`);
+if (lines > LINE_BUDGET) {
+  fail(
+    `language-semantics.md has ${lines} lines (maximum ${LINE_BUDGET}). ` +
+      'Shorten or merge a clause rather than raising the budget; see the note above this check.',
+  );
+}
 
 const clauseIds = new Set([...language.matchAll(/id="[^"]+">(LANG\.[A-Z.]+)/g)].map((match) => match[1]));
 if (clauseIds.size === 0) fail('no language clause IDs found');
@@ -48,7 +71,9 @@ if (words.entries.length > 70) fail(`${words.entries.length} canonical Words (ma
 if (aliases > 16) fail(`${aliases} aliases (maximum 16)`);
 
 if (!process.exitCode) {
+  const headroom = LINE_BUDGET - lines;
+  const budget = headroom === 0 ? 'at the line budget' : `${headroom} lines under budget`;
   console.log(
-    `[semantic-kernel] ${lines} lines, ${clauseIds.size} clauses, ${familyIds.size} families, ${words.entries.length} Words, ${aliases} aliases.`,
+    `[semantic-kernel] ${lines} lines (${budget}), ${clauseIds.size} clauses, ${familyIds.size} families, ${words.entries.length} Words, ${aliases} aliases.`,
   );
 }


### PR DESCRIPTION
## Summary

One file, comment and messages only.

`spec/language-semantics.md` is at **400 of 400 lines**. Adding `LANG.SOURCE.FRAME` in #1449 took it to the ceiling exactly — the clause was compressed to fit rather than the budget raised — so the next clause added there fails `semantic-kernel:check` on arrival. Nothing recorded that, or said what the intended response is.

Three changes, no behavior change:

- **The green run reports headroom.** `[semantic-kernel] 400 lines (at the line budget), 42 clauses, …`. This is derived, so it cannot go stale the way a comment recording today's count would.
- **The failure message points at the fix**, instead of only restating the count:
  ```
  language-semantics.md has 401 lines (maximum 400). Shorten or merge a clause
  rather than raising the budget; see the note above this check.
  ```
- **The note above the check records the two answers that look like fixes and are not.** Raising the number right after hitting it retires the brake. Reflowing prose to put more words on fewer lines keeps the count down while the specification grows, which is the thing being measured — there are 35 three-line `<p>` blocks in the file and collapsing them would buy 70 lines without deleting a word, which is exactly why it is worth naming as a non-answer. Raising the budget *deliberately*, when the language genuinely has more to say, stays available; it just wants to be a decision rather than a reflex.

The budget, the checks and the exit codes are unchanged.

## Quality Classification

- Highest impacted level: QL-D — a build-time quality gate's diagnostics. No product code, no specification content, no runtime surface.

## Traceability

- Requirement(s): SPECIFICATION §2 semantic-kernel budget (`scripts/check-semantic-kernel.mjs`), `LANG.AUTHORITY.SOURCES` (`spec/language-semantics.md` is the normative source this gate bounds).
- Verification evidence: both branches of the modified check exercised locally — the pass path prints `400 lines (at the line budget)`, and appending one line to `spec/language-semantics.md` produces the new failure message and a non-zero exit, after which the file was restored. Every `check:*` / `*:check` gate in `test.yml` plus `npm run check` and `npm run lint` are green.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable; no Rust changed.
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable; no Rust changed.
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — not applicable; no Rust changed.
- [x] `npm run check`, if applicable — plus `npm run lint` and every `check:*` / `*:check` gate.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the one modified predicate is `lines > LINE_BUDGET`; both outcomes were run, at the boundary (400 passes, 401 fails).
- [x] Release checklist impact considered — none; no generated artifact, specification surface or published file changes.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KccayJAQNsvHedPNePRbaw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KccayJAQNsvHedPNePRbaw)_