### PR TITLE
Read the Stack in reading order, and clear it the way an editor clears

### DIFF
--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -611,7 +611,9 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <p>The GUI has four named surfaces: Input, Output, Stack, and Dictionary. Desktop presentation uses two columns (Input or Output on the left; Stack or Dictionary on the right), while mobile presentation exposes one selected surface at a time.</p>
 
-<p>The operations Run, Step, Abort, and Reset retain their current behavior. The desktop shortcuts are respectively <code>Shift+Enter</code>, <code>Ctrl+Enter</code>, <code>Escape</code>, and <code>Ctrl+Alt+Enter</code>. Output copy and focus behavior, Core/User dictionary sheets, search, deletion, canonical stack display, opt-in LaTeX display, nested-vector bracket coloring, modifier background indication, stack snapshots, and persistence of user words are compatibility requirements.</p>
+<p>The operations Run, Step, Abort, and Reset retain their current behavior. The desktop shortcuts are respectively <code>Shift+Enter</code>, <code>Ctrl+Enter</code>, <code>Escape</code>, and <code>Ctrl+Alt+Enter</code>; Format is <code>Shift+Alt+F</code> and Clear stack is <code>Shift+Alt+C</code>. Clear stack discards the values and leaves the dictionary — that is what distinguishes it from Reset. Output copy and focus behavior, Core/User dictionary sheets, search, deletion, canonical stack display, opt-in LaTeX display, nested-vector bracket coloring, modifier background indication, stack snapshots, and persistence of user words are compatibility requirements.</p>
+
+<p>The Stack surface reads in ordinary reading order: top to bottom, left to right, with the top of the stack last. The top of the stack is marked, so the value the next Word reads is identifiable without counting, at any number of values and whatever the wrapping.</p>
 
 <p>Three visibility rules are normative, because each ties what is shown to what the user is doing rather than to geometry:</p>
 

--- a/index.html
+++ b/index.html
@@ -113,6 +113,13 @@
                 <section id="stack-panel" class="stack-area" aria-label="Stack" tabindex="0">
                     <h2 class="visually-hidden">Stack</h2>
                     <div id="stack-display" class="state-display" aria-live="polite" aria-atomic="false"></div>
+                    <!--
+                      Discarding the stack is the same gesture as clearing the
+                      editor, so it is the same control in the same place: an
+                      `×` at the top right of its own area. The dictionary is
+                      untouched — that is what separates this from Reset.
+                    -->
+                    <button id="stack-clear-btn" type="button" class="inline-clear-btn" aria-label="Clear stack" title="Clear stack (Shift+Alt+C)">&times;</button>
                 </section>
 
                 <section id="dictionary-panel" class="dictionary-area" aria-label="Dictionary" tabindex="0" hidden>

--- a/spec/freeze/gui-production-files.json
+++ b/spec/freeze/gui-production-files.json
@@ -1,10 +1,30 @@
 {
   "phase": 0,
   "policy": "No production GUI file may change during specification freeze phases 0 through 2.",
-  "roots": ["index.html", "src/gui", "src/styles"],
-  "surfaces": ["Input", "Output", "Stack", "Dictionary"],
+  "roots": [
+    "index.html",
+    "src/gui",
+    "src/styles"
+  ],
+  "surfaces": [
+    "Input",
+    "Output",
+    "Stack",
+    "Dictionary"
+  ],
   "desktopColumns": 2,
   "mobileVisibleSurfaces": 1,
-  "dictionarySheets": ["core", "user", "module"],
-  "shortcuts": ["Run → Shift+Enter", "Step → Ctrl+Enter", "Reset → Ctrl+Alt+Enter", "Abort → Escape"]
+  "dictionarySheets": [
+    "core",
+    "user",
+    "module"
+  ],
+  "shortcuts": [
+    "Run → Shift+Enter",
+    "Step → Ctrl+Enter",
+    "Reset → Ctrl+Alt+Enter",
+    "Abort → Escape",
+    "Format → Shift+Alt+F",
+    "Clear stack → Shift+Alt+C"
+  ]
 }

--- a/spec/gui-semantics.md
+++ b/spec/gui-semantics.md
@@ -6,7 +6,9 @@
 
 <p>The GUI has four named surfaces: Input, Output, Stack, and Dictionary. Desktop presentation uses two columns (Input or Output on the left; Stack or Dictionary on the right), while mobile presentation exposes one selected surface at a time.</p>
 
-<p>The operations Run, Step, Abort, and Reset retain their current behavior. The desktop shortcuts are respectively <code>Shift+Enter</code>, <code>Ctrl+Enter</code>, <code>Escape</code>, and <code>Ctrl+Alt+Enter</code>. Output copy and focus behavior, Core/User dictionary sheets, search, deletion, canonical stack display, opt-in LaTeX display, nested-vector bracket coloring, modifier background indication, stack snapshots, and persistence of user words are compatibility requirements.</p>
+<p>The operations Run, Step, Abort, and Reset retain their current behavior. The desktop shortcuts are respectively <code>Shift+Enter</code>, <code>Ctrl+Enter</code>, <code>Escape</code>, and <code>Ctrl+Alt+Enter</code>; Format is <code>Shift+Alt+F</code> and Clear stack is <code>Shift+Alt+C</code>. Clear stack discards the values and leaves the dictionary — that is what distinguishes it from Reset. Output copy and focus behavior, Core/User dictionary sheets, search, deletion, canonical stack display, opt-in LaTeX display, nested-vector bracket coloring, modifier background indication, stack snapshots, and persistence of user words are compatibility requirements.</p>
+
+<p>The Stack surface reads in ordinary reading order: top to bottom, left to right, with the top of the stack last. The top of the stack is marked, so the value the next Word reads is identifiable without counting, at any number of values and whatever the wrapping.</p>
 
 <p>Three visibility rules are normative, because each ties what is shown to what the user is doing rather than to geometry:</p>
 

--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -161,19 +161,7 @@ export const createGUI = (): GUI => {
         mobile = createMobileHandler(extractMobileElements(elements), {
             onModeChange: (mode) => layoutController.setArea(mode)
         });
-        display = createDisplay(extractDisplayElements(elements), {
-            // Clearing the stack keeps the dictionary, which is the whole point
-            // of having it separate from the full reset. The handler reads
-            // `persistence` at call time because it is assigned further down.
-            onClearStack: () => {
-                const interpreter = INTERPRETER_CLIENT.getOptional();
-                if (!interpreter) return;
-                interpreter.clear_stack();
-                updateAllDisplays();
-                display.renderInfo('Stack cleared', false);
-                void persistence?.saveCurrentState();
-            }
-        });
+        display = createDisplay(extractDisplayElements(elements));
         display.init();
         updateEditorPlaceholder(elements, mobile);
 
@@ -257,6 +245,17 @@ export const createGUI = (): GUI => {
             persistence,
             switchArea: (mode) => layoutController.setArea(mode),
             updateAllDisplays,
+            // Clearing the stack keeps the dictionary — that is the whole point
+            // of having it apart from Reset — so it is the interpreter's
+            // `clear_stack` and nothing else, followed by a redraw and a save.
+            clearStack: () => {
+                const interpreter = INTERPRETER_CLIENT.getOptional();
+                if (!interpreter) return;
+                interpreter.clear_stack();
+                updateAllDisplays();
+                display.renderInfo('Stack cleared', false);
+                void persistence.saveCurrentState();
+            },
             doSwitchDictionarySheet,
             layoutController
         });

--- a/src/gui/gui-dom-cache.ts
+++ b/src/gui/gui-dom-cache.ts
@@ -6,6 +6,7 @@ import type { DictionarySheetSelectElement } from './dictionary-sheet-selector';
 export interface GUIElements {
     readonly codeInput: HTMLTextAreaElement;
     readonly clearBtn: HTMLButtonElement;
+    readonly stackClearBtn: HTMLButtonElement;
     readonly formatBtn: HTMLButtonElement;
     readonly exportBtn: HTMLButtonElement;
     readonly importBtn: HTMLButtonElement;
@@ -79,6 +80,7 @@ function requireElementBySelector<T extends HTMLElement>(selector: string, expec
 export const cacheElements = (): GUIElements => ({
     codeInput: requireElementById('code-input', HTMLTextAreaElement),
     clearBtn: requireElementById('clear-btn', HTMLButtonElement),
+    stackClearBtn: requireElementById('stack-clear-btn', HTMLButtonElement),
     formatBtn: requireElementById('format-btn', HTMLButtonElement),
     exportBtn: requireElementById('export-btn', HTMLButtonElement),
     importBtn: requireElementById('import-btn', HTMLButtonElement),

--- a/src/gui/gui-event-bindings.ts
+++ b/src/gui/gui-event-bindings.ts
@@ -23,6 +23,10 @@ export type GuiEventBindingContext = {
     readonly persistence: Persistence;
     readonly switchArea: (mode: ViewMode) => void;
     readonly updateAllDisplays: () => void;
+    /// Discard every value on the stack, leaving the dictionary alone. Lives on
+    /// the context rather than being reached from here because the interpreter
+    /// client is owned by the application module.
+    readonly clearStack: () => void;
     readonly doSwitchDictionarySheet: (sheetId: string) => void;
 };
 
@@ -102,7 +106,7 @@ function bindLayoutEvents(context: GuiEventBindingContext): void {
 }
 
 function bindInteractionEvents(context: GuiEventBindingContext): void {
-    const { elements, vocabulary, editor, mobile, layoutState, switchArea, display, persistence, executionController } = context;
+    const { elements, vocabulary, editor, mobile, layoutState, switchArea, display, persistence, executionController, clearStack } = context;
     // Session-lived recall of submitted programs, so a run (which clears the
     // editor) and a Reset are both recoverable. See editor-history.ts.
     const history = createEditorHistory();
@@ -126,6 +130,10 @@ function bindInteractionEvents(context: GuiEventBindingContext): void {
     elements.mobileDictionarySearchClearBtn.addEventListener('click', () => applySearchFilter(''));
 
     elements.clearBtn.addEventListener('click', () => editor.clear());
+    // Same control, same corner, same gesture as clearing the editor — the
+    // Stack area's `×` throws away the values and keeps the dictionary, which
+    // is what separates it from Reset.
+    elements.stackClearBtn.addEventListener('click', () => clearStack());
     elements.formatBtn.addEventListener('click', () => editor.format());
 
     // Reformat the editor before running it, so the source that defines words
@@ -295,6 +303,16 @@ function bindInteractionEvents(context: GuiEventBindingContext): void {
             if (confirm('Are you sure you want to reset the system?')) {
                 executionController.executeReset();
             }
+            e.preventDefault();
+            e.stopImmediatePropagation();
+        }
+        // Shift+Alt+C clears the stack, following Shift+Alt+F for Format. It is
+        // bound on the window rather than the editor because the Stack area can
+        // hold focus, and `e.code` so the binding does not move with the layout.
+        // No confirmation: unlike Reset this loses only values, and the same
+        // values are one re-run away.
+        if (e.code === 'KeyC' && e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+            clearStack();
             e.preventDefault();
             e.stopImmediatePropagation();
         }

--- a/src/gui/gui-layout-state.ts
+++ b/src/gui/gui-layout-state.ts
@@ -37,6 +37,7 @@ const DESKTOP_EDITOR_PLACEHOLDER = [
     'Run → Shift+Enter',
     'Step → Ctrl+Enter',
     'Format → Shift+Alt+F',
+    'Clear stack → Shift+Alt+C',
     'Suggestions → Ctrl+Space',
     'Recall → Ctrl+Up / Ctrl+Down',
     'Reset → Ctrl+Alt+Enter',

--- a/src/gui/output-display-renderer.ts
+++ b/src/gui/output-display-renderer.ts
@@ -20,14 +20,6 @@ export interface DisplayState {
     readonly mainOutput: string;
 }
 
-export interface DisplayCallbacks {
-    /// Discard every value on the stack. The Stack area offers this because the
-    /// stack persists between runs — which is what a REPL should do — and until
-    /// there was a button for it the only way to drop a leftover intermediate
-    /// was the full reset, which takes the User dictionary with it.
-    readonly onClearStack?: () => void;
-}
-
 export interface Display {
     readonly init: () => void;
     readonly renderExecutionResult: (result: ExecuteResult) => void;
@@ -682,10 +674,7 @@ const renderJsonExportLinks = (jsonExportCommands: readonly string[], outputDisp
     });
 };
 
-export const createDisplay = (
-    elements: DisplayElements,
-    callbacks: DisplayCallbacks = {}
-): Display => {
+export const createDisplay = (elements: DisplayElements): Display => {
     let mainOutput = '';
     let mathViewEnabled = readMathViewPreference();
     let lastStack: Value[] = [];
@@ -717,22 +706,8 @@ export const createDisplay = (
         panel.appendChild(wrapper);
     };
 
-    const createClearButton = (): void => {
-        const panel = elements.stackDisplay.parentElement;
-        if (!panel || !callbacks.onClearStack || panel.querySelector('.stack-clear-btn')) return;
-
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'stack-clear-btn';
-        button.textContent = 'Clear';
-        button.title = 'Discard every value on the stack (the dictionary is kept)';
-        button.addEventListener('click', () => callbacks.onClearStack?.());
-        panel.appendChild(button);
-    };
-
     const init = (): void => {
         elements.outputDisplay.style.whiteSpace = 'pre-wrap';
-        createClearButton();
         createLatexToggle();
         AUDIO_ENGINE.init().catch(console.error);
     };
@@ -845,6 +820,11 @@ export const createDisplay = (
         const display = elements.stackDisplay;
         clearElement(display);
 
+        // The clear control follows the same rule the editor's does: it is not
+        // drawn when there is nothing to clear. The flag goes on the panel
+        // because the button is a sibling of the display, not a child.
+        display.parentElement?.classList.toggle('is-empty-stack', lastStack.length === 0);
+
         if (lastStack.length === 0) {
             display.classList.add('is-empty');
             const message = document.createElement('div');
@@ -866,15 +846,6 @@ export const createDisplay = (
         lastStack.forEach((item, index) => {
             const elem = document.createElement('span');
             elem.className = 'stack-item';
-            // Depth from the top, so the operand a word will read next is 0.
-            // The area flows bottom-up and wrap-reverse, which puts the top at
-            // the *right end of the top row* — readable while everything fits
-            // on one line and unreadable the moment it wraps. A number per
-            // value answers "which one is the top" without depending on where
-            // the row broke.
-            const depth = lastStack.length - 1 - index;
-            elem.dataset.stackDepth = String(depth);
-            if (depth === 0) elem.classList.add('stack-item-top');
             try {
                 const mathNode = mathViewEnabled ? renderMathValueNode(item) : null;
                 elem.appendChild(mathNode ?? renderStackValueNode(item, 1, budget));

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -261,6 +261,19 @@
     color: var(--input-text);
 }
 
+/* Discarding the stack is the same gesture as clearing the editor, so it is the
+   same control in the same corner: an `×` at the top right of its area. */
+#stack-clear-btn {
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 2;
+    color: var(--color-text-light);
+}
+
+#stack-panel.is-empty-stack #stack-clear-btn {
+    display: none;
+}
+
 #code-input:placeholder-shown ~ #clear-btn,
 #code-input:placeholder-shown ~ #format-btn {
     display: none;
@@ -342,26 +355,6 @@
     user-select: none;
 }
 
-/* Discard-the-stack control, beside the LaTeX toggle in the Stack area's
-   corner. Deliberately quiet: it is reached rarely, and it throws work away. */
-.stack-clear-btn {
-    align-self: flex-end;
-    margin: 0 0.125rem 0.125rem 0;
-    padding: 0.1rem 0.45rem;
-    font-family: var(--font-stack-primary);
-    font-size: 0.75rem;
-    color: var(--color-text-light);
-    background: var(--color-white);
-    border: var(--border-main);
-    border-radius: var(--radius-main);
-    cursor: pointer;
-}
-
-.stack-clear-btn:hover {
-    background: var(--color-light);
-    color: var(--color-text);
-}
-
 .stack-latex-toggle input {
     margin: 0;
     cursor: pointer;
@@ -404,6 +397,10 @@
     min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
+    /* Keep the top-right corner free for the clear control, which is drawn over
+       this area rather than beside it: without the reserve, a first row that
+       fills the width runs underneath the `×`. */
+    padding-right: 1.75rem;
 }
 
 #stack-display.is-empty {
@@ -575,9 +572,20 @@
 }
 
 
+/* The Stack area reads the way prose does: top to bottom, left to right, with
+   the top of the stack last.
+
+   It used to wrap-reverse, so that values appeared to pile upward. That reads
+   as a stack while everything fits on one line, and stops reading the moment it
+   wraps: the top of the stack becomes the right-hand end of the *top* row, and
+   working out which value a Word will take next means reconstructing where the
+   rows broke. Ordinary reading order costs the piling-up image and buys a
+   position that never has to be reconstructed. The top of the stack keeps its
+   own marks either way — it is the bold item, and the one the operand highlight
+   fills. */
 #stack-display .stack-content-flow {
-    flex-wrap: wrap-reverse;
-    align-content: flex-end;
+    flex-wrap: wrap;
+    align-content: flex-start;
     align-items: center;
 }
 
@@ -795,29 +803,6 @@
 
 .stack-item:last-child {
     font-weight: bold;
-}
-
-
-/* Depth from the top, drawn as a small leading index on every value.
-
-   The area flows bottom-up and `wrap-reverse`, so the top of the stack is the
-   right-hand end of the *top* row. That reads fine while the values fit on one
-   line and stops reading the moment they wrap — finding which of nine values a
-   word will take next then means reconstructing the wrap. The index does not
-   depend on the layout: 0 is always the top, and the marker on it says so
-   outright. */
-.stack-item::before {
-    content: attr(data-stack-depth);
-    font-size: 0.6rem;
-    vertical-align: super;
-    margin-right: 0.15rem;
-    color: var(--color-text-light);
-    font-weight: normal;
-}
-
-.stack-item.stack-item-top::before {
-    content: attr(data-stack-depth) "\25B8";
-    color: var(--color-stack);
 }
 
 


### PR DESCRIPTION
## Summary

Acts on the maintainer's review of the 4-10 change from #1449. Three parts, GUI only.

**1. The depth-index badges are reverted.** The top of the stack was already marked — it is the bold item, and the one the operand highlight fills — so the numbers restated what the panel already said, on every value, forever.

**2. The Stack area reads in ordinary reading order.** It wrapped upward, so values appeared to pile up. That reads as a stack while everything fits on one line and stops reading the moment it wraps: the top of the stack becomes the right-hand end of the *first* row, and finding the next operand means reconstructing where the rows broke. It now goes top to bottom, left to right, with the top of the stack last. The piling-up image is the cost; a position that never has to be reconstructed is what it buys. The top keeps its own marks either way.

**3. Clearing the stack is the same control the editor already has.** An `×` at the top right of its own area — markup rather than JS-built, bound where every other control is bound, and hidden when there is nothing to clear. It is joined by `Shift+Alt+C`, following `Shift+Alt+F` for Format: bound on the window because the Stack area can hold focus, and on `e.code` so it does not move with the keyboard layout. No confirmation, unlike Reset — this loses only values, and the dictionary is untouched.

`#stack-display` reserves its top-right corner, because the control is drawn over the area rather than beside it and a full first row would otherwise run underneath it. The editor placeholder lists the new shortcut, and `spec/gui-semantics.md` records both the reading order and the shortcut.

The shortcut choice is the one judgement call here and is easy to change: `Shift+Alt+C` was picked only because `Shift+Alt+F` already exists for Format.

## Quality Classification

- Highest impacted level: QL-D — presentation and host controls. No language semantics, no interpreter behavior, no protocol surface.

## Traceability

- Requirement(s): `spec/gui-semantics.md` presentation profile (canonical stack display, desktop shortcuts), `LANG.AUTHORITY.PRESENT` (the profile describes the GUI as it currently is — the rationale for the layout change lives in the CSS comment, not on the reading surface).
- Verification evidence: driven in Chromium against the built bundle —
  - twenty values wrap into reading order (`1/1 … 11/1` on the first row, `12/1 … 20/1` on the second), with `20/1` bold and carrying the operand fill;
  - no `.stack-item` intersects the clear control's rectangle at a full first row of six-digit values;
  - the `×` and `Shift+Alt+C` each take the stack from 20 items to 0, and the control hides when the stack is empty;
  - `Shift+Alt+F` still formats (`{ { 2 LT | 1 * }\n  { IDLE | 1 - FOO } COND } 'FOO' DEF`), so the new binding did not shadow it.
  - Every `check:*` / `*:check` gate, `npm run check`, `npm run lint`, `npm test` (337) and `cargo test` are green.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable; no Rust changed.
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable; no Rust changed.
- [x] `cargo test --all-targets --verbose` (in `rust/`) — run anyway, green.
- [x] `npm run check`, if applicable — plus `npm run lint`, `npm test` and every gate in `test.yml`.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the new predicate is the `Shift+Alt+C` guard (`e.code === 'KeyC' && e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey`). Exercised true (clears the stack) and false by a neighbouring combination that must not clear (`Shift+Alt+F` still formats).
- [x] Release checklist impact considered — `spec/gui-semantics.md` and the generated `SPECIFICATION.html` are updated together, and the shortcut list in `spec/freeze/gui-production-files.json` now includes Format and Clear stack.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KccayJAQNsvHedPNePRbaw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KccayJAQNsvHedPNePRbaw)_