### PR TITLE
perf(mcp): remove the padding from a result, not the information

### DIFF
--- a/docs/dev/mcp-claude-code-handoff.md
+++ b/docs/dev/mcp-claude-code-handoff.md
@@ -1,6 +1,6 @@
 # Ajisai MCP development handoff for Claude Code
 
-Updated: 2026-08-11 (algebraic exactDisplay; previously MCP onboarding)
+Updated: 2026-08-11 (response compaction; previously algebraic exactDisplay, MCP onboarding)
 
 - Current tracker: [`mcp-readiness.md`](./mcp-readiness.md)
 - Host profiles: [`mcp-host-profiles.md`](./mcp-host-profiles.md)
@@ -126,8 +126,11 @@ names or spawn diagnostics into it; that belongs on stderr, and
   harness fixture, not model evidence.
 - `evaluation-contract.js` and `validate-evaluation.js`: reject malformed,
   duplicated or selectively incomplete evaluation data.
-- `benchmark.js` and `eval/performance.json`: post-warmup local latency gate;
-  current committed p95 budget is 1 second.
+- `benchmark.js` and `eval/performance.json`: post-warmup local latency gate
+  (committed p95 budget 1 second) and response-size gate
+  (`medianResponseBytesBudget`). Response bytes are deterministic for a fixed
+  corpus and engine, so that budget is exact — lower it when a response
+  genuinely shrinks, never raise it to make a regression pass.
 - `number-baseline.js` and `eval/number-baseline.json`: deliberately narrow
   comparison with JavaScript `Number`, including exact controls. Do not present
   it as a general language or CAS benchmark.
@@ -153,10 +156,9 @@ measurement behind it**. Do not report it as one.
 
 ## 5. Recommended next pull request
 
-P1 backend work, P1 onboarding and the algebraic short display are done (see
-the readiness tracker's P1 section for the bin-entry, `--doctor`,
-`serverVersion`, quickstart and `exactDisplay` items). Three threads remain, in
-this order:
+P1 backend work, P1 onboarding, the algebraic short display and response
+compaction are done (see the readiness tracker's P1 section). Three threads
+remain, in this order:
 
 1. **Recalibrate the numeric work meter** so the declared size ceilings bind
    before the wall clock. Today `numericWork`, `bigintBits` and
@@ -170,19 +172,16 @@ this order:
    bounded only by `executionSteps`.
 2. **Collect real model traces** (see §6). The harness is not the bottleneck.
 
-3. **Compact the tool response, without breaking the text mirror.** The same
-   result is serialized into both `content[0].text` and `structuredContent`:
-   2,988 bytes total for an exact rational, 14,003 for an unknown-Word
-   diagnosis. The mirroring itself should stay — MCP asks a tool with an output
-   schema to also return the serialized JSON as text, so a text-only client
-   still receives the whole result, and replacing that text with a prose
-   summary would drop information those clients have no other way to reach.
-   What can go is padding: `JSON.stringify(value, null, 2)` alone accounts for
-   roughly 28–36% of the text, and always-null fields (`message`,
-   `diagnosis`, `aiDiagnostic`, `contractDecls` on a plain success) account for
-   more. Measure before and after on the evaluation corpus and re-run the
-   repair scorer; a reduction that lowers the diagnosis-observation rate is not
-   a win.
+3. **Provenance size, if it ever becomes the constraint.** Considered and
+   rejected during the response-compaction work, recorded so it is not
+   re-derived from scratch: on the *smallest* results the `mcp` block is the
+   single largest field (416 bytes of a 1,165-byte exact-rational result), and
+   about 290 of those are `limits`, identical on every response and already
+   published at `ajisai://limits`. Dropping it would shrink small responses by
+   a quarter — and would cost exactly what provenance is for, since a stored
+   result would no longer say which ceilings produced it. Do not trade that for
+   bytes without a demonstrated cost; `registryDigest` and the version pair are
+   even less compressible and even more load-bearing.
 
 Do not add MCP tools without demonstrated need. A `trace` tool mirroring the
 playground's step mode, and the unused `prompts` capability, are both plausible
@@ -287,6 +286,15 @@ but do not silently raise the committed budget to fix a regression.
   normal form, and reducing it would make the string disagree with the
   `exactTerms` printed beside it — trading a surprise a reader can see for one
   they cannot.
+- Do not replace the text content block with a prose summary. MCP asks a tool
+  with an output schema to also return the serialized JSON there, and it is the
+  only route a text-only client has to the result. Compaction means removing
+  padding, not information.
+- Do not prune empty arrays or all-zero `runtimeMetrics` to save bytes. Both
+  were measured (≈1 and ≈7 points of median respectively) and both make
+  presence conditional, so `output.length` starts throwing on exactly the
+  results that have nothing to report. `null`-valued fields are different:
+  absent and `null` mean the same thing to every reader.
 - Do not let a `nextChecks` locale carry another locale's language, and do not
   match on its display text anywhere; `code` is the stable identifier.
 - Do not delete or subordinate the browser playground to the MCP package.

--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -1,6 +1,6 @@
 # MCP product readiness
 
-Status date: 2026-08-11 (updated after the algebraic short-display work; before that, declared-limit, provenance and
+Status date: 2026-08-11 (updated after the response-compaction work; before that, algebraic short display, declared-limit, provenance and
 host-failure work). This is an implementation tracker, not a language
 specification. Percentages measure completion of the concrete exit criteria
 below; they are not forecasts.
@@ -168,6 +168,39 @@ Completed:
   a stored envelope naming only the engine could not say which adapter wrote
   it — so a missing field was indistinguishable from a field that adapter
   version never sent.
+- **A result costs less without saying less.** Two-space indentation on the
+  text content block cost about a third of it, and an optional field carrying
+  no value was sent as `null`, so a plain success advertised `message`,
+  `diagnosis`, `aiDiagnostic` and `contractDecls`, all empty. Both are gone.
+  Across the seven benchmark cases the text block's median fell 32%
+  (1,618 → 1,094 bytes) and the whole response's 22% (3,049 → 2,376), measured
+  before and after on the same corpus.
+
+  What did **not** change is the mirroring. MCP asks a tool with an output
+  schema to also return the serialized JSON in a text block, and that is a
+  text-only client's only route to the result — so replacing it with a prose
+  summary, which is what the original proposal asked for, is the one compaction
+  that loses information. The self-test now pins that a text-only client can
+  still tell a value, a reason-carrying NIL, a language error and a host
+  failure apart from the text alone, and that the text parses back to exactly
+  the structured result.
+
+  Consequently the proposal's ">= 50% content reduction" target is **not met**,
+  and deliberately so: 32% is what is available without removing information.
+  The remaining levers were measured and declined — pruning empty arrays
+  (≈1 point) and dropping all-zero `runtimeMetrics` (≈7 points) both make a
+  field's presence conditional, so `output.length` would start throwing on
+  exactly the results that have nothing to report. Nested `null` pruning
+  (≈4 points on the largest diagnosis) was declined for a different reason: it
+  turns one stated rule into a transformation a reader must apply mentally to
+  every nested object.
+
+  `eval:performance` now reports median and maximum response size alongside
+  latency and fails against a committed `medianResponseBytesBudget`, so the
+  padding cannot return unnoticed. Response bytes are deterministic for a fixed
+  corpus and engine, so that gate is exact rather than machine-dependent.
+  Diagnosis-observation and diagnosis-driven repair rates were re-scored after
+  the change and are unmoved.
 - **An algebraic value can be read without decoding anything.**
   `semantics.exactDisplay` writes the multiquadratic normal form as one short
   string — `sqrt(2)`, `2/1*sqrt(2)`, `1/1 + sqrt(2)`, `sqrt(2) - sqrt(3)` —

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -102,6 +102,32 @@ All four tools answer with the same envelope (`result.schema.json`, also served
 as `ajisai://schema/result`), so one schema describes every result a caller can
 receive and there is no second contract to keep in step.
 
+### What a result costs
+
+Every result arrives twice: as `structuredContent`, which a caller branches on,
+and serialized into a text content block, because MCP asks a tool with an
+output schema to also return the serialized JSON that way — a text-only client
+has no other route to any of it. That mirror stays. Replacing it with a prose
+summary is the one compaction that would actually lose information, and the
+self-test pins that a text-only client can still tell a value, a
+reason-carrying NIL, a language error and a host failure apart from the text
+alone.
+
+What was removed instead is padding. The text used to be written with
+two-space indentation, which cost about a third of it and told a machine
+nothing, and an optional field carrying no value used to be sent as `null` —
+so a plain success advertised `message`, `diagnosis`, `aiDiagnostic` and
+`contractDecls`, all empty. Those fields are now absent. **Test for presence,
+not for `null`.** Nested fields are untouched: one stated rule at the top level
+is worth more than the ~4% recursing would add.
+
+Measured across the seven benchmark cases, the text block's median fell 32%
+(1,618 → 1,094 bytes) and the whole response's 22% (3,049 → 2,376).
+`npm run eval:performance` reports both and fails against a committed
+`medianResponseBytesBudget`, so the padding cannot come back unnoticed. The
+budget is a ceiling to lower when a response genuinely shrinks, never one to
+raise so a regression passes.
+
 A host failure is machine-readable: `error.code` is a stable identifier
 (`invalidRequest`, `unknownTool`, `sourceTooLarge`, `backendUnavailable`,
 `capacityExhausted`, `timeout`, `responseTooLarge`, `malformedBackendResponse`,
@@ -268,8 +294,12 @@ silently producing plausible metrics.
 `eval:performance` measures five post-warmup rounds over seven representative
 compute, check, inference and registry cases. It reports p50/p95/max latency by
 tool and fails when the overall p95 exceeds the committed one-second local
-stdio budget. The measurements describe this adapter and machine, not remote
-service latency.
+stdio budget. It also reports median and maximum response size — for the whole
+result and for its text block alone — and fails against
+`medianResponseBytesBudget`; response bytes are deterministic for a fixed
+corpus and engine, so unlike the latency figures that gate is exact and
+reproducible. The latency measurements describe this adapter and machine, not
+remote service latency.
 `eval:number-baseline` compares canonical results for five selected rational,
 decimal and integer operations with JavaScript `Number`. It includes two
 exactly representable controls as well as known precision-sensitive cases, and

--- a/tools/mcp-server/assets/quickstart.md
+++ b/tools/mcp-server/assets/quickstart.md
@@ -41,6 +41,9 @@ its contents as `source`.
 4. On `hostError`: branch on `error.code`, and retry only if `error.retryable`
    is true. `mcp.limits` states every ceiling that applies.
 
+A field carrying no value is **absent**, not `null`: a successful result simply
+has no `diagnosis`. Test for presence.
+
 Do not collapse these into "it worked / it broke". Retrying a division by zero
 and rewriting a program that merely timed out are both wasted turns.
 

--- a/tools/mcp-server/benchmark.js
+++ b/tools/mcp-server/benchmark.js
@@ -25,6 +25,7 @@ validateCorpus(corpus);
 const config = read("./eval/performance.json");
 if (config.schemaVersion !== 1 || !Number.isInteger(config.measuredRuns) || config.measuredRuns < 1 ||
     !Number.isInteger(config.warmupRuns) || config.warmupRuns < 0 || !(config.p95BudgetMs > 0) ||
+    !(config.medianResponseBytesBudget > 0) ||
     !Array.isArray(config.caseIds) || config.caseIds.length === 0) {
   throw new Error("performance configuration is invalid");
 }
@@ -53,7 +54,28 @@ try {
         .every(([pointer, expected]) =>
           JSON.stringify(atPointer(result.structuredContent, pointer)) === JSON.stringify(expected));
       if (!semanticsOk) throw new Error(`performance case failed: ${testCase.id}`);
-      if (round >= 0) measurements.push({ caseId: testCase.id, tool: testCase.expectedTool, elapsedMs });
+      // What a caller actually receives, both halves of it: the structured
+      // result and the text block mirroring it. Measuring only one would hide
+      // the duplication that makes a response its real size, and measuring
+      // nothing is how a response grows a third larger without anyone noticing
+      // — which is what the two-space indentation this used to be serialized
+      // with had already done.
+      const responseBytes = Buffer.byteLength(JSON.stringify(result), "utf8");
+      // The text half on its own, because it is the half that was padded and
+      // the half a text-only client is limited to.
+      const contentBytes = Buffer.byteLength(
+        result.content?.map(({ text }) => text ?? "").join("") ?? "",
+        "utf8",
+      );
+      if (round >= 0) {
+        measurements.push({
+          caseId: testCase.id,
+          tool: testCase.expectedTool,
+          elapsedMs,
+          responseBytes,
+          contentBytes,
+        });
+      }
     }
   }
 } finally {
@@ -72,21 +94,52 @@ const byTool = Object.fromEntries([...new Set(measurements.map(({ tool }) => too
     maxMs: values.at(-1),
   }];
 }));
+// One response per case, not per sample: repeated rounds of the same case
+// return the same bytes, so a median over samples would just weight the cases
+// by how often they ran.
+const perCase = (field) => [...new Map(
+  measurements.map((sample) => [sample.caseId, sample[field]]),
+).values()].sort((a, b) => a - b);
+const responseBytes = perCase("responseBytes");
+const contentBytes = perCase("contentBytes");
 const report = {
   schemaVersion: 1,
   measuredRuns: config.measuredRuns,
   cases: selected.length,
   samples: measurements.length,
-  budget: { p95Ms: config.p95BudgetMs },
+  budget: {
+    p95Ms: config.p95BudgetMs,
+    medianResponseBytes: config.medianResponseBytesBudget,
+  },
   overall: {
     p50Ms: percentile(elapsed, 0.5),
     p95Ms: percentile(elapsed, 0.95),
     maxMs: elapsed.at(-1),
   },
+  responseSize: {
+    medianBytes: percentile(responseBytes, 0.5),
+    maxBytes: responseBytes.at(-1),
+    medianContentBytes: percentile(contentBytes, 0.5),
+    maxContentBytes: contentBytes.at(-1),
+  },
   byTool,
 };
 console.log(JSON.stringify(report, null, 2));
-if (process.argv.includes("--require-budget") && report.overall.p95Ms > config.p95BudgetMs) {
-  console.error(`p95 ${report.overall.p95Ms.toFixed(1)} ms exceeds ${config.p95BudgetMs} ms budget`);
-  process.exit(1);
+if (process.argv.includes("--require-budget")) {
+  const failures = [];
+  if (report.overall.p95Ms > config.p95BudgetMs) {
+    failures.push(`p95 ${report.overall.p95Ms.toFixed(1)} ms exceeds ${config.p95BudgetMs} ms budget`);
+  }
+  // A ceiling, not a target: it exists so a later change cannot quietly give
+  // back what this one removed. Lowering it when a response genuinely shrinks
+  // is the intended edit; raising it to make a regression pass is not.
+  if (report.responseSize.medianBytes > config.medianResponseBytesBudget) {
+    failures.push(
+      `median response ${report.responseSize.medianBytes} bytes exceeds ${config.medianResponseBytesBudget} byte budget`,
+    );
+  }
+  if (failures.length) {
+    for (const failure of failures) console.error(failure);
+    process.exit(1);
+  }
 }

--- a/tools/mcp-server/eval/performance.json
+++ b/tools/mcp-server/eval/performance.json
@@ -3,6 +3,7 @@
   "warmupRuns": 1,
   "measuredRuns": 5,
   "p95BudgetMs": 1000,
+  "medianResponseBytesBudget": 2600,
   "caseIds": [
     "exact-fraction",
     "decimal-no-float",

--- a/tools/mcp-server/index.js
+++ b/tools/mcp-server/index.js
@@ -285,8 +285,44 @@ function provenance() {
   };
 }
 
+/**
+ * Drop the envelope fields whose value is `null`.
+ *
+ * The backend fills every slot of the schema-1 envelope on every answer, so a
+ * successful `compute` used to advertise `message: null`, `diagnosis: null`,
+ * `aiDiagnostic: null` and `contractDecls: null` — four diagnostic-sounding
+ * fields inviting a reader to look at nothing. Absence says the same thing in
+ * no bytes, and `result.schema.json` requires only `schemaVersion` and
+ * `status`, so nothing that was promised stops being there.
+ *
+ * Top level only, and deliberately so. Recursing would save a further ~4% on
+ * the largest diagnosis and would turn one stated rule into a transformation a
+ * reader has to apply mentally to every nested object; the rule is worth more
+ * than the bytes. The backend's own envelope is untouched — this is the
+ * adapter's presentation of it, which is why the native/WASM parity test,
+ * which compares what the backends return, is unaffected.
+ */
+function withoutEmptyFields(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, field]) => field !== null));
+}
+
+/**
+ * One result, in the two shapes MCP asks for.
+ *
+ * `structuredContent` is what a caller branches on. `content` carries the
+ * *same* object serialized, because the specification asks a tool with an
+ * output schema to also return the serialized JSON in a text block for
+ * backwards compatibility — a text-only client has no other way to reach any
+ * of this. Replacing that text with a prose summary would have been the one
+ * compaction that actually loses information, so what shrank instead is
+ * padding: the two-space indentation this used to be written with cost about a
+ * third of the text and told a machine nothing.
+ *
+ * Both shapes are built from one object, so the mirror cannot drift.
+ */
 function envelope(value) {
-  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }], structuredContent: value };
+  const result = withoutEmptyFields(value);
+  return { content: [{ type: "text", text: JSON.stringify(result) }], structuredContent: result };
 }
 
 /**
@@ -316,7 +352,7 @@ function fail(error, context = "tool call") {
     // Provenance itself is what failed; the error block above already says so.
   }
   return {
-    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    content: [{ type: "text", text: JSON.stringify(payload) }],
     structuredContent: payload,
     isError: true,
   };

--- a/tools/mcp-server/mcp-quickstart.md
+++ b/tools/mcp-server/mcp-quickstart.md
@@ -41,6 +41,9 @@ its contents as `source`.
 4. On `hostError`: branch on `error.code`, and retry only if `error.retryable`
    is true. `mcp.limits` states every ceiling that applies.
 
+A field carrying no value is **absent**, not `null`: a successful result simply
+has no `diagnosis`. Test for presence.
+
 Do not collapse these into "it worked / it broke". Retrying a division by zero
 and rewriting a program that merely timed out are both wasted turns.
 

--- a/tools/mcp-server/result.schema.json
+++ b/tools/mcp-server/result.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "ajisai://schema/result",
   "title": "Ajisai MCP result",
-  "description": "One envelope for every Ajisai MCP tool result. `status` separates the three outcomes the boundary keeps distinct: a successful run (which includes a reason-carrying NIL), an Ajisai language error carrying its diagnosis, and a failure of the host rather than of the program.",
+  "description": "One envelope for every Ajisai MCP tool result. `status` separates the three outcomes the boundary keeps distinct: a successful run (which includes a reason-carrying NIL), an Ajisai language error carrying its diagnosis, and a failure of the host rather than of the program. An optional field carrying no value is omitted rather than sent as `null`, so `diagnosis`, `aiDiagnostic`, `message` and `contractDecls` are simply absent from a plain success — test for presence, not for `null`. The text content block of a tool result carries this same object serialized, so a text-only client receives the whole result and not a summary of it.",
   "type": "object",
   "additionalProperties": true,
   "required": ["schemaVersion", "status"],

--- a/tools/mcp-server/selftest.js
+++ b/tools/mcp-server/selftest.js
@@ -313,6 +313,52 @@ for (const limit of limitCases()) {
   }
 }
 
+// The two halves of a result, and the padding between them.
+//
+// MCP asks a tool with an output schema to also return the serialized JSON in
+// a text block, so a text-only client receives the whole result rather than a
+// summary of it. That makes the text a *mirror*: if it ever stops being the
+// same object, the two kinds of client stop seeing the same answer. These pin
+// the mirror, and pin the padding that used to cost a third of it.
+const mirrored = await client.callTool({ name: "compute", arguments: { source: "1 3 /" } });
+check(
+  "the text block is the structured result, not a summary of it",
+  JSON.stringify(JSON.parse(mirrored.content?.[0]?.text ?? "null")) ===
+    JSON.stringify(mirrored.structuredContent),
+);
+check(
+  "the text block carries no indentation padding",
+  typeof mirrored.content?.[0]?.text === "string" &&
+    !/\n\s/.test(mirrored.content[0].text),
+);
+// An optional field with nothing in it is absent, not `null`. A plain success
+// used to advertise `diagnosis`, `aiDiagnostic`, `message` and
+// `contractDecls`, all empty — four diagnostic-sounding fields pointing at
+// nothing.
+check(
+  "a successful result carries no null-valued fields",
+  Object.values(mirrored.structuredContent ?? {}).every((field) => field !== null) &&
+    !("diagnosis" in (mirrored.structuredContent ?? {})),
+);
+// Compaction must not cost a text-only client the outcome distinction, which
+// is the whole reason the text is the serialized result rather than prose.
+for (const [label, call] of [
+  ["a value", { name: "compute", arguments: { source: "1 3 /" } }],
+  ["a reason-carrying NIL", { name: "compute", arguments: { source: "1 0 /" } }],
+  ["a language error", { name: "compute", arguments: { source: "FROBNICATE" } }],
+  ["a host failure", { name: "compute", arguments: { source: "" } }],
+]) {
+  const observed = await client.callTool(call);
+  const text = JSON.parse(observed.content?.[0]?.text ?? "null");
+  check(
+    `a text-only client can still identify ${label}`,
+    typeof text?.status === "string" &&
+      text.status === observed.structuredContent?.status &&
+      (text.status !== "hostError" || typeof text.error?.code === "string") &&
+      (text.status !== "error" || typeof text.diagnosis?.why === "string"),
+  );
+}
+
 const compute = await client.callTool({
   name: "compute",
   arguments: { source: "[ 2 ] SQRT" },


### PR DESCRIPTION
## Summary

PR 3 of the MCP improvement proposal: response compaction.

Every result arrives twice — as `structuredContent`, which a caller branches on, and serialized into a text content block. That duplication is **not** waste. The MCP specification says, verbatim:

> "For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block."

It is the only route a text-only client has to any of the result. So the mirror stays, and what shrank is padding:

- The text was written with **two-space indentation**, costing about a third of it and telling a machine nothing.
- An optional field carrying no value was sent as **`null`**, so a plain success advertised `message`, `diagnosis`, `aiDiagnostic` and `contractDecls` — four diagnostic-sounding fields pointing at nothing. The schema requires only `schemaVersion` and `status`, so nothing promised stopped being there. **Callers test for presence now**, which the schema, README and packaged quickstart all state.

### Measured, before and after, on the seven benchmark cases

| | before | after | |
|---|---:|---:|---:|
| text block, median | 1,618 | **1,094** | −32.4% |
| text block, max | 2,646 | 1,592 | −39.8% |
| whole response, median | 3,049 | **2,376** | −22.1% |
| whole response, max | 4,699 | 3,456 | −26.5% |

`eval:performance` now reports both and fails against a committed `medianResponseBytesBudget`, so the padding cannot return unnoticed. Response bytes are deterministic for a fixed corpus and engine, so unlike the latency figures beside them that gate is exact and reproducible rather than machine-dependent.

### The proposal's ≥50% target is not met, deliberately

32% is what is available without removing information. The rest was measured and declined:

| lever | gain | why declined |
|---|---:|---|
| prose summary instead of JSON text (the proposal's own remedy) | large | drops what text-only clients cannot otherwise reach; contradicts the spec SHOULD above |
| prune empty arrays | ~1 pt | makes presence conditional — `output.length` throws on exactly the results with nothing to report |
| drop all-zero `runtimeMetrics` | ~7 pt | same; and the counters do carry data (verified: `scalarFastpathCount`, `resolveCacheHitCount`, `compiledPlan*` all tick on real programs) |
| prune nested nulls | ~4 pt | turns one stated rule into a transformation a reader applies to every nested object |

`null` is different from all of these: absent and `null` mean the same thing to every reader, which is why that one is safe.

### The surprise worth recording

Measuring where the bytes actually are turned up something the proposal missed: **on the smallest results, the `mcp` provenance block is the single largest field** — 416 bytes of a 1,165-byte exact rational, of which ~290 is the `limits` table, identical on every response and already published at `ajisai://limits`.

Dropping it would shrink small results by a quarter and would cost exactly what provenance is for: a stored result would no longer say which ceilings produced it. Listed in the handoff as considered-and-rejected so it is not rediscovered from scratch.

### Guarding the mirror

New self-test checks pin the properties compaction could have broken:
- the text block parses back to **exactly** `structuredContent` (the mirror cannot drift)
- the text carries no indentation padding (the actual regression guard)
- a successful result carries no `null`-valued fields
- a text-only client can still identify a value, a reason-carrying NIL, a language error and a host failure **from the text alone**

## Quality Classification

- Highest impacted level: QL-C (Node MCP adapter presentation layer; no Rust changes, no engine semantics touched)

## Traceability

- Requirement(s): MCP proposal P0-3; `docs/dev/mcp-readiness.md` P1 section; `tools/mcp-server/result.schema.json` envelope contract
- Verification evidence:
  - `npm run test:mcp` (WASM **and** native `AJISAI_BIN`) — all checks pass, including 7 new compaction/mirror checks
  - `npm run eval:mcp-repairs` — `diagnosisObservedRate: 1`, `diagnosisDrivenRepairRate: 1`, unmoved by the change (this is the check that compaction did not cost diagnostic reachability)
  - `npm run eval:mcp-traces`, `npm run eval:mcp` — unchanged
  - `npm run eval:mcp-performance --require-budget` — passes both the latency and the new size budget
  - `npm run test:mcp-backends`, `npm run test:mcp-pack` — green; the parity test compares what the *backends* return, so it is unaffected by adapter-side presentation
  - `npm run check`, `npm run lint`, `npm test` (359 tests), `check:mcp-assets`, `check:mcp-evaluation`, `check:agent-cli-contract`, `check:skill`, `check:version-sync`, `check:reading-surfaces`, `check:file-size`, `check:semantic-firewall`
  - Before/after figures produced by stashing only `index.js` and re-running the same benchmark, so the two measurements differ in exactly one thing

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not run; this PR contains no Rust changes
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not run; no Rust changes
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — not run; no Rust changes
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable, no Rust changes
- [x] MC/DC-like checklist reviewed for modified boolean logic — the new decision is `field !== null` in `withoutEmptyFields`, exercised both ways by every golden case (success drops four fields, an error keeps `diagnosis`/`aiDiagnostic`/`message`); the benchmark's two budget conditions are exercised independently, the size one having been observed failing at a deliberately low budget before being set
- [x] Release checklist impact considered — `structuredContent` shape changes for MCP callers (absent vs `null`); documented in the schema description, the README and the packaged quickstart. The CLI/WASM schema-1 envelope is untouched, so the playground and `ajisai agent` are unaffected.

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

**Not claimed:** no real-model evaluation was run. The repair scorer confirms diagnostic reachability is unchanged against committed fixtures, which prove the scorer, not a model. Whether smaller responses change real model behaviour is what P1-4 trace collection is for.

**Divergence introduced:** the MCP `structuredContent` is no longer byte-identical to the CLI's schema-1 envelope, since the adapter drops `null` fields. `result.schema.json` is the authority for MCP callers and now says so explicitly. `docs/dev/agent-cli-output-contract.md` continues to describe the CLI envelope and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt3hjmf1Rn1RQyzNpnyGEn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt3hjmf1Rn1RQyzNpnyGEn)_