### PR TITLE
measure(eval): the expanded negatives fire, and on one behaviour

### DIFF
--- a/docs/dev/mcp-readiness.md
+++ b/docs/dev/mcp-readiness.md
@@ -696,6 +696,75 @@ compare within one composition; `irrelevantToolRate` restarts, because its
 denominator is what changed. Every trace document records `composition` so a
 later reader can tell which corpus a number came from rather than inferring it.
 
+### The expanded negatives, measured
+
+`claude-opus-5-after-negatives.json` — 158 prompts, same server as the syntax
+round, so the only difference from the previous capture is the 14 added cases.
+The comparable series continues, and the two rounds' gains hold:
+
+| metric | baseline | + entry surface | + syntax rules | + negatives |
+|---|---:|---:|---:|---:|
+| positive selection accuracy | 0.415 | 0.847 | 0.856 | 0.864 |
+| first-attempt generation rate | 0.331 | 0.585 | 0.763 | 0.771 |
+
+`irrelevantToolRate` is **0.175** — 7 activations in 40 negative prompts, the
+first number this metric has had at usable resolution. It is not comparable to
+the 0.083 of the previous round, and the movement is not a regression: the 14
+new cases were chosen to be hard, and all 7 activations are theirs.
+
+**The original six are clean, including the one that fired last round.** Twelve
+prompts, no calls — the haiku/mora case did not repeat. One miss on six cases
+was, as suspected, inside the noise of a single prompt. That is the argument for
+the expansion restated as evidence.
+
+**The transcendentals group is clean too, and that is a description working.**
+Sine, natural log and pi's digits produced no call in either language. These are
+numeric asks phrased exactly like the positive cases; what separates them is that
+the closed domain excludes them, and the only place a caller learns that before
+its first call is the "Out of domain: transcendentals" sentence in the `compute`
+description. Three cases in two languages is not proof, but it is the sentence's
+first test and it passed.
+
+**All 7 activations are one behaviour, and it is not the failure the metric was
+built to catch.** Read them together:
+
+| case | what it called |
+|---|---|
+| `irrelevant-weekday` (en, ja) | Zeller's congruence, spelled out in Ajisai |
+| `irrelevant-explain-rpn` (en, ja) | `3 4 ADD 5 MUL` vs `3 4 5 MUL ADD`, as worked examples |
+| `irrelevant-currency` (ja) | 100 × a self-supplied 140–156 rate band |
+| `irrelevant-estimate` (ja) | 300,000 words ÷ a self-supplied 400/500/600 wpm |
+| `irrelevant-debug` (ja) | `[ 0 5 ] RANGE`, to show the off-by-one |
+
+In none of them does the model claim the engine holds data it does not. It
+supplies the missing constant itself and uses the engine for the arithmetic
+underneath — a rate band it names, a reading speed it names, a calendar formula
+it knows. `irrelevant-currency` is the clearest: the engine cannot know the yen
+rate, the model does not pretend it can, and what it computes is 100 dollars
+across a range it chose.
+
+So `irrelevantToolRate` as defined — *any* call on a case whose expected tool is
+null — is measuring two different things at one price:
+
+- **claiming absent data**, which produces a confidently wrong answer and is the
+  failure worth a metric;
+- **using a calculator for a sub-task with self-supplied inputs**, which is what
+  a careful assistant does and what 7 of 7 activations actually were.
+
+**The cases are still not being changed, and neither is the metric — yet.**
+Splitting the definition after seeing the traces is how a metric gets tuned into
+agreeing with the model. What the traces license is the observation; separating
+the two readings needs its own criterion, decided before the next capture rather
+than after it, and ideally checked against the final answer text rather than the
+call alone. The corpus records the calls, so that judgement remains available.
+
+**Japanese activates more (0.25 vs 0.10), and the sample is too small to mean
+anything.** Five of the seven are Japanese, but three of those are cases whose
+English half also fired. The two one-sided ones (`irrelevant-estimate`,
+`irrelevant-debug`) are a two-prompt difference. Against a language gap that is
+−0.034 on positive selection — Japanese marginally *ahead* — this is noted and
+not interpreted.
+
 The `assets/quickstart.md` resource is deliberately **not** split. The
 reevaluation left the 8 KB target open to be judged on size alone; the baseline
 supplies the argument. It is fetched on demand rather than injected, so its 26 KB

--- a/tools/mcp-server/eval/traces/claude-opus-5-after-negatives.json
+++ b/tools/mcp-server/eval/traces/claude-opus-5-after-negatives.json
@@ -1,0 +1,3301 @@
+{
+  "schemaVersion": 1,
+  "provenance": {
+    "source": "model",
+    "modelId": "claude-opus-5",
+    "promptTemplateDigest": "6ab77253ef57f34a",
+    "toolChoice": "auto",
+    "capturedAt": "2026-08-13T16:53:26.018Z",
+    "serverVersion": "0.3.0",
+    "engineVersion": "0.2.0-beta.1",
+    "registryDigest": "a67241e09f36537a53ec4353e40fa740af9a7dd30c9bf0d101390d78e151243b"
+  },
+  "traces": [
+    {
+      "caseId": "exact-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-no-float",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-no-float",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "algebraic-sqrt",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 2 SQRT MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "algebraic-sqrt",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 2 SQRT MUL\n2 SQRT 1.41421356 GT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-broadcast",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] 10 ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] 10 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-broadcast",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] 10 ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] 10 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-reason",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 0 DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-reason",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 0 DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-recovery",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "VENT"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "VENT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-recovery",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "VENT"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "VENT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "language-error",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        },
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "language-error",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        },
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 3,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "contract-inference",
+      "toolCalls": [
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "infer_contracts",
+      "arguments": {
+        "source": "{ [ 1 ] + } 'INC' DEF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "contract-inference",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        },
+        {
+          "name": "infer_contracts",
+          "arguments": {
+            "source": "{ [ 1 ] + } 'INC' DEF"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MAP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "MAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reduced-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 8 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 8 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reduced-fraction",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 8 DIV"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 8 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "large-integer",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9007199254740993 1 ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9007199254740993 1 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "large-integer",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9007199254740993 1 ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9007199254740993 1 ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-pairwise",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "vector-pairwise",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-domain-nil",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "-1 SQRT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-domain-nil",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "-1 SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "SQRT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-comparison",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 2 LT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 2 LT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "exact-comparison",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 2 LT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 2 LT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "integer-modulus",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "10 4 MOD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "10 4 MOD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "integer-modulus",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "10 4 MOD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "10 4 MOD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check-error",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "static-check-error",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "FROBNICATE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FROBNICATE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "FROBNICATE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "alias-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "alias-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "+"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "+"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sort-ascending",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 3 1 2 ] SORT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 3 1 2 ] SORT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sort-ascending",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 3 1 2 ] SORT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 3 1 2 ] SORT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tally-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] TALLY"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] TALLY"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tally-labels",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'a' 'b' 'a' ] TALLY"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TALLY"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'a' 'b' 'a' ] TALLY"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "group-by-key",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GROUP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "GROUP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "group-by-key",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GROUP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "GROUP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "order-permutation",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 30 10 20 ] ORDER"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ORDER"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 30 10 20 ] ORDER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "order-permutation",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ORDER"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 30 10 20 ] ORDER"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "ORDER"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "range-sequence",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 4 ] RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 0 4 ] RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "range-sequence",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 4 ] RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 0 4 ] RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] SUM"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] SUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] SUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] SUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "zip-transpose",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "zip-transpose",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ZIP"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ [ 1 2 ] [ 3 4 ] ] ZIP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "ZIP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "take-prefix",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 5 ] 3 TAKE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 5 ] 3 TAKE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "take-prefix",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 5 ] 3 TAKE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 5 ] 3 TAKE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "concat-vectors",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "concat-vectors",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 ] [ 3 4 ] CONCAT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reverse-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] REVERSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] REVERSE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "reverse-vector",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] REVERSE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] REVERSE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "length-count",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "length-count",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "index-of-value",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 20 INDEX-OF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "INDEX-OF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 20 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "index-of-value",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 20 INDEX-OF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "INDEX-OF"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 20 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "get-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 1 GET"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 1 GET"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "get-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 10 20 30 ] 1 GET"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "GET"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 10 20 30 ] 1 GET"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "put-element",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 1 9 PUT"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "PUT"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] 1 9 PUT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "put-element",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "PUT"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 1 9 PUT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "PUT"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fill-matrix",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 0 ] FILL [ 2 0 ] FILL 2 SWAP FILL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FILL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fill-matrix",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 2 ] 0 FILL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "FILL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "map-double",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 2 MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] 2 MUL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "map-double",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] { 2 MUL } MAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] { 2 MUL } MAP"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "filter-even",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "filter-even",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] { 2 MOD 0 EQ } FILTER"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fold-product",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FOLD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "fold-product",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 4 ] 1 { MUL } FOLD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "any-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] { 2 EQ } ANY"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 2 INDEX-OF"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] { 2 EQ } ANY"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "any-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] 2 INDEX-OF"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] { 2 EQ } ANY"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] 2 INDEX-OF"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "all-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "all-predicate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 2 4 ] { 2 MOD 0 EQ } ALL"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "chars-split",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'hi' CHARS"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'hi' CHARS"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "chars-split",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'hi' CHARS"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'hi' CHARS"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "join-chars",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'h' 'i' ] '' JOIN"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 'h' 'i' ] '' JOIN"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "join-chars",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "JOIN"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 'h' 'i' ] '' JOIN"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "JOIN"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tokenize-csv",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TOKENIZE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'a,b,c' ',' TOKENIZE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TOKENIZE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "tokenize-csv",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TOKENIZE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'a,b,c' ',' TOKENIZE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TOKENIZE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "num-parse",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'42' NUM"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'42' NUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "num-parse",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'42' NUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'42' NUM"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "str-render",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "42 STR"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "42 STR"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "str-render",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "42 STR"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "42 STR"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sqrt-perfect-square",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "sqrt-perfect-square",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "9 SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "9 SQRT"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-of-two-roots",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD DUP MUL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "sum-of-two-roots",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "third-times-three",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL 1 EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV 3 MUL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "third-times-three",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 3 DIV 3 MUL 1 EQ"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 3 DIV 3 MUL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-equality",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 EQ"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 SUB"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD 0.3 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "decimal-equality",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "0.1 0.2 ADD 0.3 SUB"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "0.1 0.2 ADD\n0.1 0.2 ADD 0.3 EQ"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "boolean-and",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "TRUE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FALSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "TRUE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "boolean-and",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "TRUE FALSE AND"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "AND"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "TRUE FALSE AND"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "disjoint-domains",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'A' [ 65 ] EQ\n'A' CHARS\n'A' [ 'A' ] EQ\n'A' LENGTH"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'A' [ 65 ] EQ\n'A' CHARS\n'A' [ 'A' ] EQ\n'A' LENGTH"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "disjoint-domains",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'A' [ 65 ] EQ"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "EQ"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "CHARS"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "'A' [ 65 ] EQ"
+      },
+      "observed": {
+        "toolCalls": 3,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-is-detectable",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "NIL?"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "nil-is-detectable",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DIV"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "NIL?"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "DIV"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-collection-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-collection-work",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-numeric-work",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD 5 SQRT 7 SQRT ADD MUL"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "FILL"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD 5 SQRT 7 SQRT ADD MUL"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-numeric-work",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "2 SQRT 3 SQRT ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SQRT"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "2 SQRT 3 SQRT ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-materialization",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 100001 ] RANGE LENGTH"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-materialization",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 100001 ] RANGE LENGTH"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-execution-steps",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "DEF"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "REVERSE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 3,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "ceiling-execution-steps",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "REVERSE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "shape-mismatch",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "shape-mismatch",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 1 2 3 ] [ 1 2 ] ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "stack-shape-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "stack-shape-error",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "1 ADD"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "ADD"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "1 ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "malformed-source",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "[ 1 2"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "malformed-source",
+      "toolCalls": [
+        {
+          "name": "check",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "check",
+      "arguments": {
+        "source": "[ 1 2"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "unique-word-contract",
+      "toolCalls": [
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "UNIQUE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "word_contract",
+      "arguments": {
+        "word": "UNIQUE"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-weather",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-weather",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-writing",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-writing",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-translation",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-translation",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-history",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-history",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-recipe",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-recipe",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-opinion",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-opinion",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-sine",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-sine",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-logarithm",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-logarithm",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-pi-digits",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-pi-digits",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-currency",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-currency",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 140 156 ] RANGE { 2 MOD 0 EQ } FILTER { 100 MUL } MAP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 140 156 ] RANGE { 2 MOD 0 EQ } FILTER { 100 MUL } MAP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-weekday",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "14 13 5 1 ADD MUL 5 DIV FLOOR ADD 90 ADD 90 4 DIV FLOOR ADD 19 4 DIV FLOOR ADD 5 19 MUL ADD 7 MOD"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "14 13 5 1 ADD MUL 5 DIV FLOOR ADD 90 ADD 90 4 DIV FLOOR ADD 19 4 DIV FLOOR ADD 5 19 MUL ADD 7 MOD"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-weekday",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "14 13 5 1 ADD MUL 5 DIV FLOOR ADD 90 ADD 90 4 DIV FLOOR ADD 19 4 DIV FLOOR ADD 5 19 MUL ADD 7 MOD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "'Sat Sun Mon Tue Wed Thu Fri' TOKENIZE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "14 13 5 1 ADD MUL 5 DIV FLOOR ADD 90 ADD 90 4 DIV FLOOR ADD 19 4 DIV FLOOR ADD 5 19 MUL ADD 7 MOD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-distance",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-distance",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-explain-rpn",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "3 4 ADD 5 MUL\n10 3 SUB\n[ 1 2 3 4 ] SUM 2 DIV"
+          }
+        }
+      ],
+      "language": "en",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "3 4 ADD 5 MUL\n10 3 SUB\n[ 1 2 3 4 ] SUM 2 DIV"
+      },
+      "observed": {
+        "toolCalls": 1,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-explain-rpn",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "3 4 ADD 5 MUL\n3 4 5 MUL ADD"
+          }
+        },
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 1 2 3 4 5 ] { 2 MOD 0 EQ } FILTER SUM"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "3 4 ADD 5 MUL\n3 4 5 MUL ADD"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-estimate",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-estimate",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 400 500 600 ] { 300000 SWAP DIV } MAP"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "SWAP"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 400 500 600 ] { 300000 SWAP DIV } MAP"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-naming",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-naming",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-python",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-python",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-regex",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-regex",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-debug",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-debug",
+      "toolCalls": [
+        {
+          "name": "compute",
+          "arguments": {
+            "source": "[ 0 5 ] RANGE"
+          }
+        },
+        {
+          "name": "word_contract",
+          "arguments": {
+            "word": "RANGE"
+          }
+        }
+      ],
+      "language": "ja",
+      "selectedTool": "compute",
+      "arguments": {
+        "source": "[ 0 5 ] RANGE"
+      },
+      "observed": {
+        "toolCalls": 2,
+        "stopReason": "tool_use"
+      }
+    },
+    {
+      "caseId": "irrelevant-summary",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-summary",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-book",
+      "toolCalls": [],
+      "language": "en",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "caseId": "irrelevant-book",
+      "toolCalls": [],
+      "language": "ja",
+      "selectedTool": null,
+      "arguments": {},
+      "observed": {
+        "toolCalls": 0,
+        "stopReason": "end_turn"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #1509, which added 14 negative cases and then could not measure them — the API key had expired. This is that measurement: one full capture of the 79-case / 158-prompt corpus against the same server, so the only difference from the previous capture is the added cases.

`irrelevantToolRate` has its first number at usable resolution: **0.175** — 7 activations in 40 negative prompts. It is *not* comparable to the previous round's 0.083 (the denominator is what changed), and the movement is not a regression: all 7 activations are among the 14 cases added to be hard.

Two things the expansion was for came back answered:

- **The original six are clean in both languages** — twelve prompts, no calls, including the haiku/mora case that fired last round. One miss on six cases was inside the noise of a single prompt, which is exactly what the expansion argued.
- **The three transcendental cases are clean.** Sine, natural log and pi's digits are numeric asks phrased like the positive cases; the only thing separating them before a caller's first call is the "Out of domain: transcendentals" sentence in the `compute` description. This is that sentence's first test, and it held.

**The 7 activations are one behaviour, and it is not the one the metric was built to catch:**

| case | what it called |
|---|---|
| `irrelevant-weekday` (en, ja) | Zeller's congruence, spelled out in Ajisai |
| `irrelevant-explain-rpn` (en, ja) | `3 4 ADD 5 MUL` vs `3 4 5 MUL ADD`, as worked examples |
| `irrelevant-currency` (ja) | 100 × a self-supplied 140–156 rate band |
| `irrelevant-estimate` (ja) | 300,000 words ÷ a self-supplied 400/500/600 wpm |
| `irrelevant-debug` (ja) | `[ 0 5 ] RANGE`, to show the off-by-one |

In none of them does the model claim the engine holds data it does not. It supplies the missing constant itself and uses the engine for the arithmetic beneath. So the metric is pricing two things alike: claiming absent data (a confidently wrong answer — the failure worth a metric) and using a calculator for a sub-task with self-supplied inputs (what a careful assistant does).

**Neither the cases nor the metric are changed here.** Splitting the definition after reading the traces is how a metric gets tuned into agreeing with the model; the criterion has to be set before the next capture, and ideally checked against the final answer text rather than the call alone. The traces record every call, so that judgement stays available.

The comparable series holds across the corpus change:

| metric | baseline | + entry surface | + syntax rules | + negatives |
|---|---:|---:|---:|---:|
| positive selection accuracy | 0.415 | 0.847 | 0.856 | 0.864 |
| first-attempt generation rate | 0.331 | 0.585 | 0.763 | 0.771 |

The Japanese/English split on restraint (0.25 vs 0.10) is noted and not interpreted: five of seven are Japanese, but three of those are cases whose English half also fired, leaving a two-prompt difference.

## Quality Classification

- Highest impacted level: QL-D — evaluation evidence and documentation only; no engine, server or schema code is touched.

## Traceability

- Requirement(s): follows up the negative-case expansion in #1509; continues the measured series recorded in `docs/dev/mcp-readiness.md`.
- Verification evidence:
  - `npm run check:mcp-evaluation` — corpus, contract, both capture harnesses, and reference-trace drift check all pass (79 selection + 4 repair cases, 166 prompts).
  - `npm run check:file-size` — 198 Rust files, 0 violations.
  - The capture itself: `tools/mcp-server/eval/traces/claude-opus-5-after-negatives.json`, committed with its `provenance` and `composition` blocks so a later reader can tell which corpus and which server produced these numbers.

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated.
- [ ] `cargo fmt --check` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` (in `rust/`) — not applicable, no Rust changed
- [ ] `cargo test --all-targets --verbose` (in `rust/`) — not applicable, no Rust changed
- [x] `npm run check`, if applicable — evaluation and file-size checks run
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — not applicable
- [x] MC/DC-like checklist reviewed for modified boolean logic — no boolean logic modified
- [x] Release checklist impact considered — none; evidence only

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.

The capture used a short-lived API key supplied for this purpose. The key was stored only outside the repository, used for this one capture, and deleted; the tree was scanned for it before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VShDdwbbRBChGJbPzMKyKk)_