### PR TITLE
feat(mcp): make a trace say what produced it, and add the thing that produces one

### DIFF
--- a/docs/dev/mcp-claude-code-handoff.md
+++ b/docs/dev/mcp-claude-code-handoff.md
@@ -1,6 +1,6 @@
 # Ajisai MCP development handoff for Claude Code
 
-Updated: 2026-08-11 (response compaction; previously algebraic exactDisplay, MCP onboarding)
+Updated: 2026-08-11 (trace provenance + capture harness; previously response compaction, exactDisplay, onboarding)
 
 - Current tracker: [`mcp-readiness.md`](./mcp-readiness.md)
 - Host profiles: [`mcp-host-profiles.md`](./mcp-host-profiles.md)
@@ -118,7 +118,11 @@ names or spawn diagnostics into it; that belongs on stderr, and
 
 - `eval/cases.json`: 22 intent/semantic cases.
 - `eval/reference-traces.json`: scorer-conformance fixture, **not a real model
-  result**.
+  result** — and now says so in its own `provenance` block rather than only in
+  prose here.
+- `capture-traces.js` and `capture-traces.test.js`: the capture harness and its
+  scripted-client test. The test proves prompt assembly and tool-call
+  extraction; it is not a model measurement, and says so when it passes.
 - `score-traces.js`: tool selection, semantic success, missing trace and
   irrelevant activation metrics.
 - `eval/repair-cases.json`, `eval/reference-repair-traces.json` and
@@ -137,11 +141,11 @@ names or spawn diagnostics into it; that belongs on stderr, and
 
 ## 4. Current readiness and honest interpretation
 
-The weighted tracker is 81%:
+The weighted tracker is 81.4%:
 
 - P0 semantic boundary: 100%.
 - P1 local stdio beta: 100%.
-- P2 agent evaluation: 55%.
+- P2 agent evaluation: 57%.
 - P3 remote service: 0%, deliberately deferred.
 
 P1 completion means the package is self-contained (the WASM backend needs
@@ -170,7 +174,20 @@ remain, in this order:
    move to `boundary` coverage. Related: plain rational arithmetic does not
    pass through the algebraic size guard at all, so a large integer product is
    bounded only by `executionSteps`.
-2. **Collect real model traces** (see §6). The harness is not the bottleneck.
+2. **Collect real model traces** (see §6). The harness is not the bottleneck,
+   and as of this round neither is the tooling: `npm run eval:capture` drives a
+   real model over the four tools and writes a `model`-provenance trace under
+   `eval/traces/`. **What is missing is credentials** — it resolves them the way
+   the Anthropic SDK does and, finding none, exits non-zero having written
+   nothing. Run it once to establish the baseline, then re-run it under the same
+   model, prompt digest and tool-choice setting to compare against.
+
+   The separation is now enforced rather than documented: a trace document is
+   rejected unless it declares `provenance.source`, a `model` trace must record
+   what makes it re-runnable, and `--require-perfect` is refused on anything
+   that is not a `referenceFixture`. Do not weaken any of those to make a run
+   pass — the flag asserts that the *scorer* works, and there is no
+   corresponding assertion to make about a model.
 
 3. **Provenance size, if it ever becomes the constraint.** Considered and
    rejected during the response-compaction work, recorded so it is not

--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -1,6 +1,6 @@
 # MCP product readiness
 
-Status date: 2026-08-11 (updated after the response-compaction work; before that, algebraic short display, declared-limit, provenance and
+Status date: 2026-08-11 (updated after the trace-provenance and capture-harness work; before that, response compaction, algebraic short display, declared-limit, provenance and
 host-failure work). This is an implementation tracker, not a language
 specification. Percentages measure completion of the concrete exit criteria
 below; they are not forecasts.
@@ -23,9 +23,9 @@ host and shares the value protocol with the native CLI.
 |---|---:|---:|---:|
 | P0 — lossless semantic boundary | 35% | 100% | 35.0% |
 | P1 — local stdio beta | 35% | 100% | 35.0% |
-| P2 — agent evaluation | 20% | 55% | 11.0% |
+| P2 — agent evaluation | 20% | 57% | 11.4% |
 | P3 — remote service | 10% | 0% | 0.0% |
-| **Overall** | **100%** | — | **81.0%** |
+| **Overall** | **100%** | — | **81.4%** |
 
 ### P0 — lossless semantic boundary (100%)
 
@@ -258,7 +258,35 @@ the next engine-side task. Two related facts: plain rational arithmetic does
 not pass through the algebraic size guard, and `numericWork` is charged only
 on the exact algebraic path.
 
-### P2 — agent evaluation (55%)
+### P2 — agent evaluation (57%)
+
+**A trace now says what produced it, and the harness that produces one exists.**
+Every trace document declares `provenance.source` — `referenceFixture` or
+`model` — and a `model` trace must additionally record the model id, prompt
+digest, tool-choice setting, capture time and the server/engine/registry
+versions it ran against. Documents without that block are rejected rather than
+scored; the scorers print the provenance beside the metrics; and
+`--require-perfect` is refused on anything that is not a fixture, because that
+flag asserts the *scorer* runs and there is no matching assertion to make about
+a model. Until this round the fixture and a real capture were the same shape, so
+a fixture's `toolSelectionAccuracy: 1` could be read — or reported — as a model
+result.
+
+`npm run eval:capture` drives a real model over the four published tool
+definitions, one call per corpus case at `tool_choice: auto` so the
+irrelevant-intent cases can correctly produce no call, and writes to
+`eval/traces/`, apart from the committed fixtures.
+
+**No baseline has been collected, and the percentage above reflects that.** The
+capture harness resolves credentials the way the Anthropic SDK does and, finding
+none, exits non-zero having written nothing — a file that looks like a trace and
+is not one would be worse than no file. Everything P2 still needs is downstream
+of running it: first-attempt generation rate, diagnosis-observation and repair
+rates for a real model, and the before/after comparison the `exactDisplay` and
+response-compaction rounds are owed. The 2-point movement is for tooling and
+enforcement, not for evidence.
+
+#### Earlier P2 work
 
 A first versioned prompt corpus now covers tool intent and backend semantics for
 rationals, decimals, algebraics, vector broadcast, NIL, diagnostics, static

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -280,8 +280,35 @@ semantic correctness only; model tool selection and source generation require
 captured model traces and are not claimed by this score.
 `score-traces.js` accepts captured model traces in the documented reference
 shape and reports tool-selection accuracy, end-to-end semantic success, missing
-traces and irrelevant-tool rate. The committed reference trace is a harness
-conformance fixture, not a model benchmark result.
+traces and irrelevant-tool rate.
+
+Every trace document declares what produced it. `provenance.source` is either
+`referenceFixture` — a hand-written trace built to pass the scorer, whose
+perfect result describes the scorer and nothing else — or `model`, a real
+capture, which must additionally record the model id, prompt-template digest,
+tool-choice setting, capture time, and the server, engine and registry versions
+it ran against. A document without that block is rejected rather than scored,
+because the same numbers mean "the harness works" or "the model performs this
+well" depending on an answer the file was not carrying. The scorers print the
+provenance alongside the metrics, so a score copied out of a log still says
+which it is.
+
+`--require-perfect` is only valid on a `referenceFixture`. It asserts that the
+scorer runs end to end; pointing it at a model trace would turn the first clean
+run into a committed claim that the model is perfect, which is the one thing
+this corpus is least entitled to say. A model trace is scored and reported,
+never asserted.
+
+**No model baseline has been collected.** `npm run eval:capture` drives a real
+model over the four tools — one call per corpus case, `tool_choice: auto` so
+the irrelevant-intent cases can correctly produce no call — and writes a
+`model` trace under `eval/traces/`, kept apart from the committed fixtures so no
+directory listing presents the two as the same kind of artifact. It resolves
+credentials the way the Anthropic SDK does (`ANTHROPIC_API_KEY`,
+`ANTHROPIC_AUTH_TOKEN`, or an `ant auth login` profile) and, finding none,
+exits non-zero having written nothing. `capture-traces.test.js` exercises the
+harness against a scripted client; it tests prompt assembly and tool-call
+extraction, not a model.
 `score-repairs.js` replays a failed attempt and its model-produced revision,
 requires the expected structured diagnosis before the revision can count, and
 reports diagnosis-observation and diagnosis-driven repair rates. The seed cases

--- a/tools/mcp-server/capture-traces.js
+++ b/tools/mcp-server/capture-traces.js
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Capture what a real model does with the Ajisai tools.
+//
+// Everything else in `eval/` grades a trace. Nothing produced one: the two
+// committed traces are hand-written fixtures that prove the scorers run, and
+// the readiness tracker has said for three rounds that the harness is not the
+// bottleneck — real traces are. This is the missing half.
+//
+// It drives the actual model over the actual MCP tool definitions, one call per
+// corpus case, and writes a trace the scorers accept. What it does *not* do is
+// produce a number when it cannot measure one: with no resolvable credentials
+// it exits non-zero having written nothing, because a file that looks like a
+// trace and isn't is worse than no file.
+//
+// Usage:
+//   node capture-traces.js [--model <id>] [--out <path>] [--limit <n>]
+//
+// Credentials resolve the way the Anthropic SDK resolves them (ANTHROPIC_API_KEY,
+// ANTHROPIC_AUTH_TOKEN, or an `ant auth login` profile) — this file reads none
+// of them itself.
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { engineVersion, registryDigest, serverVersion } from "./index.js";
+import { validateCorpus } from "./evaluation-contract.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * What the model is told, verbatim.
+ *
+ * Deliberately thin. The point of a baseline is to measure what the published
+ * tool descriptions and quickstart achieve on their own — a system prompt that
+ * coaches tool selection would measure the prompt instead, and every later
+ * comparison would be against a moving target. Its digest is recorded with the
+ * trace so a changed prompt cannot be mistaken for a changed model.
+ */
+export const SYSTEM_PROMPT =
+  "You have access to Ajisai, a bounded exact-arithmetic engine, through the " +
+  "tools below. Use a tool when it is the right instrument for the request, " +
+  "and answer directly when it is not.";
+
+export const DEFAULT_MODEL = "claude-opus-5";
+
+function digest(text) {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+function argValue(argv, flag, fallback) {
+  const index = argv.indexOf(flag);
+  return index === -1 ? fallback : argv[index + 1];
+}
+
+/**
+ * The four tools, exactly as a connected client would see them.
+ *
+ * Read from the server's own declaration rather than restated here: a baseline
+ * measured against a hand-copied description would drift from the product the
+ * moment either changed, and would then be comparing two different things
+ * across the PRs it exists to compare.
+ */
+export async function toolDefinitions() {
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+  const { InMemoryTransport } = await import("@modelcontextprotocol/sdk/inMemory.js");
+  const { createServer } = await import("./index.js");
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createServer();
+  const client = new Client({ name: "ajisai-trace-capture", version: "1" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    const { tools } = await client.listTools();
+    return tools.map(({ name, description, inputSchema }) => ({
+      name,
+      description,
+      input_schema: inputSchema,
+    }));
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+/**
+ * One case: ask once, record what the model reached for.
+ *
+ * `tool_choice` is `auto` and must stay that way — a third of the corpus is
+ * irrelevant-intent cases whose correct answer is *no* tool call, and forcing a
+ * call would score the one metric that measures restraint as a guaranteed
+ * failure.
+ */
+export async function captureCase(client, { model, tools, testCase }) {
+  const response = await client.messages.create({
+    model,
+    // Thinking is on by default on current models and shares this budget with
+    // the response, so the ceiling is generous: a truncated turn would be
+    // recorded as a model that declined to call a tool.
+    max_tokens: 16000,
+    system: SYSTEM_PROMPT,
+    tools,
+    tool_choice: { type: "auto" },
+    messages: [{ role: "user", content: testCase.prompt }],
+  });
+  const toolUses = (response.content ?? []).filter((block) => block.type === "tool_use");
+  const [first] = toolUses;
+  return {
+    caseId: testCase.id,
+    // `null` is a real answer, not a missing one: it is what a correct response
+    // to an irrelevant prompt looks like.
+    selectedTool: first?.name ?? null,
+    arguments: first?.input ?? {},
+    // Observations the scorers do not consume yet, recorded because they cannot
+    // be recovered later: a second call in one turn, and a turn that stopped
+    // for a reason other than finishing.
+    observed: { toolCalls: toolUses.length, stopReason: response.stop_reason ?? null },
+  };
+}
+
+/**
+ * Resolve the SDK client, or explain why there is nothing to run.
+ *
+ * Constructing a client does not check credentials — the SDK resolves them
+ * when it builds the first request's headers, so a missing key surfaces as a
+ * stack trace partway through a run rather than as a refusal to start. This
+ * turns that into one actionable line, which `captureFailure` completes for
+ * the failure that arrives late.
+ */
+async function connect() {
+  let Anthropic;
+  try {
+    ({ default: Anthropic } = await import("@anthropic-ai/sdk"));
+  } catch {
+    throw new Error(
+      "the Anthropic SDK is not installed; run `npm install` in tools/mcp-server",
+    );
+  }
+  return new Anthropic();
+}
+
+const MISSING_CREDENTIALS = /Could not resolve authentication|authentication_error|invalid x-api-key/i;
+
+/** The message for a failed run. Nothing is ever written on this path. */
+function captureFailure(error) {
+  if (MISSING_CREDENTIALS.test(error?.message ?? "")) {
+    return (
+      "no Anthropic credentials could be resolved. Set ANTHROPIC_API_KEY, or run `ant auth login`.\n" +
+      "Nothing was written — a trace file that was not produced by a model is worse than no file."
+    );
+  }
+  return `capture failed: ${error?.message ?? error}\nNothing was written.`;
+}
+
+export async function captureAll({ client, model, tools, cases, onCase = () => {} }) {
+  const traces = [];
+  for (const testCase of cases) {
+    const trace = await captureCase(client, { model, tools, testCase });
+    traces.push(trace);
+    onCase(trace);
+  }
+  return {
+    schemaVersion: 1,
+    provenance: {
+      source: "model",
+      modelId: model,
+      promptTemplateDigest: digest(SYSTEM_PROMPT),
+      toolChoice: "auto",
+      capturedAt: new Date().toISOString(),
+      serverVersion: serverVersion(),
+      engineVersion: engineVersion(),
+      registryDigest: registryDigest(),
+    },
+    traces,
+  };
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const model = argValue(process.argv, "--model", DEFAULT_MODEL);
+  const limit = Number(argValue(process.argv, "--limit", "0")) || Infinity;
+  const corpus = JSON.parse(readFileSync(new URL("./eval/cases.json", import.meta.url), "utf8"));
+  validateCorpus(corpus);
+  const cases = corpus.cases.slice(0, limit);
+  // Real traces live apart from the committed fixtures, so no directory listing
+  // ever presents the two as the same kind of artifact.
+  const out = argValue(
+    process.argv,
+    "--out",
+    `${here}/eval/traces/${model}-${new Date().toISOString().replaceAll(":", "-")}.json`,
+  );
+
+  let document;
+  try {
+    const client = await connect();
+    document = await captureAll({
+      client,
+      model,
+      tools: await toolDefinitions(),
+      cases,
+      onCase: ({ caseId, selectedTool }) => console.error(`  ${caseId} -> ${selectedTool ?? "(no tool)"}`),
+    });
+  } catch (error) {
+    console.error(captureFailure(error));
+    process.exit(2);
+  }
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(document, null, 2)}\n`);
+  console.log(out);
+  console.error(
+    `captured ${document.traces.length} traces for ${model}; score with:\n` +
+      `  node score-traces.js ${out}`,
+  );
+}

--- a/tools/mcp-server/capture-traces.test.js
+++ b/tools/mcp-server/capture-traces.test.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// The capture harness, driven by a scripted client.
+//
+// This tests the harness — prompt assembly, tool-call extraction, the shape of
+// what gets written — and **not** a model: the client here returns canned
+// responses. That distinction is the whole subject of this round of work, so
+// the file states it rather than leaving a reader to infer it from the name.
+
+import assert from "node:assert/strict";
+import { captureAll, captureCase, DEFAULT_MODEL, SYSTEM_PROMPT, toolDefinitions } from "./capture-traces.js";
+import { indexTraces, mayAssertPerfect, validateCorpus } from "./evaluation-contract.js";
+
+const tools = await toolDefinitions();
+assert.deepEqual(
+  tools.map(({ name }) => name).sort(),
+  ["check", "compute", "infer_contracts", "word_contract"],
+  "the model is offered exactly the tools the server publishes",
+);
+assert.ok(
+  tools.every(({ description, input_schema }) => description?.length > 0 && input_schema?.type === "object"),
+  "each definition carries the server's own description and input schema",
+);
+
+/** A client that answers from a script and records what it was asked. */
+function scriptedClient(replies) {
+  const requests = [];
+  return {
+    requests,
+    messages: {
+      create: async (request) => {
+        requests.push(request);
+        return replies[requests.length - 1];
+      },
+    },
+  };
+}
+
+const compute = {
+  content: [
+    { type: "text", text: "I'll compute that." },
+    { type: "tool_use", id: "t1", name: "compute", input: { source: "1 3 /" } },
+  ],
+  stop_reason: "tool_use",
+};
+const noTool = { content: [{ type: "text", text: "That isn't arithmetic." }], stop_reason: "end_turn" };
+
+const client = scriptedClient([compute, noTool]);
+const positive = await captureCase(client, {
+  model: DEFAULT_MODEL,
+  tools,
+  testCase: { id: "exact-fraction", prompt: "Compute one third exactly." },
+});
+assert.deepEqual(positive.selectedTool, "compute");
+assert.deepEqual(positive.arguments, { source: "1 3 /" });
+assert.deepEqual(positive.observed, { toolCalls: 1, stopReason: "tool_use" });
+
+// The negative half of the corpus. A model that answers an irrelevant prompt
+// without touching Ajisai is *correct*, so this has to record `null` rather
+// than treat the absence as a missing trace.
+const negative = await captureCase(client, {
+  model: DEFAULT_MODEL,
+  tools,
+  testCase: { id: "irrelevant-translation", prompt: "Translate hello into French." },
+});
+assert.equal(negative.selectedTool, null);
+assert.deepEqual(negative.arguments, {});
+
+const [request] = client.requests;
+assert.equal(request.system, SYSTEM_PROMPT);
+// Forcing a tool call would make every irrelevant-intent case an automatic
+// failure of the one metric that measures restraint.
+assert.deepEqual(request.tool_choice, { type: "auto" });
+assert.equal(request.tools.length, 4);
+assert.ok(!("temperature" in request), "sampling parameters are rejected by current models");
+
+// What gets written must be a document the scorers accept — and must be
+// classified as a model capture, so no run of it can ever be asserted perfect.
+const corpus = JSON.parse(
+  (await import("node:fs")).readFileSync(new URL("./eval/cases.json", import.meta.url), "utf8"),
+);
+const ids = validateCorpus(corpus);
+const document = await captureAll({
+  client: scriptedClient([compute]),
+  model: DEFAULT_MODEL,
+  tools,
+  cases: [corpus.cases[0]],
+});
+assert.equal(indexTraces(document, ids).size, 1, "the captured document validates as a trace");
+assert.equal(document.provenance.source, "model");
+assert.equal(mayAssertPerfect(document), false, "a capture can be reported, never asserted perfect");
+for (const field of ["modelId", "promptTemplateDigest", "toolChoice", "capturedAt", "serverVersion", "engineVersion", "registryDigest"]) {
+  assert.ok(document.provenance[field], `provenance records ${field}`);
+}
+
+console.log("capture harness checks passed (scripted client — not a model measurement)");

--- a/tools/mcp-server/eval/reference-repair-traces.json
+++ b/tools/mcp-server/eval/reference-repair-traces.json
@@ -1,5 +1,9 @@
 {
   "schemaVersion": 1,
+  "provenance": {
+    "source": "referenceFixture",
+    "note": "Hand-written diagnosis-driven repair trace built to pass score-repairs.js. It proves the scorer runs end to end; it is not a model result."
+  },
   "traces": [
     {
       "caseId": "repair-unknown-word",

--- a/tools/mcp-server/eval/reference-traces.json
+++ b/tools/mcp-server/eval/reference-traces.json
@@ -1,5 +1,9 @@
 {
   "schemaVersion": 1,
+  "provenance": {
+    "source": "referenceFixture",
+    "note": "Hand-written tool-selection trace built to pass score-traces.js. It proves the scorer runs end to end; it is not a model result and its perfect score describes nothing about any model."
+  },
   "traces": [
     {
       "caseId": "exact-fraction",

--- a/tools/mcp-server/evaluation-contract.js
+++ b/tools/mcp-server/evaluation-contract.js
@@ -1,5 +1,57 @@
 const TOOL_NAMES = new Set(["compute", "check", "infer_contracts", "word_contract"]);
 
+/**
+ * What produced a set of traces — the field that decides what its score means.
+ *
+ * `referenceFixture` is a hand-written conformance trace: scoring it proves the
+ * scorer runs, and its perfect result says nothing whatever about a model.
+ * `model` is a real capture. Until this field existed the two were the same
+ * shape, so a fixture's `toolSelectionAccuracy: 1` could be read — or reported
+ * — as a model result, which is the single claim this evaluation harness is
+ * least entitled to make. The scorers now refuse to blur them.
+ */
+export const TRACE_SOURCES = Object.freeze(["referenceFixture", "model"]);
+
+/**
+ * What a `model` trace must record to be re-runnable and comparable.
+ *
+ * A number without these is not a measurement: comparing PR 2 and PR 3 means
+ * comparing the same corpus under the same model, prompt and tool-choice
+ * setting, against the same engine. Anything missing here is a comparison that
+ * cannot be made honestly later.
+ */
+const MODEL_PROVENANCE_FIELDS = Object.freeze([
+  "modelId",
+  "promptTemplateDigest",
+  "toolChoice",
+  "capturedAt",
+  "serverVersion",
+  "engineVersion",
+  "registryDigest",
+]);
+
+function requireProvenance(document, label) {
+  const provenance = document?.provenance;
+  if (!provenance || typeof provenance !== "object" || Array.isArray(provenance)) {
+    throw new Error(`${label} must carry a provenance block naming what produced it`);
+  }
+  if (!TRACE_SOURCES.includes(provenance.source)) {
+    throw new Error(
+      `${label} provenance.source must be one of ${TRACE_SOURCES.join(", ")}`,
+    );
+  }
+  if (provenance.source !== "model") return provenance;
+  const missing = MODEL_PROVENANCE_FIELDS.filter((field) =>
+    typeof provenance[field] !== "string" || provenance[field].length === 0
+  );
+  if (missing.length) {
+    throw new Error(
+      `${label} is a model trace and must record ${missing.join(", ")}`,
+    );
+  }
+  return provenance;
+}
+
 function requireDocument(document, label, collection) {
   if (document?.schemaVersion !== 1 || !Array.isArray(document?.[collection])) {
     throw new Error(`${label} must have schemaVersion 1 and a ${collection} array`);
@@ -60,6 +112,7 @@ function validateAttempt(attempt, label, allowNull) {
 
 export function indexTraces(document, caseIds, { repair = false } = {}) {
   requireDocument(document, "evaluation traces", "traces");
+  requireProvenance(document, "evaluation traces");
   const traces = new Map();
   for (const trace of document.traces) {
     if (!caseIds.has(trace?.caseId)) throw new Error(`trace has unknown caseId: ${trace?.caseId}`);
@@ -73,4 +126,22 @@ export function indexTraces(document, caseIds, { repair = false } = {}) {
     traces.set(trace.caseId, trace);
   }
   return traces;
+}
+
+/** The provenance of a validated trace document. */
+export function traceProvenance(document) {
+  return requireProvenance(document, "evaluation traces");
+}
+
+/**
+ * Whether a perfect score may be *asserted* for this document.
+ *
+ * `--require-perfect` exists to prove the scorer end-to-end against a fixture
+ * built to pass it. Pointing it at a model trace turns a measurement into a
+ * pass/fail gate on the model, which converts "we have not measured this" into
+ * "this is perfect" the first time a run happens to be clean. A model trace is
+ * scored and reported; it is never asserted.
+ */
+export function mayAssertPerfect(document) {
+  return traceProvenance(document).source === "referenceFixture";
 }

--- a/tools/mcp-server/evaluation-contract.test.js
+++ b/tools/mcp-server/evaluation-contract.test.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { indexTraces, validateCorpus } from "./evaluation-contract.js";
+import { indexTraces, mayAssertPerfect, validateCorpus } from "./evaluation-contract.js";
 
 const validCase = {
   id: "one",
@@ -10,6 +10,13 @@ const validCase = {
   expect: { "/status": "ok" },
 };
 const corpus = { schemaVersion: 1, cases: [validCase] };
+// Every trace document now declares what produced it. `fixture` is the shape a
+// hand-written conformance trace takes; `modelDoc` is a real capture.
+const fixture = (traces) => ({
+  schemaVersion: 1,
+  provenance: { source: "referenceFixture" },
+  traces,
+});
 const ids = validateCorpus(corpus);
 assert.throws(
   () => validateCorpus({ schemaVersion: 1, cases: [validCase, validCase] }),
@@ -20,20 +27,55 @@ assert.throws(
   /invalid JSON pointer/,
 );
 assert.throws(
-  () => indexTraces({ schemaVersion: 1, traces: [{ caseId: "other", selectedTool: null }] }, ids),
+  () => indexTraces(fixture([{ caseId: "other", selectedTool: null }]), ids),
   /unknown caseId/,
 );
 assert.throws(
-  () => indexTraces({ schemaVersion: 1, traces: [
+  () => indexTraces(fixture([
     { caseId: "one", selectedTool: "compute", arguments: {} },
     { caseId: "one", selectedTool: "compute", arguments: {} },
-  ] }, ids),
+  ]), ids),
   /duplicate trace caseId/,
 );
 assert.throws(
-  () => indexTraces({ schemaVersion: 1, traces: [
+  () => indexTraces(fixture([
     { caseId: "one", selectedTool: "shell", arguments: {} },
-  ] }, ids),
+  ]), ids),
   /known tool/,
 );
+// A trace document that does not say what produced it cannot be scored: the
+// same numbers mean "the scorer works" or "the model performs this well"
+// depending on an answer the file would not be carrying.
+assert.throws(
+  () => indexTraces({ schemaVersion: 1, traces: [] }, ids),
+  /provenance block/,
+);
+assert.throws(
+  () => indexTraces({ schemaVersion: 1, provenance: { source: "vibes" }, traces: [] }, ids),
+  /provenance.source must be one of/,
+);
+// A model trace without the metadata that makes it re-runnable is not a
+// measurement — a number nobody can reproduce or compare a later run against.
+assert.throws(
+  () => indexTraces({ schemaVersion: 1, provenance: { source: "model" }, traces: [] }, ids),
+  /must record modelId, promptTemplateDigest, toolChoice, capturedAt/,
+);
+const modelDoc = {
+  schemaVersion: 1,
+  provenance: {
+    source: "model",
+    modelId: "claude-opus-5",
+    promptTemplateDigest: "abc123",
+    toolChoice: "auto",
+    capturedAt: "2026-08-11T00:00:00Z",
+    serverVersion: "0.3.0",
+    engineVersion: "0.2.0-beta.1",
+    registryDigest: "a67241e0",
+  },
+  traces: [],
+};
+assert.deepEqual(indexTraces(modelDoc, ids).size, 0, "a complete model trace validates");
+// The asymmetry that keeps a lucky run from becoming a committed claim.
+assert.equal(mayAssertPerfect(fixture([])), true);
+assert.equal(mayAssertPerfect(modelDoc), false);
 console.log("evaluation contract rejection checks passed");

--- a/tools/mcp-server/package-lock.json
+++ b/tools/mcp-server/package-lock.json
@@ -15,8 +15,43 @@
       "bin": {
         "ajisai-mcp-server": "index.js"
       },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.116.0"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.116.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
+      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -70,6 +105,13 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -452,6 +494,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
@@ -677,6 +726,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -1076,6 +1139,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1093,6 +1167,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "2.1.0",

--- a/tools/mcp-server/package.json
+++ b/tools/mcp-server/package.json
@@ -13,9 +13,12 @@
   "engines": { "node": ">=20" },
   "files": ["index.js", "doctor.js", "host-error.js", "word-candidates.js", "backend/*.js", "result.schema.json", "README.md", "assets/*", "golden/cases.json", "golden/limits.json", "golden/limit-cases.js", "eval.js", "benchmark.js", "number-baseline.js", "evaluation-contract.js", "validate-evaluation.js", "score-traces.js", "score-repairs.js", "eval/*.json", "wasm/generated/*"],
   "bin": { "ajisai-mcp-server": "index.js" },
-  "scripts": { "start": "node index.js", "sync:assets": "node sync-assets.js", "check:assets": "node sync-assets.js --check", "prepack": "node sync-assets.js --check", "selftest": "node selftest.js", "test:pack": "node pack-smoke.js", "eval:validate": "node validate-evaluation.js && node evaluation-contract.test.js", "eval": "node eval.js", "eval:performance": "node benchmark.js --require-budget", "eval:number-baseline": "node number-baseline.js --require-ajisai-exact", "eval:traces": "node score-traces.js eval/reference-traces.json --require-perfect", "eval:repairs": "node score-repairs.js eval/reference-repair-traces.json --require-perfect", "test:backends": "node backend/parity-test.js" },
+  "scripts": { "start": "node index.js", "sync:assets": "node sync-assets.js", "check:assets": "node sync-assets.js --check", "prepack": "node sync-assets.js --check", "selftest": "node selftest.js", "test:pack": "node pack-smoke.js", "eval:validate": "node validate-evaluation.js && node evaluation-contract.test.js && node capture-traces.test.js", "eval": "node eval.js", "eval:capture": "node capture-traces.js", "eval:performance": "node benchmark.js --require-budget", "eval:number-baseline": "node number-baseline.js --require-ajisai-exact", "eval:traces": "node score-traces.js eval/reference-traces.json --require-perfect", "eval:repairs": "node score-repairs.js eval/reference-repair-traces.json --require-perfect", "test:backends": "node backend/parity-test.js" },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ajv": "^8.18.0"
+  },
+  "devDependencies": {
+    "@anthropic-ai/sdk": "^0.116.0"
   }
 }

--- a/tools/mcp-server/score-repairs.js
+++ b/tools/mcp-server/score-repairs.js
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "./index.js";
-import { indexTraces, validateCorpus } from "./evaluation-contract.js";
+import { indexTraces, mayAssertPerfect, traceProvenance, validateCorpus } from "./evaluation-contract.js";
 
 function atPointer(document, pointer) {
   return pointer.split("/").slice(1)
@@ -34,6 +34,7 @@ if (!tracePath) {
 const corpus = JSON.parse(readFileSync(new URL("./eval/repair-cases.json", import.meta.url), "utf8"));
 const traceDoc = JSON.parse(readFileSync(tracePath, "utf8"));
 const traces = indexTraces(traceDoc, validateCorpus(corpus, { repair: true }), { repair: true });
+const provenance = traceProvenance(traceDoc);
 const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 const server = createServer();
 const client = new Client({ name: "ajisai-repair-eval", version: "1" });
@@ -67,11 +68,26 @@ try {
 const total = corpus.cases.length;
 const metrics = {
   schemaVersion: 1,
+  // Travels with the numbers: a repair rate copied out of a log still says
+  // whether it describes a model or the scorer that grades one.
+  provenance,
+  measures: provenance.source === "referenceFixture"
+    ? "scorer conformance only — not model performance"
+    : `model performance for ${provenance.modelId}`,
   cases: total,
   missingTraces: missing,
   diagnosisObservedRate: diagnosesObserved / total,
   diagnosisDrivenRepairRate: repairsSucceeded / total,
 };
 console.log(JSON.stringify(metrics, null, 2));
-if (process.argv.includes("--require-perfect") &&
-    (missing !== 0 || diagnosesObserved !== total || repairsSucceeded !== total)) process.exit(1);
+if (process.argv.includes("--require-perfect")) {
+  // See score-traces.js: perfection is asserted of the harness, never of a model.
+  if (!mayAssertPerfect(traceDoc)) {
+    console.error(
+      "--require-perfect asserts scorer conformance and is only valid for a referenceFixture trace; " +
+        "a model trace is reported, never asserted.",
+    );
+    process.exit(2);
+  }
+  if (missing !== 0 || diagnosesObserved !== total || repairsSucceeded !== total) process.exit(1);
+}

--- a/tools/mcp-server/score-traces.js
+++ b/tools/mcp-server/score-traces.js
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "./index.js";
-import { indexTraces, validateCorpus } from "./evaluation-contract.js";
+import { indexTraces, mayAssertPerfect, traceProvenance, validateCorpus } from "./evaluation-contract.js";
 
 function atPointer(document, pointer) {
   return pointer.split("/").slice(1)
@@ -19,6 +19,7 @@ if (!tracePath) {
 const corpus = JSON.parse(readFileSync(new URL("./eval/cases.json", import.meta.url), "utf8"));
 const traceDoc = JSON.parse(readFileSync(tracePath, "utf8"));
 const traces = indexTraces(traceDoc, validateCorpus(corpus));
+const provenance = traceProvenance(traceDoc);
 const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 const server = createServer();
 const client = new Client({ name: "ajisai-trace-eval", version: "1" });
@@ -66,6 +67,12 @@ const total = corpus.cases.length;
 const negative = corpus.cases.filter((testCase) => testCase.expectedTool === null).length;
 const metrics = {
   schemaVersion: 1,
+  // What produced these traces travels with the numbers, so a score copied out
+  // of a log still says whether it describes a model or the scorer.
+  provenance,
+  measures: provenance.source === "referenceFixture"
+    ? "scorer conformance only — not model performance"
+    : `model performance for ${provenance.modelId}`,
   cases: total,
   missingTraces: missing,
   toolSelectionAccuracy: selectedCorrectly / total,
@@ -73,7 +80,18 @@ const metrics = {
   irrelevantToolRate: negative === 0 ? 0 : irrelevantActivations / negative,
 };
 console.log(JSON.stringify(metrics, null, 2));
-if (process.argv.includes("--require-perfect") &&
-    (missing !== 0 || semanticSuccess !== total || irrelevantActivations !== 0)) {
-  process.exit(1);
+if (process.argv.includes("--require-perfect")) {
+  // Asserting perfection is a statement about the *harness*. Allowing it on a
+  // model trace would turn the first clean run into a committed claim that the
+  // model is perfect — the exact overstatement this corpus exists to avoid.
+  if (!mayAssertPerfect(traceDoc)) {
+    console.error(
+      "--require-perfect asserts scorer conformance and is only valid for a referenceFixture trace; " +
+        "a model trace is reported, never asserted.",
+    );
+    process.exit(2);
+  }
+  if (missing !== 0 || semanticSuccess !== total || irrelevantActivations !== 0) {
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Summary

PR 4 of the MCP improvement proposal is trace collection.

**The headline deliverable — a real Claude Code baseline — is not in this PR, and could not be.** This environment resolves no Anthropic credentials: no `ANTHROPIC_API_KEY`, no `ANTHROPIC_AUTH_TOKEN`, no `ant` CLI or `~/.config/anthropic` profile, no federation vars. The only token present is the Claude Code session's own, which is not a general-purpose API credential to spend on an evaluation. I verified this properly rather than assuming it — an unset `ANTHROPIC_API_KEY` does **not** by itself mean there are no credentials, since the SDK also resolves OAuth profiles.

What is here is everything that stood between the repository and an honest baseline.

### The blocker was not tooling alone

A trace document carried **no record of what produced it**. The committed fixture and a real capture were the same shape, so `score-traces.js` printed `toolSelectionAccuracy: 1` for either with nothing distinguishing them. The proposal's own acceptance criteria ask for that separation — prose in three documents was the only thing enforcing it.

Now the format does:

| | |
|---|---|
| **`provenance.source`** | `referenceFixture` or `model`, required. A document without the block is **rejected rather than scored** — the same numbers mean "the harness works" or "the model performs this well" depending on an answer the file wasn't carrying. |
| **Model traces** | must also record `modelId`, `promptTemplateDigest`, `toolChoice`, `capturedAt`, `serverVersion`, `engineVersion`, `registryDigest` — everything needed to re-run it and to compare the `exactDisplay` and compaction rounds against each other later. A number nobody can reproduce is not a measurement. |
| **Scorer output** | prints the provenance beside the metrics plus a `measures` line, so a score copied out of a log still says which it is. |
| **`--require-perfect`** | refused on anything that is not a fixture. |

That last one is the load-bearing asymmetry. The flag asserts the *scorer* runs end to end; pointing it at a model trace would turn the first clean run into a committed claim that the model is perfect — the one thing this corpus is least entitled to say. A model trace is scored and reported, never asserted:

```
$ node score-traces.js <model-trace>.json --require-perfect
{ ...metrics printed... }
--require-perfect asserts scorer conformance and is only valid for a referenceFixture trace;
a model trace is reported, never asserted.
rc=2
```

### And `capture-traces.js` produces one

- Drives a real model over the four tool definitions **read from the server itself**, not hand-copied — a baseline can't drift from the product it measures.
- One call per corpus case at **`tool_choice: auto`**. A third of the corpus is irrelevant-intent cases whose correct answer is *no* call; forcing one would score the metric that measures restraint as a guaranteed failure.
- Writes to `eval/traces/`, apart from the committed fixtures, per the proposal's acceptance criterion.
- Records `toolCalls` and `stopReason` per case — observations that can't be recovered later.

**Finding no credentials, it exits non-zero having written nothing.** A file that looks like a trace and wasn't produced by a model is worse than no file, and this is the repository where that distinction is the entire point:

```
$ npm run eval:capture
no Anthropic credentials could be resolved. Set ANTHROPIC_API_KEY, or run `ant auth login`.
Nothing was written — a trace file that was not produced by a model is worse than no file.
rc=2
```

(The SDK resolves credentials when it builds the *first request's headers*, not at construction — so the naive guard let this surface as a stack trace partway through a run. Caught properly now.)

`capture-traces.test.js` drives the harness with a scripted client and says on success that it tested the harness, **not** a model.

## Quality Classification

- Highest impacted level: QL-D (evaluation tooling and its contracts; no product code, no Rust, no MCP server behavior changed)

## Traceability

- Requirement(s): MCP proposal P1-4; `docs/dev/mcp-readiness.md` P2 section; `docs/dev/mcp-claude-code-handoff.md` §5–6
- Verification evidence:
  - `npm run check:mcp-evaluation` — contract validation plus new rejection checks: missing provenance, unknown `source`, a `model` trace missing required metadata, and the `mayAssertPerfect` asymmetry both ways
  - `node capture-traces.test.js` — harness end-to-end against a scripted client: tool definitions match what the server publishes, `tool_choice` is `auto`, no sampling parameters, positive case extracts name+input, negative case records `null`, output validates as a trace and is classified `model`
  - Refusal paths exercised by hand: no credentials → rc=2, nothing written (`eval/traces/` does not exist afterward); `--require-perfect` on a model trace → metrics printed, then rc=2
  - `npm run test:mcp-pack` — 4 scenarios green; confirms neither `capture-traces.js` nor its test ships in the tarball (36 files, unchanged)
  - `npm run check`, `npm run lint`, `check:mcp-assets`, `test:mcp`, `test:mcp-backends`, `eval:mcp`, `eval:mcp-traces`, `eval:mcp-repairs`, `eval:mcp-performance`, `eval:mcp-number-baseline`

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` / `clippy` / `cargo test` (in `rust/`) — not run; no Rust changes
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov` — not applicable, no Rust changes
- [x] MC/DC-like checklist reviewed for modified boolean logic — the new decisions are `requireProvenance`'s source-validity and per-field completeness checks (both branches exercised by the new rejection tests plus the passing fixture and model documents) and `mayAssertPerfect`'s discriminator (asserted true and false explicitly)
- [x] Release checklist impact considered — the Anthropic SDK is a `devDependency`; capture tooling is excluded from `files` and verified absent from the tarball

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

**The readiness tracker moves P2 55% → 57%, for tooling and enforcement only.** It states plainly that no baseline exists and that everything P2 still needs — first-attempt generation rate, real diagnosis-observation and repair rates, and the before/after comparison the `exactDisplay` and compaction rounds are owed — is downstream of running the capture. The 2 points are not evidence.

**To unblock:** set `ANTHROPIC_API_KEY` (or `ant auth login`) and run `npm run eval:capture` from `tools/mcp-server`. It costs one model call per corpus case (22 by default; `--limit` to trim). Re-run under the same model, prompt digest and tool-choice setting to compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kt3hjmf1Rn1RQyzNpnyGEn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt3hjmf1Rn1RQyzNpnyGEn)_