### PR TITLE
Fix the calibration harnesses, and calibrate on the host the profile governs

### DIFF
--- a/rust/examples/work_meter_calibration.rs
+++ b/rust/examples/work_meter_calibration.rs
@@ -71,9 +71,37 @@ impl Measurement {
 }
 
 fn measure(name: String, source: &str) -> Measurement {
+    measure_after_setup(name, "", source)
+}
+
+/// Build the operand with `setup`, then time `source` alone.
+///
+/// The distinction is not cosmetic, and getting it wrong is how this harness
+/// under-reported a rate the host profile was later derived from. A rate is
+/// `charged units / elapsed ms`, so any time inside the measured interval that
+/// charges *this* meter nothing drags the rate down. `[ 0 99999 ] RANGE`
+/// materializes 100,000 elements — real milliseconds, and real
+/// `collectionWork` — while charging `numericWork` almost nothing. Timing it
+/// together with the twenty additions that follow made the dense-lane path
+/// look ~20% cheaper per millisecond than it is (6,153 vs 7,374 units/ms
+/// measured back to back on one container), and a floor rate that reads low
+/// derives a budget that is too small.
+///
+/// `execute` keeps the stack across calls and resets the counters
+/// (`execution_loop.rs`), so the second call sees the first call's operand and
+/// counts only its own work. This is the same split
+/// `collection_word_calibration::measure` has always used; the two harnesses
+/// disagreeing was itself the defect.
+fn measure_after_setup(name: String, setup: &str, source: &str) -> Measurement {
     let mut interp = Interpreter::new();
     interp.set_runtime_limits(unbounded());
     interp.set_max_execution_steps(usize::MAX);
+
+    if !setup.is_empty() {
+        if let Err(error) = block_on(interp.execute(setup)) {
+            panic!("setup `{setup}` for `{name}` must succeed, got: {error:?}");
+        }
+    }
 
     let started = Instant::now();
     let outcome = block_on(interp.execute(source));
@@ -185,10 +213,15 @@ fn main() {
             &format!("{{ {wide} + }} 'W' DEF 1{}", " W".repeat(200)),
         ),
         // Dense `i64` lanes: one charged unit per lane, and a lane here is a
-        // machine-word add inside a tensor kernel.
-        measure(
-            "dense tensor lanes (100k x i64 add)".into(),
-            &format!("[ 0 99999 ] RANGE{}", " 1 +".repeat(20)),
+        // machine-word add inside a tensor kernel. This is the *floor* path —
+        // the slowest charged rate, and therefore the one a host time budget
+        // divides by — so it is the row that most needs the operand build kept
+        // out of the timed interval, and enough repetitions that what remains
+        // is the add and not the measurement's own edges.
+        measure_after_setup(
+            "dense tensor lanes (100k x i64 add x200)".into(),
+            "[ 0 99999 ] RANGE",
+            &" 1 +".repeat(200),
         ),
         // A scalar operation on machine-word values. Its cost is dominated by
         // interpreter dispatch, which `executionSteps` prices, not this meter.

--- a/rust/src/cli/step_limit_tests.rs
+++ b/rust/src/cli/step_limit_tests.rs
@@ -45,21 +45,34 @@ fn run_cli(args: &[&str]) -> i32 {
     super::run(&args)
 }
 
-/// The CLI's default step budget really is `DEFAULT_MAX_EXECUTION_STEPS`, not
-/// some other number nobody re-checks. Structural rather than a full run:
-/// `DEFAULT_MAX_EXECUTION_STEPS` is now in the tens of millions
-/// (`runtime_limits::DEFAULT_MAX_EXECUTION_STEPS`), and actually exhausting a
-/// budget that size costs wall time proportional to dispatch speed by
-/// construction — there is no cheap operand that reaches a step *count* the
-/// way one wide BigInt reaches a work ceiling. The `#[ignore]`d test further
-/// down proves the real default end to end for whoever runs it deliberately.
+/// `ajisai run` with no `--step-limit` must actually apply the derived
+/// default, through the CLI, not merely have a constant that says so.
+///
+/// This replaced an assertion that compared `Interpreter::new()
+/// .max_execution_steps()` to `DEFAULT_MAX_EXECUTION_STEPS` — which the
+/// constructor initializes that field *from* (`interpreter_core.rs`), so it
+/// could never fail, and which never invoked the CLI at all despite saying it
+/// checked `ajisai run`.
+///
+/// `DOWN_PROBE` costs 200,002 steps: comfortably past the 100,000 this
+/// default used to be, and a rounding error against what it is now. So a
+/// clean exit here is a real end-to-end statement — the CLI reached the
+/// interpreter default, and that default is at least the old budget — while
+/// staying a fast test. What it deliberately does *not* claim is that the
+/// budget is enforced at its exact declared value; only
+/// `down_probe_exceeds_the_real_default_budget_without_step_limit` below can
+/// say that, and it costs real wall time by construction, so it is
+/// `#[ignore]`d.
 #[test]
-fn cli_run_without_step_limit_uses_the_documented_default() {
+fn down_probe_runs_under_the_default_budget_without_step_limit() {
+    let path = write_program("default", DOWN_PROBE);
+    let code = run_cli(&["run", path.to_str().unwrap()]);
+    let _ = std::fs::remove_file(&path);
     assert_eq!(
-        Interpreter::new().max_execution_steps(),
-        DEFAULT_MAX_EXECUTION_STEPS,
-        "`ajisai run` with no `--step-limit` falls through to \
-         `Interpreter::new()`'s default, which must be the documented one"
+        code, 0,
+        "200000 DOWN costs 200,002 steps and must complete under the derived \
+         default budget of {DEFAULT_MAX_EXECUTION_STEPS}, with no --step-limit \
+         given"
     );
 }
 

--- a/rust/src/interpreter/host_profile_defaults.rs
+++ b/rust/src/interpreter/host_profile_defaults.rs
@@ -44,10 +44,16 @@ pub const DEFAULT_MAX_MATERIALIZED_ELEMENTS: usize = 1_000_000;
 /// against Ajisai gets close to it — while being an amount someone could
 /// state a reason for instead of a bare "large enough". Still a judgment
 /// call, not a measurement of what a human pastes into a textarea; nobody has
-/// done that study either. Memory-constrained hosts — the MCP server in
-/// particular, which is tighter still — should inject an even lower
-/// `max_source_bytes` via `Interpreter::set_runtime_limits`; that is exactly
-/// why the limit is a per-interpreter injectable field rather than a global.
+/// done that study either.
+///
+/// Memory-constrained hosts — **the WASM playground in particular**, which is
+/// the host carrying this value and the one with the least headroom — should
+/// inject a tighter `max_source_bytes` via `Interpreter::set_runtime_limits`;
+/// that is exactly why the limit is a per-interpreter injectable field rather
+/// than a global. (The MCP server already does, at 64 KiB.) That advice
+/// predates the 2026-08-14 derivation and survives it: a byte ceiling is
+/// about the allocation the tokenizer is about to make, which a time budget
+/// has nothing to say about.
 pub const DEFAULT_MAX_SOURCE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Default cap on the digit count of a single numeric literal in source. A

--- a/scripts/wasm-profile-calibration.mjs
+++ b/scripts/wasm-profile-calibration.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// What the meters charge per millisecond *under WebAssembly* — the engine the
+// browser playground actually runs on.
+//
+// Run with:  node scripts/wasm-profile-calibration.mjs
+//
+// `rust/examples/work_meter_calibration.rs` and
+// `rust/examples/collection_word_calibration.rs` measure the same meters on
+// native. This exists because those two are not a proxy for this one, which is
+// not obvious and was assumed once: measured back to back on one container,
+// the native->WASM rate ratio is 2.1x for `numericWork`, 4.0x for
+// `collectionWork` and 0.66x for `executionSteps`. A ratio that swings from
+// "twice as fast" to "a third slower" depending on the meter means a single
+// native calibration cannot make three ceilings bound equal time on WASM —
+// which is the entire job of a derived host profile.
+//
+// Why the Node bundle rather than the browser one: `src/wasm/generated` is a
+// `--target web` build that needs `fetch`, while `tools/mcp-server/wasm/
+// generated` is `--target nodejs` and loads synchronously. Both come from the
+// same Rust through the same wasm-pack profile in the same rebuild scripts, so
+// the compiled module being measured is the module the playground ships. What
+// differs is the embedding engine, and Node and Chrome are both V8 — so this
+// measures a desktop-class V8, which is what the playground profile is
+// derived for. A mobile browser is slower; see the profile's own doc comment.
+//
+// KNOWN FINDING, 2026-08-14 — read the collectionWork floor with this in mind.
+// `UNIQUE 4k x 4096-digit` comes back roughly 300x below every other
+// collection path (248 units/ms against 73,491 for `REVERSE 100k` here; 780
+// against 45,025 on native release). That is not a property of WASM: it is
+// `Fraction::hash` on the `Big` representation, which clones through
+// `to_bigint_pair()` and runs a full `BigInt::gcd` once per element per scan.
+// Measured in isolation, hashing costs 2.1 us at 64 digits, 21.8 us at 512 and
+// 602 us at 4096 — superlinear in width — while the scan charges
+// `work_limbs(bits)`, which is linear (4, 27 and 213 units). So the charge and
+// the cost diverge with width, reaching ~470x at 4096 digits.
+//
+// Until that is resolved, the collectionWork floor printed below is the floor
+// of a meter with a known hole in it, and a budget derived from it is not
+// meaningful. The de-quadraticization follow-up fixed exactly this shape of
+// defect for the `Small` representation and left `Big` on the slow path.
+//
+// Method, matching the native harnesses after their 2026-08-14 fix:
+//   - operand construction is executed first and subtracted, in both time and
+//     charged units, so a rate is charged-work over the time that charged it;
+//   - charged units are read back from the engine's own `resourceUsage`, never
+//     derived from the pricing formula by hand;
+//   - several repetitions, reporting the *median* — a minimum over a noisy
+//     shared machine measures scheduling luck, not the path.
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundleDir = resolve(here, '../tools/mcp-server/wasm/generated');
+const require = createRequire(`${bundleDir}/`);
+const wasm = require('./ajisai_core.js');
+
+const STEP_LIMIT = 4_000_000_000;
+const REPS = 3;
+
+// `agent_compute` applies LOCAL_AGENT_RUNTIME_LIMITS (the MCP profile). Limits
+// bound when work stops, not how fast it runs, so rates measured under them
+// are the engine's rates — but every case below has to *fit*: 10,000,000
+// numericWork, 20,000,000 collectionWork, 100,000 materializedElements.
+async function once(source) {
+    const started = process.hrtime.bigint();
+    const json = await wasm.agent_compute(source, STEP_LIMIT);
+    const millis = Number(process.hrtime.bigint() - started) / 1e6;
+    const report = JSON.parse(json);
+    if (report.status !== 'ok') {
+        throw new Error(`case must complete to be measurable, got: ${report.message ?? report.status}`);
+    }
+    return { millis, usage: report.resourceUsage };
+}
+
+const median = (xs) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+
+/**
+ * Rate for `meter` over `ops`, with `setup`'s time and units subtracted.
+ *
+ * Setup and ops run in one `execute`, and the subtrahend is `setup` alone in
+ * one `execute`, because that is the interval a ceiling actually governs: a
+ * runaway computation is a loop *inside* one execute. Crossing an execute
+ * boundary costs a large fixed amount on a big operand — ~380 ms to first
+ * touch a 100,000-element vector carried over from a previous execute, against
+ * ~11 ms for the same Word repeated inside one — since the epoch snapshot
+ * shares the stack and the first mutation has to unshare it. That constant is
+ * paid once per run, not once per iteration, so folding it into a per-unit
+ * rate would misprice every budget derived from it.
+ *
+ * Returns `null` when the ops are too cheap to separate from setup jitter.
+ * That is a real answer, not a failure: a path that cannot be timed against
+ * its own setup is nowhere near the floor, which is the only thing this
+ * harness is looking for.
+ */
+async function rate(meter, setup, ops) {
+    const samples = [];
+    let units = 0;
+    for (let i = 0; i < REPS; i++) {
+        const base = setup ? await once(setup) : { millis: 0, usage: { [meter]: 0 } };
+        const full = await once(`${setup}${ops}`);
+        units = full.usage[meter] - (base.usage[meter] ?? 0);
+        const deltaMs = full.millis - base.millis;
+        // Require the ops to be both positive and clear of setup jitter.
+        if (deltaMs > 1 && deltaMs > base.millis * 0.02) samples.push(units / deltaMs);
+    }
+    if (!samples.length) return { units, rate: null };
+    return { units, rate: median(samples) };
+}
+
+const wide = '9'.repeat(4096);
+const PAIRS = [[2, 3], [5, 7], [11, 13], [17, 19], [23, 29], [31, 37], [41, 43], [47, 53]];
+const cascade = (f) => PAIRS.slice(0, f).map(([l, r], i) => `${l} SQRT ${r} SQRT +${i > 0 ? ' *' : ''}`).join(' ');
+
+const NUMERIC = [
+    // The floor candidate: one charged unit per lane, a machine-word add
+    // inside a tensor kernel, with nothing else to amortize it.
+    ['dense tensor lanes (100k) x80', '[ 0 99999 ] RANGE', ' 1 +'.repeat(80)],
+    // 19, not 20: the twentieth multiplication crosses the MCP profile's
+    // `bigintBits` (272,133 against 262,144), which is the very boundary
+    // `profile_liveness_tests` pins. Measuring under a real profile means
+    // living inside every one of its ceilings, not just the one being timed.
+    ['scalar wide MUL x19 (4096-digit)', `{ ${wide} * } 'M' DEF 1`, ' M'.repeat(19)],
+    ['scalar wide ADD x200 (4096-digit)', `{ ${wide} + } 'W' DEF 1`, ' W'.repeat(200)],
+    ['algebraic cascade(8) x18', `{ ${cascade(8)} } 'C' DEF`, ' C'.repeat(18)],
+];
+
+const COLLECTION = [
+    // Repetition counts are capped by the MCP profile's 20,000,000
+    // `collectionWork`, which the *setup* also spends: `[ 0 99999 ] RANGE`
+    // charges 1,700,000 before a single measured Word runs.
+    ['REVERSE 100k x10', '[ 0 99999 ] RANGE', ' REVERSE'.repeat(10)],
+    ['UNIQUE 100k all-distinct x5', '[ 0 99999 ] RANGE', ' UNIQUE'.repeat(5)],
+    // Built with FILL, not `RANGE { 1 MOD } MAP`: the MAP costs 100,000
+    // execution steps, and a setup that large and that variable swamps the
+    // few milliseconds nine hash-hitting UNIQUE passes actually take.
+    ['UNIQUE 100k d=1 x9', '[ 100000 7 ] FILL', ' UNIQUE'.repeat(9)],
+    ['SORT 100k x5', '[ 0 99999 ] RANGE', ' SORT'.repeat(5)],
+    ['TALLY 100k all-distinct x5', '[ 0 99999 ] RANGE', ' TALLY'.repeat(5)],
+    // Wide elements: an equality probe walks limbs, and this was by far the
+    // dearest per-element shape on native. If any collection path is the WASM
+    // floor, it is a candidate.
+    ['UNIQUE 4k x 4096-digit x2', `[ 1 4000 ] RANGE { ${wide} * } MAP`, ' UNIQUE'.repeat(2)],
+];
+
+const STEPS = [
+    ['add loop x200k', '', `1${' 7 +'.repeat(200_000)}`],
+    // Every iteration pays a dictionary lookup and a frame push, not just an
+    // arithmetic op. This was the native floor and is the shape
+    // `cli::step_limit_tests::DOWN_PROBE` uses.
+    ['DOWN trampoline x200k', '', `{\n{ [ 0 ] > | [ 1 ] - DOWN }\n{ IDLE | [ 'done' ] } COND\n} 'DOWN' DEF\n200000 DOWN`],
+];
+
+async function section(title, meter, cases) {
+    console.log(`\n── ${title} ${'─'.repeat(Math.max(0, 52 - title.length))}\n`);
+    console.log(`${'path'.padEnd(36)}${'units'.padStart(14)}${'units/ms'.padStart(12)}`);
+    let floor = Infinity;
+    let floorName = '';
+    for (const [name, setup, ops] of cases) {
+        const r = await rate(meter, setup, ops);
+        if (r.rate === null) {
+            console.log(`${name.padEnd(36)}${String(r.units).padStart(14)}${'too fast'.padStart(12)}`);
+            continue;
+        }
+        if (r.rate < floor) { floor = r.rate; floorName = name; }
+        console.log(`${name.padEnd(36)}${String(r.units).padStart(14)}${r.rate.toFixed(0).padStart(12)}`);
+    }
+    console.log(`\nfloor: ${floor.toFixed(0)} ${meter === 'executionSteps' ? 'steps' : 'units'}/ms  (${floorName})`);
+    return floor;
+}
+
+const numeric = await section('numericWork, under WASM', 'numericWork', NUMERIC);
+const collection = await section('collectionWork, under WASM', 'collectionWork', COLLECTION);
+const steps = await section('executionSteps, under WASM', 'executionSteps', STEPS);
+
+console.log('\n── derived budgets at a 30s host time budget ────────────\n');
+for (const [name, floor] of [['numericWork', numeric], ['collectionWork', collection], ['executionSteps', steps]]) {
+    console.log(`${name.padEnd(16)} 30000 ms x ${floor.toFixed(0).padStart(8)} = ${Math.round(30_000 * floor).toLocaleString()}`);
+}
+console.log(
+    '\nA budget here is only as good as the floor above it. Check that the\n' +
+    'floor path is one the meter prices correctly before deriving anything\n' +
+    'from it — see the KNOWN FINDING at the top of this file, which is why\n' +
+    'the collectionWork row currently is not.'
+);


### PR DESCRIPTION
## Summary

Follow-up to #1514, from reviewing it. Two commits so far; **the profile is not yet re-derived** because the second commit surfaced a blocker that has to be settled first (see below). Opened as a draft for that reason.

**Commit 1 — three defects in #1514 and its surroundings.**

- `work_meter_calibration::measure` timed the whole program but divided by charged units only, so `[ 0 99999 ] RANGE` materializing 100,000 elements sat inside the timed interval of the dense-lane row — the *floor* path a host time budget divides by. It read 6,153 vs 7,374 units/ms back to back once the operand build was excluded, and a floor that reads low derives a budget that is too small. `collection_word_calibration` already did this correctly; the two harnesses disagreeing was the defect.
- `cli_run_without_step_limit_uses_the_documented_default` compared `Interpreter::new().max_execution_steps()` against the constant the constructor initializes that field *from*, so it could not fail, and never invoked the CLI despite its name. Replaced with a real `ajisai run` invocation, verified non-tautological by mutation (it fails when the derived budget drops below the probe's 200,002 steps).
- Restores guidance #1514 overwrote: memory-constrained hosts, the WASM playground in particular, should inject a tighter `max_source_bytes`.

**Commit 2 — a WASM calibration harness.**

#1514 derived three ceilings from floor rates measured on **native release**, then applied them to the **WASM playground**. Measured back to back on one container, the native→WASM ratio is not a constant:

| meter | native release | WASM | ratio |
|---|---:|---:|---:|
| `numericWork` | 7,374 u/ms | 15,345 u/ms | 2.08x faster |
| `collectionWork` | 44,015 u/ms | 175,036 u/ms | 3.98x faster |
| `executionSteps` | 879 steps/ms | 584 steps/ms | 0.66x slower |

A ratio swinging from "twice as fast" to "a third slower" means one native calibration cannot make three ceilings bound equal time on WASM. What shipped buys **9.1s / 5.2s / 39.7s** on the playground against a stated 30s — a 7.6x spread, when equalizing time was the whole point. On the native CLI, where it *was* calibrated, it buys 19.0s / 20.6s / 26.4s.

## Blocker found on the harness's first full run

`UNIQUE` over wide elements charges ~300x less per millisecond than any other collection path (248 u/ms against 73,491 for `REVERSE 100k` on WASM; 780 against 45,025 on native). Cause is `Fraction::hash` on the `Big` representation, which clones through `to_bigint_pair()` and runs a full `BigInt::gcd` **once per element per scan**:

| element width | hash measured | charged (at the meter's own 6ns/unit) | under-charge |
|---|---:|---:|---:|
| 64-digit | 2.1 µs | 4 units ≈ 0.024 µs | 87x |
| 512-digit | 21.8 µs | 27 units ≈ 0.16 µs | 136x |
| 4096-digit | 602 µs | 213 units ≈ 1.3 µs | **470x** |

Cost is superlinear in width (64x wider → 287x slower); the charge is linear (53x). Under-charging is the direction the billing docs repeatedly flag as the dangerous one.

This appears to be a regression from #1513: the pre-de-quadraticization charge `probe × candidates` over-charged this path enough to mask it (measured at 1,370,000 u/ms on 2026-08-13), and `probe + hash` dropped the charge ~1000x while the cost stayed. #1513 §3.2 added a fast path for the `Small` representation and left `Big` on the slow one.

**Consequence, verified:** reaching MCP's 20,000,000 `collectionWork` on this path takes ~25.6s of native work, so `wallTimeMs` (5,000ms) answers first, as an unnamed `timeout`. `docs/dev/mcp-host-profiles.md`'s claim that "no source program reaches the clock any more — so `wallTimeMs` moved to `hostGate`" does not currently hold.

**Why it blocks the re-derivation:** at a 248 u/ms floor, a 30s budget is 7,440,000 units — smaller than the MCP profile's — which is not a usable playground ceiling. Deriving from the other paths instead would mean shipping a known 470x hole while claiming the ceilings bound equal time.

Awaiting a decision on whether to fix the implementation (`Fraction::hash`'s `Big` path — the same class of fix #1513 applied to `Small`), the pricing (charge scans superlinearly in width), or defer and record. `Hash` must stay consistent with `Eq` across representations and `create_unreduced`, which is the invariant #1513 added tests for, so this is not a change to make silently.

## Quality Classification

- Highest impacted level: QL-B (calibration tooling and a runtime-safety test; no shipped ceiling value or language semantics changed in this PR)

## Traceability

- Requirement(s): review of #1514; `docs/dev/host-profile-derivation-handoff.md` §4/§6
- Verification evidence: below

## Quality Checklist

- [x] Relevant requirements/objectives are identified.
- [x] Traceability links were added/updated (findings recorded in the harness header and commit messages).
- [x] `cargo fmt --check` (in `rust/`)
- [x] `cargo clippy --all-targets -- -D warnings` (in `rust/`)
- [x] `cargo test --all-targets --verbose` (in `rust/`) — step-limit suite green; replacement test mutation-verified
- [ ] `npm run check`, if applicable — deferred until the profile change lands in this branch
- [ ] `cargo llvm-cov --branch --workspace`, if applicable — coverage tool not installed in this environment
- [x] MC/DC-like checklist reviewed for modified boolean logic — no boolean-logic changes
- [x] Release checklist impact considered — no shipped ceiling values changed yet; WASM bundles untouched

## Notes

This repository uses a DO-178B-inspired internal process and does not claim formal DO-178B certification.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RecdhaycDtqMtCiKV4BTRK)_