### PR TITLE
feat(mcp): make the documented way in actually work

### DIFF
--- a/docs/dev/mcp-claude-code-handoff.md
+++ b/docs/dev/mcp-claude-code-handoff.md
@@ -1,6 +1,6 @@
 # Ajisai MCP development handoff for Claude Code
 
-Updated: 2026-08-11
+Updated: 2026-08-11 (MCP onboarding: bin entry, --doctor, serverVersion, quickstart)
 
 - Current tracker: [`mcp-readiness.md`](./mcp-readiness.md)
 - Host profiles: [`mcp-host-profiles.md`](./mcp-host-profiles.md)
@@ -75,7 +75,19 @@ names or spawn diagnostics into it; that belongs on stderr, and
 ### MCP adapter
 
 - `tools/mcp-server/index.js`: stdio server, four tools, Resources, execution
-  gate, startup backend selection, asset validation and MCP provenance.
+  gate, startup backend selection, asset validation and MCP provenance. Its
+  entry-point guard compares **real** paths: the bin is reached through a
+  `node_modules/.bin` symlink, and a `resolve()`-only comparison silently made
+  every launch-by-name a no-op.
+- `tools/mcp-server/doctor.js`: `--version`, `--doctor`, `--help`. Reached only
+  when arguments are present, never once a transport is open. It is the one
+  surface that deliberately prints host detail — paths, versions, spawn
+  failures — because an operator is reading it.
+- `tools/mcp-server/mcp-quickstart.md`: hand-written MCP preface that
+  `sync-assets.js` composes with `SKILL.md` into `assets/quickstart.md`. Its
+  fenced ```ajisai blocks carry `tool=`/`status=`/`stack=` attributes and are
+  executed against the live backend by the self-test, so the guidance a model
+  is told to trust cannot quietly stop being true.
 - `tools/mcp-server/host-error.js`: the host-failure vocabulary. A new failure
   mode needs a code here and in `result.schema.json`, not a new prose string.
 - `tools/mcp-server/result.schema.json`: the single `outputSchema` for all four
@@ -132,7 +144,29 @@ measurement behind it**. Do not report it as one.
 
 ## 5. Recommended next pull request
 
-P1 backend work is done. The two highest-value threads now:
+P1 backend work and P1 onboarding are done (see the readiness tracker's P1
+section for the bin-entry, `--doctor`, `serverVersion` and quickstart items).
+Two threads remain queued behind them, in this order:
+
+0. **A short agent-facing display for algebraic values.** `2 SQRT` answers with
+   the correct `exactTerms`, and with two things beside it that a model reads
+   first and should not: `stackDisplay` is the canonical continued fraction
+   *truncated at a display budget* (~194 characters for √2, with a `...)`
+   marker), and `value` is a rational approximation
+   (`768398401/543339720`) marked `semantics.approximate: true`. The packaged
+   quickstart now warns about both, which is mitigation, not a fix.
+
+   The fix is an additional short, unambiguous rendering — `sqrt(2)` — carried
+   next to `exactTerms` in the same `semantics` block, so the relationship
+   between the display and the value it renders is structural rather than
+   asserted. Do **not** rename or reshape `stackDisplay`: it is the SPEC §4.2.3
+   continued-fraction projection shared with the CLI, the REPL and the
+   playground, and changing it is a separate, spec-level decision. Do not call
+   the new field "canonical" either — `exactTerms` is the canonical value, and
+   a display string named canonical invites exactly the substitution this
+   boundary exists to prevent. Add golden cases for a rational, a vector and a
+   multi-term algebraic value, and assert native/WASM agreement on the new
+   field.
 
 1. **Recalibrate the numeric work meter** so the declared size ceilings bind
    before the wall clock. Today `numericWork`, `bigintBits` and
@@ -145,6 +179,20 @@ P1 backend work is done. The two highest-value threads now:
    pass through the algebraic size guard at all, so a large integer product is
    bounded only by `executionSteps`.
 2. **Collect real model traces** (see §6). The harness is not the bottleneck.
+
+3. **Compact the tool response, without breaking the text mirror.** The same
+   result is serialized into both `content[0].text` and `structuredContent`:
+   2,988 bytes total for an exact rational, 14,003 for an unknown-Word
+   diagnosis. The mirroring itself should stay — MCP asks a tool with an output
+   schema to also return the serialized JSON as text, so a text-only client
+   still receives the whole result, and replacing that text with a prose
+   summary would drop information those clients have no other way to reach.
+   What can go is padding: `JSON.stringify(value, null, 2)` alone accounts for
+   roughly 28–36% of the text, and always-null fields (`message`,
+   `diagnosis`, `aiDiagnostic`, `contractDecls` on a plain success) account for
+   more. Measure before and after on the evaluation corpus and re-run the
+   repair scorer; a reduction that lowers the diagnosis-observation rate is not
+   a win.
 
 Do not add MCP tools without demonstrated need. A `trace` tool mirroring the
 playground's step mode, and the unused `prompts` capability, are both plausible
@@ -232,7 +280,14 @@ but do not silently raise the committed budget to fix a regression.
   of supported-domain exactness, vector/dataflow semantics and diagnostics.
 - Do not claim `reference-traces.json` represents an LLM.
 - Do not hand-edit packaged assets; regenerate with `sync:assets` and check the
-  resulting diff.
+  resulting diff. `assets/quickstart.md` is composed from `mcp-quickstart.md`
+  and `SKILL.md`; edit the preface source, never the composed file.
+- Do not test a launch path by importing `createServer`. That is not what a
+  client does, and it is why a bin entry that served nothing survived a self
+  test, a pack smoke test and a release-readiness review.
+- Do not assert on a backend selection made after the first call in the same
+  process. The backend is resolved once and cached, so a second in-process
+  server ignores a changed `AJISAI_BIN` — spawn a process instead.
 - Do not let a `nextChecks` locale carry another locale's language, and do not
   match on its display text anywhere; `code` is the stable identifier.
 - Do not delete or subordinate the browser playground to the MCP package.

--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -93,10 +93,20 @@ Completed:
   stackDisplay, diagnosis, aiDiagnostic, errorFlowTrace, output, message,
   contractDecls), excluding host-specific `runtimeMetrics` counters. All
   golden cases currently match byte-for-byte between backends.
-- The package smoke test (`pack-smoke.js`) now proves two scenarios against
-  the packed, installed tarball: computation succeeds with neither
-  `AJISAI_REPO` nor `AJISAI_BIN` set (the packaged WASM backend), and separately
-  through an explicit `AJISAI_BIN` (the native/Docker path).
+- The package smoke test (`pack-smoke.js`) proves four scenarios against the
+  packed, installed tarball: computation with neither `AJISAI_REPO` nor
+  `AJISAI_BIN` set (the packaged WASM backend); the `ajisai-mcp-server` bin
+  serving MCP when **launched by name** through `node_modules/.bin`;
+  `--doctor` passing on the installed copy; and an explicit `AJISAI_BIN`
+  selecting the native backend, asserted through `mcp.backend.kind`.
+
+  The last scenario previously proved nothing. The backend is resolved once
+  per process, so setting `AJISAI_BIN` and constructing a second in-process
+  server reused the WASM backend the first scenario had already fixed — the
+  "native/Docker path" assertion passed on a machine with no native binary at
+  all. Both native scenarios are now spawned processes, and `npm run test:pack`
+  consequently requires a built binary (the root `npm run test:mcp-pack`
+  builds it first).
 - `scripts/rebuild-mcp-wasm.sh` (`npm run build:mcp-wasm`) regenerates the
   committed Node-target WASM bundle
   (`tools/mcp-server/wasm/generated/`), mirroring `rebuild-wasm.sh` for the
@@ -137,9 +147,41 @@ Completed:
 - `tools/mcp-server/package.json` is no longer `private`, carries repository,
   licence and publish metadata, and the README gives copy-pasteable client
   configuration JSON.
+- **The bin entry actually starts the server.** The entry-point guard compared
+  `resolve(process.argv[1])` with `import.meta.url`, and `resolve()` does not
+  follow symlinks — so every launch through `node_modules/.bin`
+  (`npx -y ajisai-mcp-server`, a bare `"command": "ajisai-mcp-server"`) fell
+  through the guard and exited 0 having served nothing: a client saw a server
+  that started, offered no tools and reported no error. Only naming `index.js`
+  directly ever worked. The self-test and the pack smoke test both imported
+  `createServer` rather than launching the executable, so nothing covered the
+  path both npm-based README recipes used. Real paths are compared now, and
+  `pack-smoke.js` spawns the installed bin.
+- The server answers for itself from a terminal: `--version` (adapter version,
+  engine version, registry digest), `--doctor` (Node floor, packaged assets,
+  backend selection and two real computations through the selected backend,
+  exit 0/1) and `--help`. Terminal commands are reached only when arguments
+  are present and never after a transport opens, so server-mode stdout stays
+  protocol-only.
+- Results and the `ajisai://limits` resource carry `mcp.serverVersion` beside
+  `mcp.engineVersion`. The adapter and the engine are separately released, and
+  a stored envelope naming only the engine could not say which adapter wrote
+  it — so a missing field was indistinguishable from a field that adapter
+  version never sent.
+- `ajisai://guide/quickstart` is now an MCP preface plus the generated
+  `SKILL.md`, not `SKILL.md` alone. The generated guide opens on a CLI run
+  loop a connected client cannot issue and never states which of the four
+  tools to call. The preface covers tool selection, the `ok`/`error`/
+  `hostError` branch, reason-carrying NIL, and the algebraic-value trap
+  (`exactTerms` is the value; `stackDisplay` is a *truncated* continued
+  fraction and `value` is a marked rational approximation). Every example in
+  it is executed against the live backend by the self-test.
 
 All P1 exit criteria are complete. `npm publish` itself remains a release
-decision, not an implementation gap.
+decision, not an implementation gap — and the README now says so in place of
+an `npm install -g ajisai-mcp-server` recipe that resolved to E404, leading
+instead with the checkout path, which needs no build because the WASM bundle
+is committed.
 
 Known gap, recorded rather than papered over: `numericWork`, `bigintBits` and
 `algebraicTerms` are declared truthfully but are **not reachable at their

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -14,56 +14,68 @@ Host-by-host resource ceilings are compared in `docs/dev/mcp-host-profiles.md`.
 
 ## Install and connect
 
+> **Not on npm yet.** `ajisai-mcp-server` is unpublished, so `npm install -g
+> ajisai-mcp-server` and `npx -y ajisai-mcp-server` do not resolve. Publishing
+> is a release decision, not a missing feature; until it is made, connect from
+> a checkout as below. This section will lead with the registry recipe on the
+> day `npm view ajisai-mcp-server version` answers.
+
+Requirements: **Node 20 or newer**, and a checkout of this repository. Nothing
+else — no build step, no `cargo`, no native binary. The WASM backend is
+committed under `wasm/generated/`, so a fresh clone computes immediately.
+
 ```sh
-npm install -g ajisai-mcp-server
+git clone https://github.com/masamoto1982/Ajisai.git
+cd Ajisai/tools/mcp-server
+npm install
+node index.js --doctor     # exits 0 when this copy can actually compute
 ```
 
-No build step and no native binary are required: the packaged WASM backend
-ships inside the package.
-
 Most MCP clients take a JSON server entry. Claude Desktop
-(`claude_desktop_config.json`), Claude Code (`.mcp.json`), and Cursor
+(`claude_desktop_config.json`), Claude Code (`.mcp.json`) and Cursor
 (`.cursor/mcp.json`) all use this shape:
 
 ```json
 {
   "mcpServers": {
     "ajisai": {
-      "command": "npx",
-      "args": ["-y", "ajisai-mcp-server"]
-    }
-  }
-}
-```
-
-A globally installed copy, or a checkout, can be named directly instead:
-
-```json
-{
-  "mcpServers": {
-    "ajisai": {
-      "command": "ajisai-mcp-server"
-    }
-  }
-}
-```
-
-```json
-{
-  "mcpServers": {
-    "ajisai": {
       "command": "node",
-      "args": ["/path/to/Ajisai/tools/mcp-server/index.js"],
-      "env": { "AJISAI_BIN": "/path/to/Ajisai/rust/target/release/ajisai" }
+      "args": ["/path/to/Ajisai/tools/mcp-server/index.js"]
     }
   }
 }
 ```
 
-`AJISAI_BIN` is optional and selects a native `ajisai` binary instead of the
-packaged WASM backend — useful in a Docker image that builds one in.
-`AJISAI_REPO` is a development-only fallback for discovering a locally built
-binary without naming it.
+That is the whole configuration. No `env` block is needed, and pointing
+`AJISAI_BIN` at a native binary — as an earlier version of this file did in its
+only working example — is an optional override, not a prerequisite:
+
+- `AJISAI_BIN` selects a native `ajisai` binary instead of the packaged WASM
+  backend, which is how a Docker image that builds one in should be wired.
+- `AJISAI_REPO` is a development-only fallback for discovering a locally built
+  binary without naming it.
+
+Both backends answer identically (see [Backends and
+provenance](#backends-and-provenance)); the override is about deployment, not
+about results.
+
+### Checking an installation
+
+The server is silent when it is healthy, which makes it indistinguishable from
+one that is wedged. The same executable answers for itself:
+
+```sh
+node index.js --version    # adapter version, engine version, registry digest
+node index.js --doctor     # Node, assets, backend and two real computations
+node index.js --help
+```
+
+`--doctor` exits 0 when every check passes and 1 when any fails, so it can gate
+a container start or a support request. It computes `2 3 / 1 3 / +` and
+`2 SQRT` through the selected backend: a server that starts and loads its
+assets but answers wrongly is still broken, and only running something proves
+otherwise. With no arguments the process speaks MCP on stdin/stdout and writes
+nothing else there.
 
 ## Agent surface
 
@@ -132,10 +144,16 @@ finishing mid-session silently moved later calls onto a different execution
 path, with nothing in the response saying so. Parity is what makes the two
 answers equal; provenance is what would make an unequal one investigable.
 
-Every result also carries `mcp.engineVersion`, `mcp.registryDigest` and the
-applied `mcp.limits`. The packaged registry is verified against its recorded
-digest at **startup**, so a corrupt asset stops the server rather than
-surfacing as a generic failure on whichever request touched it first.
+Every result also carries `mcp.serverVersion`, `mcp.engineVersion`,
+`mcp.registryDigest` and the applied `mcp.limits`. The two versions are two
+separately released components: `serverVersion` is this Node adapter, and
+`engineVersion` is the Ajisai language it speaks for. A saved result used to
+name only the second, so a field missing from an archived envelope could not be
+told apart from a field that adapter version never sent.
+
+The packaged registry is verified against its recorded digest at **startup**,
+so a corrupt asset stops the server rather than surfacing as a generic failure
+on whichever request touched it first.
 
 ## Limits
 
@@ -162,6 +180,16 @@ and `ajisai://limits`. The `ajisai://words/{name}` template exposes the same
 complete Word contract as `word_contract` without a tool call. Contract lookups
 accept canonical names and aliases; their registry digest is calculated from
 the canonical specification, not from a reduced documentation manifest.
+
+`ajisai://guide/quickstart` is an MCP preface (`mcp-quickstart.md`) followed by
+the generated writing protocol (`SKILL.md`), joined by `sync-assets.js`. The
+guide used to be `SKILL.md` alone, which opens on a CLI run loop — `ajisai run
+file --json`, commands a connected client cannot issue — and never says which
+of the four tools to call, so a model that read it first learned the language
+before it learned the interface. The preface answers tool selection, result
+branching and the algebraic-value trap in one screen, then hands off. Its own
+examples are executed against the live backend by the self-test, the same
+guarantee the generator gives the half below it.
 
 All four tools declare read-only, non-destructive and idempotent MCP
 annotations.
@@ -216,12 +244,21 @@ service latency.
 decimal and integer operations with JavaScript `Number`. It includes two
 exactly representable controls as well as known precision-sensitive cases, and
 labels its scope explicitly; it is not a general JavaScript or CAS benchmark.
-`npm run test:pack` creates the allowlisted tarball, installs it into an empty
-temporary prefix and imports that installed copy. It computes through the
-real backend twice: first with neither `AJISAI_REPO` nor `AJISAI_BIN` set,
-proving the installed package computes through its packaged, self-contained
-WASM backend with no repository and no native binary in reach; then again
-with an explicit `AJISAI_BIN`, proving the native/Docker override path still
-works.
+`npm run test:pack` creates the allowlisted tarball and installs it into an
+empty temporary prefix, then exercises that installed copy four ways: importing
+`createServer` with neither `AJISAI_REPO` nor `AJISAI_BIN` set, proving it
+computes through its packaged, self-contained WASM backend with no repository
+and no native binary in reach; **launching the `ajisai-mcp-server` bin through
+`node_modules/.bin`**, which is how every documented client entry starts it;
+running `--doctor` on the installed package; and finally spawning that bin
+again with an explicit `AJISAI_BIN`, asserting `mcp.backend.kind` is
+`nativeCli`.
+
+The last two of those are spawned processes on purpose. The backend is resolved
+once per process, so setting `AJISAI_BIN` and constructing a second server in
+the same process reused the WASM backend the first scenario had already fixed —
+the native assertion passed on machines with no native binary at all. Because
+it is now real, `npm run test:pack` needs one built; `npm run test:mcp-pack`
+from the repository root builds it first.
 
 The browser playground is independent of this package and remains available.

--- a/tools/mcp-server/assets/quickstart.md
+++ b/tools/mcp-server/assets/quickstart.md
@@ -1,3 +1,123 @@
+<!-- MCP-facing preface to the generated writing protocol below.
+     Hand-written source; `sync-assets.js` composes it with SKILL.md into
+     assets/quickstart.md, and `selftest.js` runs every ```ajisai block here
+     against the live backend, so no example can drift from what the server
+     actually answers. -->
+
+# Ajisai over MCP — read this first
+
+You are connected to Ajisai: a small, bounded, deterministic calculator whose
+numbers are **exact rationals closed under square root** — no floats anywhere in
+its supported domain. Use it when the arithmetic has to be right and the failure
+has to be explainable. It is not a general-purpose language runtime.
+
+This preface is the MCP entry point. Everything after it is the generated
+protocol for *writing* Ajisai, and is the reference to consult once you know
+which call to make.
+
+## 1. Choose a tool
+
+| you want | call | pass |
+|---|---|---|
+| a number, a vector, an exact root, a `PRINT` line | `compute` | `source` |
+| to know whether source parses and resolves, without running it | `check` | `source` |
+| the inferred contract of Words *you* defined | `infer_contracts` | `source` |
+| a built-in Word's contract, or "did I spell it right?" | `word_contract` | `word` |
+
+All four take text, never a file path. To run a file, read it yourself and pass
+its contents as `source`.
+
+## 2. Read a result in this order
+
+1. **`status`** decides everything else. `ok` — a value. `error` — an *Ajisai*
+   error, still an ordinary successful call carrying a full diagnosis.
+   `hostError` (with `isError` set) — this server failed, and your program may
+   be fine.
+2. On `ok`: `stackDisplay` is the final stack bottom→top, `output` holds `PRINT`
+   lines, and `stack` is the machine-readable form of the same values.
+3. On `error`: `diagnosis.why` and `.where` locate it; `diagnosis.candidates`
+   names the Word you probably meant; `diagnosis.nextChecks[].code` is a stable
+   identifier to act on — never match on its display text, which is localized.
+4. On `hostError`: branch on `error.code`, and retry only if `error.retryable`
+   is true. `mcp.limits` states every ceiling that applies.
+
+Do not collapse these into "it worked / it broke". Retrying a division by zero
+and rewriting a program that merely timed out are both wasted turns.
+
+## 3. Absence is a value, not an exception
+
+A partial operation that has no answer produces `NIL` carrying a reason, and the
+call still succeeds:
+
+```ajisai tool=compute status=ok stack="NIL"
+1 0 /
+```
+
+The reason is on the value (`semantics.absence.reason`, here `divisionByZero`)
+and in `errorFlowTrace` as a `nilProduced` event. Supply a fallback with `^`:
+
+```ajisai tool=compute status=ok stack="[ 99/1 ]"
+[ 1 ] [ 0 ] / ^ [ 99 ]
+```
+
+## 4. Exact arithmetic: what to read, and what not to
+
+Rationals are exact and their display is exact too:
+
+```ajisai tool=compute status=ok stack="1/1"
+2 3 / 1 3 / +
+```
+
+An irrational square root is where display and value part company. Read
+`stack[…].semantics.exactTerms` — a list of `{ numerator, denominator,
+radicand }` terms, arbitrary-precision integers as strings. That is the
+canonical value, and for `2 SQRT` it is exactly one term: `1/1 · √2`.
+
+```ajisai tool=compute status=ok
+2 SQRT
+```
+
+Two things on that same result are **not** the value, and reading either as if
+it were will mislead you:
+
+- `stackDisplay` shows the canonical continued fraction, truncated at a display
+  budget (`( 1 ( 2 ( 2 …)`). It is a rendering, and a truncated one.
+- `value.numerator / value.denominator` is a rational *approximation*, marked
+  `semantics.approximate: true`. It is a convenience, not the number.
+
+Comparisons decide on the exact value regardless, so let Ajisai do the deciding
+rather than comparing displays or approximations yourself:
+
+```ajisai tool=compute status=ok stack="TRUE"
+8 SQRT 2 SQRT 2 SQRT + =
+```
+
+## 5. When a name is wrong, the answer says so
+
+```ajisai tool=compute status=error
+[ 1 2 3 ] LENGHT
+```
+
+That returns `status: "error"` with `diagnosis.candidates` beginning `LENGTH`.
+Fix from the diagnosis rather than guessing. Before writing an unfamiliar Word,
+`word_contract` gives its arity, purity and NIL policy — and answers a
+misspelling with `suggestions`.
+
+## 6. Bounds
+
+Every result carries the profile it ran under in `mcp.limits`, alongside
+`mcp.serverVersion`, `mcp.engineVersion` and `mcp.backend.kind`. Exceeding a
+ceiling is a diagnosed outcome, never a hang. The full profile is also readable
+without a tool call at `ajisai://limits`, the result contract at
+`ajisai://schema/result`, and the whole vocabulary at `ajisai://vocabulary`.
+
+---
+
+The rest of this document is the generated writing protocol: syntax, the full
+Word table, and worked examples verified against the real interpreter.
+
+<!-- BEGIN GENERATED SKILL.md -->
+
 <!-- GENERATED FILE — do not edit by hand.
      Regenerate: npm run generate:skill   (verified against the ajisai CLI)
      Source of truth for semantics: SPECIFICATION.html.

--- a/tools/mcp-server/doctor.js
+++ b/tools/mcp-server/doctor.js
@@ -1,0 +1,181 @@
+// The operator-facing half of the same executable.
+//
+// A stdio MCP server is silent when it is healthy and silent when it is
+// wedged, and from a terminal the two are indistinguishable: the operator sees
+// a process that started and a client that offers no tools, with nothing
+// saying whether the fault is the Node version, a corrupt packaged asset, a
+// missing WASM bundle or the client's own configuration. `--doctor` is the
+// difference. It runs the same asset validation, backend selection and real
+// computation the server runs, against the same installed copy, and answers
+// with an exit code.
+//
+// Everything here is reached only when `index.js` was given arguments, and
+// never after a transport is open, so the stdout MCP frames travel over is
+// never written to by a diagnostic.
+
+import {
+  createBackend,
+  engineVersion,
+  LIMITS,
+  packageEngines,
+  registryDigest,
+  serverVersion,
+  validateAssets,
+} from "./index.js";
+
+const USAGE = `ajisai-mcp-server — bounded, diagnostic Ajisai computation over MCP (stdio)
+
+  ajisai-mcp-server              serve MCP on stdin/stdout (what a client launches)
+  ajisai-mcp-server --doctor     check this installation, exit 0 (healthy) or 1
+  ajisai-mcp-server --version    print adapter, engine and registry provenance
+  ajisai-mcp-server --help       print this message
+
+With no arguments the process speaks MCP and writes nothing else to stdout.
+The commands above are for a human at a terminal and never run in that mode.`;
+
+/**
+ * The provenance line, and the reason there is more than one version on it.
+ *
+ * The adapter and the language engine are separately versioned components, and
+ * a bug report that names only one of them is a bug report missing half its
+ * subject.
+ */
+function versionLine() {
+  let registry;
+  try {
+    registry = registryDigest().slice(0, 16);
+  } catch {
+    // A corrupt registry is exactly what `--doctor` is for; `--version` still
+    // answers what it can rather than failing to identify the build at all.
+    registry = "unavailable";
+  }
+  return `ajisai-mcp-server ${serverVersion()} (engine ${engineVersion()}, registry ${registry})`;
+}
+
+/** The declared Node floor, read from the package rather than restated here. */
+function requiredNodeMajor() {
+  const declared = packageEngines().node ?? "";
+  const [match] = declared.match(/\d+/) ?? [];
+  return match ? Number(match) : 0;
+}
+
+/**
+ * One diagnostic step: a stable label, and either the observation that made it
+ * pass or the reason it did not.
+ *
+ * A step reports *host* detail — paths, versions, spawn failures — on purpose.
+ * That is the inverse of the rule the tool boundary follows, and for the same
+ * reason: this output has an operator in front of it, and the MCP boundary
+ * does not.
+ */
+async function step(label, run) {
+  try {
+    const detail = await run();
+    return { label, ok: true, detail };
+  } catch (error) {
+    return { label, ok: false, detail: error?.detail ?? error?.message ?? String(error) };
+  }
+}
+
+function requireThat(condition, reason, detail) {
+  if (!condition) throw new Error(reason);
+  return detail;
+}
+
+async function doctor(write) {
+  const steps = [];
+  const required = requiredNodeMajor();
+  steps.push(await step("node runtime satisfies the declared engine range", () => {
+    const major = Number(process.versions.node.split(".")[0]);
+    return requireThat(
+      major >= required,
+      `running Node ${process.versions.node}, package requires ${packageEngines().node}`,
+      `Node ${process.versions.node} (requires ${packageEngines().node})`,
+    );
+  }));
+
+  steps.push(await step("packaged assets load and match their recorded digest", () => {
+    validateAssets();
+    return `registry ${registryDigest().slice(0, 16)}, engine ${engineVersion()}`;
+  }));
+
+  // Resolved once and reused: `--doctor` must exercise the very backend a
+  // served session would use, not a second selection that could differ.
+  let backend = null;
+  steps.push(await step("an execution backend is available", () => {
+    backend = createBackend();
+    return requireThat(
+      backend !== null,
+      "no native binary found (build rust/ or set AJISAI_BIN) and the packaged WASM bundle is missing",
+      `${backend?.kind} backend selected`,
+    );
+  }));
+
+  // The two claims the product is actually about. A server that starts, loads
+  // its assets and then rounds is a working server answering wrongly, and only
+  // running something proves it does not.
+  steps.push(await step("exact rational arithmetic stays exact", async () => {
+    requireThat(backend !== null, "skipped: no execution backend");
+    const result = await backend.compute("2 3 / 1 3 / +");
+    const [display] = result.stackDisplay ?? [];
+    return requireThat(
+      result.status === "ok" && display === "1/1",
+      `2 3 / 1 3 / + answered ${result.status} ${JSON.stringify(result.stackDisplay)}`,
+      "2 3 / 1 3 / + = 1/1",
+    );
+  }));
+
+  steps.push(await step("an algebraic value keeps its exact normal form", async () => {
+    requireThat(backend !== null, "skipped: no execution backend");
+    const result = await backend.compute("2 SQRT");
+    const [term] = result.stack?.[0]?.semantics?.exactTerms ?? [];
+    return requireThat(
+      term?.numerator === "1" && term?.denominator === "1" && term?.radicand === "2",
+      `2 SQRT produced no (1/1)·√2 exact term: ${JSON.stringify(term ?? null)}`,
+      "2 SQRT = (1/1)·√2 in exactTerms",
+    );
+  }));
+
+  write(versionLine());
+  write("");
+  for (const { label, ok, detail } of steps) {
+    write(`${ok ? "ok  " : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`);
+  }
+  write("");
+  const failed = steps.filter(({ ok }) => !ok).length;
+  if (failed === 0) {
+    write(`doctor: ${steps.length} checks passed; wall-time limit ${LIMITS.wallTimeMs} ms`);
+    return 0;
+  }
+  write(`doctor: ${failed} of ${steps.length} checks failed`);
+  return 1;
+}
+
+/**
+ * Run the terminal command line. Returns the process exit code.
+ *
+ * `write` is injected so the self-test can assert on what a command prints
+ * without capturing the process's own streams.
+ */
+export async function runCli(argv, write = (line) => console.log(line)) {
+  const [command, ...rest] = argv;
+  if (rest.length > 0) {
+    write(`ajisai-mcp-server: ${command} takes no further arguments`);
+    write("");
+    write(USAGE);
+    return 2;
+  }
+  if (command === "--help" || command === "-h") {
+    write(USAGE);
+    return 0;
+  }
+  if (command === "--version" || command === "-v") {
+    write(versionLine());
+    return 0;
+  }
+  if (command === "--doctor") return doctor(write);
+  write(`ajisai-mcp-server: unknown option ${command}`);
+  write("");
+  write(USAGE);
+  return 2;
+}

--- a/tools/mcp-server/index.js
+++ b/tools/mcp-server/index.js
@@ -11,7 +11,7 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NativeCliBackend } from "./backend/native-cli.js";
@@ -236,7 +236,7 @@ function manifest() { return manifestCache ??= JSON.parse(readFileSync(manifestP
 function contracts() {
   return contractsCache ??= JSON.parse(readFileSync(contractsPath, "utf8"));
 }
-function registryDigest() {
+export function registryDigest() {
   const calculated = registryDigestCache ??= createHash("sha256")
     .update(readFileSync(contractsPath))
     .digest("hex");
@@ -250,14 +250,25 @@ function registryDigest() {
   return calculated;
 }
 function metadata() { return metadataCache ??= JSON.parse(readFileSync(metadataPath, "utf8")); }
-function engineVersion() { return metadata().engineVersion; }
-function serverVersion() {
+export function engineVersion() { return metadata().engineVersion; }
+export function serverVersion() {
   return serverVersionCache ??= JSON.parse(readFileSync(serverPackagePath, "utf8")).version;
+}
+export function packageEngines() {
+  return JSON.parse(readFileSync(serverPackagePath, "utf8")).engines ?? {};
 }
 
 /**
- * Provenance every answer carries: which engine, which registry, which of the
- * two interchangeable backends actually ran, and the limits that were applied.
+ * Provenance every answer carries: which adapter, which engine, which
+ * registry, which of the two interchangeable backends actually ran, and the
+ * limits that were applied.
+ *
+ * `serverVersion` and `engineVersion` are two independently versioned
+ * components — this adapter and the Ajisai language it speaks for — and a
+ * saved result used to name only the second. Which adapter produced a stored
+ * envelope decided whether a field was absent because the engine cannot
+ * answer it or because this version of the server never sent it, and that
+ * question was unanswerable from the result alone.
  *
  * The backend identifier does not weaken the abstraction the two backends
  * share — parity testing is what guarantees they agree. It is what makes a
@@ -266,6 +277,7 @@ function serverVersion() {
 function provenance() {
   const selected = backend();
   return {
+    serverVersion: serverVersion(),
     engineVersion: engineVersion(),
     registryDigest: registryDigest(),
     backend: { kind: selected?.kind ?? null },
@@ -456,6 +468,7 @@ export function createServer() {
           text: JSON.stringify(
             {
               profile: "mcp-local-stdio",
+              serverVersion: serverVersion(),
               engineVersion: engineVersion(),
               backend: { kind: backend()?.kind ?? null },
               limits: LIMITS,
@@ -484,13 +497,59 @@ export function createServer() {
   return server;
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+/**
+ * Whether this module was the process entry point.
+ *
+ * `resolve()` normalizes a path; it does not follow symlinks. Every documented
+ * way of launching this package by name — `npx ajisai-mcp-server`, a client
+ * spawning the installed `ajisai-mcp-server` command — runs it through
+ * `node_modules/.bin/ajisai-mcp-server`, a *symlink*, so `argv[1]` was the
+ * link and `import.meta.url` was its target. The comparison was false, the
+ * guard did not fire, and the process exited 0 having served nothing: a client
+ * saw a server that started, offered no tools and reported no error. Only
+ * naming `index.js` directly ever worked, which is why the self-test and the
+ * pack smoke test — both of which import `createServer` rather than launch the
+ * binary — never saw it. Comparing real paths is what makes the bin entry the
+ * same entry point as the file.
+ */
+function isEntryPoint() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (resolve(entry) === self) return true;
   try {
-    await createServer().connect(new StdioServerTransport());
-  } catch (error) {
-    // Startup faults are the operator's to fix, and a stdio server that keeps
-    // running while unable to answer is worse than one that does not start.
-    console.error(`[ajisai-mcp] failed to start: ${error.detail ?? error.message}`);
-    process.exit(1);
+    return realpathSync(entry) === self;
+  } catch {
+    return false;
+  }
+}
+
+if (isEntryPoint()) {
+  // Any argument means a human at a terminal, not a client opening a session:
+  // `--version`, `--doctor`, `--help`, or a mistake worth naming rather than
+  // ignoring. The terminal commands live in `doctor.js` so the server path
+  // never loads them, and they are never reached once a transport is open —
+  // the stdout MCP frames travel over stays free of diagnostics.
+  //
+  // Deliberately not awaited: `doctor.js` imports back from this module, so
+  // awaiting the import here would suspend this module's evaluation waiting
+  // for a module that is waiting for this one. Continuing lets evaluation
+  // finish first, which is what resolves the cycle.
+  if (process.argv.length > 2) {
+    import("./doctor.js")
+      .then(async ({ runCli }) => process.exit(await runCli(process.argv.slice(2))))
+      .catch((error) => {
+        console.error(`[ajisai-mcp] ${error.detail ?? error.message}`);
+        process.exit(1);
+      });
+  } else {
+    try {
+      await createServer().connect(new StdioServerTransport());
+    } catch (error) {
+      // Startup faults are the operator's to fix, and a stdio server that keeps
+      // running while unable to answer is worse than one that does not start.
+      console.error(`[ajisai-mcp] failed to start: ${error.detail ?? error.message}`);
+      process.exit(1);
+    }
   }
 }

--- a/tools/mcp-server/mcp-quickstart.md
+++ b/tools/mcp-server/mcp-quickstart.md
@@ -1,0 +1,118 @@
+<!-- MCP-facing preface to the generated writing protocol below.
+     Hand-written source; `sync-assets.js` composes it with SKILL.md into
+     assets/quickstart.md, and `selftest.js` runs every ```ajisai block here
+     against the live backend, so no example can drift from what the server
+     actually answers. -->
+
+# Ajisai over MCP — read this first
+
+You are connected to Ajisai: a small, bounded, deterministic calculator whose
+numbers are **exact rationals closed under square root** — no floats anywhere in
+its supported domain. Use it when the arithmetic has to be right and the failure
+has to be explainable. It is not a general-purpose language runtime.
+
+This preface is the MCP entry point. Everything after it is the generated
+protocol for *writing* Ajisai, and is the reference to consult once you know
+which call to make.
+
+## 1. Choose a tool
+
+| you want | call | pass |
+|---|---|---|
+| a number, a vector, an exact root, a `PRINT` line | `compute` | `source` |
+| to know whether source parses and resolves, without running it | `check` | `source` |
+| the inferred contract of Words *you* defined | `infer_contracts` | `source` |
+| a built-in Word's contract, or "did I spell it right?" | `word_contract` | `word` |
+
+All four take text, never a file path. To run a file, read it yourself and pass
+its contents as `source`.
+
+## 2. Read a result in this order
+
+1. **`status`** decides everything else. `ok` — a value. `error` — an *Ajisai*
+   error, still an ordinary successful call carrying a full diagnosis.
+   `hostError` (with `isError` set) — this server failed, and your program may
+   be fine.
+2. On `ok`: `stackDisplay` is the final stack bottom→top, `output` holds `PRINT`
+   lines, and `stack` is the machine-readable form of the same values.
+3. On `error`: `diagnosis.why` and `.where` locate it; `diagnosis.candidates`
+   names the Word you probably meant; `diagnosis.nextChecks[].code` is a stable
+   identifier to act on — never match on its display text, which is localized.
+4. On `hostError`: branch on `error.code`, and retry only if `error.retryable`
+   is true. `mcp.limits` states every ceiling that applies.
+
+Do not collapse these into "it worked / it broke". Retrying a division by zero
+and rewriting a program that merely timed out are both wasted turns.
+
+## 3. Absence is a value, not an exception
+
+A partial operation that has no answer produces `NIL` carrying a reason, and the
+call still succeeds:
+
+```ajisai tool=compute status=ok stack="NIL"
+1 0 /
+```
+
+The reason is on the value (`semantics.absence.reason`, here `divisionByZero`)
+and in `errorFlowTrace` as a `nilProduced` event. Supply a fallback with `^`:
+
+```ajisai tool=compute status=ok stack="[ 99/1 ]"
+[ 1 ] [ 0 ] / ^ [ 99 ]
+```
+
+## 4. Exact arithmetic: what to read, and what not to
+
+Rationals are exact and their display is exact too:
+
+```ajisai tool=compute status=ok stack="1/1"
+2 3 / 1 3 / +
+```
+
+An irrational square root is where display and value part company. Read
+`stack[…].semantics.exactTerms` — a list of `{ numerator, denominator,
+radicand }` terms, arbitrary-precision integers as strings. That is the
+canonical value, and for `2 SQRT` it is exactly one term: `1/1 · √2`.
+
+```ajisai tool=compute status=ok
+2 SQRT
+```
+
+Two things on that same result are **not** the value, and reading either as if
+it were will mislead you:
+
+- `stackDisplay` shows the canonical continued fraction, truncated at a display
+  budget (`( 1 ( 2 ( 2 …)`). It is a rendering, and a truncated one.
+- `value.numerator / value.denominator` is a rational *approximation*, marked
+  `semantics.approximate: true`. It is a convenience, not the number.
+
+Comparisons decide on the exact value regardless, so let Ajisai do the deciding
+rather than comparing displays or approximations yourself:
+
+```ajisai tool=compute status=ok stack="TRUE"
+8 SQRT 2 SQRT 2 SQRT + =
+```
+
+## 5. When a name is wrong, the answer says so
+
+```ajisai tool=compute status=error
+[ 1 2 3 ] LENGHT
+```
+
+That returns `status: "error"` with `diagnosis.candidates` beginning `LENGTH`.
+Fix from the diagnosis rather than guessing. Before writing an unfamiliar Word,
+`word_contract` gives its arity, purity and NIL policy — and answers a
+misspelling with `suggestions`.
+
+## 6. Bounds
+
+Every result carries the profile it ran under in `mcp.limits`, alongside
+`mcp.serverVersion`, `mcp.engineVersion` and `mcp.backend.kind`. Exceeding a
+ceiling is a diagnosed outcome, never a hang. The full profile is also readable
+without a tool call at `ajisai://limits`, the result contract at
+`ajisai://schema/result`, and the whole vocabulary at `ajisai://vocabulary`.
+
+---
+
+The rest of this document is the generated writing protocol: syntax, the full
+Word table, and worked examples verified against the real interpreter.
+

--- a/tools/mcp-server/pack-smoke.js
+++ b/tools/mcp-server/pack-smoke.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
-import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 const execFileAsync = promisify(execFile);
 const here = dirname(fileURLToPath(import.meta.url));
@@ -22,7 +23,7 @@ try {
   tarball = join(here, packed.filename);
   const paths = new Set(packed.files.map(({ path }) => path));
   for (const required of [
-    "index.js", "result.schema.json", "assets/metadata.json", "assets/words.json",
+    "index.js", "doctor.js", "result.schema.json", "assets/metadata.json", "assets/words.json",
     "assets/word-manifest.json", "assets/quickstart.md", "eval/cases.json", "score-repairs.js",
     "eval/repair-cases.json", "backend/native-cli.js", "backend/wasm-worker.js",
     "backend/wasm-worker-entry.js", "wasm/generated/ajisai_core.js", "wasm/generated/ajisai_core_bg.wasm",
@@ -97,16 +98,91 @@ try {
   });
   console.log(`PASS clean-installed ${packed.filename} computes with no repository and no native binary (WASM backend)`);
 
+  // Scenario 1b: launch the package the way every documented client entry
+  // launches it — by its `bin` name, through `node_modules/.bin`.
+  //
+  // Everything above imports `createServer` from the installed file, and that
+  // is a different code path from running the executable: the entry-point
+  // guard compared `argv[1]` (the .bin *symlink*) with `import.meta.url` (its
+  // target), so launching by name started a process that served nothing and
+  // exited 0. A client saw a server with no tools and no error. Both npm-based
+  // README recipes — `npx -y ajisai-mcp-server` and a bare
+  // `"command": "ajisai-mcp-server"` — went through that symlink, so the only
+  // invocation anyone had actually tested was the one naming `index.js`
+  // directly. Spawning the real binary is what closes that gap.
+  const binDirectory = join(scratch, "node_modules", ".bin");
+  const binPath = join(binDirectory, "ajisai-mcp-server");
+  if (!existsSync(binPath)) {
+    // The offline fallback above unpacks the tarball by hand and never runs
+    // npm's bin linking. Recreate the symlink it would have made: launching
+    // through a symlink is the whole point of this scenario.
+    mkdirSync(binDirectory, { recursive: true });
+    symlinkSync(installedEntry, binPath);
+  }
+  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+  const spawned = new Client({ name: "pack-smoke-bin", version: "1" });
+  await spawned.connect(new StdioClientTransport({ command: process.execPath, args: [binPath] }));
+  try {
+    const tools = await spawned.listTools();
+    if (tools.tools.length !== 4) {
+      throw new Error("the installed bin entry served no tools when launched by name");
+    }
+    const computed = await spawned.callTool({ name: "compute", arguments: { source: "1 3 /" } });
+    if (computed.structuredContent?.stackDisplay?.[0] !== "1/3") {
+      throw new Error("the installed bin entry did not compute when launched by name");
+    }
+  } finally {
+    await spawned.close();
+  }
+  console.log("PASS the installed bin entry serves MCP when launched by name through node_modules/.bin");
+
+  // The same installed copy must be able to say whether it is healthy, without
+  // a checkout and without an MCP client — that is the only thing an operator
+  // whose client shows an empty tool list can run.
+  const doctored = await execFileAsync(process.execPath, [binPath, "--doctor"], {
+    encoding: "utf8",
+  });
+  if (!doctored.stdout.includes("checks passed") || doctored.stdout.includes("FAIL")) {
+    throw new Error(`--doctor did not pass on the installed package:\n${doctored.stdout}`);
+  }
+  console.log("PASS the installed package self-diagnoses with --doctor and exits 0");
+
   // Scenario 2: AJISAI_BIN is an explicit override (the native/Docker
-  // deployment story). The installed tarball must still prefer and use the
-  // native backend when pointed at one.
-  process.env.AJISAI_BIN = join(repoRoot, "rust", "target", "debug", "ajisai");
-  await withServer(async (client) => {
-    const computed = await client.callTool({ name: "compute", arguments: { source: "1 3 /" } });
+  // deployment story). The installed tarball must prefer and use the native
+  // backend when pointed at one.
+  //
+  // This runs in a spawned process, and has to. The backend is resolved once
+  // per *process* and cached, so setting `AJISAI_BIN` and calling
+  // `installed.createServer()` again reused the WASM backend scenario 1 had
+  // already fixed: the assertion passed on a machine with no native binary at
+  // all, which is exactly the machine it exists to catch. It proved the WASM
+  // backend twice and reported it as proof of the override.
+  const nativeBin = join(repoRoot, "rust", "target", "debug", "ajisai");
+  if (!existsSync(nativeBin)) {
+    throw new Error(
+      `no native binary at ${nativeBin}; build it first (npm run test:mcp-pack from the ` +
+        "repository root does, or: cargo build --manifest-path rust/Cargo.toml --bin ajisai)",
+    );
+  }
+  const native = new Client({ name: "pack-smoke-native", version: "1" });
+  await native.connect(new StdioClientTransport({
+    command: process.execPath,
+    args: [binPath],
+    env: { ...process.env, AJISAI_BIN: nativeBin },
+  }));
+  try {
+    const computed = await native.callTool({ name: "compute", arguments: { source: "1 3 /" } });
+    if (computed.structuredContent?.mcp?.backend?.kind !== "nativeCli") {
+      throw new Error(
+        `AJISAI_BIN did not select the native backend (got ${computed.structuredContent?.mcp?.backend?.kind})`,
+      );
+    }
     if (computed.structuredContent?.stackDisplay?.[0] !== "1/3") {
       throw new Error("installed package could not compute through the native AJISAI_BIN backend");
     }
-  });
+  } finally {
+    await native.close();
+  }
   console.log(`PASS clean-installed ${packed.filename} computes through an explicit AJISAI_BIN (native backend, ${packed.files.length} files)`);
 } finally {
   if (tarball) rmSync(tarball, { force: true });

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -11,7 +11,7 @@
   "keywords": ["mcp", "modelcontextprotocol", "ajisai", "exact-arithmetic", "rational", "agent-tools"],
   "publishConfig": { "access": "public" },
   "engines": { "node": ">=20" },
-  "files": ["index.js", "host-error.js", "word-candidates.js", "backend/*.js", "result.schema.json", "README.md", "assets/*", "golden/cases.json", "golden/limits.json", "golden/limit-cases.js", "eval.js", "benchmark.js", "number-baseline.js", "evaluation-contract.js", "validate-evaluation.js", "score-traces.js", "score-repairs.js", "eval/*.json", "wasm/generated/*"],
+  "files": ["index.js", "doctor.js", "host-error.js", "word-candidates.js", "backend/*.js", "result.schema.json", "README.md", "assets/*", "golden/cases.json", "golden/limits.json", "golden/limit-cases.js", "eval.js", "benchmark.js", "number-baseline.js", "evaluation-contract.js", "validate-evaluation.js", "score-traces.js", "score-repairs.js", "eval/*.json", "wasm/generated/*"],
   "bin": { "ajisai-mcp-server": "index.js" },
   "scripts": { "start": "node index.js", "sync:assets": "node sync-assets.js", "check:assets": "node sync-assets.js --check", "prepack": "node sync-assets.js --check", "selftest": "node selftest.js", "test:pack": "node pack-smoke.js", "eval:validate": "node validate-evaluation.js && node evaluation-contract.test.js", "eval": "node eval.js", "eval:performance": "node benchmark.js --require-budget", "eval:number-baseline": "node number-baseline.js --require-ajisai-exact", "eval:traces": "node score-traces.js eval/reference-traces.json --require-perfect", "eval:repairs": "node score-repairs.js eval/reference-repair-traces.json --require-perfect", "test:backends": "node backend/parity-test.js" },
   "dependencies": {

--- a/tools/mcp-server/result.schema.json
+++ b/tools/mcp-server/result.schema.json
@@ -60,8 +60,13 @@
     "mcp": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["engineVersion", "registryDigest", "backend", "limits"],
+      "required": ["serverVersion", "engineVersion", "registryDigest", "backend", "limits"],
       "properties": {
+        "serverVersion": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version of this MCP adapter — a separate component from the Ajisai engine below it. A stored result names both, so a missing field can be told apart from a field this adapter version never sent."
+        },
         "engineVersion": { "type": "string", "minLength": 1 },
         "registryDigest": {
           "type": "string",

--- a/tools/mcp-server/selftest.js
+++ b/tools/mcp-server/selftest.js
@@ -2,9 +2,11 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import Ajv2020 from "ajv/dist/2020.js";
-import { CAPACITY_WAIT_MS, createServer, ExecutionGate, LIMITS } from "./index.js";
+import { CAPACITY_WAIT_MS, createServer, ExecutionGate, LIMITS, serverVersion } from "./index.js";
+import { runCli } from "./doctor.js";
 import { coveredLimitNames, limitCases } from "./golden/limit-cases.js";
 import { HOST_ERRORS } from "./host-error.js";
+import { SKILL_BOUNDARY } from "./sync-assets.js";
 import { readFileSync } from "node:fs";
 
 let failures = 0;
@@ -117,6 +119,7 @@ check(
 check(
   "word_contract carries the same provenance as an execution result",
   contract.structuredContent?.mcp?.registryDigest?.length === 64 &&
+    contract.structuredContent?.mcp?.serverVersion === serverVersion() &&
     contract.structuredContent?.suggestions?.length === 0,
 );
 
@@ -139,8 +142,68 @@ check(
   limitsResource.profile === "mcp-local-stdio" &&
     JSON.stringify(limitsResource.limits) === JSON.stringify(LIMITS),
 );
+// The adapter and the engine are separately versioned, and a stored result
+// naming only the engine cannot say which adapter produced it.
+check(
+  "the host profile resource names the adapter version as well as the engine",
+  limitsResource.serverVersion === serverVersion() &&
+    limitsResource.engineVersion !== undefined &&
+    typeof serverVersion() === "string",
+);
 const guide = await client.readResource({ uri: "ajisai://guide/quickstart" });
-check("quickstart resource reads generated guidance", guide.contents[0]?.text?.includes("Agent Writing Protocol"));
+const guideText = guide.contents[0]?.text ?? "";
+check("quickstart resource reads generated guidance", guideText.includes("Agent Writing Protocol"));
+
+// The served guide leads with the MCP interface, not with the CLI run loop the
+// generated protocol opens on. A connected client cannot issue `ajisai run`,
+// and a model that met that first learned the language before learning which
+// of the four tools to call.
+const [preface] = guideText.split(SKILL_BOUNDARY);
+check(
+  "the quickstart opens with MCP tool selection, not the CLI run loop",
+  preface.length > 0 && preface.length < guideText.length &&
+    ["compute", "check", "infer_contracts", "word_contract"].every((tool) =>
+      preface.includes(`\`${tool}\``)
+    ) &&
+    !preface.includes("ajisai run"),
+);
+check(
+  "the quickstart distinguishes every outcome class a caller must branch on",
+  ["`ok`", "`error`", "`hostError`", "NIL", "exactTerms"].every((token) =>
+    preface.includes(token)
+  ),
+);
+
+// Every example in the hand-written preface runs against the live backend. The
+// generated half is verified by its generator against the real interpreter;
+// this is the same guarantee for the half a human wrote, so guidance the model
+// is told to trust cannot quietly stop being true.
+const prefaceExamples = [...preface.matchAll(/^```ajisai([^\n]*)\n([\s\S]*?)^```$/gm)].map(
+  ([, attributes, source]) => ({
+    source: source.trim(),
+    expect: Object.fromEntries(
+      [...attributes.matchAll(/(\w+)=("[^"]*"|\S+)/g)].map(([, key, raw]) => [
+        key,
+        raw.startsWith('"') ? raw.slice(1, -1) : raw,
+      ]),
+    ),
+  }),
+);
+check("the quickstart preface carries executable examples", prefaceExamples.length >= 5);
+for (const { source, expect } of prefaceExamples) {
+  const observed = await client.callTool({
+    name: expect.tool ?? "compute",
+    arguments: { source },
+  });
+  const structured = observed.structuredContent;
+  const statusAgrees = structured?.status === (expect.status ?? "ok");
+  const stackAgrees =
+    expect.stack === undefined || (structured?.stackDisplay ?? []).join(" ") === expect.stack;
+  check(`quickstart example: ${source.replaceAll("\n", " ")}`, statusAgrees && stackAgrees);
+  if (!statusAgrees || !stackAgrees) {
+    console.error(`  got status=${structured?.status} stack=${JSON.stringify(structured?.stackDisplay)}`);
+  }
+}
 const schemaResource = await client.readResource({ uri: "ajisai://schema/result" });
 const resultSchema = JSON.parse(schemaResource.contents[0]?.text ?? "{}");
 const validateResult = new Ajv2020().compile(resultSchema);
@@ -272,7 +335,8 @@ if (compute.structuredContent?.error?.code === "backendUnavailable") {
   );
   check(
     "compute reports engine provenance and applied limits",
-    compute.structuredContent?.mcp?.engineVersion === "0.2.0-beta.1" &&
+    compute.structuredContent?.mcp?.serverVersion === serverVersion() &&
+      compute.structuredContent?.mcp?.engineVersion === "0.2.0-beta.1" &&
       compute.structuredContent?.mcp?.limits?.wallTimeMs === 5000 &&
       compute.structuredContent?.mcp?.limits?.materializedElements === 100000 &&
       compute.structuredContent?.mcp?.limits?.bigintBits === 262144 &&
@@ -339,6 +403,44 @@ if (compute.structuredContent?.error?.code === "backendUnavailable") {
     validateResult(inferred.structuredContent),
   );
 }
+
+// The terminal command line. A stdio server is silent whether it is healthy or
+// wedged, so `--doctor` is the only thing that tells an operator which; and it
+// has to answer through an exit code, because that is what a script reads.
+async function cli(...argv) {
+  const lines = [];
+  const code = await runCli(argv, (line) => lines.push(line));
+  return { code, text: lines.join("\n") };
+}
+const version = await cli("--version");
+check(
+  "--version names the adapter, the engine and the registry",
+  version.code === 0 &&
+    version.text.includes(`ajisai-mcp-server ${serverVersion()}`) &&
+    /engine \d/.test(version.text) &&
+    /registry [a-f0-9]{16}/.test(version.text),
+);
+const help = await cli("--help");
+check(
+  "--help documents every command the binary accepts",
+  help.code === 0 && ["--doctor", "--version", "--help"].every((flag) => help.text.includes(flag)),
+);
+const doctorRun = await cli("--doctor");
+check(
+  "--doctor exercises the real backend and exits 0 when healthy",
+  doctorRun.code === 0 &&
+    doctorRun.text.includes("checks passed") &&
+    !doctorRun.text.includes("FAIL"),
+);
+check(
+  "--doctor proves exactness rather than only reporting that it started",
+  doctorRun.text.includes("2 3 / 1 3 / + = 1/1") && doctorRun.text.includes("exactTerms"),
+);
+const unknownFlag = await cli("--frobnicate");
+check(
+  "an unrecognized option is named and exits non-zero rather than serving",
+  unknownFlag.code === 2 && unknownFlag.text.includes("--frobnicate"),
+);
 
 await client.close();
 await server.close();

--- a/tools/mcp-server/sync-assets.js
+++ b/tools/mcp-server/sync-assets.js
@@ -10,7 +10,6 @@ const assetsDir = join(here, "assets");
 const sources = [
   [join(repoRoot, "spec", "words.json"), join(assetsDir, "words.json")],
   [join(repoRoot, "docs", "word-manifest.json"), join(assetsDir, "word-manifest.json")],
-  [join(repoRoot, "SKILL.md"), join(assetsDir, "quickstart.md")],
 ];
 const rootPackage = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
 const words = readFileSync(sources[0][0]);
@@ -19,24 +18,51 @@ const metadata = `${JSON.stringify({
   engineVersion: rootPackage.version,
   registryDigest: createHash("sha256").update(words).digest("hex"),
 }, null, 2)}\n`;
-const outputs = [...sources.map(([source, target]) => [readFileSync(source), target]),
-  [Buffer.from(metadata), join(assetsDir, "metadata.json")]];
-const check = process.argv.includes("--check");
 
-if (check) {
-  const stale = outputs.filter(([content, target]) =>
-    !existsSync(target) || !content.equals(readFileSync(target)));
-  if (stale.length) {
-    console.error(`MCP packaged assets are stale: ${stale.map(([, path]) => path).join(", ")}`);
-    process.exit(1);
+/**
+ * The served quickstart is an MCP preface followed by the generated writing
+ * protocol, not a copy of `SKILL.md`.
+ *
+ * `SKILL.md` opens with a CLI run loop (`ajisai run file --json`) — commands a
+ * connected MCP client cannot issue and has no reason to read about — and says
+ * nothing about which of the four tools to call. A model that read it first
+ * learned the language before learning the interface. The preface answers the
+ * interface question in one screen and hands off; the generated half stays
+ * verbatim, so its examples remain the ones the generator verified.
+ *
+ * `SKILL_BOUNDARY` is what the self-test slices on to run the preface's own
+ * examples against the live backend, and what a reader sees as the seam.
+ */
+export const SKILL_BOUNDARY = "<!-- BEGIN GENERATED SKILL.md -->\n";
+const quickstart = Buffer.concat([
+  readFileSync(join(here, "mcp-quickstart.md")),
+  Buffer.from(`${SKILL_BOUNDARY}\n`),
+  readFileSync(join(repoRoot, "SKILL.md")),
+]);
+
+const outputs = [...sources.map(([source, target]) => [readFileSync(source), target]),
+  [quickstart, join(assetsDir, "quickstart.md")],
+  [Buffer.from(metadata), join(assetsDir, "metadata.json")]];
+// Generating or checking is the entry-point behaviour; importing this module
+// for `SKILL_BOUNDARY` — which the self-test does, so the seam it slices on is
+// the one that was written — must not rewrite the working tree as a side
+// effect of the import.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (process.argv.includes("--check")) {
+    const stale = outputs.filter(([content, target]) =>
+      !existsSync(target) || !content.equals(readFileSync(target)));
+    if (stale.length) {
+      console.error(`MCP packaged assets are stale: ${stale.map(([, path]) => path).join(", ")}`);
+      process.exit(1);
+    }
+    // npm includes prepack stdout before `npm pack --json`, which would corrupt
+    // machine-readable pack output consumed by the smoke test.
+    if (process.env.npm_lifecycle_event !== "prepack") {
+      console.log("MCP packaged assets are current");
+    }
+  } else {
+    mkdirSync(assetsDir, { recursive: true });
+    for (const [content, target] of outputs) writeFileSync(target, content);
+    console.log("updated MCP packaged assets");
   }
-  // npm includes prepack stdout before `npm pack --json`, which would corrupt
-  // machine-readable pack output consumed by the smoke test.
-  if (process.env.npm_lifecycle_event !== "prepack") {
-    console.log("MCP packaged assets are current");
-  }
-} else {
-  mkdirSync(assetsDir, { recursive: true });
-  for (const [content, target] of outputs) writeFileSync(target, content);
-  console.log("updated MCP packaged assets");
 }


### PR DESCRIPTION
## Summary

Implements PR 1 of the ChatGPT-derived MCP improvement proposal, after validating each of its claims against a live connection. The proposal is largely sound — every P0/P1 finding reproduced — and acting on it surfaced **two defects it could not have seen from the outside**.

### Defects found while implementing

**1. The `bin` entry never started the server.** The entry-point guard compared `resolve(process.argv[1])` with `import.meta.url`. `resolve()` normalizes a path; it does not follow symlinks. Every launch through `node_modules/.bin` — which is *both* npm-based recipes the README gave (`npx -y ajisai-mcp-server`, and a bare `"command": "ajisai-mcp-server"`) — fell through the guard and exited 0 having served nothing. A client saw a server that started, offered no tools and reported no error. Only naming `index.js` directly ever worked.

Reproduced before the fix, against the packed tarball installed into a clean prefix:

```
$ printf '<initialize request>' | ./node_modules/.bin/ajisai-mcp-server
EXIT=0        # no response, no error, no output
```

Neither the self-test nor the pack smoke test caught it, because both import `createServer` rather than launch the executable. So P0-1's "publish to npm" plan would have shipped a package whose documented entry point silently does nothing.

**2. The pack smoke test's native-override scenario proved nothing.** The backend is resolved once per process and cached, so setting `AJISAI_BIN` and constructing a second in-process server reused the WASM backend scenario 1 had already fixed. The "native/Docker path" assertion passed on a machine with **no native binary at all** — verified here by simply running it before `cargo build`.

### Proposal items implemented

- **P0-1** — README no longer opens on `npm install -g ajisai-mcp-server` (confirmed E404). Publishing is stated as an open release decision; the checkout path leads and needs no build, because the WASM bundle is committed. The one previously-working example also no longer implies `AJISAI_BIN` — a native binary is a deployment override, not a prerequisite.
- **P1-1** — `ajisai://guide/quickstart` is now an MCP preface plus the generated `SKILL.md`, composed by `sync-assets.js`. The generated guide alone opens on `ajisai run file --json` (commands a connected client cannot issue) and never says which of the four tools to call. The preface covers tool selection, the `ok`/`error`/`hostError` branch, reason-carrying NIL, and the algebraic-value trap.
- **P1-2** — `--doctor` / `--version` / `--help` in `doctor.js`. `--doctor` checks the Node floor, packaged assets, backend selection, and two *real* computations through the selected backend, exiting 0 or 1.
- **P1-3** — `mcp.serverVersion` joins `mcp.engineVersion` on every result and on `ajisai://limits`.

### Corrections to the proposal

- **P0-2 is understated.** `stackDisplay` for `2 SQRT` is not merely long — it is *truncated* at a display budget, and the sibling `value` (`768398401/543339720`, `semantics.approximate: true`) is a rational **approximation**. The proposal treats this as a verbosity problem; it is a correctness-of-reading problem. The quickstart now warns about both explicitly, which is mitigation. The field itself stays in PR 2, with a naming correction recorded in the handoff: do not call it `canonicalDisplay`, since `exactTerms` is the canonical value and a display string named "canonical" invites exactly the substitution this boundary exists to prevent.
- **P0-3's remedy would violate an MCP recommendation.** Replacing `content` with a prose summary drops information text-only clients have no other way to reach; the spec asks a tool with an output schema to also return the serialized JSON as text. Measured alternative recorded in the handoff: pretty-printing alone is ~28–36% of the text, and always-null fields more, so most of the target reduction is available without breaking the mirror.

No semantic change in this PR: `stackDisplay`, `exactTerms` and the four outcome classes are untouched.

## Quality Classification

- Highest impacted level: QL-C (Node MCP adapter, packaging and generated agent-facing documentation; no Rust semantic surface touched)

## Traceability

- Requirement(s): MCP P1 local-stdio beta exit criteria, `docs/dev/mcp-readiness.md` (P1 section updated); next-PR guidance in `docs/dev/mcp-claude-code-handoff.md` §3, §5, §9
- Verification evidence:
  - `npm run test:mcp` (self-test, WASM **and** native `AJISAI_BIN`) — all checks passed, incl. 16 new checks covering the CLI, `serverVersion`, and 6 quickstart examples executed against the live backend
  - `npm run test:mcp-backends` — native and WASM agree on every golden case and every declared limit boundary
  - `npm run test:mcp-pack` — 4 scenarios, now including launch-by-name through `node_modules/.bin` and `--doctor` on the installed tarball
  - `npm run check`, `npm run lint`, `npm test` (359 tests), `check:mcp-assets`, `check:mcp-evaluation`, `check:agent-cli-contract`, `check:skill`, `check:version-sync`, `check:reading-surfaces`, `check:file-size`, `check:semantic-firewall`
  - `eval:mcp`, `eval:mcp-traces`, `eval:mcp-repairs`, `eval:mcp-performance`, `eval:mcp-number-baseline`
  - `cargo fmt --check`

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`)
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not run; this PR contains no Rust changes
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — not run; this PR contains no Rust changes
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable, no Rust changes
- [x] MC/DC-like checklist reviewed for modified boolean logic — the entry-point guard is the only new branching decision: `resolve()` match, `realpathSync()` match, and the throwing case are each exercised (self-test, pack-smoke launch-by-name, and the `catch` for a missing path)
- [x] Release checklist impact considered — the README and readiness tracker now state npm publication as an open decision rather than implying it is done

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

**Limitation reported honestly:** the proposal's P1-4 (real Claude Code traces) is deliberately *not* started here, per its own sequencing. No claim in this PR is backed by reference fixtures presented as model performance. The response-size figures quoted above are measured on this machine through the real backend, not estimates.

**Behaviour change for developers:** `npm run test:pack` now requires a built native binary, because its native-override scenario is real for the first time. `npm run test:mcp-pack` from the repository root builds it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt3hjmf1Rn1RQyzNpnyGEn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt3hjmf1Rn1RQyzNpnyGEn)_