### PR TITLE
Execute RSQRT and WHERE tensor nodes

### DIFF
--- a/docs/dev/tensor-profile-progress-2026-08.md
+++ b/docs/dev/tensor-profile-progress-2026-08.md
@@ -7,9 +7,17 @@ semantics remain under `spec/`.
 
 The repository can now deserialize a typed graph, validate SSA ordering and
 Tensor types, bind symbolic dimensions from concrete f32/f64 inputs, and execute
-`MATMUL`, broadcast arithmetic, `EXP`, `LOG`, `REDUCE_SUM`, and `REDUCE_MAX` on the deterministic
-reference CPU backend. Shape products and output bytes are checked before
-allocation. The Core kernel and its exact Scalar domain remain unchanged.
+`MATMUL`, broadcast arithmetic, `EXP`, `LOG`, `RSQRT`, `REDUCE_SUM`,
+`REDUCE_MAX`, and `WHERE` on the deterministic reference CPU backend. Shape
+products and output bytes are checked before allocation. The Core kernel and its
+exact Scalar domain remain unchanged.
+
+`WHERE` introduced the profile's `bool` predicate dtype. It is deliberately not
+one of the numeric dtypes: the graph validator and the reference backend both
+reject a predicate wherever an operator's contract ranges over `f32`/`f64`, so
+"no implicit casts" is enforced rather than assumed. With `RSQRT` and `WHERE`
+in place, masked softmax and RMS normalization are executable graph
+compositions, which is the property the profile claims about NN operations.
 
 ## Milestone progress
 
@@ -18,24 +26,26 @@ claim that the overall LLM system is that complete.
 
 | Milestone | Progress | Completed | Remaining critical work |
 | --- | ---: | --- | --- |
-| Tensor Profile 0.1 semantics | 65% | value boundary, f32/f64, numeric classes, operator schema, explicit RNG contract | complete CAST rules, NaN payload/rounding details, conformance tolerances |
+| Tensor Profile 0.1 semantics | 70% | value boundary, f32/f64, bool predicate dtype, numeric classes, operator schema, explicit RNG contract | complete CAST rules, NaN payload/rounding details, conformance tolerances |
 | Checked Tensor runtime | 55% | immutable buffers, checked shape/strides, element and byte budgets | views/layouts, reshape/permute/slice, temporary/peak budgets |
-| Typed Graph IR | 40% | serde exchange, SSA validation, symbolic dimensions, semantic identity, operator-aware inference | constants/artifacts loading, graph normalization, effects/resource analysis, stable canonical encoding |
-| Reference tensor algebra | 40% | MATMUL, broadcast ADD/SUB/MUL/DIV, EXP, LOG, REDUCE_SUM, REDUCE_MAX | RSQRT, WHERE, reshape/permute, gather, concat |
-| Tiny Transformer inference | 15% | projections and numerically stable softmax are executable graph compositions | embedding/gather, normalization, RoPE, tokenizer/weights, sampling |
+| Typed Graph IR | 45% | serde exchange, SSA validation, symbolic dimensions, semantic identity, operator-aware inference, dtype-domain enforcement | constants/artifacts loading, graph normalization, effects/resource analysis, stable canonical encoding |
+| Reference tensor algebra | 55% | MATMUL, broadcast ADD/SUB/MUL/DIV, EXP, LOG, RSQRT, REDUCE_SUM, REDUCE_MAX, WHERE | reshape/permute, gather, concat |
+| Tiny Transformer inference | 25% | projections, masked stable softmax, and RMS normalization are executable graph compositions | embedding/gather, RoPE, tokenizer/weights, sampling |
 | Reverse-mode autodiff | 0% | VJP identifiers exist only as contracts | graph transform, gradient graph validation, VJP conformance |
 | Accelerator backend | 0% | backend boundary is specified | lowering, receipts, bounded-error conformance |
 
 ## Next implementation sequence
 
-1. Add `RSQRT` and `WHERE` for normalization and masks.
-2. Add reshape/permute and gather so embedding and attention layouts are
-   expressible.
+1. Add reshape/permute so multi-head attention layouts are expressible without
+   materializing a transposed copy per node.
+2. Add gather so token embedding — currently the only step of a tiny
+   Transformer with no expressible form at all — becomes a graph node.
 3. Define canonical graph encoding and execution receipts before introducing an
    optimized backend.
 4. Implement VJP-driven reverse-mode transformation only after forward graph
    contracts cover the minimal Transformer algebra.
 
-At this point Ajisai has a validated executable Tensor graph slice, but it is
-not yet a usable LLM inference runtime. The largest missing dependency for a
-first tiny Transformer is structural Tensor algebra and artifact-backed weights.
+At this point Ajisai has a validated executable Tensor graph slice covering the
+pointwise and reduction algebra a Transformer block needs, but it is not yet a
+usable LLM inference runtime. The remaining dependencies are structural Tensor
+algebra (reshape/permute/gather) and artifact-backed weights.

--- a/rust/src/tensor_profile/composition_tests.rs
+++ b/rust/src/tensor_profile/composition_tests.rs
@@ -1,0 +1,206 @@
+//! The operations an LLM is actually built from are graph compositions over
+//! profile primitives, not primitives of their own. These tests execute those
+//! compositions end to end so that "softmax/RMSNorm/masking are library code"
+//! is a checked property rather than a stated intention.
+
+use super::test_support::{
+    bool_tensor, bool_type, context, declare, f32_tensor, f32_type, keeping_reduction, node, OPEN,
+};
+use super::*;
+use std::collections::BTreeMap;
+
+#[test]
+fn stable_softmax_is_a_graph_composition_not_a_primitive() {
+    let matrix = f32_type(&[2, 3]);
+    let column = f32_type(&[2, 1]);
+    let graph = Graph {
+        schema_version: 1,
+        profiles: vec!["org.ajisai.tensor/0.1".to_owned()],
+        inputs: vec![declare("%input", matrix.clone())],
+        nodes: softmax_chain("%input", &matrix, &column),
+        outputs: vec!["%softmax".to_owned()],
+        artifacts: vec![],
+    };
+    let inputs = BTreeMap::from([(
+        "%input".to_owned(),
+        // Large logits: without the REDUCE_MAX centering step these overflow.
+        f32_tensor(vec![2, 3], vec![1000.0, 1001.0, 1002.0, 1.0, 2.0, 3.0]),
+    )]);
+    let outputs = execute_graph(&graph, &context(), &inputs, OPEN).unwrap();
+    let TensorData::F32(values) = outputs["%softmax"].data() else {
+        panic!("dtype changed")
+    };
+    for row in values.chunks_exact(3) {
+        assert!((row.iter().sum::<f32>() - 1.0).abs() < 1e-6);
+        assert!(row.iter().all(|value| value.is_finite()));
+    }
+}
+
+/// A causal attention mask is WHERE prefixed onto the same softmax chain.
+/// Masked positions must come out exactly zero, and the negative infinity that
+/// produces them must never become an arithmetic input.
+#[test]
+fn masked_softmax_composes_where_with_the_stable_softmax_chain() {
+    let matrix = f32_type(&[2, 3]);
+    let column = f32_type(&[2, 1]);
+    let mut nodes = vec![node(
+        "@mask",
+        "tensor.where.v1",
+        &["%keep", "%scores", "%fill"],
+        declare("%masked", matrix.clone()),
+    )];
+    nodes.extend(softmax_chain("%masked", &matrix, &column));
+    let graph = Graph {
+        schema_version: 1,
+        profiles: vec!["org.ajisai.tensor/0.1".to_owned()],
+        inputs: vec![
+            declare("%scores", matrix),
+            declare("%keep", bool_type(&[2, 3])),
+            declare("%fill", f32_type(&[])),
+        ],
+        nodes,
+        outputs: vec!["%softmax".to_owned()],
+        artifacts: vec![],
+    };
+    let inputs = BTreeMap::from([
+        (
+            "%scores".to_owned(),
+            f32_tensor(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ),
+        (
+            "%keep".to_owned(),
+            bool_tensor(vec![2, 3], vec![true, false, false, true, true, false]),
+        ),
+        (
+            "%fill".to_owned(),
+            f32_tensor(vec![], vec![f32::NEG_INFINITY]),
+        ),
+    ]);
+    let outputs = execute_graph(&graph, &context(), &inputs, OPEN).unwrap();
+    let TensorData::F32(values) = outputs["%softmax"].data() else {
+        panic!("dtype changed")
+    };
+    assert_eq!(values[0], 1.0);
+    assert_eq!(&values[1..3], &[0.0, 0.0]);
+    assert_eq!(values[5], 0.0);
+    assert!((values[3] + values[4] - 1.0).abs() < 1e-6);
+    assert!(values.iter().all(|value| value.is_finite()));
+}
+
+/// RMSNorm is a composition over RSQRT: `x * rsqrt(mean(x^2) + epsilon)` along
+/// the trailing axis.
+#[test]
+fn rms_normalization_is_a_graph_composition_over_rsqrt() {
+    let row = f32_type(&[2, 3]);
+    let column = f32_type(&[2, 1]);
+    let scalar = f32_type(&[]);
+    let graph = Graph {
+        schema_version: 1,
+        profiles: vec!["org.ajisai.tensor/0.1".to_owned()],
+        inputs: vec![
+            declare("%input", row.clone()),
+            declare("%reciprocal_width", scalar.clone()),
+            declare("%epsilon", scalar),
+        ],
+        nodes: vec![
+            node(
+                "@square",
+                "tensor.mul.v1",
+                &["%input", "%input"],
+                declare("%squared", row.clone()),
+            ),
+            keeping_reduction(
+                "@total",
+                "tensor.reduce_sum.v1",
+                "%squared",
+                declare("%total", column.clone()),
+                &[1],
+            ),
+            node(
+                "@mean",
+                "tensor.mul.v1",
+                &["%total", "%reciprocal_width"],
+                declare("%mean", column.clone()),
+            ),
+            node(
+                "@stabilize",
+                "tensor.add.v1",
+                &["%mean", "%epsilon"],
+                declare("%stabilized", column.clone()),
+            ),
+            node(
+                "@scale",
+                "tensor.rsqrt.v1",
+                &["%stabilized"],
+                declare("%scale", column),
+            ),
+            node(
+                "@normalize",
+                "tensor.mul.v1",
+                &["%input", "%scale"],
+                declare("%normalized", row),
+            ),
+        ],
+        outputs: vec!["%normalized".to_owned()],
+        artifacts: vec![],
+    };
+    let inputs = BTreeMap::from([
+        (
+            "%input".to_owned(),
+            f32_tensor(vec![2, 3], vec![1.0, 2.0, 2.0, 3.0, 0.0, 4.0]),
+        ),
+        (
+            "%reciprocal_width".to_owned(),
+            f32_tensor(vec![], vec![1.0 / 3.0]),
+        ),
+        ("%epsilon".to_owned(), f32_tensor(vec![], vec![1e-12])),
+    ]);
+    let outputs = execute_graph(&graph, &context(), &inputs, OPEN).unwrap();
+    let TensorData::F32(values) = outputs["%normalized"].data() else {
+        panic!("dtype changed")
+    };
+    // Every row leaves the composition with unit root-mean-square.
+    for row in values.chunks_exact(3) {
+        let mean_square = row.iter().map(|value| value * value).sum::<f32>() / 3.0;
+        assert!((mean_square - 1.0).abs() < 1e-5);
+    }
+}
+
+/// REDUCE_MAX with retained axes, subtraction, EXP, REDUCE_SUM with retained
+/// axes, and division — producing `%softmax` from `input`.
+fn softmax_chain(input: &str, matrix: &GraphType, column: &GraphType) -> Vec<GraphNode> {
+    vec![
+        keeping_reduction(
+            "@max",
+            "tensor.reduce_max.v1",
+            input,
+            declare("%max", column.clone()),
+            &[1],
+        ),
+        node(
+            "@center",
+            "tensor.sub.v1",
+            &[input, "%max"],
+            declare("%centered", matrix.clone()),
+        ),
+        node(
+            "@exp",
+            "tensor.exp.v1",
+            &["%centered"],
+            declare("%exp", matrix.clone()),
+        ),
+        keeping_reduction(
+            "@sum",
+            "tensor.reduce_sum.v1",
+            "%exp",
+            declare("%sum", column.clone()),
+            &[1],
+        ),
+        node(
+            "@divide",
+            "tensor.div.v1",
+            &["%exp", "%sum"],
+            declare("%softmax", matrix.clone()),
+        ),
+    ]
+}

--- a/rust/src/tensor_profile/cpu.rs
+++ b/rust/src/tensor_profile/cpu.rs
@@ -29,6 +29,14 @@ pub enum TensorOperatorError {
         left: Vec<usize>,
         right: Vec<usize>,
     },
+    NonNumericDType {
+        operator: &'static str,
+        dtype: DType,
+    },
+    PredicateDTypeMismatch {
+        operator: &'static str,
+        dtype: DType,
+    },
     Shape(ShapeError),
     Tensor(TensorError),
 }
@@ -69,6 +77,13 @@ impl fmt::Display for TensorOperatorError {
                 f,
                 "elementwise shapes {left:?} and {right:?} do not broadcast"
             ),
+            Self::NonNumericDType { operator, dtype } => {
+                write!(f, "{operator} requires a numeric dtype, received {dtype:?}")
+            }
+            Self::PredicateDTypeMismatch { operator, dtype } => write!(
+                f,
+                "{operator} requires a bool predicate, received {dtype:?}"
+            ),
             Self::Shape(error) => error.fmt(f),
             Self::Tensor(error) => error.fmt(f),
         }
@@ -104,6 +119,7 @@ pub fn matmul(
             right: right.dtype(),
         });
     }
+    require_numeric("MATMUL", left.dtype())?;
     let left_dimensions = left.shape().dimensions();
     let right_dimensions = right.shape().dimensions();
     check_rank(left_dimensions.len())?;
@@ -156,7 +172,7 @@ pub fn matmul(
             |sum, left, right| sum + left * right,
             0.0f64,
         )),
-        _ => unreachable!("dtype equality was checked"),
+        _ => unreachable!("dtype equality and numeric dtype were checked"),
     };
     debug_assert_eq!(data_len(&data), output_shape.element_count());
     Tensor::new(output_dimensions, data, budget).map_err(Into::into)
@@ -168,7 +184,7 @@ pub fn tensor_exp(
     input: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    map_unary(input, budget, f32::exp, f64::exp)
+    map_unary(input, "EXP", budget, f32::exp, f64::exp)
 }
 
 /// Reference implementation of `tensor.log.v1`. IEEE domain results (including
@@ -177,15 +193,37 @@ pub fn tensor_log(
     input: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    map_unary(input, budget, f32::ln, f64::ln)
+    map_unary(input, "LOG", budget, f32::ln, f64::ln)
+}
+
+/// Reference implementation of `tensor.rsqrt.v1`, the reciprocal square root
+/// that normalization layers such as RMSNorm are composed from. It is declared
+/// `bounded` rather than `bitwise`, so a backend may fuse the square root and
+/// reciprocal only within the tolerance recorded for the operator.
+///
+/// The IEEE domain results stay tensor elements: `rsqrt(0)` is positive
+/// infinity and `rsqrt(x < 0)` is NaN, neither of which becomes NIL.
+pub fn tensor_rsqrt(
+    input: &Tensor,
+    budget: TensorMemoryBudget,
+) -> Result<Tensor, TensorOperatorError> {
+    map_unary(
+        input,
+        "RSQRT",
+        budget,
+        |value| value.sqrt().recip(),
+        |value| value.sqrt().recip(),
+    )
 }
 
 fn map_unary(
     input: &Tensor,
+    operator: &'static str,
     budget: TensorMemoryBudget,
     f32_operation: impl Fn(f32) -> f32,
     f64_operation: impl Fn(f64) -> f64,
 ) -> Result<Tensor, TensorOperatorError> {
+    require_numeric(operator, input.dtype())?;
     CheckedShape::new(
         input.shape().dimensions().to_vec(),
         input.dtype().element_bytes(),
@@ -198,8 +236,22 @@ fn map_unary(
         TensorData::F64(values) => {
             TensorData::F64(values.iter().copied().map(f64_operation).collect())
         }
+        TensorData::Bool(_) => unreachable!("numeric dtype was checked"),
     };
     Tensor::new(input.shape().dimensions().to_vec(), data, budget).map_err(Into::into)
+}
+
+/// Reject the predicate dtype wherever an operator's contract says `D` ranges
+/// over the profile's numeric dtypes. Without this the profile's "no implicit
+/// casts" rule would be enforced only by convention.
+pub(crate) fn require_numeric(
+    operator: &'static str,
+    dtype: DType,
+) -> Result<(), TensorOperatorError> {
+    if dtype.is_numeric() {
+        return Ok(());
+    }
+    Err(TensorOperatorError::NonNumericDType { operator, dtype })
 }
 
 fn check_rank(rank: usize) -> Result<(), TensorOperatorError> {
@@ -319,5 +371,6 @@ fn data_len(data: &TensorData) -> usize {
     match data {
         TensorData::F32(values) => values.len(),
         TensorData::F64(values) => values.len(),
+        TensorData::Bool(values) => values.len(),
     }
 }

--- a/rust/src/tensor_profile/cpu_tests.rs
+++ b/rust/src/tensor_profile/cpu_tests.rs
@@ -78,6 +78,62 @@ fn reference_log_keeps_ieee_domain_states_inside_the_tensor() {
 }
 
 #[test]
+fn reference_rsqrt_inverts_the_square_root_within_its_declared_tolerance() {
+    let result = tensor_rsqrt(&f32_tensor(vec![3], vec![1.0, 4.0, 0.25]), OPEN).unwrap();
+    assert_eq!(result.shape().dimensions(), &[3]);
+    let TensorData::F32(values) = result.data() else {
+        panic!("dtype changed")
+    };
+    for (actual, expected) in values.iter().zip([1.0, 0.5, 2.0]) {
+        assert!((actual - expected).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn reference_rsqrt_keeps_ieee_domain_states_inside_the_tensor() {
+    let result = tensor_rsqrt(&f32_tensor(vec![2], vec![0.0, -1.0]), OPEN).unwrap();
+    let TensorData::F32(values) = result.data() else {
+        panic!("dtype changed")
+    };
+    assert_eq!(values[0], f32::INFINITY);
+    assert!(values[1].is_nan());
+}
+
+#[test]
+fn numeric_operators_reject_the_predicate_dtype_rather_than_casting_it() {
+    let mask = Tensor::new(vec![2], TensorData::Bool(vec![true, false]), OPEN).unwrap();
+    assert_eq!(
+        tensor_rsqrt(&mask, OPEN),
+        Err(TensorOperatorError::NonNumericDType {
+            operator: "RSQRT",
+            dtype: DType::Bool,
+        })
+    );
+    assert_eq!(
+        tensor_add(&mask, &mask, OPEN),
+        Err(TensorOperatorError::NonNumericDType {
+            operator: "ADD",
+            dtype: DType::Bool,
+        })
+    );
+    assert_eq!(
+        reduce_sum(&mask, &[0], false, OPEN),
+        Err(TensorOperatorError::NonNumericDType {
+            operator: "REDUCE_SUM",
+            dtype: DType::Bool,
+        })
+    );
+    let square = Tensor::new(vec![2, 2], TensorData::Bool(vec![true; 4]), OPEN).unwrap();
+    assert_eq!(
+        matmul(&square, &square, OPEN),
+        Err(TensorOperatorError::NonNumericDType {
+            operator: "MATMUL",
+            dtype: DType::Bool,
+        })
+    );
+}
+
+#[test]
 fn reference_reduce_sum_supports_multiple_axes_and_keep_dimensions() {
     let input = f32_tensor(vec![2, 2, 2], (1..=8).map(|value| value as f32).collect());
     let reduced = reduce_sum(&input, &[0, 2], false, OPEN).unwrap();

--- a/rust/src/tensor_profile/elementwise.rs
+++ b/rust/src/tensor_profile/elementwise.rs
@@ -1,11 +1,13 @@
-use super::{CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError};
+use super::{
+    require_numeric, CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError,
+};
 
 pub fn tensor_add(
     left: &Tensor,
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, budget, |a, b| a + b, |a, b| a + b)
+    binary(left, right, "ADD", budget, |a, b| a + b, |a, b| a + b)
 }
 
 pub fn tensor_sub(
@@ -13,7 +15,7 @@ pub fn tensor_sub(
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, budget, |a, b| a - b, |a, b| a - b)
+    binary(left, right, "SUB", budget, |a, b| a - b, |a, b| a - b)
 }
 
 pub fn tensor_mul(
@@ -21,7 +23,7 @@ pub fn tensor_mul(
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, budget, |a, b| a * b, |a, b| a * b)
+    binary(left, right, "MUL", budget, |a, b| a * b, |a, b| a * b)
 }
 
 pub fn tensor_div(
@@ -29,12 +31,13 @@ pub fn tensor_div(
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, budget, |a, b| a / b, |a, b| a / b)
+    binary(left, right, "DIV", budget, |a, b| a / b, |a, b| a / b)
 }
 
 fn binary(
     left: &Tensor,
     right: &Tensor,
+    operator: &'static str,
     budget: TensorMemoryBudget,
     f32_operation: impl Fn(f32, f32) -> f32,
     f64_operation: impl Fn(f64, f64) -> f64,
@@ -45,6 +48,7 @@ fn binary(
             right: right.dtype(),
         });
     }
+    require_numeric(operator, left.dtype())?;
     let dimensions = broadcast_shape(left.shape().dimensions(), right.shape().dimensions())?;
     let output_shape = CheckedShape::new(dimensions.clone(), left.dtype().element_bytes(), budget)?;
     let data = match (left.data(), right.data()) {
@@ -64,12 +68,15 @@ fn binary(
             &output_shape,
             f64_operation,
         )),
-        _ => unreachable!("dtype equality was checked"),
+        _ => unreachable!("dtype equality and numeric dtype were checked"),
     };
     Tensor::new(dimensions, data, budget).map_err(Into::into)
 }
 
-fn broadcast_shape(left: &[usize], right: &[usize]) -> Result<Vec<usize>, TensorOperatorError> {
+pub(crate) fn broadcast_shape(
+    left: &[usize],
+    right: &[usize],
+) -> Result<Vec<usize>, TensorOperatorError> {
     let rank = left.len().max(right.len());
     let mut output = Vec::with_capacity(rank);
     for offset in (0..rank).rev() {
@@ -110,7 +117,7 @@ fn binary_data<T: Copy>(
         .collect()
 }
 
-fn broadcast_index(output_coordinates: &[usize], input_shape: &CheckedShape) -> usize {
+pub(crate) fn broadcast_index(output_coordinates: &[usize], input_shape: &CheckedShape) -> usize {
     let offset = output_coordinates.len() - input_shape.dimensions().len();
     input_shape
         .dimensions()
@@ -135,7 +142,7 @@ fn trailing_dimension(shape: &[usize], offset: usize) -> Option<usize> {
         .map(|index| shape[index])
 }
 
-fn unravel(mut linear: usize, shape: &[usize]) -> Vec<usize> {
+pub(crate) fn unravel(mut linear: usize, shape: &[usize]) -> Vec<usize> {
     let mut coordinates = vec![0; shape.len()];
     for axis in (0..shape.len()).rev() {
         if shape[axis] != 0 {

--- a/rust/src/tensor_profile/execute.rs
+++ b/rust/src/tensor_profile/execute.rs
@@ -1,8 +1,8 @@
 use super::{
     graph_operators::reduction_attributes, matmul, reduce_max, reduce_sum, tensor_add, tensor_div,
-    tensor_exp, tensor_log, tensor_mul, tensor_sub, Graph, GraphType, GraphValidationContext,
-    GraphValidationError, OperatorSemantics, SymbolicDimension, Tensor, TensorMemoryBudget,
-    TensorOperatorError,
+    tensor_exp, tensor_log, tensor_mul, tensor_rsqrt, tensor_sub, tensor_where, Graph, GraphType,
+    GraphValidationContext, GraphValidationError, OperatorSemantics, SymbolicDimension, Tensor,
+    TensorMemoryBudget, TensorOperatorError,
 };
 use std::collections::BTreeMap;
 use std::fmt;
@@ -124,6 +124,16 @@ pub fn execute_graph(
             OperatorSemantics::Log => {
                 let input = runtime_value(&values, &node.inputs[0])?;
                 tensor_log(input, budget)?
+            }
+            OperatorSemantics::Rsqrt => {
+                let input = runtime_value(&values, &node.inputs[0])?;
+                tensor_rsqrt(input, budget)?
+            }
+            OperatorSemantics::Where => {
+                let predicate = runtime_value(&values, &node.inputs[0])?;
+                let on_true = runtime_value(&values, &node.inputs[1])?;
+                let on_false = runtime_value(&values, &node.inputs[2])?;
+                tensor_where(predicate, on_true, on_false, budget)?
             }
             OperatorSemantics::ReduceSum => {
                 let input = runtime_value(&values, &node.inputs[0])?;

--- a/rust/src/tensor_profile/execute_tests.rs
+++ b/rust/src/tensor_profile/execute_tests.rs
@@ -1,41 +1,6 @@
+use super::test_support::{bool_tensor, context, declare, example, f32_tensor, f32_type, OPEN};
 use super::*;
 use std::collections::{BTreeMap, BTreeSet};
-
-const OPEN: TensorMemoryBudget = TensorMemoryBudget::new(usize::MAX, usize::MAX);
-
-fn context() -> GraphValidationContext {
-    GraphValidationContext {
-        profile_id: "org.ajisai.tensor/0.1".to_owned(),
-        operator_semantics: BTreeMap::from([
-            ("tensor.matmul.v1".to_owned(), OperatorSemantics::Matmul),
-            ("tensor.exp.v1".to_owned(), OperatorSemantics::Exp),
-            ("tensor.log.v1".to_owned(), OperatorSemantics::Log),
-            (
-                "tensor.reduce_sum.v1".to_owned(),
-                OperatorSemantics::ReduceSum,
-            ),
-            (
-                "tensor.reduce_max.v1".to_owned(),
-                OperatorSemantics::ReduceMax,
-            ),
-            ("tensor.add.v1".to_owned(), OperatorSemantics::Add),
-            ("tensor.sub.v1".to_owned(), OperatorSemantics::Sub),
-            ("tensor.mul.v1".to_owned(), OperatorSemantics::Mul),
-            ("tensor.div.v1".to_owned(), OperatorSemantics::Div),
-        ]),
-    }
-}
-
-fn example() -> Graph {
-    serde_json::from_str(include_str!(
-        "../../../spec/examples/tiny-matmul.graph.json"
-    ))
-    .unwrap()
-}
-
-fn f32_tensor(shape: Vec<usize>, values: Vec<f32>) -> Tensor {
-    Tensor::new(shape, TensorData::F32(values), OPEN).unwrap()
-}
 
 #[test]
 fn committed_graph_executes_end_to_end() {
@@ -211,67 +176,54 @@ fn execution_reduces_max_over_a_graph_axis() {
     assert_eq!(outputs["%max"].data(), &TensorData::F32(vec![5.0, 6.0]));
 }
 
+/// RMSNorm is a library composition over RSQRT, not a profile primitive:
+/// `x * rsqrt(mean(x^2) + epsilon)` over the trailing axis.
 #[test]
-fn stable_softmax_is_a_graph_composition_not_a_primitive() {
-    let matrix = GraphType::Tensor {
-        dtype: DType::F32,
-        shape: vec![SymbolicDimension::Known(2), SymbolicDimension::Known(3)],
-    };
-    let column = GraphType::Tensor {
-        dtype: DType::F32,
-        shape: vec![SymbolicDimension::Known(2), SymbolicDimension::Known(1)],
-    };
-    let value = |id: &str, value_type: GraphType| GraphValue {
-        id: id.to_owned(),
-        value_type,
-    };
-    let binary = |id: &str, operator: &str, left: &str, right: &str, output: &str| GraphNode {
-        id: id.to_owned(),
-        operator_semantic_id: operator.to_owned(),
-        inputs: vec![left.to_owned(), right.to_owned()],
-        outputs: vec![value(output, matrix.clone())],
-        attributes: BTreeMap::new(),
-    };
-    let reduction = |id: &str, operator: &str, input: &str, output: &str| GraphNode {
-        id: id.to_owned(),
-        operator_semantic_id: operator.to_owned(),
-        inputs: vec![input.to_owned()],
-        outputs: vec![value(output, column.clone())],
-        attributes: BTreeMap::from([
-            ("axes".to_owned(), serde_json::json!([1])),
-            ("keepDimensions".to_owned(), serde_json::json!(true)),
-        ]),
-    };
+fn execution_rejects_a_runtime_predicate_that_is_not_bool() {
     let graph = Graph {
         schema_version: 1,
         profiles: vec!["org.ajisai.tensor/0.1".to_owned()],
-        inputs: vec![value("%input", matrix.clone())],
-        nodes: vec![
-            reduction("@max", "tensor.reduce_max.v1", "%input", "%max"),
-            binary("@center", "tensor.sub.v1", "%input", "%max", "%centered"),
-            GraphNode {
-                id: "@exp".to_owned(),
-                operator_semantic_id: "tensor.exp.v1".to_owned(),
-                inputs: vec!["%centered".to_owned()],
-                outputs: vec![value("%exp", matrix.clone())],
-                attributes: BTreeMap::new(),
-            },
-            reduction("@sum", "tensor.reduce_sum.v1", "%exp", "%sum"),
-            binary("@divide", "tensor.div.v1", "%exp", "%sum", "%softmax"),
+        inputs: vec![
+            declare(
+                "%keep",
+                GraphType::Tensor {
+                    dtype: DType::Bool,
+                    shape: vec![SymbolicDimension::Known(2)],
+                },
+            ),
+            declare("%on_true", f32_type(&[2])),
+            declare("%on_false", f32_type(&[2])),
         ],
-        outputs: vec!["%softmax".to_owned()],
+        nodes: vec![GraphNode {
+            id: "@select".to_owned(),
+            operator_semantic_id: "tensor.where.v1".to_owned(),
+            inputs: vec![
+                "%keep".to_owned(),
+                "%on_true".to_owned(),
+                "%on_false".to_owned(),
+            ],
+            outputs: vec![declare("%selected", f32_type(&[2]))],
+            attributes: BTreeMap::new(),
+        }],
+        outputs: vec!["%selected".to_owned()],
         artifacts: vec![],
     };
-    let inputs = BTreeMap::from([(
-        "%input".to_owned(),
-        f32_tensor(vec![2, 3], vec![1000.0, 1001.0, 1002.0, 1.0, 2.0, 3.0]),
-    )]);
+    let mut inputs = BTreeMap::from([
+        ("%keep".to_owned(), bool_tensor(vec![2], vec![true, false])),
+        ("%on_true".to_owned(), f32_tensor(vec![2], vec![1.0, 2.0])),
+        ("%on_false".to_owned(), f32_tensor(vec![2], vec![3.0, 4.0])),
+    ]);
     let outputs = execute_graph(&graph, &context(), &inputs, OPEN).unwrap();
-    let TensorData::F32(values) = outputs["%softmax"].data() else {
-        panic!("dtype changed")
-    };
-    for row in values.chunks_exact(3) {
-        assert!((row.iter().sum::<f32>() - 1.0).abs() < 1e-6);
-        assert!(row.iter().all(|value| value.is_finite()));
-    }
+    assert_eq!(
+        outputs["%selected"].data(),
+        &TensorData::F32(vec![1.0, 4.0])
+    );
+
+    // A numeric tensor is not silently accepted where the graph declared a
+    // predicate: there is no implicit cast in either direction.
+    inputs.insert("%keep".to_owned(), f32_tensor(vec![2], vec![1.0, 0.0]));
+    assert_eq!(
+        execute_graph(&graph, &context(), &inputs, OPEN),
+        Err(GraphExecutionError::InputDTypeMismatch("%keep".to_owned()))
+    );
 }

--- a/rust/src/tensor_profile/graph.rs
+++ b/rust/src/tensor_profile/graph.rs
@@ -71,8 +71,10 @@ pub enum OperatorSemantics {
     Matmul,
     Exp,
     Log,
+    Rsqrt,
     ReduceSum,
     ReduceMax,
+    Where,
     Add,
     Sub,
     Mul,
@@ -95,6 +97,8 @@ pub enum GraphValidationError {
         actual_outputs: usize,
     },
     DTypeMismatch(String),
+    NonNumericDType(String),
+    PredicateDTypeMismatch(String),
     ShapeMismatch(String),
     OutputTypeMismatch(String),
     InvalidSymbolicDimension(String),
@@ -119,6 +123,12 @@ impl fmt::Display for GraphValidationError {
             Self::UnsupportedOperator(id) => write!(f, "unsupported operator semantic ID {id}"),
             Self::OperatorArity { operator, expected_inputs, actual_inputs, expected_outputs, actual_outputs } => write!(f, "{operator} requires {expected_inputs} inputs and {expected_outputs} output(s), received {actual_inputs} and {actual_outputs}"),
             Self::DTypeMismatch(id) => write!(f, "{id} input dtypes do not match"),
+            Self::NonNumericDType(id) => {
+                write!(f, "{id} requires a numeric dtype, received the bool predicate dtype")
+            }
+            Self::PredicateDTypeMismatch(id) => {
+                write!(f, "{id} requires a bool predicate input")
+            }
             Self::ShapeMismatch(message) => write!(f, "shape mismatch: {message}"),
             Self::OutputTypeMismatch(id) => write!(f, "{id} declared output type does not match its inferred type"),
             Self::InvalidSymbolicDimension(symbol) => {

--- a/rust/src/tensor_profile/graph_operators.rs
+++ b/rust/src/tensor_profile/graph_operators.rs
@@ -1,6 +1,7 @@
 use super::graph::{
     GraphNode, GraphType, GraphValidationError, OperatorSemantics, SymbolicDimension,
 };
+use super::DType;
 use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) fn validate_operator(
@@ -10,17 +11,27 @@ pub(crate) fn validate_operator(
 ) -> Result<(), GraphValidationError> {
     match semantics {
         OperatorSemantics::Matmul => validate_matmul(node, values),
-        OperatorSemantics::Exp | OperatorSemantics::Log => {
+        OperatorSemantics::Exp | OperatorSemantics::Log | OperatorSemantics::Rsqrt => {
             validate_shape_preserving_unary(node, values)
         }
         OperatorSemantics::ReduceSum | OperatorSemantics::ReduceMax => {
             validate_reduction(node, values)
         }
+        OperatorSemantics::Where => validate_where(node, values),
         OperatorSemantics::Add
         | OperatorSemantics::Sub
         | OperatorSemantics::Mul
         | OperatorSemantics::Div => validate_elementwise_binary(node, values),
     }
+}
+
+/// The graph validator is the profile's contract certifier, so it — not the
+/// backend — is where a predicate tensor is refused entry to arithmetic.
+fn require_numeric(node: &GraphNode, dtype: DType) -> Result<(), GraphValidationError> {
+    if dtype.is_numeric() {
+        return Ok(());
+    }
+    Err(GraphValidationError::NonNumericDType(node.id.clone()))
 }
 
 fn validate_elementwise_binary(
@@ -47,6 +58,7 @@ fn validate_elementwise_binary(
     if left_dtype != right_dtype {
         return Err(GraphValidationError::DTypeMismatch(node.id.clone()));
     }
+    require_numeric(node, *left_dtype)?;
     let output_shape = broadcast_dimensions(left, right)?;
     let inferred = GraphType::Tensor {
         dtype: *left_dtype,
@@ -73,6 +85,7 @@ fn validate_reduction(
     }
     let (axes, keep_dimensions) = reduction_attributes(node)?;
     let GraphType::Tensor { dtype, shape } = &values[&node.inputs[0]];
+    require_numeric(node, *dtype)?;
     let mut seen = BTreeSet::new();
     for axis in axes {
         if axis >= shape.len() || !seen.insert(axis) {
@@ -146,7 +159,57 @@ fn validate_shape_preserving_unary(
             actual_outputs: node.outputs.len(),
         });
     }
+    let GraphType::Tensor { dtype, .. } = &values[&node.inputs[0]];
+    require_numeric(node, *dtype)?;
     if node.outputs[0].value_type != values[&node.inputs[0]] {
+        return Err(GraphValidationError::OutputTypeMismatch(node.id.clone()));
+    }
+    Ok(())
+}
+
+/// `WHERE` is the one operator whose inputs deliberately do not share a dtype:
+/// a `bool` predicate selects between two operands of a common dtype `D`, and
+/// the output shape is the three-way broadcast of all of them.
+fn validate_where(
+    node: &GraphNode,
+    values: &BTreeMap<String, GraphType>,
+) -> Result<(), GraphValidationError> {
+    if node.inputs.len() != 3 || node.outputs.len() != 1 {
+        return Err(GraphValidationError::OperatorArity {
+            operator: node.operator_semantic_id.clone(),
+            expected_inputs: 3,
+            actual_inputs: node.inputs.len(),
+            expected_outputs: 1,
+            actual_outputs: node.outputs.len(),
+        });
+    }
+    let GraphType::Tensor {
+        dtype: predicate_dtype,
+        shape: predicate,
+    } = &values[&node.inputs[0]];
+    if *predicate_dtype != DType::Bool {
+        return Err(GraphValidationError::PredicateDTypeMismatch(
+            node.id.clone(),
+        ));
+    }
+    let GraphType::Tensor {
+        dtype: true_dtype,
+        shape: on_true,
+    } = &values[&node.inputs[1]];
+    let GraphType::Tensor {
+        dtype: false_dtype,
+        shape: on_false,
+    } = &values[&node.inputs[2]];
+    if true_dtype != false_dtype {
+        return Err(GraphValidationError::DTypeMismatch(node.id.clone()));
+    }
+    let values_shape = broadcast_dimensions(on_true, on_false)?;
+    let output_shape = broadcast_dimensions(predicate, &values_shape)?;
+    let inferred = GraphType::Tensor {
+        dtype: *true_dtype,
+        shape: output_shape,
+    };
+    if node.outputs[0].value_type != inferred {
         return Err(GraphValidationError::OutputTypeMismatch(node.id.clone()));
     }
     Ok(())
@@ -176,6 +239,7 @@ fn validate_matmul(
     if left_dtype != right_dtype {
         return Err(GraphValidationError::DTypeMismatch(node.id.clone()));
     }
+    require_numeric(node, *left_dtype)?;
     if left.len() < 2 || right.len() < 2 {
         return Err(GraphValidationError::ShapeMismatch(format!(
             "{} requires rank >= 2",

--- a/rust/src/tensor_profile/graph_tests.rs
+++ b/rust/src/tensor_profile/graph_tests.rs
@@ -188,6 +188,85 @@ fn unary_numeric_operator_must_preserve_declared_type() {
 }
 
 #[test]
+fn where_infers_the_three_way_broadcast_of_predicate_and_branches() {
+    let mut graph = valid_graph();
+    graph.inputs.push(GraphValue {
+        id: "%mask".to_owned(),
+        value_type: GraphType::Tensor {
+            dtype: DType::Bool,
+            shape: vec![SymbolicDimension::Known(2), SymbolicDimension::Known(1)],
+        },
+    });
+    graph.nodes = vec![GraphNode {
+        id: "@select".to_owned(),
+        operator_semantic_id: "tensor.where.v1".to_owned(),
+        inputs: vec!["%mask".to_owned(), "%left".to_owned(), "%left".to_owned()],
+        outputs: vec![tensor(
+            "%result",
+            vec![SymbolicDimension::Known(2), SymbolicDimension::Known(3)],
+        )],
+        attributes: BTreeMap::new(),
+    }];
+    let mut context = context();
+    context
+        .operator_semantics
+        .insert("tensor.where.v1".to_owned(), OperatorSemantics::Where);
+    graph.validate(&context).unwrap();
+}
+
+#[test]
+fn where_requires_a_bool_predicate_not_a_numeric_one() {
+    let mut graph = valid_graph();
+    graph.nodes = vec![GraphNode {
+        id: "@select".to_owned(),
+        operator_semantic_id: "tensor.where.v1".to_owned(),
+        inputs: vec!["%left".to_owned(), "%left".to_owned(), "%left".to_owned()],
+        outputs: vec![tensor(
+            "%result",
+            vec![SymbolicDimension::Known(2), SymbolicDimension::Known(3)],
+        )],
+        attributes: BTreeMap::new(),
+    }];
+    let mut context = context();
+    context
+        .operator_semantics
+        .insert("tensor.where.v1".to_owned(), OperatorSemantics::Where);
+    assert_eq!(
+        graph.validate(&context),
+        Err(GraphValidationError::PredicateDTypeMismatch(
+            "@select".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn arithmetic_operators_refuse_the_predicate_dtype_at_validation_time() {
+    let mut graph = valid_graph();
+    graph.inputs[0].value_type = GraphType::Tensor {
+        dtype: DType::Bool,
+        shape: vec![SymbolicDimension::Known(2), SymbolicDimension::Known(3)],
+    };
+    graph.nodes = vec![GraphNode {
+        id: "@rsqrt".to_owned(),
+        operator_semantic_id: "tensor.rsqrt.v1".to_owned(),
+        inputs: vec!["%left".to_owned()],
+        outputs: vec![GraphValue {
+            id: "%result".to_owned(),
+            value_type: graph.inputs[0].value_type.clone(),
+        }],
+        attributes: BTreeMap::new(),
+    }];
+    let mut context = context();
+    context
+        .operator_semantics
+        .insert("tensor.rsqrt.v1".to_owned(), OperatorSemantics::Rsqrt);
+    assert_eq!(
+        graph.validate(&context),
+        Err(GraphValidationError::NonNumericDType("@rsqrt".to_owned()))
+    );
+}
+
+#[test]
 fn reduce_sum_infers_removed_axes_from_attributes() {
     let mut graph = valid_graph();
     graph.nodes = vec![GraphNode {

--- a/rust/src/tensor_profile/mod.rs
+++ b/rust/src/tensor_profile/mod.rs
@@ -9,10 +9,12 @@ mod execute;
 mod graph;
 mod graph_operators;
 mod reductions;
+mod select;
 mod shape;
 mod tensor;
 
-pub use cpu::{matmul, tensor_exp, tensor_log, TensorOperatorError};
+pub(crate) use cpu::require_numeric;
+pub use cpu::{matmul, tensor_exp, tensor_log, tensor_rsqrt, TensorOperatorError};
 pub use elementwise::{tensor_add, tensor_div, tensor_mul, tensor_sub};
 pub use execute::{execute_graph, GraphExecutionError};
 pub use graph::{
@@ -20,8 +22,12 @@ pub use graph::{
     GraphValue, OperatorSemantics, SymbolicDimension,
 };
 pub use reductions::{reduce_max, reduce_sum};
+pub use select::tensor_where;
 pub use shape::{CheckedShape, ShapeError, TensorMemoryBudget};
 pub use tensor::{DType, Tensor, TensorData, TensorError};
+
+#[cfg(test)]
+mod test_support;
 
 #[cfg(test)]
 mod graph_tests;
@@ -31,3 +37,6 @@ mod cpu_tests;
 
 #[cfg(test)]
 mod execute_tests;
+
+#[cfg(test)]
+mod composition_tests;

--- a/rust/src/tensor_profile/reductions.rs
+++ b/rust/src/tensor_profile/reductions.rs
@@ -1,4 +1,6 @@
-use super::{CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError};
+use super::{
+    require_numeric, CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError,
+};
 
 pub fn reduce_sum(
     input: &Tensor,
@@ -6,7 +8,14 @@ pub fn reduce_sum(
     keep_dimensions: bool,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    reduce(input, axes, keep_dimensions, budget, Reduction::Sum)
+    reduce(
+        input,
+        axes,
+        keep_dimensions,
+        budget,
+        Reduction::Sum,
+        "REDUCE_SUM",
+    )
 }
 
 pub fn reduce_max(
@@ -15,7 +24,14 @@ pub fn reduce_max(
     keep_dimensions: bool,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    reduce(input, axes, keep_dimensions, budget, Reduction::Maximum)
+    reduce(
+        input,
+        axes,
+        keep_dimensions,
+        budget,
+        Reduction::Maximum,
+        "REDUCE_MAX",
+    )
 }
 
 #[derive(Clone, Copy)]
@@ -30,7 +46,9 @@ fn reduce(
     keep_dimensions: bool,
     budget: TensorMemoryBudget,
     reduction: Reduction,
+    operator: &'static str,
 ) -> Result<Tensor, TensorOperatorError> {
+    require_numeric(operator, input.dtype())?;
     let rank = input.shape().dimensions().len();
     let axes = checked_axes(axes, rank)?;
     let output_dimensions = reduced_shape(input.shape().dimensions(), &axes, keep_dimensions);
@@ -84,6 +102,7 @@ fn reduce(
                 }
             },
         )),
+        (TensorData::Bool(_), _) => unreachable!("numeric dtype was checked"),
     };
     Tensor::new(output_dimensions, data, budget).map_err(Into::into)
 }

--- a/rust/src/tensor_profile/select.rs
+++ b/rust/src/tensor_profile/select.rs
@@ -1,0 +1,216 @@
+use super::elementwise::{broadcast_index, broadcast_shape, unravel};
+use super::{CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError};
+
+/// Reference implementation of `tensor.where.v1`.
+///
+/// The predicate is a `bool` tensor, never a numeric tensor read as truthy:
+/// the profile forbids implicit casts, so "nonzero means true" would be an
+/// unrecorded conversion. All three operands broadcast against one another and
+/// the two value operands share the output dtype.
+///
+/// Selection is `bitwise` deterministic. It copies the chosen element rather
+/// than computing with it, so a masked-out NaN or infinity can never leak into
+/// the result — which is what makes `WHERE` usable for attention masks, where
+/// the discarded branch is routinely negative infinity.
+pub fn tensor_where(
+    predicate: &Tensor,
+    on_true: &Tensor,
+    on_false: &Tensor,
+    budget: TensorMemoryBudget,
+) -> Result<Tensor, TensorOperatorError> {
+    let TensorData::Bool(mask) = predicate.data() else {
+        return Err(TensorOperatorError::PredicateDTypeMismatch {
+            operator: "WHERE",
+            dtype: predicate.dtype(),
+        });
+    };
+    if on_true.dtype() != on_false.dtype() {
+        return Err(TensorOperatorError::DTypeMismatch {
+            left: on_true.dtype(),
+            right: on_false.dtype(),
+        });
+    }
+
+    let values_shape =
+        broadcast_shape(on_true.shape().dimensions(), on_false.shape().dimensions())?;
+    let dimensions = broadcast_shape(predicate.shape().dimensions(), &values_shape)?;
+    let output_shape =
+        CheckedShape::new(dimensions.clone(), on_true.dtype().element_bytes(), budget)?;
+
+    let data = match (on_true.data(), on_false.data()) {
+        (TensorData::F32(left), TensorData::F32(right)) => TensorData::F32(select(
+            mask,
+            left,
+            right,
+            predicate.shape(),
+            on_true.shape(),
+            on_false.shape(),
+            &output_shape,
+        )),
+        (TensorData::F64(left), TensorData::F64(right)) => TensorData::F64(select(
+            mask,
+            left,
+            right,
+            predicate.shape(),
+            on_true.shape(),
+            on_false.shape(),
+            &output_shape,
+        )),
+        (TensorData::Bool(left), TensorData::Bool(right)) => TensorData::Bool(select(
+            mask,
+            left,
+            right,
+            predicate.shape(),
+            on_true.shape(),
+            on_false.shape(),
+            &output_shape,
+        )),
+        _ => unreachable!("dtype equality was checked"),
+    };
+    Tensor::new(dimensions, data, budget).map_err(Into::into)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn select<T: Copy>(
+    mask: &[bool],
+    on_true: &[T],
+    on_false: &[T],
+    predicate_shape: &CheckedShape,
+    true_shape: &CheckedShape,
+    false_shape: &CheckedShape,
+    output_shape: &CheckedShape,
+) -> Vec<T> {
+    (0..output_shape.element_count())
+        .map(|linear| {
+            let coordinates = unravel(linear, output_shape.dimensions());
+            if mask[broadcast_index(&coordinates, predicate_shape)] {
+                on_true[broadcast_index(&coordinates, true_shape)]
+            } else {
+                on_false[broadcast_index(&coordinates, false_shape)]
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tensor_profile::DType;
+
+    const OPEN: TensorMemoryBudget = TensorMemoryBudget::new(usize::MAX, usize::MAX);
+
+    fn f32_tensor(shape: Vec<usize>, values: Vec<f32>) -> Tensor {
+        Tensor::new(shape, TensorData::F32(values), OPEN).unwrap()
+    }
+
+    fn mask(shape: Vec<usize>, values: Vec<bool>) -> Tensor {
+        Tensor::new(shape, TensorData::Bool(values), OPEN).unwrap()
+    }
+
+    #[test]
+    fn selects_elementwise_from_both_branches() {
+        let result = tensor_where(
+            &mask(vec![4], vec![true, false, true, false]),
+            &f32_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]),
+            &f32_tensor(vec![4], vec![10.0, 20.0, 30.0, 40.0]),
+            OPEN,
+        )
+        .unwrap();
+        assert_eq!(result.data(), &TensorData::F32(vec![1.0, 20.0, 3.0, 40.0]));
+    }
+
+    #[test]
+    fn broadcasts_predicate_and_both_value_operands() {
+        // A causal-style mask: one column of predicates chooses between a
+        // full matrix and a scalar fill value.
+        let result = tensor_where(
+            &mask(vec![2, 1], vec![true, false]),
+            &f32_tensor(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            &f32_tensor(vec![], vec![f32::NEG_INFINITY]),
+            OPEN,
+        )
+        .unwrap();
+        assert_eq!(result.shape().dimensions(), &[2, 3]);
+        let TensorData::F32(values) = result.data() else {
+            panic!("dtype changed")
+        };
+        assert_eq!(&values[..3], &[1.0, 2.0, 3.0]);
+        assert!(values[3..].iter().all(|value| *value == f32::NEG_INFINITY));
+    }
+
+    #[test]
+    fn masked_out_nan_never_reaches_the_result() {
+        let result = tensor_where(
+            &mask(vec![2], vec![true, true]),
+            &f32_tensor(vec![2], vec![1.0, 2.0]),
+            &f32_tensor(vec![2], vec![f32::NAN, f32::NAN]),
+            OPEN,
+        )
+        .unwrap();
+        assert_eq!(result.data(), &TensorData::F32(vec![1.0, 2.0]));
+    }
+
+    #[test]
+    fn rejects_a_numeric_predicate_instead_of_reading_it_as_truthy() {
+        assert_eq!(
+            tensor_where(
+                &f32_tensor(vec![2], vec![1.0, 0.0]),
+                &f32_tensor(vec![2], vec![1.0, 2.0]),
+                &f32_tensor(vec![2], vec![3.0, 4.0]),
+                OPEN,
+            ),
+            Err(TensorOperatorError::PredicateDTypeMismatch {
+                operator: "WHERE",
+                dtype: DType::F32,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_branches_that_disagree_on_dtype() {
+        let on_false = Tensor::new(vec![2], TensorData::F64(vec![0.0, 0.0]), OPEN).unwrap();
+        assert_eq!(
+            tensor_where(
+                &mask(vec![2], vec![true, false]),
+                &f32_tensor(vec![2], vec![1.0, 2.0]),
+                &on_false,
+                OPEN,
+            ),
+            Err(TensorOperatorError::DTypeMismatch {
+                left: DType::F32,
+                right: DType::F64,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_shapes_that_do_not_broadcast() {
+        assert!(matches!(
+            tensor_where(
+                &mask(vec![2], vec![true, false]),
+                &f32_tensor(vec![3], vec![1.0, 2.0, 3.0]),
+                &f32_tensor(vec![3], vec![4.0, 5.0, 6.0]),
+                OPEN,
+            ),
+            Err(TensorOperatorError::ElementwiseBroadcastMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn checks_the_output_budget_before_allocating() {
+        assert_eq!(
+            tensor_where(
+                &mask(vec![4], vec![true; 4]),
+                &f32_tensor(vec![4], vec![1.0; 4]),
+                &f32_tensor(vec![4], vec![0.0; 4]),
+                TensorMemoryBudget::new(4, 15),
+            ),
+            Err(TensorOperatorError::Shape(
+                super::super::ShapeError::ByteBudgetExceeded {
+                    requested: 16,
+                    limit: 15,
+                }
+            ))
+        );
+    }
+}

--- a/rust/src/tensor_profile/tensor.rs
+++ b/rust/src/tensor_profile/tensor.rs
@@ -7,6 +7,10 @@ use std::fmt;
 pub enum DType {
     F32,
     F64,
+    /// The predicate dtype. It carries selection decisions such as attention
+    /// masks; it is not a numeric element type and no arithmetic operator
+    /// accepts it.
+    Bool,
 }
 
 impl DType {
@@ -14,7 +18,15 @@ impl DType {
         match self {
             Self::F32 => 4,
             Self::F64 => 8,
+            Self::Bool => 1,
         }
+    }
+
+    /// Whether this dtype names an approximate floating-point element type.
+    /// The profile forbids implicit casts, so a predicate never silently
+    /// becomes a number and a number never silently becomes a predicate.
+    pub const fn is_numeric(self) -> bool {
+        matches!(self, Self::F32 | Self::F64)
     }
 }
 
@@ -22,6 +34,7 @@ impl DType {
 pub enum TensorData {
     F32(Vec<f32>),
     F64(Vec<f64>),
+    Bool(Vec<bool>),
 }
 
 impl TensorData {
@@ -29,6 +42,7 @@ impl TensorData {
         match self {
             Self::F32(_) => DType::F32,
             Self::F64(_) => DType::F64,
+            Self::Bool(_) => DType::Bool,
         }
     }
 
@@ -36,6 +50,7 @@ impl TensorData {
         match self {
             Self::F32(values) => values.len(),
             Self::F64(values) => values.len(),
+            Self::Bool(values) => values.len(),
         }
     }
 }
@@ -129,6 +144,15 @@ mod tests {
                 actual: 1
             })
         );
+    }
+
+    #[test]
+    fn predicate_dtype_is_one_byte_and_not_numeric() {
+        let mask = Tensor::new(vec![2], TensorData::Bool(vec![true, false]), OPEN).unwrap();
+        assert_eq!(mask.dtype(), DType::Bool);
+        assert_eq!(DType::Bool.element_bytes(), 1);
+        assert!(!DType::Bool.is_numeric());
+        assert!(DType::F32.is_numeric() && DType::F64.is_numeric());
     }
 
     #[test]

--- a/rust/src/tensor_profile/test_support.rs
+++ b/rust/src/tensor_profile/test_support.rs
@@ -1,0 +1,117 @@
+//! Shared builders for the graph execution and composition test suites.
+
+use super::{
+    DType, Graph, GraphType, GraphValidationContext, GraphValue, OperatorSemantics,
+    SymbolicDimension, Tensor, TensorData, TensorMemoryBudget,
+};
+use std::collections::BTreeMap;
+
+pub(super) const OPEN: TensorMemoryBudget = TensorMemoryBudget::new(usize::MAX, usize::MAX);
+
+/// Every operator semantic ID the reference backend can execute. Tests that
+/// need to reject an operator remove it rather than rebuilding the map.
+pub(super) fn context() -> GraphValidationContext {
+    GraphValidationContext {
+        profile_id: "org.ajisai.tensor/0.1".to_owned(),
+        operator_semantics: BTreeMap::from([
+            ("tensor.matmul.v1".to_owned(), OperatorSemantics::Matmul),
+            ("tensor.exp.v1".to_owned(), OperatorSemantics::Exp),
+            ("tensor.log.v1".to_owned(), OperatorSemantics::Log),
+            ("tensor.rsqrt.v1".to_owned(), OperatorSemantics::Rsqrt),
+            ("tensor.where.v1".to_owned(), OperatorSemantics::Where),
+            (
+                "tensor.reduce_sum.v1".to_owned(),
+                OperatorSemantics::ReduceSum,
+            ),
+            (
+                "tensor.reduce_max.v1".to_owned(),
+                OperatorSemantics::ReduceMax,
+            ),
+            ("tensor.add.v1".to_owned(), OperatorSemantics::Add),
+            ("tensor.sub.v1".to_owned(), OperatorSemantics::Sub),
+            ("tensor.mul.v1".to_owned(), OperatorSemantics::Mul),
+            ("tensor.div.v1".to_owned(), OperatorSemantics::Div),
+        ]),
+    }
+}
+
+/// The committed exchange-format example, so the tests exercise the same graph
+/// the specification ships.
+pub(super) fn example() -> Graph {
+    serde_json::from_str(include_str!(
+        "../../../spec/examples/tiny-matmul.graph.json"
+    ))
+    .unwrap()
+}
+
+pub(super) fn f32_tensor(shape: Vec<usize>, values: Vec<f32>) -> Tensor {
+    Tensor::new(shape, TensorData::F32(values), OPEN).unwrap()
+}
+
+pub(super) fn bool_tensor(shape: Vec<usize>, values: Vec<bool>) -> Tensor {
+    Tensor::new(shape, TensorData::Bool(values), OPEN).unwrap()
+}
+
+pub(super) fn f32_type(shape: &[usize]) -> GraphType {
+    typed(DType::F32, shape)
+}
+
+pub(super) fn bool_type(shape: &[usize]) -> GraphType {
+    typed(DType::Bool, shape)
+}
+
+fn typed(dtype: DType, shape: &[usize]) -> GraphType {
+    GraphType::Tensor {
+        dtype,
+        shape: shape
+            .iter()
+            .copied()
+            .map(SymbolicDimension::Known)
+            .collect(),
+    }
+}
+
+pub(super) fn declare(id: &str, value_type: GraphType) -> GraphValue {
+    GraphValue {
+        id: id.to_owned(),
+        value_type,
+    }
+}
+
+/// A node with no attributes, which covers every operator except the
+/// reductions.
+pub(super) fn node(
+    id: &str,
+    operator: &str,
+    inputs: &[&str],
+    output: GraphValue,
+) -> super::GraphNode {
+    super::GraphNode {
+        id: id.to_owned(),
+        operator_semantic_id: operator.to_owned(),
+        inputs: inputs.iter().copied().map(str::to_owned).collect(),
+        outputs: vec![output],
+        attributes: BTreeMap::new(),
+    }
+}
+
+/// A reduction over `axes` that retains the reduced axes, the form the softmax
+/// and normalization compositions rely on for broadcasting.
+pub(super) fn keeping_reduction(
+    id: &str,
+    operator: &str,
+    input: &str,
+    output: GraphValue,
+    axes: &[usize],
+) -> super::GraphNode {
+    super::GraphNode {
+        id: id.to_owned(),
+        operator_semantic_id: operator.to_owned(),
+        inputs: vec![input.to_owned()],
+        outputs: vec![output],
+        attributes: BTreeMap::from([
+            ("axes".to_owned(), serde_json::json!(axes)),
+            ("keepDimensions".to_owned(), serde_json::json!(true)),
+        ]),
+    }
+}

--- a/scripts/check-tensor-profile.mjs
+++ b/scripts/check-tensor-profile.mjs
@@ -9,6 +9,8 @@ const runtimeDtypes = readFileSync('rust/src/tensor_profile/tensor.rs', 'utf8');
 const referenceCpu = readFileSync('rust/src/tensor_profile/cpu.rs', 'utf8');
 const reductions = readFileSync('rust/src/tensor_profile/reductions.rs', 'utf8');
 const elementwise = readFileSync('rust/src/tensor_profile/elementwise.rs', 'utf8');
+const select = readFileSync('rust/src/tensor_profile/select.rs', 'utf8');
+const graphOperators = readFileSync('rust/src/tensor_profile/graph_operators.rs', 'utf8');
 const graphExample = JSON.parse(readFileSync('spec/examples/tiny-matmul.graph.json', 'utf8'));
 const errors = [];
 const fail = (message) => errors.push(message);
@@ -19,10 +21,17 @@ if (!prose.includes(profile.profile)) fail('normative prose does not name the ma
 if (!graphSchema.properties.profiles) fail('typed graph IR has no explicit profile selection');
 if (profile.implicitCasts !== false) fail('exact Scalar to approximate Tensor conversion must remain explicit');
 if (profile.ambientRng !== false) fail('ambient RNG is forbidden');
-for (const dtype of profile.dtypes) {
+for (const dtype of [...profile.dtypes, profile.predicateDtype]) {
   const rustVariant = dtype[0].toUpperCase() + dtype.slice(1);
   if (!runtimeDtypes.includes(`    ${rustVariant},`)) fail(`runtime DType is missing ${dtype}`);
 }
+// The predicate dtype only stays outside the numeric domain if something
+// mechanically keeps it there: `is_numeric` must exclude it, and both the
+// graph validator and the reference backend must refuse it for arithmetic.
+if (profile.dtypes.includes(profile.predicateDtype)) fail('the predicate dtype must not be listed as a numeric dtype');
+if (!/pub const fn is_numeric\(self\) -> bool \{\s*matches!\(self, Self::F32 \| Self::F64\)/.test(runtimeDtypes)) fail('runtime DType::is_numeric does not exclude the predicate dtype');
+if (!referenceCpu.includes('pub(crate) fn require_numeric(')) fail('reference CPU backend does not gate numeric operators on dtype');
+if (!graphOperators.includes('fn require_numeric(')) fail('graph validation does not gate numeric operators on dtype');
 
 const coreNames = new Set(coreWords.entries.map(({ name }) => name));
 const names = new Set();
@@ -55,6 +64,8 @@ for (const operator of exampleOperators) {
 if (!referenceCpu.includes('pub fn matmul(')) fail('reference CPU backend is missing MATMUL');
 if (!referenceCpu.includes('pub fn tensor_exp(')) fail('reference CPU backend is missing EXP');
 if (!referenceCpu.includes('pub fn tensor_log(')) fail('reference CPU backend is missing LOG');
+if (!referenceCpu.includes('pub fn tensor_rsqrt(')) fail('reference CPU backend is missing RSQRT');
+if (!select.includes('pub fn tensor_where(')) fail('reference CPU backend is missing WHERE');
 if (!reductions.includes('pub fn reduce_sum(')) fail('reference CPU backend is missing REDUCE_SUM');
 if (!reductions.includes('pub fn reduce_max(')) fail('reference CPU backend is missing REDUCE_MAX');
 for (const operation of ['add', 'sub', 'mul', 'div']) {

--- a/spec/tensor-profile-v0.1.json
+++ b/spec/tensor-profile-v0.1.json
@@ -6,6 +6,7 @@
     "f32",
     "f64"
   ],
+  "predicateDtype": "bool",
   "rounding": "nearestTiesToEven",
   "implicitCasts": false,
   "ambientRng": false,

--- a/spec/tensor-profile-v0.1.md
+++ b/spec/tensor-profile-v0.1.md
@@ -21,9 +21,13 @@ a finite sequence of non-negative dimensions and elements are stored in
 row-major logical order. Device, allocation, strides, layout, fusion, and
 backend are execution properties, not value identity.
 
-Profile 0.1 supports `f32` and `f64`. An exact Core Scalar enters the approximate
-domain only through `CAST`; no operator performs an implicit Scalar-to-Tensor or
-dtype conversion. `CAST` uses IEEE-754 round-to-nearest, ties-to-even.
+Profile 0.1 supports the numeric dtypes `f32` and `f64`, plus the separate
+predicate dtype `bool`. A predicate carries selection decisions such as an
+attention mask; it is not a numeric element type, and every arithmetic and
+reduction operator rejects it rather than reading a number as truthy or a
+predicate as zero-or-one. An exact Core Scalar enters the approximate domain
+only through `CAST`; no operator performs an implicit Scalar-to-Tensor or dtype
+conversion. `CAST` uses IEEE-754 round-to-nearest, ties-to-even.
 
 Tensor NaN and infinities are floating-point elements, not `NIL`. A resource
 budget failure produces `NIL(spaceExhausted)`. A malformed dtype, rank, axis, or
@@ -78,10 +82,21 @@ broadcasting before indexing, and validates output elements and bytes before
 allocating the result buffer. Accelerated kernels may replace this loop only
 under the numerical contract recorded for `tensor.matmul.v1`.
 
-The reference backend also implements the shape-preserving `tensor.exp.v1` and
-`tensor.log.v1` primitives for f32/f64. Their graph contracts require exactly
-one input and one output with identical dtype and shape. IEEE results such as
-NaN and infinity remain Tensor elements and are not converted to NIL.
+The reference backend also implements the shape-preserving `tensor.exp.v1`,
+`tensor.log.v1`, and `tensor.rsqrt.v1` primitives for f32/f64. Their graph
+contracts require exactly one input and one output with identical dtype and
+shape. IEEE results such as NaN and infinity remain Tensor elements and are not
+converted to NIL, so `rsqrt(0)` is positive infinity and `rsqrt(x < 0)` is NaN.
+`tensor.rsqrt.v1` is `bounded`, not `bitwise`: a backend may fuse the square
+root and the reciprocal only inside the tolerance recorded for the operator.
+
+`tensor.where.v1` selects elementwise between two operands of a common dtype
+`D` under a `bool` predicate. It is the only operator whose inputs deliberately
+do not share a dtype, and the graph validator rejects a numeric predicate
+instead of interpreting nonzero as true. All three operands broadcast against
+one another and the output shape is their three-way broadcast. Selection copies
+the chosen element rather than computing with it, so the negative infinity used
+to mask attention scores can never enter an arithmetic result.
 
 `tensor.reduce_sum.v1` takes one Tensor plus graph attributes `axes` (a required
 array of unique zero-based axes) and `keepDimensions` (an optional Boolean,
@@ -97,7 +112,10 @@ zero produces IEEE infinity or NaN inside the Tensor rather than NIL.
 
 Numerically stable softmax is intentionally a library graph composition:
 REDUCE_MAX with retained axes, subtraction, EXP, REDUCE_SUM with retained axes,
-and division. It is not a Core Word or a Tensor Profile primitive.
+and division. It is not a Core Word or a Tensor Profile primitive. Masked
+attention prefixes that chain with WHERE, and RMS normalization is likewise a
+composition — square, REDUCE_SUM with retained axes, scale to a mean, add
+epsilon, RSQRT, multiply. Neither becomes a primitive by being useful.
 
 `execute_graph` is the reference bridge from the exchange IR to that backend.
 It validates the graph before execution, binds symbolic dimensions from runtime

--- a/spec/tensor-profile.schema.json
+++ b/spec/tensor-profile.schema.json
@@ -8,6 +8,7 @@
     "profile",
     "status",
     "dtypes",
+    "predicateDtype",
     "rounding",
     "implicitCasts",
     "ambientRng",
@@ -39,6 +40,12 @@
       },
       "minItems": 1,
       "uniqueItems": true
+    },
+    "predicateDtype": {
+      "description": "The selection dtype carried by WHERE predicates and masks. It is deliberately outside `dtypes`: no arithmetic operator accepts it, and `implicitCasts: false` forbids converting between it and a numeric dtype.",
+      "enum": [
+        "bool"
+      ]
     },
     "rounding": {
       "enum": [


### PR DESCRIPTION
## Summary

Implements `RSQRT` and `WHERE`, the two operators the Tensor Profile progress note listed as the next implementation step, and executes them on the deterministic reference CPU backend.

`WHERE`'s committed contract in `spec/tensor-profile-v0.1.json` takes a `Tensor<bool,S>` predicate, but the runtime had no way to represent one. The alternative — reading a numeric tensor as truthy — is exactly the unrecorded conversion the profile's `implicitCasts: false` rule forbids, so this adds `bool` as a **predicate dtype** that sits deliberately outside the numeric dtype list:

- `DType::Bool` (1 byte) and `TensorData::Bool`, with `DType::is_numeric()` excluding it.
- The graph validator and the reference backend both reject a predicate wherever an operator's contract ranges over `f32`/`f64` (MATMUL, elementwise arithmetic, reductions, EXP/LOG/RSQRT). The no-implicit-cast rule is now enforced rather than assumed.
- New profile field `predicateDtype: "bool"`, kept out of `dtypes` so the numeric domain is unchanged; `check-tensor-profile.mjs` fails if the two are ever merged or if either gate disappears.

`RSQRT` is a bounded shape-preserving unary. IEEE domain results stay tensor elements, so `rsqrt(0)` is positive infinity and `rsqrt(x < 0)` is NaN — neither becomes NIL.

`WHERE` copies the selected element rather than computing with it, which is what lets an attention mask use negative infinity as its fill value without that value ever entering an arithmetic result.

With both operators in place, **masked softmax and RMS normalization are executable graph compositions**, not primitives — the property the profile claims about NN operations. A new `composition_tests.rs` suite runs them end to end so that claim is checked rather than stated.

Core and its exact Scalar domain are untouched; this is entirely inside the opt-in `tensor_profile` module.

## Quality Classification

- Highest impacted level: **QL-C** — opt-in profile surface only, no change to Core semantics, the kernel, or the frozen Word set.

## Traceability

- Requirement(s): Tensor Profile 0.1 operator contracts `tensor.rsqrt.v1` and `tensor.where.v1` (`spec/tensor-profile-v0.1.json`); next-step item 1 of `docs/dev/tensor-profile-progress-2026-08.md`.
- Verification evidence:
  - `rust/src/tensor_profile/select.rs` unit tests — selection, three-way broadcast, masked-out NaN containment, predicate/dtype/shape/budget rejections.
  - `rust/src/tensor_profile/cpu_tests.rs` — RSQRT values and IEEE domain states; every numeric operator rejecting the predicate dtype.
  - `rust/src/tensor_profile/graph_tests.rs` — WHERE shape inference, predicate requirement, arithmetic refusing `bool` at validation time.
  - `rust/src/tensor_profile/composition_tests.rs` — stable softmax, masked softmax, RMS normalization executed end to end.
  - `rust/src/tensor_profile/execute_tests.rs` — runtime predicate dtype checking through `execute_graph`.
  - `scripts/check-tensor-profile.mjs` — spec/implementation drift guard, extended to cover the new operators and the predicate-dtype separation.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated (`spec/tensor-profile-v0.1.md`, `docs/dev/tensor-profile-progress-2026-08.md`).
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — 14 test binaries green, 0 failures
- [ ] `npm run check` — not applicable; no TypeScript changed. (Not runnable in this environment: dependencies are not installed, so `tsc` reports missing `vitest` types across pre-existing test files.)
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not run; coverage instrumentation unavailable in this environment.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the new boolean decisions are the dtype gates (`is_numeric`, predicate check) and the three-way broadcast; each branch has a dedicated test, including both outcomes of the `WHERE` selection.
- [x] Release checklist impact considered — draft profile surface, no Core or frozen-vocabulary impact.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

Other repository guards run clean: `check:tensor-profile`, `check:file-size`, `check:reading-surfaces`, `check:semantic-firewall`, `specification:check`, `check:minimal-core`.

Adding the composition tests pushed `execute_tests.rs` past the §14.1 500-line budget, so the library-composition tests moved to `composition_tests.rs` and shared builders to `test_support.rs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEpVxYuSGpnUwVWL1UvdXG)_