### PR TITLE
Bound exact tensor denominators with REGRID

### DIFF
--- a/docs/dev/rational-tensor-growth-2026-08.md
+++ b/docs/dev/rational-tensor-growth-2026-08.md
@@ -1,0 +1,192 @@
+# Denominator growth in exact tensors — 2026-08
+
+This is a development-status note, not a normative source. Normative profile
+semantics remain under `spec/`.
+
+## Why exactness is the requirement, not a preference
+
+The Tensor Profile exists so Ajisai can host a language model. The purpose of
+that model is to give Ajisai a completely free surface syntax: free-form input
+is mapped to a canonical Ajisai program by a learned front end.
+
+That makes the model part of the language, and it changes what "good numerics"
+means. A syntax front end must be *specifiable*. If the same input can map to
+different programs on different hardware, the language has no definition — only
+a current implementation. Floating point cannot offer that: an operator's
+result depends on association order, fused multiply-add availability, and the
+backend's libm. The profile handles this honestly for approximate dtypes by
+declaring tolerances, but a declared tolerance is exactly what a parser cannot
+have. Two programs are not "within 1e-6" of each other.
+
+Exact rational arithmetic gives reproducibility rather than accuracy, and
+reproducibility is the property the free-syntax goal actually needs. Every
+backend must produce the identical rational, because there is nothing left
+unspecified for a backend to decide.
+
+The price is representation size, and that price is what this note is about.
+
+## Where the growth comes from
+
+A rational `p/q` in lowest terms costs about `bits(q)` to represent, for values
+of bounded magnitude. The problem is that arithmetic adds those bits:
+
+- `a/q + b/s = (as + bq)/(qs)`, reduced by `gcd`
+- `(a/q)(b/s) = ab/(qs)`
+
+For rationals that do not share factors — the generic case — nothing cancels
+and denominator bits simply add. Growth is therefore not a property of any one
+operator but of *chain length*.
+
+The worst offender is the contraction inside `MATMUL`. A dot product of length
+`K` sums `K` products, each with its own denominator, so the sum's denominator
+is generically the product of all `2K` operand denominators:
+
+```
+bits ≈ Σ (bits(qᵢ) + bits(sᵢ)) ≈ 2·K·b
+```
+
+At a hidden width of 512 with 16-bit denominators, one layer produces ~16,000-bit
+denominators. The second layer takes those as input and produces ~16 million
+bits *per element*. This is why exact arithmetic is usually dismissed for
+machine learning: not because it gives wrong answers, but because it stops
+giving answers at all.
+
+Measured, on `[1,K]·[K,1]` contractions of unit fractions over distinct primes:
+
+| K | denominator bits |
+| ---: | ---: |
+| 2 | 14 |
+| 8 | 70 |
+| 32 | 221 |
+
+Linear in `K`, exactly as predicted.
+
+## The strategy
+
+### 1. A shared grid removes the dependence on reduction length
+
+Suppose every element of both operands lies on the grid `(1/d)ℤ` — that is,
+every denominator divides `d`. Write `aᵢ = αᵢ/d` and `bᵢ = βᵢ/d` with integer
+`α, β`. Then
+
+```
+Σᵢ aᵢbᵢ  =  (Σᵢ αᵢβᵢ) / d²
+```
+
+The products already share the denominator `d²`, so the sum has denominator
+`d²` — **whatever `K` is**. The reduction length drops out completely. The
+numerator is an ordinary integer sum.
+
+This is the important result, and note what it does *not* depend on: the grid
+need not be a power of two. Any common `d` works. Sharing the denominator is
+what matters; the grid's fineness is a separate, independent choice.
+
+Measured, at `d = 256` (so the `d²` bound is 17 bits):
+
+| K | gridded | ungridded |
+| ---: | ---: | ---: |
+| 2 | 16 | 14 |
+| 8 | 14 | 70 |
+| 32 | 13 | 221 |
+| 64 | 13 | — |
+
+The gridded column does not grow. It slightly *falls*, because longer sums
+offer more opportunities for common factors to cancel.
+
+### 2. Regridding per layer removes the dependence on depth
+
+A grid bounds one contraction, but chaining squares the denominator each time:
+`d → d² → d⁴ → …`, which is `d^(2^L)` at depth `L`. So the grid alone is not
+enough.
+
+`REGRID` — round every element back onto the grid `1/d` — restores the
+invariant after each layer, so the cost per layer is `d → d² → d` and the
+representation size becomes constant in both `K` and `L`.
+
+This is the tensor lifting of Core's `QUANTIZE` word, whose documentation
+already states the principle: *"an exact number carries its whole history in
+its denominator, so an iterative method grows one without bound; quantizing
+each step keeps the representation the size of the answer rather than the size
+of the computation."* The tensor operator carries a different name only because
+profile operators must not collide with frozen Core vocabulary; the tie rule
+(halves away from zero) is inherited so the language does not hold two.
+
+Measured over 8 chained `[2,2]` matmuls on a `d = 16` grid, the denominator
+without regridding runs `5, 6, 10, 11, 15, 16, 20, 21, 25` bits and keeps
+climbing; with a `REGRID` after each layer it holds at 5.
+
+The climb is milder than the `d^(2^L)` worst case — about 2.5 bits per layer
+rather than a doubling — because a power-of-two grid lets sums cancel trailing
+zeros. Milder is not bounded: nothing in that sequence stops it, and the cost is
+still a function of depth rather than of the answer.
+
+### 3. The denominator is a budgeted resource
+
+Exact arithmetic's characteristic failure is not a wrong answer but an
+unbounded one: the program does not fail, it stops finishing. That is the worst
+possible failure mode, because it is indistinguishable from slowness.
+
+`TensorMemoryBudget::max_denominator_bits` makes the denominator a checked
+resource like element count and byte count. It is verified in `Tensor::new`,
+which every operator publishes its result through, so no exact tensor can exist
+without having passed it. A graph that does not regrid often enough now reports
+which node overflowed instead of disappearing into bignum arithmetic.
+
+This follows the profile's existing rule that resource exhaustion is a declared
+outcome rather than a silent one.
+
+## What exactness costs, stated honestly
+
+- **Error.** Regridding to `1/d` moves each element by at most `1/(2d)`. This
+  is a hard bound, not a statistical expectation, but it is a real
+  approximation: an exact graph with `REGRID` nodes is a fixed-point scheme
+  whose rounding is *specified* rather than delegated to hardware. Exactness
+  buys reproducibility, not freedom from approximation.
+- **Numerators.** Bounding denominators does not bound magnitude. A sum of `K`
+  products of size `M` reaches `K·M²`, and depth compounds it. Normalization is
+  what bounds the numerator, so `REGRID` and RMSNorm are complementary: one
+  holds the denominator, the other the numerator.
+- **Speed.** Bignum arithmetic is far slower than hardware floating point even
+  at a bounded size. The exact path is for cases where a reproducible answer is
+  worth more than throughput — which is the syntax front end's situation, not
+  every model's.
+
+## What is not solved
+
+**Transcendentals.** `EXP`, `LOG`, and `RSQRT` are irrational for essentially
+all rational inputs, so there is no exact result to return. They are declared
+`dtypeDomain: "approximate"` and reject `q` rather than silently returning an
+approximation, which would be the implicit conversion the profile forbids.
+
+This is the blocking gap for a fully exact Transformer, because attention needs
+softmax. Closing it requires an operator contract carrying a *declared
+precision* — for example, "the best rational approximation of `exp(x)` with
+denominator at most `d`, by a specified series with a proven truncation bound".
+That is a well-posed problem and it is the natural next piece of work, but it
+is a new contract rather than an extension of an existing one, and Profile 0.1
+does not define it.
+
+Worth noting for the free-syntax goal specifically: the *decode* step needs
+only `argmax` over logits, which is exact over `q` and needs no transcendental
+at all. It is the softmax inside attention, not the choice of output token,
+that currently forces the approximate domain.
+
+**Training.** `REGRID` is declared non-differentiable (`kind: "none"`), because
+rounding to a grid has zero derivative almost everywhere. The straight-through
+estimator that quantization-aware training normally uses is a *different*
+function, and giving it to `REGRID` implicitly would make the gradient graph
+disagree with the forward graph. If it is wanted, it belongs in its own
+declared contract.
+
+## Status
+
+| Piece | State |
+| --- | --- |
+| `q` exact dtype, NIL and denominator boundaries | implemented |
+| Exact ADD/SUB/MUL/DIV, MATMUL, REDUCE_SUM/MAX, WHERE | implemented |
+| `REGRID` (`tensor.regrid.v1`) | implemented |
+| Denominator budget enforcement | implemented |
+| Declared `dtypeDomain` per operator, gated in validator and backend | implemented |
+| Exact transcendentals with declared precision | not defined |
+| Exact `argmax` for decoding | not implemented |
+| Straight-through gradient contract | not defined |

--- a/rust/src/tensor_profile/cpu.rs
+++ b/rust/src/tensor_profile/cpu.rs
@@ -1,4 +1,6 @@
 use super::{CheckedShape, DType, ShapeError, Tensor, TensorData, TensorError, TensorMemoryBudget};
+use crate::types::fraction::Fraction;
+use num_bigint::BigInt;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -37,6 +39,19 @@ pub enum TensorOperatorError {
         operator: &'static str,
         dtype: DType,
     },
+    ExactDTypeUnsupported {
+        operator: &'static str,
+        dtype: DType,
+    },
+    ApproximateDTypeUnsupported {
+        operator: &'static str,
+        dtype: DType,
+    },
+    ExactDivisionByZero,
+    EmptyExactReduction {
+        operator: &'static str,
+    },
+    NonPositiveDenominator,
     Shape(ShapeError),
     Tensor(TensorError),
 }
@@ -84,6 +99,24 @@ impl fmt::Display for TensorOperatorError {
                 f,
                 "{operator} requires a bool predicate, received {dtype:?}"
             ),
+            Self::ExactDTypeUnsupported { operator, dtype } => write!(
+                f,
+                "{operator} has no exact value for rational inputs, so it is undefined over {dtype:?}"
+            ),
+            Self::ApproximateDTypeUnsupported { operator, dtype } => write!(
+                f,
+                "{operator} is defined only over exact dtypes, received {dtype:?}"
+            ),
+            Self::ExactDivisionByZero => {
+                write!(f, "exact division by zero has no rational result")
+            }
+            Self::EmptyExactReduction { operator } => write!(
+                f,
+                "{operator} over an empty exact slice has no identity element"
+            ),
+            Self::NonPositiveDenominator => {
+                write!(f, "QUANTIZE requires a positive integer denominator")
+            }
             Self::Shape(error) => error.fmt(f),
             Self::Tensor(error) => error.fmt(f),
         }
@@ -172,6 +205,22 @@ pub fn matmul(
             |sum, left, right| sum + left * right,
             0.0f64,
         )),
+        // The exact contraction accumulates in the same increasing-K order.
+        // Ordering is not a numerical choice here — rational addition is
+        // associative, so the result is order-independent — but keeping one
+        // traversal means the exact and approximate paths cannot drift.
+        (TensorData::Q(left_data), TensorData::Q(right_data)) => TensorData::Q(matmul_data(
+            left_data,
+            right_data,
+            left.shape(),
+            right.shape(),
+            &batch_shape,
+            m,
+            left_k,
+            n,
+            |sum: Fraction, left: Fraction, right: Fraction| sum.add(&left.mul(&right)),
+            Fraction::new(BigInt::from(0), BigInt::from(1)),
+        )),
         _ => unreachable!("dtype equality and numeric dtype were checked"),
     };
     debug_assert_eq!(data_len(&data), output_shape.element_count());
@@ -223,7 +272,7 @@ fn map_unary(
     f32_operation: impl Fn(f32) -> f32,
     f64_operation: impl Fn(f64) -> f64,
 ) -> Result<Tensor, TensorOperatorError> {
-    require_numeric(operator, input.dtype())?;
+    require_approximate(operator, input.dtype())?;
     CheckedShape::new(
         input.shape().dimensions().to_vec(),
         input.dtype().element_bytes(),
@@ -236,7 +285,9 @@ fn map_unary(
         TensorData::F64(values) => {
             TensorData::F64(values.iter().copied().map(f64_operation).collect())
         }
-        TensorData::Bool(_) => unreachable!("numeric dtype was checked"),
+        TensorData::Q(_) | TensorData::Bool(_) => {
+            unreachable!("approximate dtype was checked")
+        }
     };
     Tensor::new(input.shape().dimensions().to_vec(), data, budget).map_err(Into::into)
 }
@@ -252,6 +303,35 @@ pub(crate) fn require_numeric(
         return Ok(());
     }
     Err(TensorOperatorError::NonNumericDType { operator, dtype })
+}
+
+/// Reject the exact dtype for operators whose value is irrational for rational
+/// inputs. `exp`, `ln`, and `x^(-1/2)` leave the rationals for all but trivial
+/// arguments, so there is no exact result to return. Returning an approximate
+/// one instead would be a silent exact-to-approximate conversion, which the
+/// profile forbids; an exact transcendental needs its own contract carrying a
+/// declared precision, which Profile 0.1 does not define.
+pub(crate) fn require_approximate(
+    operator: &'static str,
+    dtype: DType,
+) -> Result<(), TensorOperatorError> {
+    require_numeric(operator, dtype)?;
+    if dtype.is_approximate() {
+        return Ok(());
+    }
+    Err(TensorOperatorError::ExactDTypeUnsupported { operator, dtype })
+}
+
+/// The mirror of [`require_approximate`], for operators that only make sense
+/// over exact values.
+pub(crate) fn require_exact(
+    operator: &'static str,
+    dtype: DType,
+) -> Result<(), TensorOperatorError> {
+    if dtype.is_exact() {
+        return Ok(());
+    }
+    Err(TensorOperatorError::ApproximateDTypeUnsupported { operator, dtype })
 }
 
 fn check_rank(rank: usize) -> Result<(), TensorOperatorError> {
@@ -300,7 +380,7 @@ fn trailing_dimension(shape: &[usize], offset: usize) -> Option<usize> {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn matmul_data<T: Copy>(
+fn matmul_data<T: Clone>(
     left: &[T],
     right: &[T],
     left_shape: &CheckedShape,
@@ -322,10 +402,11 @@ fn matmul_data<T: Copy>(
         let right_row_stride = right_shape.row_major_strides()[right_shape.dimensions().len() - 2];
         for row in 0..m {
             for column in 0..n {
-                let mut sum = zero;
+                let mut sum = zero.clone();
                 for contraction in 0..k {
-                    let left_value = left[left_base + row * left_row_stride + contraction];
-                    let right_value = right[right_base + contraction * right_row_stride + column];
+                    let left_value = left[left_base + row * left_row_stride + contraction].clone();
+                    let right_value =
+                        right[right_base + contraction * right_row_stride + column].clone();
                     sum = multiply_add(sum, left_value, right_value);
                 }
                 output.push(sum);
@@ -371,6 +452,7 @@ fn data_len(data: &TensorData) -> usize {
     match data {
         TensorData::F32(values) => values.len(),
         TensorData::F64(values) => values.len(),
+        TensorData::Q(values) => values.len(),
         TensorData::Bool(values) => values.len(),
     }
 }

--- a/rust/src/tensor_profile/elementwise.rs
+++ b/rust/src/tensor_profile/elementwise.rs
@@ -1,13 +1,22 @@
 use super::{
     require_numeric, CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError,
 };
+use crate::types::fraction::Fraction;
 
 pub fn tensor_add(
     left: &Tensor,
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, "ADD", budget, |a, b| a + b, |a, b| a + b)
+    binary(
+        left,
+        right,
+        "ADD",
+        budget,
+        |a, b| a + b,
+        |a, b| a + b,
+        |a, b| a.add(&b),
+    )
 }
 
 pub fn tensor_sub(
@@ -15,7 +24,15 @@ pub fn tensor_sub(
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, "SUB", budget, |a, b| a - b, |a, b| a - b)
+    binary(
+        left,
+        right,
+        "SUB",
+        budget,
+        |a, b| a - b,
+        |a, b| a - b,
+        |a, b| a.sub(&b),
+    )
 }
 
 pub fn tensor_mul(
@@ -23,17 +40,48 @@ pub fn tensor_mul(
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, "MUL", budget, |a, b| a * b, |a, b| a * b)
+    binary(
+        left,
+        right,
+        "MUL",
+        budget,
+        |a, b| a * b,
+        |a, b| a * b,
+        |a, b| a.mul(&b),
+    )
 }
 
+/// Exact division differs from the approximate path in kind, not degree. A
+/// float divided by zero is an IEEE infinity or NaN and stays a tensor
+/// element; a rational divided by zero has no rational value at all, so it is
+/// reported as a contract error instead of being invented.
 pub fn tensor_div(
     left: &Tensor,
     right: &Tensor,
     budget: TensorMemoryBudget,
 ) -> Result<Tensor, TensorOperatorError> {
-    binary(left, right, "DIV", budget, |a, b| a / b, |a, b| a / b)
+    if let TensorData::Q(divisors) = right.data() {
+        // Every element of a broadcast divisor is reached at least once when
+        // the output is non-empty, so a single scan decides this exactly.
+        if !left.shape().dimensions().contains(&0)
+            && !right.shape().dimensions().contains(&0)
+            && divisors.iter().any(Fraction::is_zero)
+        {
+            return Err(TensorOperatorError::ExactDivisionByZero);
+        }
+    }
+    binary(
+        left,
+        right,
+        "DIV",
+        budget,
+        |a, b| a / b,
+        |a, b| a / b,
+        |a, b| a.div(&b),
+    )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn binary(
     left: &Tensor,
     right: &Tensor,
@@ -41,6 +89,7 @@ fn binary(
     budget: TensorMemoryBudget,
     f32_operation: impl Fn(f32, f32) -> f32,
     f64_operation: impl Fn(f64, f64) -> f64,
+    q_operation: impl Fn(Fraction, Fraction) -> Fraction,
 ) -> Result<Tensor, TensorOperatorError> {
     if left.dtype() != right.dtype() {
         return Err(TensorOperatorError::DTypeMismatch {
@@ -67,6 +116,14 @@ fn binary(
             right.shape(),
             &output_shape,
             f64_operation,
+        )),
+        (TensorData::Q(left_data), TensorData::Q(right_data)) => TensorData::Q(binary_data(
+            left_data,
+            right_data,
+            left.shape(),
+            right.shape(),
+            &output_shape,
+            q_operation,
         )),
         _ => unreachable!("dtype equality and numeric dtype were checked"),
     };
@@ -99,7 +156,7 @@ pub(crate) fn broadcast_shape(
     Ok(output)
 }
 
-fn binary_data<T: Copy>(
+fn binary_data<T: Clone>(
     left: &[T],
     right: &[T],
     left_shape: &CheckedShape,
@@ -112,7 +169,7 @@ fn binary_data<T: Copy>(
             let coordinates = unravel(linear, output_shape.dimensions());
             let left_index = broadcast_index(&coordinates, left_shape);
             let right_index = broadcast_index(&coordinates, right_shape);
-            operation(left[left_index], right[right_index])
+            operation(left[left_index].clone(), right[right_index].clone())
         })
         .collect()
 }

--- a/rust/src/tensor_profile/execute.rs
+++ b/rust/src/tensor_profile/execute.rs
@@ -1,6 +1,7 @@
 use super::{
-    graph_operators::reduction_attributes, matmul, reduce_max, reduce_sum, tensor_add, tensor_div,
-    tensor_exp, tensor_log, tensor_mul, tensor_rsqrt, tensor_sub, tensor_where, Graph, GraphType,
+    graph_operators::{reduction_attributes, regrid_denominator},
+    matmul, reduce_max, reduce_sum, tensor_add, tensor_div, tensor_exp, tensor_log, tensor_mul,
+    tensor_regrid, tensor_rsqrt, tensor_sub, tensor_where, Graph, GraphType,
     GraphValidationContext, GraphValidationError, OperatorSemantics, SymbolicDimension, Tensor,
     TensorMemoryBudget, TensorOperatorError,
 };
@@ -128,6 +129,10 @@ pub fn execute_graph(
             OperatorSemantics::Rsqrt => {
                 let input = runtime_value(&values, &node.inputs[0])?;
                 tensor_rsqrt(input, budget)?
+            }
+            OperatorSemantics::Regrid => {
+                let input = runtime_value(&values, &node.inputs[0])?;
+                tensor_regrid(input, &regrid_denominator(node)?, budget)?
             }
             OperatorSemantics::Where => {
                 let predicate = runtime_value(&values, &node.inputs[0])?;

--- a/rust/src/tensor_profile/graph.rs
+++ b/rust/src/tensor_profile/graph.rs
@@ -72,6 +72,7 @@ pub enum OperatorSemantics {
     Exp,
     Log,
     Rsqrt,
+    Regrid,
     ReduceSum,
     ReduceMax,
     Where,
@@ -98,6 +99,8 @@ pub enum GraphValidationError {
     },
     DTypeMismatch(String),
     NonNumericDType(String),
+    ExactDTypeUnsupported(String),
+    ApproximateDTypeUnsupported(String),
     PredicateDTypeMismatch(String),
     ShapeMismatch(String),
     OutputTypeMismatch(String),
@@ -125,6 +128,13 @@ impl fmt::Display for GraphValidationError {
             Self::DTypeMismatch(id) => write!(f, "{id} input dtypes do not match"),
             Self::NonNumericDType(id) => {
                 write!(f, "{id} requires a numeric dtype, received the bool predicate dtype")
+            }
+            Self::ExactDTypeUnsupported(id) => write!(
+                f,
+                "{id} has no exact value for rational inputs, so it is undefined over the exact dtype"
+            ),
+            Self::ApproximateDTypeUnsupported(id) => {
+                write!(f, "{id} is defined only over the exact dtype")
             }
             Self::PredicateDTypeMismatch(id) => {
                 write!(f, "{id} requires a bool predicate input")

--- a/rust/src/tensor_profile/graph_operators.rs
+++ b/rust/src/tensor_profile/graph_operators.rs
@@ -2,6 +2,7 @@ use super::graph::{
     GraphNode, GraphType, GraphValidationError, OperatorSemantics, SymbolicDimension,
 };
 use super::DType;
+use num_bigint::BigInt;
 use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) fn validate_operator(
@@ -12,7 +13,11 @@ pub(crate) fn validate_operator(
     match semantics {
         OperatorSemantics::Matmul => validate_matmul(node, values),
         OperatorSemantics::Exp | OperatorSemantics::Log | OperatorSemantics::Rsqrt => {
-            validate_shape_preserving_unary(node, values)
+            validate_shape_preserving_unary(node, values, DTypeDomain::Approximate)
+        }
+        OperatorSemantics::Regrid => {
+            regrid_denominator(node)?;
+            validate_shape_preserving_unary(node, values, DTypeDomain::Exact)
         }
         OperatorSemantics::ReduceSum | OperatorSemantics::ReduceMax => {
             validate_reduction(node, values)
@@ -25,13 +30,63 @@ pub(crate) fn validate_operator(
     }
 }
 
+/// Which numeric domain an operator's contract is written over.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DTypeDomain {
+    /// Any numeric dtype, exact or approximate.
+    Numeric,
+    /// Approximate only: the operator's value is irrational for rational
+    /// inputs, so there is no exact result to return.
+    Approximate,
+    /// Exact only: the operator acts on a denominator, which the approximate
+    /// dtypes do not have.
+    Exact,
+}
+
 /// The graph validator is the profile's contract certifier, so it — not the
-/// backend — is where a predicate tensor is refused entry to arithmetic.
-fn require_numeric(node: &GraphNode, dtype: DType) -> Result<(), GraphValidationError> {
-    if dtype.is_numeric() {
-        return Ok(());
+/// backend — is where a tensor is refused entry to an operator whose contract
+/// is not written over its dtype. Rejecting here means an unexecutable graph is
+/// never certified as valid in the first place.
+fn require_domain(
+    node: &GraphNode,
+    dtype: DType,
+    domain: DTypeDomain,
+) -> Result<(), GraphValidationError> {
+    if !dtype.is_numeric() {
+        return Err(GraphValidationError::NonNumericDType(node.id.clone()));
     }
-    Err(GraphValidationError::NonNumericDType(node.id.clone()))
+    match domain {
+        DTypeDomain::Numeric => Ok(()),
+        DTypeDomain::Approximate if dtype.is_approximate() => Ok(()),
+        DTypeDomain::Approximate => {
+            Err(GraphValidationError::ExactDTypeUnsupported(node.id.clone()))
+        }
+        DTypeDomain::Exact if dtype.is_exact() => Ok(()),
+        DTypeDomain::Exact => Err(GraphValidationError::ApproximateDTypeUnsupported(
+            node.id.clone(),
+        )),
+    }
+}
+
+fn require_numeric(node: &GraphNode, dtype: DType) -> Result<(), GraphValidationError> {
+    require_domain(node, dtype, DTypeDomain::Numeric)
+}
+
+/// The `denominator` attribute of a `QUANTIZE` node: the grid the operator
+/// rounds onto, and therefore the denominator bound it establishes.
+pub(crate) fn regrid_denominator(node: &GraphNode) -> Result<BigInt, GraphValidationError> {
+    let invalid = || GraphValidationError::InvalidAttribute {
+        node: node.id.clone(),
+        attribute: "denominator".to_owned(),
+    };
+    let denominator = node
+        .attributes
+        .get("denominator")
+        .ok_or_else(invalid)?
+        .as_u64()
+        .filter(|denominator| *denominator > 0)
+        .ok_or_else(invalid)?;
+    Ok(BigInt::from(denominator))
 }
 
 fn validate_elementwise_binary(
@@ -149,6 +204,7 @@ pub(crate) fn reduction_attributes(
 fn validate_shape_preserving_unary(
     node: &GraphNode,
     values: &BTreeMap<String, GraphType>,
+    domain: DTypeDomain,
 ) -> Result<(), GraphValidationError> {
     if node.inputs.len() != 1 || node.outputs.len() != 1 {
         return Err(GraphValidationError::OperatorArity {
@@ -160,7 +216,7 @@ fn validate_shape_preserving_unary(
         });
     }
     let GraphType::Tensor { dtype, .. } = &values[&node.inputs[0]];
-    require_numeric(node, *dtype)?;
+    require_domain(node, *dtype, domain)?;
     if node.outputs[0].value_type != values[&node.inputs[0]] {
         return Err(GraphValidationError::OutputTypeMismatch(node.id.clone()));
     }

--- a/rust/src/tensor_profile/mod.rs
+++ b/rust/src/tensor_profile/mod.rs
@@ -1,7 +1,9 @@
 //! Runtime foundations for the opt-in Ajisai Tensor Profile.
 //!
-//! This module is intentionally separate from [`crate::kernel`]. Approximate
-//! tensors are profile values and never widen Core's exact `Scalar` domain.
+//! This module is intentionally separate from [`crate::kernel`]. Profile
+//! tensors never widen Core's `Scalar` domain — including the exact `q`
+//! tensors, whose elements are Core fractions but whose containing value is a
+//! profile value that Core cannot observe.
 
 mod cpu;
 mod elementwise;
@@ -9,12 +11,13 @@ mod execute;
 mod graph;
 mod graph_operators;
 mod reductions;
+mod regrid;
 mod select;
 mod shape;
 mod tensor;
 
-pub(crate) use cpu::require_numeric;
 pub use cpu::{matmul, tensor_exp, tensor_log, tensor_rsqrt, TensorOperatorError};
+pub(crate) use cpu::{require_exact, require_numeric};
 pub use elementwise::{tensor_add, tensor_div, tensor_mul, tensor_sub};
 pub use execute::{execute_graph, GraphExecutionError};
 pub use graph::{
@@ -22,6 +25,7 @@ pub use graph::{
     GraphValue, OperatorSemantics, SymbolicDimension,
 };
 pub use reductions::{reduce_max, reduce_sum};
+pub use regrid::tensor_regrid;
 pub use select::tensor_where;
 pub use shape::{CheckedShape, ShapeError, TensorMemoryBudget};
 pub use tensor::{DType, Tensor, TensorData, TensorError};
@@ -40,3 +44,6 @@ mod execute_tests;
 
 #[cfg(test)]
 mod composition_tests;
+
+#[cfg(test)]
+mod rational_growth_tests;

--- a/rust/src/tensor_profile/rational_growth_tests.rs
+++ b/rust/src/tensor_profile/rational_growth_tests.rs
@@ -1,0 +1,347 @@
+//! Measurements of the property the denominator growth strategy exists to
+//! control. Exact arithmetic is only usable if representation size stays a
+//! function of the answer rather than of the computation, and these tests
+//! measure that directly instead of asserting it in prose.
+//!
+//! See `docs/dev/rational-tensor-growth-2026-08.md` for the analysis.
+
+use super::*;
+use crate::types::fraction::Fraction;
+use num_bigint::BigInt;
+use std::collections::BTreeMap;
+
+const OPEN: TensorMemoryBudget = TensorMemoryBudget::new(usize::MAX, usize::MAX);
+
+fn q(numerator: i64, denominator: i64) -> Fraction {
+    Fraction::new(BigInt::from(numerator), BigInt::from(denominator))
+}
+
+fn q_tensor(shape: Vec<usize>, values: Vec<Fraction>) -> Tensor {
+    Tensor::new(shape, TensorData::Q(values), OPEN).unwrap()
+}
+
+/// The widest denominator in the tensor, in bits — the representation cost the
+/// strategy is trying to bound.
+fn denominator_bits(tensor: &Tensor) -> u64 {
+    let TensorData::Q(values) = tensor.data() else {
+        panic!("not an exact tensor")
+    };
+    values
+        .iter()
+        .map(|value| value.denominator().bits())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Distinct primes, so no two denominators share a factor and nothing cancels.
+/// This is the generic case for rationals that were never put on a grid.
+const PRIMES: [i64; 64] = [
+    3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+    101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193,
+    197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307,
+    311, 313,
+];
+
+fn ungridded_row(length: usize, offset: usize) -> Vec<Fraction> {
+    (0..length).map(|i| q(1, PRIMES[offset + i])).collect()
+}
+
+/// Numerators over a common denominator `d`: every element is on the grid 1/d.
+fn gridded_row(length: usize, d: i64) -> Vec<Fraction> {
+    (0..length).map(|i| q(2 * (i as i64 % 7) + 1, d)).collect()
+}
+
+fn contraction(left: Vec<Fraction>, right: Vec<Fraction>) -> Tensor {
+    let k = left.len();
+    matmul(
+        &q_tensor(vec![1, k], left),
+        &q_tensor(vec![k, 1], right),
+        OPEN,
+    )
+    .unwrap()
+}
+
+#[test]
+fn exact_arithmetic_has_no_rounding_error_to_be_free_of() {
+    // The float identity that famously fails, and its exact counterpart.
+    assert_ne!(0.1f64 + 0.2f64, 0.3f64);
+    let sum = tensor_add(
+        &q_tensor(vec![1], vec![q(1, 10)]),
+        &q_tensor(vec![1], vec![q(2, 10)]),
+        OPEN,
+    )
+    .unwrap();
+    assert_eq!(sum.data(), &TensorData::Q(vec![q(3, 10)]));
+}
+
+/// Without a shared grid, a contraction's denominator is the product of its
+/// terms' denominators, so representation cost grows with the reduction length.
+#[test]
+fn ungridded_contraction_denominator_grows_with_reduction_length() {
+    let measure =
+        |k: usize| denominator_bits(&contraction(ungridded_row(k, 0), ungridded_row(k, 24)));
+    let (two, eight, twenty_four) = (measure(2), measure(8), measure(24));
+    assert!(
+        two < eight && eight < twenty_four,
+        "expected growth with K, measured {two} < {eight} < {twenty_four}"
+    );
+    // Denominator bits accumulate per term, so the cost is about linear in K.
+    assert!(
+        twenty_four > 8 * two,
+        "K=24 reached only {twenty_four} bits against {two} at K=2"
+    );
+}
+
+/// The core of the strategy. Once both operands are on the grid 1/d, every
+/// product already shares the denominator d², so the sum has denominator d²
+/// whatever the reduction length is — the reduction length drops out.
+#[test]
+fn a_shared_grid_makes_contraction_denominator_independent_of_length() {
+    const D: i64 = 256;
+    let squared_grid_bits = BigInt::from(D * D).bits();
+    for k in [2usize, 8, 32, 64] {
+        let bits = denominator_bits(&contraction(gridded_row(k, D), gridded_row(k, D)));
+        assert!(
+            bits <= squared_grid_bits,
+            "K={k} produced {bits} denominator bits, above the d² bound {squared_grid_bits}"
+        );
+    }
+    // The same contraction length without a shared grid is an order of
+    // magnitude more expensive to represent, and keeps getting worse with K.
+    let gridded = denominator_bits(&contraction(gridded_row(24, D), gridded_row(24, D)));
+    let ungridded = denominator_bits(&contraction(ungridded_row(24, 0), ungridded_row(24, 24)));
+    assert!(
+        ungridded > 10 * gridded,
+        "gridded {gridded} bits vs ungridded {ungridded} bits at K=24"
+    );
+}
+
+/// A grid bounds one contraction, but chaining squares the denominator each
+/// time, so depth alone still runs away. Quantizing per layer is what makes the
+/// cost constant.
+///
+/// The measured growth is milder than the d^(2^L) worst case because a
+/// power-of-two grid lets sums cancel trailing zeros. Milder is not bounded:
+/// the unquantized chain keeps climbing, and only the quantized one holds.
+#[test]
+fn quantizing_each_layer_holds_the_denominator_constant_across_depth() {
+    const D: i64 = 16;
+    const LAYERS: usize = 8;
+    let grid_bits = BigInt::from(D).bits();
+    let weights = q_tensor(vec![2, 2], gridded_row(4, D));
+
+    let mut unquantized = q_tensor(vec![2, 2], gridded_row(4, D));
+    let mut quantized = unquantized.clone();
+    let mut unquantized_bits = vec![denominator_bits(&unquantized)];
+    for _ in 0..LAYERS {
+        unquantized = matmul(&unquantized, &weights, OPEN).unwrap();
+        unquantized_bits.push(denominator_bits(&unquantized));
+
+        quantized = matmul(&quantized, &weights, OPEN).unwrap();
+        quantized = tensor_regrid(&quantized, &BigInt::from(D), OPEN).unwrap();
+        assert!(
+            denominator_bits(&quantized) <= grid_bits,
+            "quantized layer exceeded the declared grid"
+        );
+    }
+    assert!(
+        unquantized_bits.windows(2).all(|pair| pair[1] >= pair[0]),
+        "denominator cost should never fall without quantizing: {unquantized_bits:?}"
+    );
+    assert!(
+        *unquantized_bits.last().unwrap() >= 3 * unquantized_bits[0],
+        "unquantized depth should compound: {unquantized_bits:?}"
+    );
+}
+
+/// Rounding onto a grid of step 1/d moves each element by at most 1/(2d). The
+/// bound is exact and declared, not a statistical expectation.
+#[test]
+fn quantization_error_is_bounded_by_half_a_grid_step() {
+    const D: i64 = 512;
+    let input = q_tensor(vec![8], ungridded_row(8, 0));
+    let rounded = tensor_regrid(&input, &BigInt::from(D), OPEN).unwrap();
+    let (TensorData::Q(before), TensorData::Q(after)) = (input.data(), rounded.data()) else {
+        panic!("dtype changed")
+    };
+    let half_step = q(1, 2 * D);
+    for (original, quantized) in before.iter().zip(after) {
+        assert!(original.sub(quantized).abs() <= half_step);
+    }
+}
+
+/// The enforcement half of the strategy. Exact arithmetic's classic failure
+/// mode is not a wrong answer but an unbounded one: the computation simply
+/// stops finishing. A declared denominator ceiling converts that into a report
+/// naming the operation that overflowed it.
+#[test]
+fn the_denominator_budget_reports_unbounded_growth_instead_of_absorbing_it() {
+    let budget = TensorMemoryBudget::new(usize::MAX, usize::MAX).with_denominator_bits(24);
+    let row = q_tensor(vec![1, 16], ungridded_row(16, 0));
+    let column = q_tensor(vec![16, 1], ungridded_row(16, 16));
+    assert!(matches!(
+        matmul(&row, &column, budget),
+        Err(TensorOperatorError::Tensor(
+            TensorError::DenominatorBudgetExceeded { limit: 24, .. }
+        ))
+    ));
+}
+
+/// The same computation, under the same ceiling, with the strategy applied.
+#[test]
+fn quantizing_keeps_the_same_computation_inside_the_same_ceiling() {
+    const D: i64 = 256;
+    let budget = TensorMemoryBudget::new(usize::MAX, usize::MAX).with_denominator_bits(24);
+    let row = q_tensor(vec![1, 16], gridded_row(16, D));
+    let column = q_tensor(vec![16, 1], gridded_row(16, D));
+    let product = matmul(&row, &column, budget).unwrap();
+    let bounded = tensor_regrid(&product, &BigInt::from(D), budget).unwrap();
+    assert!(denominator_bits(&bounded) <= BigInt::from(D).bits());
+}
+
+/// An exact tensor never carries Core's absence marker: a NIL fraction is not
+/// a number and cannot enter a profile value.
+#[test]
+fn a_nil_fraction_is_refused_entry_to_an_exact_tensor() {
+    assert_eq!(
+        Tensor::new(vec![2], TensorData::Q(vec![q(1, 2), Fraction::nil()]), OPEN),
+        Err(TensorError::NilExactElement(1))
+    );
+}
+
+/// Division by zero is where the exact and approximate domains genuinely
+/// differ: a float gets an infinity that stays in the tensor, a rational has
+/// no value at all and the operation is reported.
+#[test]
+fn exact_division_by_zero_is_reported_rather_than_given_a_value() {
+    assert_eq!(
+        tensor_div(
+            &q_tensor(vec![2], vec![q(1, 1), q(2, 1)]),
+            &q_tensor(vec![2], vec![q(1, 2), q(0, 1)]),
+            OPEN,
+        ),
+        Err(TensorOperatorError::ExactDivisionByZero)
+    );
+}
+
+/// REDUCE_MAX leans on negative infinity as its identity. The rationals have
+/// no such element, so an empty exact slice is reported instead of answered.
+#[test]
+fn an_empty_exact_maximum_has_no_identity_to_return() {
+    let empty = q_tensor(vec![2, 0], vec![]);
+    assert_eq!(
+        reduce_max(&empty, &[1], false, OPEN),
+        Err(TensorOperatorError::EmptyExactReduction {
+            operator: "REDUCE_MAX"
+        })
+    );
+    // A sum does have one, so it answers zero.
+    assert_eq!(
+        reduce_sum(&empty, &[1], false, OPEN).unwrap().data(),
+        &TensorData::Q(vec![q(0, 1), q(0, 1)])
+    );
+}
+
+/// Operators whose value is irrational for rational inputs are undefined over
+/// the exact dtype rather than silently returning an approximation.
+#[test]
+fn transcendental_operators_are_undefined_over_the_exact_dtype() {
+    let input = q_tensor(vec![2], vec![q(1, 2), q(2, 1)]);
+    for (operator, result) in [
+        ("EXP", tensor_exp(&input, OPEN)),
+        ("LOG", tensor_log(&input, OPEN)),
+        ("RSQRT", tensor_rsqrt(&input, OPEN)),
+    ] {
+        assert_eq!(
+            result,
+            Err(TensorOperatorError::ExactDTypeUnsupported {
+                operator,
+                dtype: DType::Q,
+            }),
+            "{operator} should be undefined over Q"
+        );
+    }
+}
+
+/// End to end: the same graph shape with and without a QUANTIZE node, under a
+/// declared denominator ceiling. One completes; the other reports which node
+/// overflowed. This is the strategy as a graph property, not a local trick.
+#[test]
+fn a_graph_stays_inside_its_ceiling_only_when_it_quantizes() {
+    const D: u64 = 64;
+    let budget = TensorMemoryBudget::new(usize::MAX, usize::MAX).with_denominator_bits(13);
+    let exact = |shape: &[usize]| GraphType::Tensor {
+        dtype: DType::Q,
+        shape: shape
+            .iter()
+            .copied()
+            .map(SymbolicDimension::Known)
+            .collect(),
+    };
+    let value = |id: &str, shape: &[usize]| GraphValue {
+        id: id.to_owned(),
+        value_type: exact(shape),
+    };
+    let context = GraphValidationContext {
+        profile_id: "org.ajisai.tensor/0.1".to_owned(),
+        operator_semantics: BTreeMap::from([
+            ("tensor.matmul.v1".to_owned(), OperatorSemantics::Matmul),
+            ("tensor.regrid.v1".to_owned(), OperatorSemantics::Regrid),
+        ]),
+    };
+    let matmul_node = |id: &str, left: &str, right: &str, out: &str| GraphNode {
+        id: id.to_owned(),
+        operator_semantic_id: "tensor.matmul.v1".to_owned(),
+        inputs: vec![left.to_owned(), right.to_owned()],
+        outputs: vec![value(out, &[2, 2])],
+        attributes: BTreeMap::new(),
+    };
+    let quantize_node = |id: &str, input: &str, out: &str| GraphNode {
+        id: id.to_owned(),
+        operator_semantic_id: "tensor.regrid.v1".to_owned(),
+        inputs: vec![input.to_owned()],
+        outputs: vec![value(out, &[2, 2])],
+        attributes: BTreeMap::from([("denominator".to_owned(), serde_json::json!(D))]),
+    };
+    let inputs = BTreeMap::from([
+        (
+            "%activations".to_owned(),
+            q_tensor(vec![2, 2], gridded_row(4, D as i64)),
+        ),
+        (
+            "%weights".to_owned(),
+            q_tensor(vec![2, 2], gridded_row(4, D as i64)),
+        ),
+    ]);
+    let declarations = vec![value("%activations", &[2, 2]), value("%weights", &[2, 2])];
+
+    let unquantized = Graph {
+        schema_version: 1,
+        profiles: vec!["org.ajisai.tensor/0.1".to_owned()],
+        inputs: declarations.clone(),
+        nodes: vec![
+            matmul_node("@layer1", "%activations", "%weights", "%hidden"),
+            matmul_node("@layer2", "%hidden", "%weights", "%output"),
+        ],
+        outputs: vec!["%output".to_owned()],
+        artifacts: vec![],
+    };
+    assert!(matches!(
+        execute_graph(&unquantized, &context, &inputs, budget),
+        Err(GraphExecutionError::Operator(TensorOperatorError::Tensor(
+            TensorError::DenominatorBudgetExceeded { limit: 13, .. }
+        )))
+    ));
+
+    let quantized = Graph {
+        nodes: vec![
+            matmul_node("@layer1", "%activations", "%weights", "%raw1"),
+            quantize_node("@bound1", "%raw1", "%hidden"),
+            matmul_node("@layer2", "%hidden", "%weights", "%raw2"),
+            quantize_node("@bound2", "%raw2", "%output"),
+        ],
+        ..unquantized
+    };
+    let outputs = execute_graph(&quantized, &context, &inputs, budget).unwrap();
+    assert!(denominator_bits(&outputs["%output"]) <= BigInt::from(D).bits());
+}

--- a/rust/src/tensor_profile/reductions.rs
+++ b/rust/src/tensor_profile/reductions.rs
@@ -1,6 +1,8 @@
 use super::{
     require_numeric, CheckedShape, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError,
 };
+use crate::types::fraction::Fraction;
+use num_bigint::BigInt;
 
 pub fn reduce_sum(
     input: &Tensor,
@@ -102,9 +104,67 @@ fn reduce(
                 }
             },
         )),
+        // The approximate reductions lean on ±infinity as an identity element.
+        // The rationals have no such element, so the exact path carries an
+        // explicit "nothing seen yet" instead, and an empty REDUCE_MAX slice
+        // is reported rather than answered with an invented value.
+        (TensorData::Q(values), Reduction::Sum) => TensorData::Q(reduce_exact(
+            values,
+            input.shape(),
+            &output_shape,
+            &axes,
+            keep_dimensions,
+            |accumulated, value| Some(accumulated.map_or(value.clone(), |sum| sum.add(value))),
+            Some(Fraction::new(BigInt::from(0), BigInt::from(1))),
+            operator,
+        )?),
+        (TensorData::Q(values), Reduction::Maximum) => TensorData::Q(reduce_exact(
+            values,
+            input.shape(),
+            &output_shape,
+            &axes,
+            keep_dimensions,
+            |accumulated, value| {
+                Some(match accumulated {
+                    Some(current) if current >= *value => current,
+                    _ => value.clone(),
+                })
+            },
+            None,
+            operator,
+        )?),
         (TensorData::Bool(_), _) => unreachable!("numeric dtype was checked"),
     };
     Tensor::new(output_dimensions, data, budget).map_err(Into::into)
+}
+
+/// The exact counterpart of [`reduce_data`], threading an `Option` accumulator
+/// so a reduction with no identity element can report an empty slice instead
+/// of fabricating one. `empty` supplies the identity where one exists (zero,
+/// for a sum) and is `None` where none does (a maximum).
+#[allow(clippy::too_many_arguments)]
+fn reduce_exact(
+    input: &[Fraction],
+    input_shape: &CheckedShape,
+    output_shape: &CheckedShape,
+    axes: &[usize],
+    keep_dimensions: bool,
+    combine: impl Fn(Option<Fraction>, &Fraction) -> Option<Fraction>,
+    empty: Option<Fraction>,
+    operator: &'static str,
+) -> Result<Vec<Fraction>, TensorOperatorError> {
+    let mut output = vec![None; output_shape.element_count()];
+    for (linear, value) in input.iter().enumerate() {
+        let output_linear = reduced_index(linear, input_shape, output_shape, axes, keep_dimensions);
+        output[output_linear] = combine(output[output_linear].take(), value);
+    }
+    output
+        .into_iter()
+        .map(|slot| {
+            slot.or_else(|| empty.clone())
+                .ok_or(TensorOperatorError::EmptyExactReduction { operator })
+        })
+        .collect()
 }
 
 fn checked_axes(axes: &[usize], rank: usize) -> Result<Vec<usize>, TensorOperatorError> {
@@ -146,25 +206,35 @@ fn reduce_data<T: Copy>(
 ) -> Vec<T> {
     let mut output = vec![identity; output_shape.element_count()];
     for (linear, value) in input.iter().copied().enumerate() {
-        let coordinates = unravel(linear, input_shape.dimensions());
-        let output_coordinates =
-            coordinates
-                .into_iter()
-                .enumerate()
-                .filter_map(|(axis, coordinate)| {
-                    if axes.binary_search(&axis).is_ok() {
-                        keep_dimensions.then_some(0)
-                    } else {
-                        Some(coordinate)
-                    }
-                });
-        let output_linear = output_coordinates
-            .zip(output_shape.row_major_strides())
-            .map(|(coordinate, stride)| coordinate * stride)
-            .sum::<usize>();
+        let output_linear = reduced_index(linear, input_shape, output_shape, axes, keep_dimensions);
         update(&mut output[output_linear], value);
     }
     output
+}
+
+/// Map an input element's linear index to the output slot it reduces into.
+/// Shared by the approximate and exact paths so the two cannot disagree about
+/// which elements belong to the same reduced slice.
+fn reduced_index(
+    linear: usize,
+    input_shape: &CheckedShape,
+    output_shape: &CheckedShape,
+    axes: &[usize],
+    keep_dimensions: bool,
+) -> usize {
+    unravel(linear, input_shape.dimensions())
+        .into_iter()
+        .enumerate()
+        .filter_map(|(axis, coordinate)| {
+            if axes.binary_search(&axis).is_ok() {
+                keep_dimensions.then_some(0)
+            } else {
+                Some(coordinate)
+            }
+        })
+        .zip(output_shape.row_major_strides())
+        .map(|(coordinate, stride)| coordinate * stride)
+        .sum()
 }
 
 fn unravel(mut linear: usize, shape: &[usize]) -> Vec<usize> {

--- a/rust/src/tensor_profile/regrid.rs
+++ b/rust/src/tensor_profile/regrid.rs
@@ -1,0 +1,149 @@
+use super::{require_exact, Tensor, TensorData, TensorMemoryBudget, TensorOperatorError};
+use crate::types::fraction::{Fraction, RoundingMode};
+use num_bigint::BigInt;
+
+/// The tie rule is inherited from Core's `QUANTIZE`, which rounds halves away
+/// from zero to match `ROUND`. A language should not hold two tie rules, so the
+/// tensor operator does not introduce a second one.
+const TIE_RULE: RoundingMode = RoundingMode::HalfAway;
+
+/// Reference implementation of `tensor.regrid.v1`: round every element to the
+/// nearest multiple of `1/denominator`.
+///
+/// This is the profile's denominator growth strategy, and it is the tensor
+/// lifting of Core's `QUANTIZE` word. Exact arithmetic pays for exactness in
+/// representation size: a rational's denominator records the whole history of
+/// the computation that produced it, so a chain of operations grows one without
+/// bound. Rounding back onto a declared grid keeps the representation the size
+/// of the answer rather than the size of the computation.
+///
+/// Two properties make it worth doing at tensor rank rather than element by
+/// element:
+///
+/// - Once every element of both operands shares the grid `1/d`, a contraction
+///   of length `K` sums terms that already share the denominator `d²`. The
+///   result's denominator is `d²` **whatever `K` is** — the reduction length
+///   drops out. Without a shared grid the denominators are generically coprime
+///   and the contraction's denominator is their product, which grows with `K`.
+/// - Applying it once per layer holds the denominator at `d` across depth, so
+///   representation size stops depending on how deep the graph is.
+///
+/// Rounding is exact and fully specified, so every backend must produce the
+/// identical rational. That is the property the approximate dtypes cannot
+/// offer, and the reason an exact graph is reproducible rather than merely
+/// accurate.
+pub fn tensor_regrid(
+    input: &Tensor,
+    denominator: &BigInt,
+    budget: TensorMemoryBudget,
+) -> Result<Tensor, TensorOperatorError> {
+    require_exact("REGRID", input.dtype())?;
+    if denominator <= &BigInt::from(0) {
+        return Err(TensorOperatorError::NonPositiveDenominator);
+    }
+    let TensorData::Q(values) = input.data() else {
+        unreachable!("exact dtype was checked")
+    };
+    let step = Fraction::new(BigInt::from(1), denominator.clone());
+    let quantized = values
+        .iter()
+        .map(|value| value.quantize(&step, TIE_RULE).0)
+        .collect();
+    Tensor::new(
+        input.shape().dimensions().to_vec(),
+        TensorData::Q(quantized),
+        budget,
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tensor_profile::DType;
+
+    const OPEN: TensorMemoryBudget = TensorMemoryBudget::new(usize::MAX, usize::MAX);
+
+    fn q(numerator: i64, denominator: i64) -> Fraction {
+        Fraction::new(BigInt::from(numerator), BigInt::from(denominator))
+    }
+
+    fn q_tensor(shape: Vec<usize>, values: Vec<Fraction>) -> Tensor {
+        Tensor::new(shape, TensorData::Q(values), OPEN).unwrap()
+    }
+
+    #[test]
+    fn rounds_every_element_onto_the_declared_grid() {
+        let input = q_tensor(vec![3], vec![q(119, 125), q(32, 125), q(-119, 125)]);
+        let result = tensor_regrid(&input, &BigInt::from(10), OPEN).unwrap();
+        let TensorData::Q(values) = result.data() else {
+            panic!("dtype changed")
+        };
+        // 0.952 -> 10/10, 0.256 -> 3/10, -0.952 -> -10/10.
+        assert_eq!(values, &vec![q(1, 1), q(3, 10), q(-1, 1)]);
+    }
+
+    #[test]
+    fn every_result_denominator_divides_the_grid() {
+        let input = q_tensor(vec![4], vec![q(1, 7), q(2, 11), q(5, 13), q(9, 17)]);
+        let result = tensor_regrid(&input, &BigInt::from(64), OPEN).unwrap();
+        let TensorData::Q(values) = result.data() else {
+            panic!("dtype changed")
+        };
+        for value in values {
+            assert_eq!(BigInt::from(64) % value.denominator(), BigInt::from(0));
+        }
+    }
+
+    #[test]
+    fn ties_round_away_from_zero_exactly_as_core_quantize_does() {
+        let input = q_tensor(vec![2], vec![q(1, 2), q(-1, 2)]);
+        let result = tensor_regrid(&input, &BigInt::from(1), OPEN).unwrap();
+        assert_eq!(result.data(), &TensorData::Q(vec![q(1, 1), q(-1, 1)]));
+    }
+
+    #[test]
+    fn error_is_bounded_by_half_a_grid_step() {
+        let denominator = BigInt::from(1000);
+        let input = q_tensor(vec![3], vec![q(1, 7), q(22, 7), q(-355, 113)]);
+        let result = tensor_regrid(&input, &denominator, OPEN).unwrap();
+        let (TensorData::Q(before), TensorData::Q(after)) = (input.data(), result.data()) else {
+            panic!("dtype changed")
+        };
+        let half_step = q(1, 2000);
+        for (original, rounded) in before.iter().zip(after) {
+            assert!(original.sub(rounded).abs() <= half_step);
+        }
+    }
+
+    #[test]
+    fn quantizing_is_idempotent_on_its_own_grid() {
+        let input = q_tensor(vec![3], vec![q(1, 3), q(2, 7), q(9, 11)]);
+        let once = tensor_regrid(&input, &BigInt::from(128), OPEN).unwrap();
+        let twice = tensor_regrid(&once, &BigInt::from(128), OPEN).unwrap();
+        assert_eq!(once.data(), twice.data());
+    }
+
+    #[test]
+    fn rejects_a_non_positive_denominator() {
+        let input = q_tensor(vec![1], vec![q(1, 3)]);
+        for denominator in [BigInt::from(0), BigInt::from(-8)] {
+            assert_eq!(
+                tensor_regrid(&input, &denominator, OPEN),
+                Err(TensorOperatorError::NonPositiveDenominator)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_an_approximate_input_that_has_no_denominator_to_bound() {
+        let input = Tensor::new(vec![2], TensorData::F32(vec![0.5, 0.25]), OPEN).unwrap();
+        assert_eq!(
+            tensor_regrid(&input, &BigInt::from(4), OPEN),
+            Err(TensorOperatorError::ApproximateDTypeUnsupported {
+                operator: "REGRID",
+                dtype: DType::F32,
+            })
+        );
+    }
+}

--- a/rust/src/tensor_profile/select.rs
+++ b/rust/src/tensor_profile/select.rs
@@ -71,7 +71,7 @@ pub fn tensor_where(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn select<T: Copy>(
+fn select<T: Clone>(
     mask: &[bool],
     on_true: &[T],
     on_false: &[T],
@@ -84,9 +84,9 @@ fn select<T: Copy>(
         .map(|linear| {
             let coordinates = unravel(linear, output_shape.dimensions());
             if mask[broadcast_index(&coordinates, predicate_shape)] {
-                on_true[broadcast_index(&coordinates, true_shape)]
+                on_true[broadcast_index(&coordinates, true_shape)].clone()
             } else {
-                on_false[broadcast_index(&coordinates, false_shape)]
+                on_false[broadcast_index(&coordinates, false_shape)].clone()
             }
         })
         .collect()

--- a/rust/src/tensor_profile/shape.rs
+++ b/rust/src/tensor_profile/shape.rs
@@ -1,17 +1,40 @@
 use std::fmt;
 
 /// Host/device allocation ceilings used before a tensor buffer is allocated.
+///
+/// `max_elements` and `max_bytes` bound how many elements a tensor has and how
+/// much room their fixed-width parts occupy. `max_denominator_bits` bounds
+/// something the other two cannot see: an exact rational element's denominator
+/// lives on the heap and grows with the *length of the computation* that
+/// produced it, not with the tensor's shape. Without a ceiling on it, an
+/// unquantized exact graph does not fail — it slows to a halt inside bignum
+/// arithmetic. Bounding it turns that into a reported contract failure naming
+/// the node that overflowed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TensorMemoryBudget {
     pub max_elements: usize,
     pub max_bytes: usize,
+    pub max_denominator_bits: u64,
 }
 
 impl TensorMemoryBudget {
+    /// A budget with no denominator ceiling. Approximate dtypes have
+    /// fixed-width elements, so they never need one.
     pub const fn new(max_elements: usize, max_bytes: usize) -> Self {
         Self {
             max_elements,
             max_bytes,
+            max_denominator_bits: u64::MAX,
+        }
+    }
+
+    /// Bound the denominator of every exact rational element. This is the
+    /// enforcement half of the growth strategy: the graph must quantize often
+    /// enough to stay under the ceiling it declared.
+    pub const fn with_denominator_bits(self, max_denominator_bits: u64) -> Self {
+        Self {
+            max_denominator_bits,
+            ..self
         }
     }
 }

--- a/rust/src/tensor_profile/tensor.rs
+++ b/rust/src/tensor_profile/tensor.rs
@@ -1,4 +1,5 @@
 use super::{CheckedShape, ShapeError, TensorMemoryBudget};
+use crate::types::fraction::Fraction;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -7,6 +8,12 @@ use std::fmt;
 pub enum DType {
     F32,
     F64,
+    /// The exact rational dtype. Elements are Core fractions, so every
+    /// arithmetic result is the mathematically exact value rather than a
+    /// rounded one — and the price is that a denominator records the whole
+    /// history of the computation that produced it. `REGRID` is what pays that
+    /// price down; see `docs/dev/rational-tensor-growth-2026-08.md`.
+    Q,
     /// The predicate dtype. It carries selection decisions such as attention
     /// masks; it is not a numeric element type and no arithmetic operator
     /// accepts it.
@@ -14,19 +21,39 @@ pub enum DType {
 }
 
 impl DType {
+    /// The fixed-width footprint of one element. For `Q` this is the element
+    /// handle only: an exact rational's magnitude lives on the heap and is
+    /// bounded by `TensorMemoryBudget::max_denominator_bits` instead, because
+    /// it is a function of the computation rather than of the shape.
     pub const fn element_bytes(self) -> usize {
         match self {
             Self::F32 => 4,
             Self::F64 => 8,
+            Self::Q => core::mem::size_of::<Fraction>(),
             Self::Bool => 1,
         }
     }
 
-    /// Whether this dtype names an approximate floating-point element type.
+    /// Whether this dtype names an element type arithmetic is defined over.
     /// The profile forbids implicit casts, so a predicate never silently
     /// becomes a number and a number never silently becomes a predicate.
     pub const fn is_numeric(self) -> bool {
-        matches!(self, Self::F32 | Self::F64)
+        matches!(self, Self::F32 | Self::F64 | Self::Q)
+    }
+
+    /// Whether results in this dtype are exact. Operators whose value is
+    /// irrational for rational inputs — `EXP`, `LOG`, `RSQRT` — are defined
+    /// only over the approximate dtypes, since there is no exact rational to
+    /// return and silently returning an approximate one would be the implicit
+    /// conversion this profile forbids.
+    pub const fn is_exact(self) -> bool {
+        matches!(self, Self::Q)
+    }
+
+    /// Whether this dtype is numeric and inexact, i.e. carries a declared
+    /// tolerance rather than an exact value.
+    pub const fn is_approximate(self) -> bool {
+        self.is_numeric() && !self.is_exact()
     }
 }
 
@@ -34,6 +61,7 @@ impl DType {
 pub enum TensorData {
     F32(Vec<f32>),
     F64(Vec<f64>),
+    Q(Vec<Fraction>),
     Bool(Vec<bool>),
 }
 
@@ -42,6 +70,7 @@ impl TensorData {
         match self {
             Self::F32(_) => DType::F32,
             Self::F64(_) => DType::F64,
+            Self::Q(_) => DType::Q,
             Self::Bool(_) => DType::Bool,
         }
     }
@@ -50,12 +79,28 @@ impl TensorData {
         match self {
             Self::F32(values) => values.len(),
             Self::F64(values) => values.len(),
+            Self::Q(values) => values.len(),
             Self::Bool(values) => values.len(),
+        }
+    }
+
+    /// The widest denominator carried by any element, in bits. Zero for the
+    /// approximate dtypes, whose elements have no denominator.
+    fn widest_denominator_bits(&self) -> u64 {
+        match self {
+            Self::Q(values) => values
+                .iter()
+                .map(|value| value.denominator().bits())
+                .max()
+                .unwrap_or(0),
+            _ => 0,
         }
     }
 }
 
-/// An immutable, explicitly approximate Tensor Profile value.
+/// An immutable Tensor Profile value. Whether its elements are approximate
+/// or exact is carried by the dtype; either way it is a profile value and
+/// never a Core one.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Tensor {
     dtype: DType,
@@ -67,6 +112,8 @@ pub struct Tensor {
 pub enum TensorError {
     Shape(ShapeError),
     ElementCountMismatch { expected: usize, actual: usize },
+    DenominatorBudgetExceeded { requested: u64, limit: u64 },
+    NilExactElement(usize),
 }
 
 impl fmt::Display for TensorError {
@@ -79,6 +126,14 @@ impl fmt::Display for TensorError {
                     "tensor shape requires {expected} elements, received {actual}"
                 )
             }
+            Self::DenominatorBudgetExceeded { requested, limit } => write!(
+                f,
+                "exact element denominator needs {requested} bits, exceeding the limit of {limit}; regrid earlier in the graph"
+            ),
+            Self::NilExactElement(index) => write!(
+                f,
+                "exact tensor element {index} is NIL, which is Core absence rather than a number"
+            ),
         }
     }
 }
@@ -103,6 +158,24 @@ impl Tensor {
             return Err(TensorError::ElementCountMismatch {
                 expected: shape.element_count(),
                 actual: data.len(),
+            });
+        }
+        // A NIL fraction is Core's absence marker, not a number. Admitting one
+        // here would smuggle a Core value domain into a profile tensor, which
+        // is exactly the boundary this module exists to hold.
+        if let TensorData::Q(values) = &data {
+            if let Some(index) = values.iter().position(Fraction::is_nil) {
+                return Err(TensorError::NilExactElement(index));
+            }
+        }
+        // Every operator publishes its result through this constructor, so
+        // checking here is what makes the denominator ceiling unskippable: no
+        // exact tensor can exist without having passed it.
+        let denominator_bits = data.widest_denominator_bits();
+        if denominator_bits > budget.max_denominator_bits {
+            return Err(TensorError::DenominatorBudgetExceeded {
+                requested: denominator_bits,
+                limit: budget.max_denominator_bits,
             });
         }
         Ok(Self { dtype, shape, data })

--- a/scripts/check-tensor-profile.mjs
+++ b/scripts/check-tensor-profile.mjs
@@ -10,6 +10,7 @@ const referenceCpu = readFileSync('rust/src/tensor_profile/cpu.rs', 'utf8');
 const reductions = readFileSync('rust/src/tensor_profile/reductions.rs', 'utf8');
 const elementwise = readFileSync('rust/src/tensor_profile/elementwise.rs', 'utf8');
 const select = readFileSync('rust/src/tensor_profile/select.rs', 'utf8');
+const regrid = readFileSync('rust/src/tensor_profile/regrid.rs', 'utf8');
 const graphOperators = readFileSync('rust/src/tensor_profile/graph_operators.rs', 'utf8');
 const graphExample = JSON.parse(readFileSync('spec/examples/tiny-matmul.graph.json', 'utf8'));
 const errors = [];
@@ -29,7 +30,25 @@ for (const dtype of [...profile.dtypes, profile.predicateDtype]) {
 // mechanically keeps it there: `is_numeric` must exclude it, and both the
 // graph validator and the reference backend must refuse it for arithmetic.
 if (profile.dtypes.includes(profile.predicateDtype)) fail('the predicate dtype must not be listed as a numeric dtype');
-if (!/pub const fn is_numeric\(self\) -> bool \{\s*matches!\(self, Self::F32 \| Self::F64\)/.test(runtimeDtypes)) fail('runtime DType::is_numeric does not exclude the predicate dtype');
+if (!/pub const fn is_numeric\(self\) -> bool \{\s*matches!\(self, ([^)]*)\)/.test(runtimeDtypes)) fail('runtime DType::is_numeric is not a simple dtype list');
+else {
+  const numericVariants = runtimeDtypes.match(/pub const fn is_numeric\(self\) -> bool \{\s*matches!\(self, ([^)]*)\)/)[1].split('|').map((v) => v.trim().replace('Self::', '').toLowerCase());
+  const predicateVariant = profile.predicateDtype;
+  if (numericVariants.includes(predicateVariant)) fail('runtime DType::is_numeric does not exclude the predicate dtype');
+  for (const dtype of profile.dtypes) if (!numericVariants.includes(dtype)) fail(`runtime DType::is_numeric omits the declared numeric dtype ${dtype}`);
+}
+// Exactness must be a property of the dtype, not a convention: the domain each
+// operator is written over is declared, and the runtime must gate on it.
+if (!/pub const fn is_exact\(self\) -> bool/.test(runtimeDtypes)) fail('runtime DType does not distinguish exact from approximate dtypes');
+if (!referenceCpu.includes('pub(crate) fn require_approximate(')) fail('reference CPU backend does not gate approximate-only operators');
+if (!referenceCpu.includes('pub(crate) fn require_exact(')) fail('reference CPU backend does not gate exact-only operators');
+if (!graphOperators.includes('fn require_domain(')) fail('graph validation does not gate operators on their declared dtype domain');
+if (!regrid.includes('pub fn tensor_regrid(')) fail('reference CPU backend is missing REGRID');
+for (const operator of profile.operators) {
+  if (operator.dtypeDomain === 'exact' && operator.differentiation.kind !== 'none') fail(`${operator.name} rounds onto a grid, so it cannot declare a VJP`);
+}
+if (!profile.dtypes.some((dtype) => dtype === 'q')) fail('the profile declares no exact dtype for the growth strategy to bound');
+if (!/max_denominator_bits/.test(readFileSync('rust/src/tensor_profile/shape.rs', 'utf8'))) fail('the memory budget carries no denominator ceiling');
 if (!referenceCpu.includes('pub(crate) fn require_numeric(')) fail('reference CPU backend does not gate numeric operators on dtype');
 if (!graphOperators.includes('fn require_numeric(')) fail('graph validation does not gate numeric operators on dtype');
 

--- a/spec/tensor-profile-v0.1.json
+++ b/spec/tensor-profile-v0.1.json
@@ -4,7 +4,8 @@
   "status": "draft",
   "dtypes": [
     "f32",
-    "f64"
+    "f64",
+    "q"
   ],
   "predicateDtype": "bool",
   "rounding": "nearestTiesToEven",
@@ -22,6 +23,7 @@
       ],
       "shape": "output=input",
       "dtype": "D is explicit; Scalar conversion is IEEE-754 nearestTiesToEven",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "ieee754",
@@ -49,6 +51,7 @@
       ],
       "shape": "product(S)=product(T)",
       "dtype": "preserve",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "identity",
@@ -76,6 +79,7 @@
       ],
       "shape": "P is a permutation of axes(S)",
       "dtype": "preserve",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "identity",
@@ -103,6 +107,7 @@
       ],
       "shape": "leading axes broadcast; contraction K must match",
       "dtype": "inputs and output share D",
+      "dtypeDomain": "any",
       "determinism": "bounded",
       "numeric": {
         "model": "ieee754OrderedReduction",
@@ -129,6 +134,7 @@
       ],
       "shape": "A contains unique in-range axes",
       "dtype": "preserve",
+      "dtypeDomain": "any",
       "determinism": "bounded",
       "numeric": {
         "model": "ieee754OrderedReduction",
@@ -159,6 +165,7 @@
       ],
       "shape": "A contains unique in-range axes",
       "dtype": "preserve",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "ieee754Maximum",
@@ -189,6 +196,7 @@
       ],
       "shape": "preserve",
       "dtype": "preserve",
+      "dtypeDomain": "approximate",
       "determinism": "bounded",
       "numeric": {
         "model": "correctlyRoundedOrBounded",
@@ -215,6 +223,7 @@
       ],
       "shape": "preserve",
       "dtype": "preserve",
+      "dtypeDomain": "approximate",
       "determinism": "bounded",
       "numeric": {
         "model": "ieee754Log",
@@ -241,6 +250,7 @@
       ],
       "shape": "preserve",
       "dtype": "preserve",
+      "dtypeDomain": "approximate",
       "determinism": "bounded",
       "numeric": {
         "model": "ieee754ReciprocalSqrt",
@@ -269,6 +279,7 @@
       ],
       "shape": "all inputs broadcast-compatible",
       "dtype": "value inputs and output share D",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "selection",
@@ -297,6 +308,7 @@
       ],
       "shape": "explicit S",
       "dtype": "explicit D",
+      "dtypeDomain": "approximate",
       "determinism": "bitwise",
       "numeric": {
         "model": "counterBasedUniform01",
@@ -324,6 +336,7 @@
       ],
       "shape": "output length=count",
       "dtype": "not applicable",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "cryptographicHashDerivation",
@@ -351,6 +364,7 @@
       ],
       "shape": "all dimensions broadcast-compatible from the trailing axis",
       "dtype": "inputs and output share D",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "ieee754Elementwise+",
@@ -378,6 +392,7 @@
       ],
       "shape": "all dimensions broadcast-compatible from the trailing axis",
       "dtype": "inputs and output share D",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "ieee754Elementwise-",
@@ -405,6 +420,7 @@
       ],
       "shape": "all dimensions broadcast-compatible from the trailing axis",
       "dtype": "inputs and output share D",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "ieee754Elementwise*",
@@ -432,6 +448,7 @@
       ],
       "shape": "all dimensions broadcast-compatible from the trailing axis",
       "dtype": "inputs and output share D",
+      "dtypeDomain": "any",
       "determinism": "bitwise",
       "numeric": {
         "model": "ieee754Elementwise/",
@@ -441,6 +458,34 @@
       "differentiation": {
         "kind": "vjp",
         "rule": "div_vjp_v1"
+      },
+      "resource": {
+        "compute": "O(n)",
+        "memory": "O(n)"
+      }
+    },
+    {
+      "name": "REGRID",
+      "semanticId": "tensor.regrid.v1",
+      "inputs": [
+        "Tensor<q,S>",
+        "Denominator<d>"
+      ],
+      "outputs": [
+        "Tensor<q,S>"
+      ],
+      "shape": "preserve",
+      "dtype": "preserve",
+      "dtypeDomain": "exact",
+      "determinism": "bitwise",
+      "numeric": {
+        "model": "exactRationalGridRounding",
+        "absoluteTolerance": 0,
+        "relativeTolerance": 0
+      },
+      "differentiation": {
+        "kind": "none",
+        "rule": null
       },
       "resource": {
         "compute": "O(n)",

--- a/spec/tensor-profile-v0.1.md
+++ b/spec/tensor-profile-v0.1.md
@@ -21,13 +21,30 @@ a finite sequence of non-negative dimensions and elements are stored in
 row-major logical order. Device, allocation, strides, layout, fusion, and
 backend are execution properties, not value identity.
 
-Profile 0.1 supports the numeric dtypes `f32` and `f64`, plus the separate
-predicate dtype `bool`. A predicate carries selection decisions such as an
-attention mask; it is not a numeric element type, and every arithmetic and
-reduction operator rejects it rather than reading a number as truthy or a
-predicate as zero-or-one. An exact Core Scalar enters the approximate domain
-only through `CAST`; no operator performs an implicit Scalar-to-Tensor or dtype
-conversion. `CAST` uses IEEE-754 round-to-nearest, ties-to-even.
+Profile 0.1 supports the approximate numeric dtypes `f32` and `f64`, the exact
+numeric dtype `q`, and the separate predicate dtype `bool`. A predicate carries
+selection decisions such as an attention mask; it is not a numeric element
+type, and every arithmetic and reduction operator rejects it rather than
+reading a number as truthy or a predicate as zero-or-one. An exact Core Scalar
+enters the approximate domain only through `CAST`; no operator performs an
+implicit Scalar-to-Tensor or dtype conversion. `CAST` uses IEEE-754
+round-to-nearest, ties-to-even.
+
+`q` elements are exact rationals. They are the same numbers Core computes with,
+so an exact tensor result is the mathematically exact value and every backend
+must produce the identical rational — there is nothing left for a backend to
+decide. A `q` element is never `NIL`: `NIL` is Core's absence marker, not a
+number, and an exact tensor carrying one is a contract error rather than a
+value.
+
+Each operator declares the numeric domain its contract is written over, as
+`dtypeDomain`. `approximate` means the operator's value is irrational for
+rational inputs, so there is no exact result to return; `exact` means it acts
+on a denominator, which the approximate dtypes do not have; `any` means both.
+For an `any` operator the declared numeric tolerances describe approximate
+evaluation only — exact evaluation is bitwise by construction. Both the graph
+validator and the reference backend reject a dtype outside an operator's
+declared domain, so an unexecutable graph is never certified as valid.
 
 Tensor NaN and infinities are floating-point elements, not `NIL`. A resource
 budget failure produces `NIL(spaceExhausted)`. A malformed dtype, rank, axis, or
@@ -106,9 +123,46 @@ the dtype, and either removes reduced axes or replaces them with dimension one.
 and uses negative infinity as the identity for an empty reduced slice.
 
 `tensor.add.v1`, `tensor.sub.v1`, `tensor.mul.v1`, and `tensor.div.v1` are
-elementwise IEEE operations. Inputs must share a dtype; shapes broadcast from
-the trailing axis using equality-or-one, with no implicit cast. Division by
-zero produces IEEE infinity or NaN inside the Tensor rather than NIL.
+elementwise operations. Inputs must share a dtype; shapes broadcast from the
+trailing axis using equality-or-one, with no implicit cast. Over an approximate
+dtype they are IEEE operations and division by zero produces IEEE infinity or
+NaN inside the Tensor rather than NIL. Over `q` they are exact, and division by
+zero is a contract error: a rational divided by zero has no rational value, so
+none is invented. `tensor.reduce_max.v1` differs for the same reason — the
+approximate path uses negative infinity as the identity of an empty slice, and
+the rationals have no such element, so an empty exact maximum is reported
+rather than answered.
+
+## Bounding exact representation size
+
+An exact rational records the whole history of the computation that produced
+it: denominators multiply under both addition and multiplication, so a chain of
+operations grows one without bound. This is a representation-size problem, not
+an accuracy problem, and Profile 0.1 addresses it explicitly.
+
+`tensor.regrid.v1` rounds every element of a `q` tensor to the nearest multiple
+of `1/d`, where the required `denominator` attribute is a positive integer `d`.
+It is the tensor lifting of Core's `QUANTIZE` word and inherits its tie rule,
+halves away from zero. Rounding is exact and fully specified, so the operator is
+`bitwise` deterministic; each element moves by at most `1/(2d)`.
+
+Two properties make it the profile's growth strategy rather than a convenience.
+Once every element of both operands of a contraction lies on the grid `1/d`,
+each product already carries the denominator `d²`, so the contraction's
+denominator is `d²` regardless of the reduction length — the length drops out.
+Applying `REGRID` once per layer then holds the denominator at `d` across
+depth. Representation size therefore stops depending on either the width or the
+depth of the graph.
+
+`REGRID` declares no VJP. Rounding to a grid has zero derivative almost
+everywhere, and a straight-through estimator is a different function; treating
+one as the other would make a gradient graph disagree with its forward graph,
+so it requires its own contract.
+
+Denominator size is a budgeted resource alongside element and byte counts.
+Every tensor is checked against the declared ceiling as it is constructed, so a
+graph that does not regrid often enough reports the operation that exceeded it
+instead of continuing into unbounded arithmetic.
 
 Numerically stable softmax is intentionally a library graph composition:
 REDUCE_MAX with retained axes, subtraction, EXP, REDUCE_SUM with retained axes,

--- a/spec/tensor-profile.schema.json
+++ b/spec/tensor-profile.schema.json
@@ -33,6 +33,7 @@
         "enum": [
           "f32",
           "f64",
+          "q",
           "bf16",
           "f16",
           "i8"
@@ -77,6 +78,7 @@
         "outputs",
         "shape",
         "dtype",
+        "dtypeDomain",
         "determinism",
         "numeric",
         "differentiation",
@@ -112,6 +114,14 @@
         "dtype": {
           "type": "string",
           "minLength": 1
+        },
+        "dtypeDomain": {
+          "description": "Which numeric domain the operator contract is written over. \"approximate\" means the value is irrational for rational inputs, so there is no exact result to return; \"exact\" means the operator acts on a denominator, which the approximate dtypes do not have; \"any\" means both. For \"any\" operators the declared numeric tolerances describe approximate evaluation only — exact evaluation is bitwise by construction.",
+          "enum": [
+            "any",
+            "approximate",
+            "exact"
+          ]
         },
         "determinism": {
           "enum": [


### PR DESCRIPTION
## Summary

The denominator growth strategy for exact rational tensors, plus the `q` dtype it operates on.

**Why exactness, given the purpose.** The LLM work exists to give Ajisai a completely free surface syntax — free-form input mapped to a canonical program by a learned front end. That makes the model part of the language, and it changes what good numerics means. A syntax front end must be *specifiable*; a declared float tolerance is exactly what a parser cannot have, because two programs are not "within 1e-6" of each other. Exact rationals buy **reproducibility rather than accuracy**, and reproducibility is the property this goal actually needs: every backend must produce the identical rational because nothing is left for a backend to decide.

**The price, measured.** Denominators multiply under both addition and multiplication, so a rational records the whole history of the computation that produced it. An ungridded contraction of length K reaches 14 / 70 / 221 denominator bits at K = 2 / 8 / 32 — linear in K — and depth compounds it. Exact arithmetic's characteristic failure is not a wrong answer but an unbounded one: the program stops finishing rather than failing, which is indistinguishable from slowness.

**The strategy, in three parts.**

1. **A shared grid removes the dependence on reduction length.** Once both operands lie on the grid `1/d`, every product already carries the denominator `d²`, so the contraction's denominator is `d²` whatever K is — the reduction length drops out. Measured at `d = 256`: 16 / 14 / 13 / 13 bits at K = 2 / 8 / 32 / 64, against an ungridded column that keeps climbing. Notably this does *not* require a power-of-two grid; sharing the denominator is what matters, and the grid's fineness is an independent choice.
2. **`REGRID` (`tensor.regrid.v1`) removes the dependence on depth.** Rounding back onto `1/d` after each layer holds the cost at `d → d² → d`. Over 8 chained matmuls the unregridded denominator runs 5, 6, 10, 11, 15, 16, 20, 21, 25 bits and keeps going; the regridded chain holds at 5.
3. **Denominator bits become a budgeted resource**, checked in `Tensor::new` — which every operator publishes its result through, making the ceiling unskippable. A graph that under-regrids now reports the node that overflowed instead of disappearing into bignum arithmetic.

`REGRID` is the tensor lifting of Core's `QUANTIZE` word and inherits its tie rule (halves away from zero) so the language does not hold two. It carries a different name only because the profile checker forbids operator names colliding with frozen Core vocabulary — the collision was caught by that guard, and the guard was respected rather than weakened.

**Supporting work.**

- The `q` dtype, with exact ADD/SUB/MUL/DIV, MATMUL, reductions and WHERE reusing the *same* broadcast/contraction/reduction kernels as the approximate path (relaxed from `Copy` to `Clone`), so the two cannot drift.
- A declared `dtypeDomain` per operator (`any` / `approximate` / `exact`), gated in both the graph validator and the backend. `EXP`/`LOG`/`RSQRT` reject `q` rather than silently returning an approximation, which would be the implicit conversion the profile forbids.
- The exact-domain boundaries that differ **in kind** from the float path: division by zero and empty `REDUCE_MAX` are reported, because the rationals have no infinity to return; and a NIL fraction is refused entry to an exact tensor, because NIL is Core absence rather than a number.
- `REGRID` declares no VJP: rounding to a grid has zero derivative almost everywhere, and a straight-through estimator is a different function that needs its own contract.

## Quality Classification

- Highest impacted level: **QL-C** — opt-in profile surface only. No change to Core semantics, the kernel, or the frozen Word set; `Fraction` is reused as a representation without widening Core's `Scalar` domain.

## Traceability

- Requirement(s): new operator contract `tensor.regrid.v1` and the `q` dtype in `spec/tensor-profile-v0.1.json`; analysis and open problems in `docs/dev/rational-tensor-growth-2026-08.md`.
- Verification evidence:
  - `rust/src/tensor_profile/rational_growth_tests.rs` — the growth measurements themselves: K-independence under a shared grid, depth-independence under `REGRID`, the ungridded contrast, the half-grid-step error bound, budget enforcement, and an end-to-end graph pair that differs only by its `REGRID` nodes.
  - `rust/src/tensor_profile/regrid.rs` — grid membership, tie rule matching Core, idempotence, error bound, rejections.
  - `scripts/check-tensor-profile.mjs` — extended to verify the runtime dtype classification matches the declared `dtypes`/`predicateDtype`, that both domain gates exist in validator and backend, that an `exact`-domain operator declares no VJP, and that the budget carries a denominator ceiling.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated (`spec/tensor-profile-v0.1.md`, `docs/dev/rational-tensor-growth-2026-08.md`).
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — 14 test binaries green, 0 failures
- [ ] `npm run check` — not applicable; no TypeScript changed. (Not runnable in this environment: dependencies are not installed.)
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not run; coverage instrumentation unavailable in this environment.
- [x] MC/DC-like checklist reviewed for modified boolean logic — the new decisions are the three-way dtype domain gate (`is_numeric` / `is_exact` / `is_approximate`), the NIL and denominator-ceiling guards in `Tensor::new`, and the exact division-by-zero and empty-reduction checks. Each branch has a dedicated test.
- [x] Release checklist impact considered — draft profile surface, no Core or frozen-vocabulary impact.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

Other repository guards run clean: `check:tensor-profile`, `check:file-size`, `check:reading-surfaces`, `check:semantic-firewall`, `specification:check`, `check:minimal-core`.

**Known gap, recorded rather than hidden:** transcendentals block a fully exact Transformer. Softmax needs `exp`, which is irrational for rational inputs, so `EXP`/`LOG`/`RSQRT` remain approximate-only. Closing this needs an operator contract carrying a *declared precision* (e.g. the best rational approximation of `exp(x)` with denominator at most `d`, by a specified series with a proven truncation bound) — a new contract rather than an extension of an existing one. Worth noting for the free-syntax goal specifically: the decode step needs only `argmax` over logits, which is exact over `q`; it is the softmax inside attention, not the output token choice, that currently forces the approximate domain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEpVxYuSGpnUwVWL1UvdXG)_