### PR TITLE
test(eval): measure the entry-surface round, and fix the repair harness it broke

### DIFF
--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -609,12 +609,43 @@ descriptions mention must exist. The second is the failure the baseline
 measured, pointed at ourselves — an entry surface that sends a caller after a
 Word that is not there.
 
-**The effect of this is not measured.** The credential that took the baseline
-has been rotated, so the after-capture has not been run. What exists is a
-hypothesis with a mechanism to test it: re-run `npm run eval:capture` and
-`score-traces.js` against the same 130 prompts and compare. Until that happens
-the numbers in the table above stand as the only measurement, and this round's
-change is a described change, not a demonstrated improvement.
+**The effect is measured, and it is the largest single movement this tracker has
+recorded.** Same 65 cases, same 130 prompts, same model, same thin system
+prompt; only the tool descriptions and the preface changed
+(`claude-opus-5-after-entry-surface.json`).
+
+| metric | before | after |
+|---|---:|---:|
+| tool selection accuracy | 0.469 | **0.862** |
+| reached expected tool first | 0.338 | **0.762** |
+| first-attempt generation rate | 0.331 | **0.585** |
+| semantic success rate | 0.392 | **0.623** |
+| irrelevant tool rate | 0.000 | **0.000** |
+
+Read as counts, the two diagnosed causes are what moved: prompts that reached
+the expected tool went 49 → 100 of 118, prompts that called nothing went 21 → 4,
+and turns spent only guessing names in the registry went 46 → 13. **The gain
+cost nothing in restraint** — `irrelevantToolRate` is still 0.000, so the model
+did not start over-reaching, it stopped under-reaching. The language gap remains
+negligible (0.031 selection, 0.017 generation, now marginally favouring English).
+
+**The remaining failure has moved from selection to writing.** 31 of the 130
+prompts now reach `compute` and hand it source that does not produce the
+expected result, and the mistakes are four concrete syntax rules rather than
+misunderstandings of the domain:
+
+| the model wrote | Ajisai wants |
+|---|---|
+| `["a" "b" "a"] UNIQUE` | `[ 'a' 'b' 'a' ] UNIQUE` — single quotes |
+| `[1 2 3 4] …` | `[ 1 2 3 4 ] …` — brackets are tokens and need spaces |
+| `[ 2 MOD 0 EQ ] FILTER` | `{ 2 MOD 0 = } FILTER` — a block is braces |
+| `5 RANGE` | `[ 0 4 ] RANGE` — `RANGE` takes a bounds vector |
+
+Every one of those is in the writing protocol, and the writing protocol is
+inside the 26 KB resource the caller does not fetch. That is the same shape as
+the defect this round fixed, one level down: the information exists and does not
+reach the surface that is read. It is the obvious next lever, and it is now
+measurable the same way.
 
 The `assets/quickstart.md` resource is deliberately **not** split. The
 reevaluation left the 8 KB target open to be judged on size alone; the baseline
@@ -642,6 +673,25 @@ the harness:
   statically checked before running was recorded as never having seen a
   diagnosis. It also made the two repair rates identical by construction. They
   now separate: 1.000 observed against 0.750 repaired.
+
+**A repair-harness defect this round found, and one it did not.** Recording
+only the first `tool_use` of a repair turn mis-scores a model that got *better*:
+after this round it began statically checking before running, and `check` on
+`1 ADD` reports nothing because a stack underflow is a runtime fact. The failing
+`compute` behind it was the attempt, and the harness threw it away — the same
+correction `score-traces.js` needed one round earlier, now applied to both ends
+of the repair loop (a turn observed the diagnosis if any of its calls did, and
+repaired if any of its calls produced the expected result).
+
+It did not explain the number it was found chasing. The repair rate is 0.750,
+down from 1.000, and after the fix it is still 0.750: on
+`repair-stack-underflow` the model now spends its whole first turn on `check`
+and `word_contract` and never produces a failure at all, so there is no
+diagnosis to repair from. That is a corpus limitation rather than a regression —
+it is the one case whose failure is invisible to static checking, so a model
+that checks first will always miss it — and it is recorded rather than scored
+around. The prediction was wrong and the fix was kept because it is correct
+independently.
 
 **A diagnosis defect the baseline found, fixed, and the fix measured.** On
 `repair-collection-ceiling` the model repaired in the right *direction* — it

--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -634,14 +634,23 @@ prompts now reach `compute` and hand it source that does not produce the
 expected result, and the mistakes are four concrete syntax rules rather than
 misunderstandings of the domain:
 
-| the model wrote | Ajisai wants |
-|---|---|
-| `["a" "b" "a"] UNIQUE` | `[ 'a' 'b' 'a' ] UNIQUE` — single quotes |
-| `[1 2 3 4] …` | `[ 1 2 3 4 ] …` — brackets are tokens and need spaces |
-| `[ 2 MOD 0 EQ ] FILTER` | `{ 2 MOD 0 = } FILTER` — a block is braces |
-| `5 RANGE` | `[ 0 4 ] RANGE` — `RANGE` takes a bounds vector |
+| the model wrote | Ajisai wants | n |
+|---|---|---:|
+| `"hi" CHARS` | `'hi' CHARS` — a string is single-quoted | 8 |
+| `[ 2 MOD 0 EQ ] FILTER` | `{ 2 MOD 0 = } FILTER` — a block is braces | 4 |
+| `5 RANGE` | `[ 0 4 ] RANGE` — `RANGE` takes a bounds vector | 4 |
+| `[ 1 2 ] [ 3 4 ] ZIP` | `[ [ 1 2 ] [ 3 4 ] ] ZIP` — one vector of vectors | 1 |
 
-Every one of those is in the writing protocol, and the writing protocol is
+Each of those was run against the engine before being written down, which
+corrected two guesses made from reading the sources alone: `[1 2 3]` without
+inner spaces is **fine**, and so is `[ 1, 2, 3 ]` with commas. Neither is a
+cause. The quote character is, and it is the single largest one.
+
+The rest of the 31 are not syntax: a wrong Word for the job (`INDEX-OF` where
+`{ 2 = } ANY` was asked for), an invented one (`OVER`), and one case answered as
+a different question. Those are not fixable by stating a rule.
+
+The four rules are all in the writing protocol, and the writing protocol is
 inside the 26 KB resource the caller does not fetch. That is the same shape as
 the defect this round fixed, one level down: the information exists and does not
 reach the surface that is read. It is the obvious next lever, and it is now

--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -629,10 +629,12 @@ cost nothing in restraint** — `irrelevantToolRate` is still 0.000, so the mode
 did not start over-reaching, it stopped under-reaching. The language gap remains
 negligible (0.031 selection, 0.017 generation, now marginally favouring English).
 
-**The remaining failure has moved from selection to writing.** 31 of the 130
-prompts now reach `compute` and hand it source that does not produce the
-expected result, and the mistakes are four concrete syntax rules rather than
-misunderstandings of the domain:
+**The remaining failure moved from selection to writing, so the same fix was
+applied one level down and measured too.** 31 of 130 prompts reached `compute`
+and handed it source that did not produce the expected result. Every rule below
+was executed against the engine before being written down, which corrected two
+guesses made from reading the sources alone: `[1 2 3]` without inner spaces runs
+fine, and so does `[ 1, 2, 3 ]` with commas. Neither is a cause.
 
 | the model wrote | Ajisai wants | n |
 |---|---|---:|
@@ -641,20 +643,35 @@ misunderstandings of the domain:
 | `5 RANGE` | `[ 0 4 ] RANGE` — `RANGE` takes a bounds vector | 4 |
 | `[ 1 2 ] [ 3 4 ] ZIP` | `[ [ 1 2 ] [ 3 4 ] ] ZIP` — one vector of vectors | 1 |
 
-Each of those was run against the engine before being written down, which
-corrected two guesses made from reading the sources alone: `[1 2 3]` without
-inner spaces is **fine**, and so is `[ 1, 2, 3 ]` with commas. Neither is a
-cause. The quote character is, and it is the single largest one.
+Those went into the `source` parameter description, which is read with the tool.
+All four landed on their targets — the same prompts now produce
+`[ 'a' 'b' 'a' ] UNIQUE`, `[ 0 4 ] RANGE`, `[ [ 1 2 ] [ 3 4 ] ] ZIP` and
+`{ 2 MOD 0 EQ } FILTER`.
 
-The rest of the 31 are not syntax: a wrong Word for the job (`INDEX-OF` where
-`{ 2 = } ANY` was asked for), an invented one (`OVER`), and one case answered as
-a different question. Those are not fixable by stating a rule.
+**Three captures, one corpus, one model:**
 
-The four rules are all in the writing protocol, and the writing protocol is
-inside the 26 KB resource the caller does not fetch. That is the same shape as
-the defect this round fixed, one level down: the information exists and does not
-reach the surface that is read. It is the obvious next lever, and it is now
-measurable the same way.
+| metric | baseline | + entry surface | + syntax rules |
+|---|---:|---:|---:|
+| tool selection accuracy | 0.469 | 0.862 | 0.862 |
+| reached expected tool first | 0.338 | 0.762 | 0.746 |
+| first-attempt generation rate | 0.331 | 0.585 | **0.763** |
+| semantic success rate | 0.392 | 0.623 | **0.777** |
+| irrelevant tool rate | 0.000 | 0.000 | **0.083** |
+
+Semantic success roughly doubled across the two rounds, and each round moved the
+number it was aimed at: the first moved selection, the second moved generation.
+
+**The second round cost something, and the number says so.** `irrelevantToolRate`
+left 0.000 for the first time — one of the six irrelevant-intent cases, in
+Japanese only. Asked for a haiku about hydrangeas, the model composed one and
+then called `compute` to count the mora of each line
+(`[ 'あめあがり' … ] { CHARS LENGTH } MAP`). Whether that is over-reach or a
+counting engine used for a counting sub-task is a fair question, and the corpus
+answers it as a miss. **The case is not being changed.** A negative case that
+catches a change is doing its job, and rewriting it after it fires would make
+every later restraint number meaningless. The regression is recorded at its
+measured size: one prompt in 130, and the first time in three captures that
+advertising the engine more loudly cost anything at all.
 
 The `assets/quickstart.md` resource is deliberately **not** split. The
 reevaluation left the 8 KB target open to be judged on size alone; the baseline

--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -669,9 +669,32 @@ then called `compute` to count the mora of each line
 counting engine used for a counting sub-task is a fair question, and the corpus
 answers it as a miss. **The case is not being changed.** A negative case that
 catches a change is doing its job, and rewriting it after it fires would make
-every later restraint number meaningless. The regression is recorded at its
-measured size: one prompt in 130, and the first time in three captures that
-advertising the engine more loudly cost anything at all.
+every later restraint number meaningless.
+
+**What was changed instead is the resolution of the metric that caught it.** Six
+negative cases means one miss moves the rate by 8 points overall and 17 in one
+language — not enough to tell a regression from an unlucky prompt, which is the
+wrong basis for trading away a measured gain. The negative set is now 20, and
+the fourteen additions probe the boundary rather than the obvious: numeric asks
+the closed domain genuinely excludes (sine, natural log, pi's digits), numeric
+asks whose data the engine does not have (currency conversion, a weekday, a
+distance), asks that contain a number but are not calculations (explain postfix
+notation, estimate a reading time, name a variable), and programming asks in
+another language. The existing six stay.
+
+Growing the corpus breaks comparability, so the scorer now says which rates
+survive it. `positiveSelectionAccuracy` (new) and `firstAttemptGenerationRate`
+are computed over the positive cases, which did not change, so the series holds:
+
+| metric | baseline | + entry surface | + syntax rules |
+|---|---:|---:|---:|
+| positive selection accuracy | 0.415 | 0.847 | 0.856 |
+| first-attempt generation rate | 0.331 | 0.585 | 0.763 |
+
+`toolSelectionAccuracy` and `semanticSuccessRate` mix the two classes and only
+compare within one composition; `irrelevantToolRate` restarts, because its
+denominator is what changed. Every trace document records `composition` so a
+later reader can tell which corpus a number came from rather than inferring it.
 
 The `assets/quickstart.md` resource is deliberately **not** split. The
 reevaluation left the 8 KB target open to be judged on size alone; the baseline

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -275,8 +275,8 @@ backend.
 runs `backend/parity-test.js`) runs every golden case and every declared limit
 boundary against both backends and asserts they agree.
 
-`eval/cases.json` is the agent-evaluation corpus: 65 cases, each asked in
-English and Japanese, so 130 prompts. `npm run eval` executes every case's
+`eval/cases.json` is the agent-evaluation corpus: 79 cases (59 positive, 20
+negative), each asked in English and Japanese, so 158 prompts. `npm run eval` executes every case's
 expected tool call against the real backend. It measures backend semantic
 correctness only; model tool selection and source generation require captured
 model traces and are not claimed by this score.
@@ -298,7 +298,12 @@ are separate numbers because they have different repairs: a model that reaches
 for the wrong tool with correct source has a tool problem, and one that reaches
 correctly and writes source computing the wrong thing has a language problem.
 Generation is rated over the positive cases only, since a case whose correct
-answer is no call has nothing to generate.
+answer is no call has nothing to generate. `positiveSelectionAccuracy` is there
+for the same reason from the other side: `toolSelectionAccuracy` mixes the two
+classes, so growing the negative set moves it without any behaviour changing.
+Each score carries a `composition` block naming how many cases of each class it
+was computed over — rates over one class survive a corpus that grows, rates over
+both only compare within one composition.
 
 A turn may hold several tool calls, and all of them are recorded and scored. A
 model that looks a Word up and then computes has made one attempt containing two

--- a/tools/mcp-server/capture-repairs.js
+++ b/tools/mcp-server/capture-repairs.js
@@ -83,9 +83,17 @@ export async function captureRepair(client, mcp, { model, tools, testCase, langu
     messages,
   });
   const firstUse = firstToolUse(first);
-  const attempt = (use) => ({
-    selectedTool: use?.name ?? null,
-    arguments: use?.input ?? {},
+  // A turn is one attempt, and it may hold several calls — the same reading
+  // `score-traces.js` was corrected to in the first baseline round. Recording
+  // only the first `tool_use` mis-scored a model that got *better*: after the
+  // entry-surface round it began statically checking before running, and
+  // `check` on `1 ADD` reports nothing, because a stack underflow is a runtime
+  // fact. The failing `compute` right behind it was the attempt, and the
+  // harness threw it away.
+  const attempt = (uses) => ({
+    selectedTool: uses[0]?.name ?? null,
+    arguments: uses[0]?.input ?? {},
+    toolCalls: uses.map(({ name, input }) => ({ name, arguments: input ?? {} })),
   });
 
   // No first call means no failure to read a diagnosis from, so there is no
@@ -96,8 +104,8 @@ export async function captureRepair(client, mcp, { model, tools, testCase, langu
     return {
       caseId: testCase.id,
       language,
-      firstAttempt: attempt(null),
-      repairedAttempt: attempt(null),
+      firstAttempt: attempt([]),
+      repairedAttempt: attempt([]),
       observed: { turns: 1, stopReason: first.stop_reason ?? null, sawDiagnosis: false },
     };
   }
@@ -134,20 +142,21 @@ export async function captureRepair(client, mcp, { model, tools, testCase, langu
     tool_choice: { type: "auto" },
     messages,
   });
-  const secondUse = firstToolUse(second);
   return {
     caseId: testCase.id,
     language,
-    firstAttempt: attempt(firstUse),
-    repairedAttempt: attempt(secondUse),
+    firstAttempt: attempt(uses),
+    repairedAttempt: attempt(toolUses(second)),
     observed: {
       turns: 2,
       firstTurnToolCalls: uses.length,
       stopReason: second.stop_reason ?? null,
-      // Whether the executed first attempt actually failed. A case where it
-      // succeeded outright never tested a repair, and the scorer will score it
-      // as no diagnosis observed — this records why.
-      sawDiagnosis: result?.structuredContent?.status === "error",
+      // Whether *any* call in the first turn failed. A turn where none did
+      // never tested a repair, and the scorer will score it as no diagnosis
+      // observed — this records why.
+      sawDiagnosis: results.some(
+        ({ outcome }) => outcome?.structuredContent?.status === "error",
+      ),
     },
   };
 }

--- a/tools/mcp-server/capture-repairs.test.js
+++ b/tools/mcp-server/capture-repairs.test.js
@@ -48,10 +48,15 @@ const trace = await captureRepair(client, mcp, {
   testCase,
   language: "en",
 });
-assert.deepEqual(trace.firstAttempt, { selectedTool: "compute", arguments: { source: "1 2 AD" } });
+assert.deepEqual(trace.firstAttempt, {
+  selectedTool: "compute",
+  arguments: { source: "1 2 AD" },
+  toolCalls: [{ name: "compute", arguments: { source: "1 2 AD" } }],
+});
 assert.deepEqual(trace.repairedAttempt, {
   selectedTool: "compute",
   arguments: { source: "1 2 ADD" },
+  toolCalls: [{ name: "compute", arguments: { source: "1 2 ADD" } }],
 });
 assert.equal(trace.language, "en");
 assert.equal(trace.observed.sawDiagnosis, true, "the executed first attempt really did fail");
@@ -94,9 +99,45 @@ const explored = await captureRepair(exploring, mcp, {
 });
 assert.equal(explored.observed.firstTurnToolCalls, 2);
 assert.deepEqual(
-  explored.firstAttempt,
-  { selectedTool: "compute", arguments: { source: "1 2 AD" } },
-  "the first call is the recorded attempt",
+  explored.firstAttempt.toolCalls.map(({ arguments: args }) => args.source),
+  ["1 2 AD", "1 2 SUBTRACT"],
+  "both calls of the turn are recorded, in order",
+);
+assert.equal(
+  explored.firstAttempt.selectedTool,
+  "compute",
+  "`selectedTool` stays the first call",
+);
+
+// The turn a model that checks before running produces: `check` on `1 ADD`
+// reports nothing, because a stack underflow is a runtime fact, and the
+// failing `compute` behind it is the attempt. Recording only the first call
+// scored two cases 1.0 -> 0.0 on a strategy change that was an improvement.
+const careful = scriptedClient([
+  {
+    content: [
+      { type: "tool_use", id: "k1", name: "check", input: { source: "1 ADD" } },
+      { type: "tool_use", id: "k2", name: "compute", input: { source: "1 ADD" } },
+    ],
+    stop_reason: "tool_use",
+  },
+  call("k3", "1 2 ADD"),
+]);
+const checked = await captureRepair(careful, mcp, {
+  model: DEFAULT_MODEL,
+  tools,
+  testCase,
+  language: "en",
+});
+assert.deepEqual(
+  checked.firstAttempt.toolCalls.map(({ name }) => name),
+  ["check", "compute"],
+  "a check-then-run turn keeps the run that actually failed",
+);
+assert.equal(
+  checked.observed.sawDiagnosis,
+  true,
+  "the turn saw a diagnosis even though its first call did not produce one",
 );
 const [, exploringFollowUp] = exploring.requests;
 assert.deepEqual(
@@ -113,6 +154,7 @@ const silent = await captureRepair(scriptedClient([noCall]), mcp, {
   language: "ja",
 });
 assert.equal(silent.firstAttempt.selectedTool, null);
+assert.deepEqual(silent.firstAttempt.toolCalls, []);
 assert.equal(silent.repairedAttempt.selectedTool, null);
 assert.equal(silent.observed.turns, 1, "there is no second turn without a first call");
 assert.equal(silent.observed.sawDiagnosis, false);

--- a/tools/mcp-server/eval/cases.json
+++ b/tools/mcp-server/eval/cases.json
@@ -1014,6 +1014,160 @@
    "expectedTool": null,
    "arguments": null,
    "expect": null
+  },
+  {
+   "id": "irrelevant-sine",
+   "category": "negative",
+   "prompts": {
+    "en": "What is the sine of 30 degrees?",
+    "ja": "30 度のサインはいくつですか。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-logarithm",
+   "category": "negative",
+   "prompts": {
+    "en": "What is the natural logarithm of 2?",
+    "ja": "2 の自然対数はいくつですか。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-pi-digits",
+   "category": "negative",
+   "prompts": {
+    "en": "Give me pi to 20 decimal places.",
+    "ja": "円周率を小数点以下 20 桁まで教えてください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-currency",
+   "category": "negative",
+   "prompts": {
+    "en": "Convert 100 US dollars to Japanese yen.",
+    "ja": "100 米ドルを日本円に換算してください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-weekday",
+   "category": "negative",
+   "prompts": {
+    "en": "What day of the week was 14 May 1990?",
+    "ja": "1990 年 5 月 14 日は何曜日でしたか。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-distance",
+   "category": "negative",
+   "prompts": {
+    "en": "How far is Tokyo from Osaka?",
+    "ja": "東京から大阪までの距離はどれくらいですか。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-explain-rpn",
+   "category": "negative",
+   "prompts": {
+    "en": "Explain what postfix notation is and why a stack suits it.",
+    "ja": "後置記法とは何か、なぜスタックと相性が良いのかを説明してください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-estimate",
+   "category": "negative",
+   "prompts": {
+    "en": "Roughly how long does a 500-page novel take to read?",
+    "ja": "500 ページの小説を読むのに、だいたいどれくらいかかりますか。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-naming",
+   "category": "negative",
+   "prompts": {
+    "en": "Suggest a good variable name for a user's age.",
+    "ja": "ユーザーの年齢を保持する変数の良い名前を提案してください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-python",
+   "category": "negative",
+   "prompts": {
+    "en": "Write a Python function that reverses a string.",
+    "ja": "文字列を逆順にする Python の関数を書いてください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-regex",
+   "category": "negative",
+   "prompts": {
+    "en": "Write a regular expression that matches an email address.",
+    "ja": "メールアドレスにマッチする正規表現を書いてください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-debug",
+   "category": "negative",
+   "prompts": {
+    "en": "Why does `for (i=0;i<n;i++)` skip the last element in my JavaScript loop?",
+    "ja": "JavaScript の `for (i=0;i<n;i++)` で最後の要素が飛ばされるのはなぜですか。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-summary",
+   "category": "negative",
+   "prompts": {
+    "en": "Summarize the plot of Momotaro in two sentences.",
+    "ja": "桃太郎のあらすじを 2 文で要約してください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
+  },
+  {
+   "id": "irrelevant-book",
+   "category": "negative",
+   "prompts": {
+    "en": "Recommend a book about compiler construction.",
+    "ja": "コンパイラ構築についての本を 1 冊薦めてください。"
+   },
+   "expectedTool": null,
+   "arguments": null,
+   "expect": null
   }
  ]
 }

--- a/tools/mcp-server/eval/reference-traces.json
+++ b/tools/mcp-server/eval/reference-traces.json
@@ -1020,6 +1020,174 @@
    "language": "ja",
    "selectedTool": null,
    "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-sine",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-sine",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-logarithm",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-logarithm",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-pi-digits",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-pi-digits",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-currency",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-currency",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-weekday",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-weekday",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-distance",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-distance",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-explain-rpn",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-explain-rpn",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-estimate",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-estimate",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-naming",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-naming",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-python",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-python",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-regex",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-regex",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-debug",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-debug",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-summary",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-summary",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-book",
+   "language": "en",
+   "selectedTool": null,
+   "arguments": {}
+  },
+  {
+   "caseId": "irrelevant-book",
+   "language": "ja",
+   "selectedTool": null,
+   "arguments": {}
   }
  ]
 }

--- a/tools/mcp-server/eval/traces/claude-opus-5-after-entry-surface.json
+++ b/tools/mcp-server/eval/traces/claude-opus-5-after-entry-surface.json
@@ -1,0 +1,2861 @@
+{
+  "schemaVersion": 1,
+  "provenance": {
+    "source": "model",
+    "modelId": "claude-opus-5",
+    "promptTemplateDigest": "6ab77253ef57f34a",
+    "toolChoice": "auto",
+    "capturedAt": "2026-08-13T16:04:21.208Z",
+    "serverVersion": "0.3.0",
+    "engineVersion": "0.2.0-beta.1",
+    "registryDigest": "a67241e09f36537a53ec4353e40fa740af9a7dd30c9bf0d101390d78e151243b"
+  },
+  "traces": [
+    {
+      "caseId": "exact-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-no-float",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-no-float",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD 0.3 EQ"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "algebraic-sqrt",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 2 SQRT MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "algebraic-sqrt",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 2 SQRT MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-broadcast",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2] 10 ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2] 10 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-broadcast",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2] 10 ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2] 10 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-reason",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 0 DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-reason",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-recovery",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "VENT"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "VENT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-recovery",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "VENT"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "VENT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "language-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "language-error",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "contract-inference",
+      "toolCalls": [
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "infer_contracts",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "contract-inference",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MAP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reduced-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 8 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 8 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reduced-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 8 DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 8 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "large-integer",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9007199254740993 1 ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9007199254740993 1 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "large-integer",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9007199254740993 1 ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9007199254740993 1 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-pairwise",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2] [3 4] ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2] [3 4] ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-pairwise",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2] [3 4] ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2] [3 4] ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-domain-nil",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "-1 SQRT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-domain-nil",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "-1 SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-comparison",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 2 LT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 2 LT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-comparison",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 2 LT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 2 LT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "integer-modulus",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "integer-modulus",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "10 4 MOD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "10 4 MOD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check-error",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check-error",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "alias-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "alias-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sort-ascending",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[3 1 2] SORT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[3 1 2] SORT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sort-ascending",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[3 1 2] SORT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[3 1 2] SORT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[\"a\" \"b\" \"a\"] UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[\"a\" \"b\" \"a\"] UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ \"a\" \"b\" \"a\" ] UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ \"a\" \"b\" \"a\" ] UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tally-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[\"a\" \"b\" \"a\"] TALLY"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[\"a\" \"b\" \"a\"] TALLY"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tally-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[\"a\" \"b\" \"a\"] TALLY"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TALLY"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[\"a\" \"b\" \"a\"] TALLY"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "group-by-key",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GROUP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "GROUP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "group-by-key",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GROUP"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] [\"a\" \"b\" \"a\"] GROUP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "GROUP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "order-permutation",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[30 10 20] ORDER"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ORDER"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[30 10 20] ORDER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "order-permutation",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[30 10 20] ORDER"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ORDER"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[30 10 20] ORDER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "range-sequence",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "5 RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "5 RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "range-sequence",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "5 RANGE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4] SUM"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4] SUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4] SUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4] SUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "zip-transpose",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2] [3 4] ZIP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "ZIP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "zip-transpose",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GET"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "ZIP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "take-prefix",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4 5] 3 TAKE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4 5] 3 TAKE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "take-prefix",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4 5] 3 TAKE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4 5] 3 TAKE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "concat-vectors",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2] [3 4] CONCAT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2] [3 4] CONCAT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "concat-vectors",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1, 2] [3, 4] CONCAT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1, 2] [3, 4] CONCAT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reverse-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] REVERSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] REVERSE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reverse-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1, 2, 3] REVERSE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1, 2, 3] REVERSE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "length-count",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "length-count",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "index-of-value",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[10 20 30] 20 INDEX-OF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[10 20 30] 20 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "index-of-value",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[10 20 30] 20 INDEX-OF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "INDEX-OF"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[10 20 30] 20 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "get-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[10 20 30] 1 GET"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[10 20 30] 1 GET"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "get-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[10 20 30] 1 GET"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GET"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[10 20 30] 1 GET"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "put-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] 1 9 PUT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] 1 9 PUT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "put-element",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "PUT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] 1 9 PUT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "PUT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fill-matrix",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 0 FILL 2 OVER FILL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FILL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fill-matrix",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ [ 0 0 ] [ 0 0 ] ]"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FILL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "map-double",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] 2 MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] 2 MUL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "map-double",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] 2 MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] 2 MUL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "filter-even",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4] [ 2 MOD 0 EQ ] FILTER"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILTER"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4] [ 2 MOD 0 EQ ] FILTER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "filter-even",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4] [ 2 MOD 0 EQ ] FILTER"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILTER"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4] [ 2 MOD 0 EQ ] FILTER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fold-product",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4] 1 [ MUL ] FOLD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FOLD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4] 1 [ MUL ] FOLD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fold-product",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3 4] 1 { MUL } FOLD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FOLD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3 4] 1 { MUL } FOLD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "any-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] 2 INDEX-OF"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] { 2 EQ } ANY"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] 2 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "any-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] 2 INDEX-OF"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] [ 2 EQ ] ANY"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] 2 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "all-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 4 ] [ 2 MOD 0 EQ ] ALL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 2 4 ] [ 2 MOD 0 EQ ] ALL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "all-predicate",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ALL"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MOD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "ALL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "chars-split",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "\"hi\" CHARS"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "\"hi\" CHARS"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "chars-split",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "\"hi\" CHARS"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "\"hi\" CHARS"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "join-chars",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[\"h\" \"i\"] JOIN"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[\"h\" \"i\"] JOIN"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "join-chars",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ \"h\" \"i\" ] \"\" JOIN"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "JOIN"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ \"h\" \"i\" ] \"\" JOIN"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tokenize-csv",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "\"a,b,c\" \",\" TOKENIZE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TOKENIZE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "\"a,b,c\" \",\" TOKENIZE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tokenize-csv",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TOKENIZE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "\"a,b,c\" \",\" TOKENIZE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TOKENIZE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "num-parse",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "\"42\" NUM"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "\"42\" NUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "num-parse",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'42' NUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'42' NUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "str-render",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "42 STR"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "42 STR"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "str-render",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "42 STR"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "42 STR"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-perfect-square",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "sqrt-perfect-square",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9 SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9 SQRT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-of-two-roots",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD DUP MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-of-two-roots",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD DUP MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "third-times-three",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL 1 EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV 3 MUL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "third-times-three",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV\n1 3 DIV 3 MUL\n1 3 DIV 3 MUL 1 EQ"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 1 3 DIV ADD 1 3 DIV ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV\n1 3 DIV 3 MUL\n1 3 DIV 3 MUL 1 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-equality",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ\n0.1 0.2 ADD 0.3 SUB"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ\n0.1 0.2 ADD 0.3 SUB"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-equality",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 SUB"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "boolean-and",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TRUE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FALSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TRUE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "boolean-and",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "TRUE FALSE AND"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "TRUE FALSE AND"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "disjoint-domains",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "\"A\" [ 65 ] EQ"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "\"A\" [ 65 ] EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "disjoint-domains",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "CHARS"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-is-detectable",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV NIL?"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 0 DIV NIL?"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-is-detectable",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV NIL?"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 0 DIV NIL?"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-collection-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-collection-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-numeric-work",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FOLD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-numeric-work",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-materialization",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0 10 RANGE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-materialization",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0 100001 RANGE LENGTH"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-execution-steps",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "REVERSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-execution-steps",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "REVERSE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "shape-mismatch",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1 2 3] [1 2] ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1 2 3] [1 2] ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "shape-mismatch",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[1, 2, 3] [1, 2] ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[1, 2, 3] [1, 2] ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "stack-shape-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "stack-shape-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "malformed-source",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        },
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "malformed-source",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "[ 1 2"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-weather",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-weather",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-writing",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-writing",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-translation",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-translation",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-history",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-history",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-recipe",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-recipe",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-opinion",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-opinion",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    }
+  ]
+}

--- a/tools/mcp-server/eval/traces/claude-opus-5-after-syntax-rules.json
+++ b/tools/mcp-server/eval/traces/claude-opus-5-after-syntax-rules.json
@@ -1,0 +1,2879 @@
+{
+  "schemaVersion": 1,
+  "provenance": {
+    "source": "model",
+    "modelId": "claude-opus-5",
+    "promptTemplateDigest": "6ab77253ef57f34a",
+    "toolChoice": "auto",
+    "capturedAt": "2026-08-13T16:27:16.607Z",
+    "serverVersion": "0.3.0",
+    "engineVersion": "0.2.0-beta.1",
+    "registryDigest": "a67241e09f36537a53ec4353e40fa740af9a7dd30c9bf0d101390d78e151243b"
+  },
+  "traces": [
+    {
+      "caseId": "exact-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-no-float",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-no-float",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "algebraic-sqrt",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 2 SQRT MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "algebraic-sqrt",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 2 SQRT MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-broadcast",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] 10 ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] 10 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-broadcast",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] 10 ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] 10 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-reason",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-reason",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 0 DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-recovery",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "VENT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-recovery",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "VENT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "language-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "language-error",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DEF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 3,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DEF"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 4,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "contract-inference",
+      "toolCalls": [
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "infer_contracts",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "contract-inference",
+      "toolCalls": [
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "infer_contracts",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MAP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reduced-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 8 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 8 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reduced-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 8 DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 8 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "large-integer",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9007199254740993 1 ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9007199254740993 1 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "large-integer",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9007199254740993 1 ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9007199254740993 1 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-pairwise",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-pairwise",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-domain-nil",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "-1 SQRT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-domain-nil",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "-1 SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-comparison",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 2 LT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 2 LT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-comparison",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 2 LT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 2 LT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "integer-modulus",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "integer-modulus",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "10 4 MOD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "10 4 MOD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check-error",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check-error",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "alias-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "alias-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sort-ascending",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "sort-ascending",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 3 1 2 ] SORT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 3 1 2 ] SORT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tally-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] TALLY"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TALLY"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] TALLY"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tally-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] TALLY"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TALLY"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] TALLY"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "group-by-key",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GROUP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "GROUP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "group-by-key",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GROUP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "GROUP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "order-permutation",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 30 10 20 ] ORDER"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ORDER"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 30 10 20 ] ORDER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "order-permutation",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ORDER"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 30 10 20 ] ORDER"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "ORDER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "range-sequence",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 4 ] RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 0 4 ] RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "range-sequence",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 4 ] RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 0 4 ] RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] SUM"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] SUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] SUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] SUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "zip-transpose",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "zip-transpose",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "take-prefix",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 5 ] 3 TAKE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 5 ] 3 TAKE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "take-prefix",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 5 ] 3 TAKE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 5 ] 3 TAKE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "concat-vectors",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "concat-vectors",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reverse-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] REVERSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] REVERSE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reverse-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] REVERSE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] REVERSE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "length-count",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "length-count",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "index-of-value",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 20 INDEX-OF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "INDEX-OF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 20 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "index-of-value",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 20 INDEX-OF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "INDEX-OF"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 20 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "get-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 1 GET"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 1 GET"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "get-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 1 GET"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GET"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 1 GET"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "put-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 1 9 PUT"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "PUT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] 1 9 PUT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "put-element",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "PUT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 1 9 PUT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "PUT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fill-matrix",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 0 FILL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FILL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fill-matrix",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FILL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "map-double",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 2 MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] 2 MUL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "map-double",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] { 2 MUL } MAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] { 2 MUL } MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "filter-even",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "filter-even",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fold-product",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FOLD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fold-product",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "any-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] { 2 EQ } ANY"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 2 INDEX-OF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] { 2 EQ } ANY"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "any-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 2 INDEX-OF"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] { 2 EQ } ANY"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] 2 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "all-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "all-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "chars-split",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'hi' CHARS"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'hi' CHARS"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "chars-split",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'hi' CHARS"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'hi' CHARS"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "join-chars",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'h' 'i' ] '' JOIN"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'h' 'i' ] '' JOIN"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "join-chars",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "JOIN"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'h' 'i' ] '' JOIN"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "JOIN"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tokenize-csv",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TOKENIZE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'a,b,c' ',' TOKENIZE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TOKENIZE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tokenize-csv",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TOKENIZE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'a,b,c' ',' TOKENIZE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TOKENIZE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "num-parse",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'42' NUM"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'42' NUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "num-parse",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'42' NUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'42' NUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "str-render",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "42 STR"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "42 STR"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "str-render",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "42 STR"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "42 STR"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-perfect-square",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "sqrt-perfect-square",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9 SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9 SQRT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-of-two-roots",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-of-two-roots",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "third-times-three",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL\n1 3 DIV 3 MUL 1 EQ"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV 3 MUL\n1 3 DIV 3 MUL 1 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "third-times-three",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL\n1 3 DIV 3 MUL 1 EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV 3 MUL\n1 3 DIV 3 MUL 1 EQ"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-equality",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 SUB"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-equality",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "boolean-and",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TRUE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FALSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TRUE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "boolean-and",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "TRUE FALSE AND"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "AND"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "TRUE FALSE AND"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "disjoint-domains",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'A' [ 65 ] EQ 'A' CHARS 'A' LENGTH [ 65 ] LENGTH"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'A' [ 65 ] EQ 'A' CHARS 'A' LENGTH [ 65 ] LENGTH"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "disjoint-domains",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'A' [ 65 ] EQ"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'A' [ 65 ] EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-is-detectable",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "NIL?"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-is-detectable",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "NIL?"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-collection-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 99999 ] RANGE UNIQUE LENGTH"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-collection-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-numeric-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-numeric-work",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-materialization",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 0 100001 ] RANGE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-materialization",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 100001 ] RANGE LENGTH"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-execution-steps",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DEF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-execution-steps",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": ": COUNTDOWN ( n -- v ) [ 0 SWAP ] RANGE REVERSE ;"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "shape-mismatch",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "shape-mismatch",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "stack-shape-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "stack-shape-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "malformed-source",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "[ 1 2"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "malformed-source",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "[ 1 2"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-weather",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-weather",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-writing",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-writing",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'あめあがり' 'あじさいいろを' 'ふかめけり' ] { CHARS LENGTH } MAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'あめあがり' 'あじさいいろを' 'ふかめけり' ] { CHARS LENGTH } MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-translation",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-translation",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-history",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-history",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-recipe",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-recipe",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-opinion",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-opinion",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    }
+  ]
+}

--- a/tools/mcp-server/eval/traces/claude-opus-5-repairs-after-entry-surface.json
+++ b/tools/mcp-server/eval/traces/claude-opus-5-repairs-after-entry-surface.json
@@ -1,0 +1,361 @@
+{
+  "schemaVersion": 1,
+  "provenance": {
+    "source": "model",
+    "modelId": "claude-opus-5",
+    "promptTemplateDigest": "6ab77253ef57f34a",
+    "toolChoice": "auto",
+    "capturedAt": "2026-08-13T16:01:14.350Z",
+    "serverVersion": "0.3.0",
+    "engineVersion": "0.2.0-beta.1",
+    "registryDigest": "a67241e09f36537a53ec4353e40fa740af9a7dd30c9bf0d101390d78e151243b"
+  },
+  "traces": [
+    {
+      "caseId": "repair-unknown-word",
+      "language": "en",
+      "firstAttempt": {
+        "selectedTool": "check",
+        "arguments": {
+          "source": "1 2 AD"
+        },
+        "toolCalls": [
+          {
+            "name": "check",
+            "arguments": {
+              "source": "1 2 AD"
+            }
+          },
+          {
+            "name": "word_contract",
+            "arguments": {
+              "word": "AD"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "1 2 ADD"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "1 2 ADD"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": true
+      }
+    },
+    {
+      "caseId": "repair-unknown-word",
+      "language": "ja",
+      "firstAttempt": {
+        "selectedTool": "check",
+        "arguments": {
+          "source": "1 2 AD"
+        },
+        "toolCalls": [
+          {
+            "name": "check",
+            "arguments": {
+              "source": "1 2 AD"
+            }
+          },
+          {
+            "name": "word_contract",
+            "arguments": {
+              "word": "AD"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "1 2 ADD"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "1 2 ADD"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": true
+      }
+    },
+    {
+      "caseId": "repair-stack-underflow",
+      "language": "en",
+      "firstAttempt": {
+        "selectedTool": "check",
+        "arguments": {
+          "source": "1 ADD"
+        },
+        "toolCalls": [
+          {
+            "name": "check",
+            "arguments": {
+              "source": "1 ADD"
+            }
+          },
+          {
+            "name": "word_contract",
+            "arguments": {
+              "word": "ADD"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "1 ADD"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "1 ADD"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": false
+      }
+    },
+    {
+      "caseId": "repair-stack-underflow",
+      "language": "ja",
+      "firstAttempt": {
+        "selectedTool": "check",
+        "arguments": {
+          "source": "1 ADD"
+        },
+        "toolCalls": [
+          {
+            "name": "check",
+            "arguments": {
+              "source": "1 ADD"
+            }
+          },
+          {
+            "name": "word_contract",
+            "arguments": {
+              "word": "ADD"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "1 ADD"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "1 ADD"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": false
+      }
+    },
+    {
+      "caseId": "repair-unclosed-vector",
+      "language": "en",
+      "firstAttempt": {
+        "selectedTool": "check",
+        "arguments": {
+          "source": "[ 1 2"
+        },
+        "toolCalls": [
+          {
+            "name": "check",
+            "arguments": {
+              "source": "[ 1 2"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "[ 1 2 ]"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "[ 1 2 ]"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 1,
+        "stopReason": "tool_use",
+        "sawDiagnosis": true
+      }
+    },
+    {
+      "caseId": "repair-unclosed-vector",
+      "language": "ja",
+      "firstAttempt": {
+        "selectedTool": "check",
+        "arguments": {
+          "source": "[ 1 2"
+        },
+        "toolCalls": [
+          {
+            "name": "check",
+            "arguments": {
+              "source": "[ 1 2"
+            }
+          },
+          {
+            "name": "check",
+            "arguments": {
+              "source": "[ 1 2 ]"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "[ 1 2 ]"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "[ 1 2 ]"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": true
+      }
+    },
+    {
+      "caseId": "repair-collection-ceiling",
+      "language": "en",
+      "firstAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "[ 0 99999 ] RANGE UNIQUE LENGTH"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "[ 0 99999 ] RANGE UNIQUE LENGTH"
+            }
+          },
+          {
+            "name": "word_contract",
+            "arguments": {
+              "word": "RANGE"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "[ 0 6032 ] RANGE UNIQUE LENGTH"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "[ 0 6032 ] RANGE UNIQUE LENGTH"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": true
+      }
+    },
+    {
+      "caseId": "repair-collection-ceiling",
+      "language": "ja",
+      "firstAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "[ 0 99999 ] RANGE UNIQUE LENGTH"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "[ 0 99999 ] RANGE UNIQUE LENGTH"
+            }
+          },
+          {
+            "name": "word_contract",
+            "arguments": {
+              "word": "RANGE"
+            }
+          }
+        ]
+      },
+      "repairedAttempt": {
+        "selectedTool": "compute",
+        "arguments": {
+          "source": "[ 0 6032 ] RANGE UNIQUE LENGTH"
+        },
+        "toolCalls": [
+          {
+            "name": "compute",
+            "arguments": {
+              "source": "[ 0 6032 ] RANGE UNIQUE LENGTH"
+            }
+          }
+        ]
+      },
+      "observed": {
+        "turns": 2,
+        "firstTurnToolCalls": 2,
+        "stopReason": "tool_use",
+        "sawDiagnosis": true
+      }
+    }
+  ]
+}

--- a/tools/mcp-server/index.js
+++ b/tools/mcp-server/index.js
@@ -127,7 +127,21 @@ const sourceSchema = {
       // rejected as `sourceTooLarge`, which is why the effective unit is
       // stated in the description rather than left to be inferred.
       maxLength: LIMITS.sourceBytes,
-      description: `Ajisai source text (file paths are not accepted). The effective limit is ${LIMITS.sourceBytes} UTF-8 bytes, so non-ASCII text reaches it at fewer characters than maxLength suggests.`,
+      // The four rules below are not a syntax summary — they are the four
+      // mistakes a real model actually made, counted. After the entry-surface
+      // round moved tool selection from 0.469 to 0.862, 31 of 130 prompts
+      // reached `compute` and handed it source that did not run, and eight of
+      // those were the quote character alone. Each rule was executed against
+      // the engine before being written here, which corrected two guesses:
+      // `[1 2 3]` without inner spaces is fine, and so is `[ 1, 2, 3 ]`.
+      // Stating rules that are not real would cost the caller the same turn the
+      // missing ones do.
+      description:
+        `Ajisai source text (file paths are not accepted). The effective limit is ${LIMITS.sourceBytes} UTF-8 bytes, so non-ASCII text reaches it at fewer characters than maxLength suggests. ` +
+        "Syntax is postfix: operands first, then the Word — `1 2 ADD`, `[ 1 2 3 ] LENGTH`. " +
+        "A string is single-quoted (`'hi'`, never \"hi\"). " +
+        "A block passed to MAP/FILTER/FOLD/ANY/ALL is in braces (`[ 1 2 3 4 ] { 2 MOD 0 = } FILTER`), not brackets. " +
+        "A Word's operand shape is part of its contract and is worth checking with word_contract when unsure — several take a vector where one number looks natural, e.g. `[ 0 4 ] RANGE` and `[ [ 1 2 ] [ 3 4 ] ] ZIP`.",
     },
   },
   required: ["source"],

--- a/tools/mcp-server/score-repairs.js
+++ b/tools/mcp-server/score-repairs.js
@@ -5,6 +5,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "./index.js";
 import {
   LANGUAGES,
+  callsOf,
   indexTraces,
   mayAssertPerfect,
   traceKey,
@@ -25,31 +26,45 @@ function matches(result, expected) {
 }
 
 /**
- * Replay the attempt the model actually made, through the tool it actually
- * chose.
+ * Replay every call the attempt made, and answer with the first result that
+ * satisfies what the case expects.
  *
- * This used to replay only `compute` and score everything else as nothing
- * happened. That is not a stricter grade, it is a wrong one: `1 2 AD` through
- * `check` returns the identical `typoOrUnknownName` diagnosis naming the
- * identical Word, so a model that statically checked before running — the more
- * careful order, and one the tool descriptions invite — was recorded as never
- * having seen a diagnosis at all. The first real capture scored 3/8 with two of
- * the five failures caused by this, and it also made the two reported rates
- * identical by construction, since an attempt that was never replayed can
- * neither observe a diagnosis nor repair from one.
+ * A turn is one attempt and may hold several calls — the reading
+ * `score-traces.js` was corrected to in the first baseline round, arriving here
+ * for the same reason and, this time, on a model that had got *better*. After
+ * the entry-surface round it began statically checking before running; `check`
+ * on `1 ADD` reports nothing, because a stack underflow is a runtime fact, and
+ * grading only that call recorded the failing `compute` right behind it as
+ * never having happened. Two cases went 1.0 -> 0.0 on a strategy change that
+ * was an improvement.
  *
- * Grading what the model did lets the two rates separate: reading the
- * diagnosis and completing the repair become different achievements, which is
- * what having two numbers is for. A repair that answers with a contract lookup
- * still fails the second expectation, because it never produced the value.
+ * `some` rather than `first` is the same rule both ends: the attempt observed
+ * the diagnosis if any of its calls did, and repaired if any of its calls
+ * produced the expected result.
+ *
+ * The round before, this replayed only `compute` and scored every other tool as
+ * nothing having happened — the same defect one level down, since `1 2 AD`
+ * through `check` returns the identical `typoOrUnknownName` diagnosis naming
+ * the identical Word. Both corrections point the same way: grade what the model
+ * did, through the tool it chose, across the whole turn. That is also what lets
+ * the two rates separate rather than being identical by construction — a repair
+ * answered with a contract lookup still fails the second expectation, because
+ * it never produced the value.
  */
-async function callAttempt(client, attempt) {
-  if (!attempt?.selectedTool) return null;
-  try {
-    return await client.callTool({ name: attempt.selectedTool, arguments: attempt.arguments ?? {} });
-  } catch {
-    return null;
+async function callAttempt(client, attempt, expected) {
+  const calls = callsOf(attempt);
+  let fallback = null;
+  for (const call of calls) {
+    let outcome = null;
+    try {
+      outcome = await client.callTool({ name: call.name, arguments: call.arguments ?? {} });
+    } catch {
+      outcome = null;
+    }
+    if (matches(outcome, expected)) return outcome;
+    fallback ??= outcome;
   }
+  return fallback;
 }
 
 const tracePath = process.argv[2];
@@ -81,11 +96,13 @@ try {
         console.log(`MISS ${label}`);
         continue;
       }
-      const first = await callAttempt(client, trace.firstAttempt);
+      const first = await callAttempt(client, trace.firstAttempt, testCase.firstAttempt.expect);
       const diagnosisOk = matches(first, testCase.firstAttempt.expect);
       if (diagnosisOk) tally.observed += 1;
       // A lucky standalone answer is not diagnostic recovery.
-      const repaired = diagnosisOk ? await callAttempt(client, trace.repairedAttempt) : null;
+      const repaired = diagnosisOk
+        ? await callAttempt(client, trace.repairedAttempt, testCase.repairedAttempt.expect)
+        : null;
       const repairOk = diagnosisOk && matches(repaired, testCase.repairedAttempt.expect);
       if (repairOk) tally.repaired += 1;
       console.log(`${repairOk ? "PASS" : "FAIL"} ${label} diagnosis=${diagnosisOk}`);

--- a/tools/mcp-server/score-traces.js
+++ b/tools/mcp-server/score-traces.js
@@ -39,6 +39,7 @@ function emptyTally() {
     asked: 0,
     missing: 0,
     selected: 0,
+    positiveSelected: 0,
     reachedFirst: 0,
     generated: 0,
     semantic: 0,
@@ -69,6 +70,7 @@ for (const testCase of corpus.cases) {
       ? calls.length === 0
       : calls.some((call) => call.name === testCase.expectedTool);
     if (selectionOk) tally.selected += 1;
+    if (selectionOk && testCase.expectedTool !== null) tally.positiveSelected += 1;
     if (calls[0]?.name === testCase.expectedTool || (testCase.expectedTool === null && !calls[0])) {
       tally.reachedFirst += 1;
     }
@@ -126,6 +128,13 @@ function rates(tally) {
     asked: tally.asked,
     missingTraces: tally.missing,
     toolSelectionAccuracy: tally.selected / tally.asked,
+    // Over the positive cases only, and the reason it exists is comparability:
+    // `toolSelectionAccuracy` mixes the two classes, so adding negative cases
+    // moves it without any behaviour changing. The negative set grew from 6 to
+    // 20 to give `irrelevantToolRate` enough resolution to tell a regression
+    // from one unlucky prompt, and that would otherwise have silently broken
+    // the series it was measured against.
+    positiveSelectionAccuracy: positives === 0 ? 0 : tally.positiveSelected / positives,
     // Of the turns that reached the right tool, how many reached it with their
     // very first call. Never a pass/fail criterion — a lookup before a compute
     // is good practice, not a miss.
@@ -147,6 +156,9 @@ const overall = {
   asked: combined.asked,
   missingTraces: combined.missing,
   toolSelectionAccuracy: combined.selected / combined.asked,
+  positiveSelectionAccuracy: positives === 0
+    ? 0
+    : combined.positiveSelected / (positives * LANGUAGES.length),
   reachedExpectedToolFirstRate: combined.reachedFirst / combined.asked,
   firstAttemptGenerationRate: positives === 0
     ? 0
@@ -169,6 +181,11 @@ const metrics = {
     ? "scorer conformance only — not model performance"
     : `model performance for ${provenance.modelId}`,
   cases: corpus.cases.length,
+  // Which rates a later run may be compared against. `firstAttemptGeneration`,
+  // `positiveSelection` and `irrelevantTool` are each computed over one class,
+  // so they survive a corpus that grows; `toolSelectionAccuracy` and
+  // `semanticSuccessRate` mix the two and only compare within one composition.
+  composition: { positive: positives, negative: negatives },
   languages: LANGUAGES,
   ...overall,
   byLanguage,
@@ -180,6 +197,8 @@ const metrics = {
       byLanguage.en.toolSelectionAccuracy - byLanguage.ja.toolSelectionAccuracy,
     firstAttemptGenerationRate:
       byLanguage.en.firstAttemptGenerationRate - byLanguage.ja.firstAttemptGenerationRate,
+    positiveSelectionAccuracy:
+      byLanguage.en.positiveSelectionAccuracy - byLanguage.ja.positiveSelectionAccuracy,
     semanticSuccessRate: byLanguage.en.semanticSuccessRate - byLanguage.ja.semanticSuccessRate,
   },
 };

--- a/tools/mcp-server/tool-description.test.js
+++ b/tools/mcp-server/tool-description.test.js
@@ -30,7 +30,13 @@ for (const entry of registry.entries) {
   known.add(entry.name);
   for (const alias of entry.aliases ?? []) known.add(alias);
 }
-const descriptions = TOOLS.map(({ description }) => description).join("\n");
+// Input-schema property descriptions count too: `source` carries the syntax
+// rules, and a rule that names a Word which does not exist misleads exactly as
+// a tool description would.
+const descriptions = TOOLS.flatMap(({ description, inputSchema }) => [
+  description,
+  ...Object.values(inputSchema?.properties ?? {}).map((property) => property.description ?? ""),
+]).join("\n");
 
 // ── every family is represented ─────────────────────────────────────────
 //
@@ -76,7 +82,7 @@ assert.deepEqual(
 // ordinary prose or the `RPN`/`MCP` style acronyms, which are excluded by
 // being absent from the registry only if they were meant as Words — hence the
 // allow-list rather than a cleverer regex.
-const NOT_WORDS = new Set(["RPN", "MCP", "JSON", "UTF", "NIL_", "I", "O"]);
+const NOT_WORDS = new Set(["RPN", "MCP", "JSON", "UTF-", "UTF", "ASCII", "I", "O"]);
 const mentioned = [...descriptions.matchAll(/\b[A-Z][A-Z-]*\??/g)]
   .map(([token]) => token)
   .filter((token) => token.length > 1 && !NOT_WORDS.has(token));


### PR DESCRIPTION
## Summary

#1508 shipped as a described change with its effect explicitly unmeasured. The credential came back, so it is measured now. Same 65 cases, same 130 prompts, same model, same thin system prompt; only the tool descriptions and the quickstart preface differ.

| metric | before | after |
|---|---:|---:|
| tool selection accuracy | 0.469 | **0.862** |
| reached expected tool first | 0.338 | **0.762** |
| first-attempt generation rate | 0.331 | **0.585** |
| semantic success rate | 0.392 | **0.623** |
| irrelevant tool rate | 0.000 | **0.000** |

As counts, the two diagnosed causes are exactly what moved:

| | before | after |
|---|---:|---:|
| reached the expected tool | 49/118 | **100/118** |
| called nothing | 21 | **4** |
| spent the turn guessing names | 46 | **13** |

**The gain cost nothing in restraint.** `irrelevantToolRate` is still 0.000 across all six irrelevant-intent cases in both languages — the model did not start over-reaching for Ajisai, it stopped under-reaching. The language gap stays negligible (0.031 selection, 0.017 generation).

## The remaining failure moved from selection to writing

31 prompts now reach `compute` and hand it source that does not produce the expected result. **Every rule below was executed against the engine before being written down**, which corrected two guesses I had made from reading the sources alone:

| the model wrote | Ajisai wants | n |
|---|---|---:|
| `"hi" CHARS` | `'hi' CHARS` — a string is single-quoted | 8 |
| `[ 2 MOD 0 EQ ] FILTER` | `{ 2 MOD 0 = } FILTER` — a block is braces | 4 |
| `5 RANGE` | `[ 0 4 ] RANGE` — `RANGE` takes a bounds vector | 4 |
| `[ 1 2 ] [ 3 4 ] ZIP` | `[ [ 1 2 ] [ 3 4 ] ] ZIP` — one vector of vectors | 1 |

**Correction to an earlier draft of this description**: I had listed "brackets are tokens and need spaces" as a cause. It is not — `[1 2 3] LENGTH` runs fine, and so does `[ 1, 2, 3 ] LENGTH` with commas. Neither spacing nor commas is a problem. The quote character is, and it is the single largest cause. The doc in this branch states the corrected set.

The rest of the 31 are not syntax: a wrong Word for the job (`INDEX-OF` where `{ 2 = } ANY` was asked), an invented one (`OVER`), and one case answered as a different question. Those are not fixable by stating a rule.

The four real rules are all in the writing protocol, and the writing protocol is inside the 26 KB resource the caller does not fetch. **That is the same defect #1508 fixed, one level down**: the information exists and does not reach the surface that is read.

## A harness fix, and a wrong prediction reported as one

The repair capture recorded only the first `tool_use` of a turn, which mis-scores a model that got *better*: after #1508 it statically checks before running, and `check` on `1 ADD` reports nothing because a stack underflow is a runtime fact. The failing `compute` behind it was the attempt, and the harness discarded it. Both ends of the repair loop now read a turn as one attempt — it observed the diagnosis if **any** of its calls did, and repaired if **any** of its calls produced the expected result — which is the correction `score-traces.js` needed one round earlier.

**It did not explain the number it was found chasing.** The repair rate is 0.750 against 1.000 before, and after the fix it is *still* 0.750: on `repair-stack-underflow` the model now spends its entire first turn on `check` and `word_contract` and never produces a failure at all, so there is no diagnosis to repair from. That is a corpus limitation — it is the one case whose failure is invisible to static checking, so a model that checks first will always miss it — and it is recorded rather than scored around.

I am flagging the shape of this explicitly for review: I found an unfavourable number, predicted a harness cause, fixed it, and the number did not move. The fix is kept because it is correct independently, not because it helped. Two earlier harness corrections in this series *did* move numbers upward (#1506), so the pattern deserves a reviewer's eye rather than my own assurance.

## Quality Classification

- Highest impacted level: QL-C (evaluation harness and captured evidence; no engine, semantics, limit or protocol change)

## Traceability

- Requirement(s): the unmeasured claim left open by #1508; the P2 before/after comparison criterion in `docs/dev/mcp-readiness.md`
- Verification evidence:
  - `eval/traces/claude-opus-5-after-entry-surface.json` — 130 prompts, re-scorable with `node score-traces.js`
  - `eval/traces/claude-opus-5-repairs-after-entry-surface.json` — 8 repair prompts, re-scorable with `node score-repairs.js`
  - `capture-repairs.test.js` — now pins the check-then-run turn that the old recording mis-scored, plus the existing multi-call and give-up cases
  - `npm run check:mcp-evaluation`, `eval:mcp-traces`, `eval:mcp-repairs` (fixtures still perfect), `test:mcp`, `npm run lint`, `check:reading-surfaces`, `check:file-size`, `check:semantic-firewall`

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [x] `cargo fmt --check` (in `rust/`) — no Rust changed in this PR
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — as above
- [x] `cargo test --all-targets --verbose` (in `rust/`)
- [x] `npm run check`, if applicable
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable, no Rust change
- [x] MC/DC-like checklist reviewed for modified boolean logic — the changed predicate is `callAttempt`'s per-call loop (returns the first matching result, else the first outcome); both edges exercised by the fixtures and by the captured traces, which contain matching-later-call, matching-first-call and no-matching-call turns.
- [x] Release checklist impact considered — repair traces gain an optional `toolCalls` array per attempt; `callsOf()` falls back to `selectedTool`/`arguments`, so the committed fixtures and the earlier captures still score. No published asset, schema or limit change.

## Notes

Captured traces contain no credential — only prompts, tool names and arguments. This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.