### PR TITLE
CLEAR, typed like RESET — and a rule that stops either shadowing a Word

### DIFF
--- a/SPECIFICATION.html
+++ b/SPECIFICATION.html
@@ -615,6 +615,8 @@ Host-only caches, allocation arenas, compiled plans, and counters are not semant
 
 <p>The Stack surface reads in ordinary reading order: top to bottom, left to right, with the top of the stack last. The top of the stack is marked, so the value the next Word reads is identifiable without counting, at any number of values and whatever the wrapping.</p>
 
+<p><strong>Host commands.</strong> A bare <code>RESET</code> or <code>CLEAR</code>, typed alone into the Input surface and run, is acted on by the host instead of being handed to the interpreter: <code>RESET</code> discards the session and <code>CLEAR</code> discards the stack. They are the typed spelling of controls that also exist as buttons and shortcuts, and they are deliberately <em>not</em> Words — the vocabulary holds nothing that throws away the values a program was handed or the dictionary it was defined in, and nothing in it should. The name must be the whole input, and a User Word of the same name takes precedence, so a host command can never shadow a definition.</p>
+
 <p>Three visibility rules are normative, because each ties what is shown to what the user is doing rather than to geometry:</p>
 
 <ol>

--- a/scripts/check-reading-surfaces.mjs
+++ b/scripts/check-reading-surfaces.mjs
@@ -45,6 +45,13 @@ const EXAMPLE_NAMES = new Set([
   'ADDW', 'PSUM', 'PDIFF', 'PMAX',
 ]);
 
+// Names the *host* allocates rather than the language: typed alone into the
+// editor, they are acted on by the GUI and never reach the interpreter. The
+// presentation profile has to be able to name them — a control nobody can
+// discover is not documented — and they are correctly absent from the
+// vocabulary registry, which is the whole point being made about them.
+const HOST_COMMANDS = new Set(['RESET', 'CLEAR']);
+
 const SURFACES = ['README.md', 'public/docs/index.html', 'SPECIFICATION.html'];
 
 // Word-shaped: upper-case initial, then the characters an Ajisai name may use.
@@ -105,6 +112,7 @@ for (const path of SURFACES) {
       const token = raw.replace(/\\([|`*_])/g, '$1');
       if (WORD_SHAPED.test(token)) {
         if (known.has(token) || EXAMPLE_NAMES.has(token)) continue;
+        if (HOST_COMMANDS.has(token)) continue;
         // A name may also be written only to say the language does not have it.
         // That was a symbol-only case until the Reference had to answer "where
         // is DUP?", which it answers by naming DUP.
@@ -134,6 +142,6 @@ if (errors.length) {
   process.exitCode = 1;
 } else {
   console.log(
-    `[reading-surfaces] ${SURFACES.length} surfaces name only the ${manifest.entries.length} registered surfaces, ${EXAMPLE_NAMES.size} declared example names and ${UNALLOCATED_MENTIONS.size} declared unallocated mentions.`,
+    `[reading-surfaces] ${SURFACES.length} surfaces name only the ${manifest.entries.length} registered surfaces, ${EXAMPLE_NAMES.size} declared example names, ${HOST_COMMANDS.size} host commands and ${UNALLOCATED_MENTIONS.size} declared unallocated mentions.`,
   );
 }

--- a/spec/gui-semantics.md
+++ b/spec/gui-semantics.md
@@ -10,6 +10,8 @@
 
 <p>The Stack surface reads in ordinary reading order: top to bottom, left to right, with the top of the stack last. The top of the stack is marked, so the value the next Word reads is identifiable without counting, at any number of values and whatever the wrapping.</p>
 
+<p><strong>Host commands.</strong> A bare <code>RESET</code> or <code>CLEAR</code>, typed alone into the Input surface and run, is acted on by the host instead of being handed to the interpreter: <code>RESET</code> discards the session and <code>CLEAR</code> discards the stack. They are the typed spelling of controls that also exist as buttons and shortcuts, and they are deliberately <em>not</em> Words — the vocabulary holds nothing that throws away the values a program was handed or the dictionary it was defined in, and nothing in it should. The name must be the whole input, and a User Word of the same name takes precedence, so a host command can never shadow a definition.</p>
+
 <p>Three visibility rules are normative, because each ties what is shown to what the user is doing rather than to geometry:</p>
 
 <ol>

--- a/src/gui/execution-controller.ts
+++ b/src/gui/execution-controller.ts
@@ -14,6 +14,7 @@ import { createStepExecutor, StepExecutor } from './step-executor';
 import { detectExecutionSurfaceChanges } from './execution-surface-changes';
 import type { ViewMode } from './mobile-view-switcher';
 import type { ExecutionSurfaceChanges } from './gui-layout-state';
+import { resolveHostCommand } from './host-commands';
 
 export interface ExecutionCallbacks {
     readonly extractEditorValue: () => string;
@@ -22,6 +23,10 @@ export interface ExecutionCallbacks {
     readonly insertEditorText: (text: string) => void;
     readonly showInfo: (text: string, append: boolean) => void;
     readonly highlightSourceRange: (start: number, end: number) => void;
+    /// Discard every value on the stack, leaving the dictionary alone. Shared
+    /// with the Stack area's `×` and `Shift+Alt+C`, so all three routes are one
+    /// behavior.
+    readonly clearStack: () => void;
     readonly showDocumentation: (text: string) => void;
     readonly showError: (error: Error | string, precedingOutput?: string) => void;
     readonly showExecutionResult: (result: ExecuteResult) => void;
@@ -40,9 +45,6 @@ export interface ExecutionController {
     readonly abortExecution: () => void;
 }
 
-const checkIsResetCommand = (code: string): boolean =>
-    code.trim().toUpperCase() === 'RESET';
-
 export const createExecutionController = (
     interpreter: AjisaiInterpreter,
     callbacks: ExecutionCallbacks
@@ -54,6 +56,7 @@ export const createExecutionController = (
         insertEditorText,
         showInfo,
         highlightSourceRange,
+        clearStack,
         showDocumentation,
         showError,
         showExecutionResult,
@@ -63,6 +66,9 @@ export const createExecutionController = (
         updateView,
         updateAfterExecution
     } = callbacks;
+
+    const checkIsUserWord = (name: string): boolean =>
+        interpreter.collect_user_words_info().some(([, word]) => word === name);
 
     const stepExecutor: StepExecutor = createStepExecutor(interpreter, {
         extractEditorValue,
@@ -157,8 +163,17 @@ export const createExecutionController = (
 
         stepExecutor.reset();
 
-        if (checkIsResetCommand(code)) {
+        const hostCommand = resolveHostCommand(code, checkIsUserWord);
+        if (hostCommand === 'RESET') {
             await executeReset();
+            return;
+        }
+        if (hostCommand === 'CLEAR') {
+            // `clearStack` redraws, reports and saves — the same call the `×`
+            // and the shortcut make — so all this route adds is consuming the
+            // command from the editor, exactly as a successful run does.
+            clearStack();
+            clearEditor(false);
             return;
         }
 

--- a/src/gui/gui-application.ts
+++ b/src/gui/gui-application.ts
@@ -122,6 +122,20 @@ export const createGUI = (): GUI => {
         }
     };
 
+    // Clearing the stack keeps the dictionary — that is the whole point of
+    // having it apart from Reset — so it is the interpreter's `clear_stack` and
+    // nothing else, followed by a redraw and a save. One definition for all
+    // three routes to it: the Stack area's `×`, `Shift+Alt+C`, and the `CLEAR`
+    // host command typed in the editor.
+    const clearStack = (): void => {
+        const interpreter = INTERPRETER_CLIENT.getOptional();
+        if (!interpreter) return;
+        interpreter.clear_stack();
+        updateAllDisplays();
+        display.renderInfo('Stack cleared', false);
+        void persistence.saveCurrentState();
+    };
+
     // Reference ページの用例から渡されたコードをエディタへ流し込む。
     // 受け渡し形式: <playground-url>#code=<encodeURIComponent したソース>
     // Ruby 公式トップのように、用例をそのまま試せる動線を実現するための入口。
@@ -222,6 +236,7 @@ export const createGUI = (): GUI => {
             insertEditorText: (text) => editor.insertText(text),
             showInfo: (text, append) => display.renderInfo(text, append),
             highlightSourceRange: (start, end) => editor.revealRange(start, end),
+            clearStack: () => clearStack(),
             showDocumentation: (text) => display.renderDocumentation(text),
             showError: (error, precedingOutput) => display.renderError(error, precedingOutput),
             showExecutionResult: (result) => display.renderExecutionResult(result),
@@ -245,17 +260,7 @@ export const createGUI = (): GUI => {
             persistence,
             switchArea: (mode) => layoutController.setArea(mode),
             updateAllDisplays,
-            // Clearing the stack keeps the dictionary — that is the whole point
-            // of having it apart from Reset — so it is the interpreter's
-            // `clear_stack` and nothing else, followed by a redraw and a save.
-            clearStack: () => {
-                const interpreter = INTERPRETER_CLIENT.getOptional();
-                if (!interpreter) return;
-                interpreter.clear_stack();
-                updateAllDisplays();
-                display.renderInfo('Stack cleared', false);
-                void persistence.saveCurrentState();
-            },
+            clearStack,
             doSwitchDictionarySheet,
             layoutController
         });

--- a/src/gui/host-commands.test.ts
+++ b/src/gui/host-commands.test.ts
@@ -1,0 +1,41 @@
+// `RESET` and `CLEAR` are answered by the host, not the language. The two rules
+// that keep them from eating a program are what these tests pin: the name must
+// be the whole input, and a User Word of that name wins.
+
+import { describe, expect, test } from 'vitest';
+import { resolveHostCommand } from './host-commands';
+
+const noUserWords = () => false;
+const userWords = (...names: string[]) => (name: string) => names.includes(name);
+
+describe('resolveHostCommand', () => {
+    test('recognizes the two host commands typed alone', () => {
+        expect(resolveHostCommand('RESET', noUserWords)).toBe('RESET');
+        expect(resolveHostCommand('CLEAR', noUserWords)).toBe('CLEAR');
+    });
+
+    test('matches case-insensitively, as Word lookup does', () => {
+        expect(resolveHostCommand('clear', noUserWords)).toBe('CLEAR');
+        expect(resolveHostCommand('  Reset  ', noUserWords)).toBe('RESET');
+    });
+
+    test('a name inside a program is not a host command', () => {
+        expect(resolveHostCommand('1 CLEAR', noUserWords)).toBeNull();
+        expect(resolveHostCommand('CLEAR CLEAR', noUserWords)).toBeNull();
+        expect(resolveHostCommand("{ CLEAR } 'X' DEF", noUserWords)).toBeNull();
+    });
+
+    test('a User Word of the same name wins', () => {
+        expect(resolveHostCommand('CLEAR', userWords('CLEAR'))).toBeNull();
+        expect(resolveHostCommand('RESET', userWords('RESET'))).toBeNull();
+        // …and only that name: an unrelated definition changes nothing.
+        expect(resolveHostCommand('CLEAR', userWords('DBL'))).toBe('CLEAR');
+    });
+
+    test('ordinary programs and empty input are not host commands', () => {
+        expect(resolveHostCommand('1 2 ADD', noUserWords)).toBeNull();
+        expect(resolveHostCommand('', noUserWords)).toBeNull();
+        expect(resolveHostCommand('   ', noUserWords)).toBeNull();
+        expect(resolveHostCommand('CLEARED', noUserWords)).toBeNull();
+    });
+});

--- a/src/gui/host-commands.ts
+++ b/src/gui/host-commands.ts
@@ -1,0 +1,40 @@
+// The names the *host* answers to, rather than the language.
+//
+// Kept apart from `execution-controller` so it is a pure function with no
+// worker, no interpreter and no DOM behind it — the shape the test suite
+// exercises directly.
+
+/// A **host command**: a bare name, typed on its own into the editor, that the
+/// host acts on instead of handing to the interpreter.
+///
+/// These are not Words, and the distinction is worth keeping sharp. `RESET`
+/// discards the session and `CLEAR` discards the stack, and neither belongs in
+/// the vocabulary: a program must not be able to throw away the values it was
+/// handed, or the dictionary it was defined in. They are the typed spelling of
+/// controls that also exist as buttons and shortcuts — `Ctrl+Alt+Enter`, and
+/// the Stack area's `×` / `Shift+Alt+C` — for people who would rather not leave
+/// the keyboard.
+export type HostCommand = 'RESET' | 'CLEAR';
+
+export const HOST_COMMANDS: readonly HostCommand[] = ['RESET', 'CLEAR'];
+
+/// Which host command `code` is, if any.
+///
+/// Two rules keep a host command from eating a program. The name has to be the
+/// *whole* input, so `1 CLEAR` is a program and fails as an unknown word if
+/// `CLEAR` is not defined. And a User Word of that name wins: nothing reserves
+/// these names — `DEF` accepts both — so without the check, defining `CLEAR`
+/// would produce a word that could never be called on its own, because the host
+/// would answer first and silently. The language is what the user is here for;
+/// the convenience yields to it.
+///
+/// Matching is case-insensitive, as Word lookup is.
+export const resolveHostCommand = (
+    code: string,
+    isUserWord: (name: string) => boolean
+): HostCommand | null => {
+    const name = code.trim().toUpperCase();
+    const command = HOST_COMMANDS.find((candidate) => candidate === name);
+    if (!command) return null;
+    return isUserWord(name) ? null : command;
+};


### PR DESCRIPTION
## Summary

One correction first, because it changes what this PR is: **`RESET` is not a Word.** Nothing in the 57 resets a session, and `spec/words.json` has no entry for it. It is a name the *host* answers to — typed alone into the editor and run, it is intercepted in `execution-controller.ts` before the interpreter sees the source. That it reads like a Word is exactly why it was worth checking.

So `CLEAR` joins it on the same terms rather than entering the vocabulary: typed alone, it discards the stack and leaves the dictionary. It is the typed spelling of the Stack area's `×` and `Shift+Alt+C`, and all three now call one `clearStack`, so the routes cannot drift.

Neither belongs in the vocabulary. A Word that throws away the values a program was handed, or the dictionary it was defined in, is not something a program should be able to reach for. Keeping them host controls also keeps the 57 at 57.

**A hazard worth closing rather than doubling.** Nothing reserves these names — `DEF` accepts both — so a user who defined `CLEAR` would get a word that could never be called on its own: the host would answer first, and silently. A User Word of the same name now wins, for `RESET` as well as `CLEAR`. The name must also still be the whole input, so `1 CLEAR` stays an ordinary program.

**Both were undocumented on every surface**, which is what made the question necessary. `spec/gui-semantics.md` now states what a host command is, that these two are not Words, and that a definition takes precedence. `check-reading-surfaces` learns the category: a host command is correctly absent from the vocabulary registry — that is the point being made about it — but the presentation profile still has to be able to name it, since a control nobody can discover is not documented.

`resolveHostCommand` lives in its own module so it is a pure function the suite can exercise directly; importing the execution controller pulls in the worker manager and with it `window`.

## Quality Classification

- Highest impacted level: QL-D — a host control and its documentation. No language semantics, no vocabulary change, no interpreter behavior, no protocol surface. The vocabulary is still 57 Words.

## Traceability

- Requirement(s): `spec/gui-semantics.md` presentation profile (host commands, desktop shortcuts), `LANG.AUTHORITY.IDENTITY` (the vocabulary is 57 canonical Words — a host command is not one), `LANG.AUTHORITY.PRESENT` (the profile names what the GUI currently does).
- Verification evidence:
  - `src/gui/host-commands.test.ts` — recognized alone; case-insensitive; not recognized inside a program (`1 CLEAR`, `CLEAR CLEAR`, `{ CLEAR } 'X' DEF`); a User Word of that name wins while an unrelated definition changes nothing; empty input and near-misses (`CLEARED`) are not commands.
  - Driven in Chromium against the built bundle: `CLEAR` and `clear` take the stack from 5 to 0 with the User dictionary intact and `Stack cleared` reported; after `{ 99 } 'CLEAR' DEF`, running `CLEAR` pushes 99 instead of clearing (stack 3 → 4); `RESET` still discards stack and dictionary together.
  - Every `check:*` / `*:check` gate, `npm run check`, `npm run lint`, `npm test` (342) and `cargo test` green.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable; no Rust changed.
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable; no Rust changed.
- [x] `cargo test --all-targets --verbose` (in `rust/`) — run anyway, green.
- [x] `npm run check`, if applicable — plus `npm run lint`, `npm test` and every gate in `test.yml`.
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable.
- [x] MC/DC-like checklist reviewed for modified boolean logic — `resolveHostCommand` has two conditions in sequence (`is one of the names` / `is not a User Word`). Both are exercised in each direction: a name that is not a command, a command with no definition, and a command with a definition of that name; plus an unrelated definition, which must not suppress it.
- [x] Release checklist impact considered — `spec/gui-semantics.md` and the generated `SPECIFICATION.html` updated together. `spec/words.json` is deliberately untouched: this adds no Word.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

If you would rather `CLEAR` *were* a Core Word, that is a different change — it would need an entry in `spec/words.json`, a contract, a law test and a conformance case, and it would make the count 58. I have not assumed it, since new Core Words were rejected earlier in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KccayJAQNsvHedPNePRbaw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KccayJAQNsvHedPNePRbaw)_